### PR TITLE
Phase 2 — Persistence + Admin CRUD

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1748,6 +1748,7 @@ dependencies = [
  "ruscker-core",
  "serde",
  "serde_json",
+ "serde_yaml_ng",
  "tokio",
  "tracing",
  "tracing-subscriber",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1727,6 +1727,7 @@ dependencies = [
  "ruscker-core",
  "serde",
  "serde_json",
+ "serde_yaml_ng",
  "sqlx",
  "thiserror",
  "tokio",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -12,6 +12,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "allocator-api2"
+version = "0.2.21"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "683d7910e743518b0e34f1186f92494becacb047c7b6bf616c96772180fef923"
+
+[[package]]
 name = "android_system_properties"
 version = "0.1.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -141,6 +147,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "atoi"
+version = "2.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f28d99ec8bfea296261ca1af174f24225171fea9664ba9003cbebee704810528"
+dependencies = [
+ "num-traits",
+]
+
+[[package]]
 name = "atomic-waker"
 version = "1.1.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -179,7 +194,7 @@ dependencies = [
  "serde_json",
  "serde_path_to_error",
  "serde_urlencoded",
- "sha1",
+ "sha1 0.10.6",
  "sync_wrapper",
  "tokio",
  "tokio-tungstenite",
@@ -261,6 +276,9 @@ name = "bitflags"
 version = "2.11.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c4512299f36f043ab09a583e57bceb5a5aab7a73db1805848e8fef3c9e8c78b3"
+dependencies = [
+ "serde_core",
+]
 
 [[package]]
 name = "block-buffer"
@@ -269,6 +287,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3078c7629b62d3f0439517fa394996acacc5cbc91c5a20d8c658e77abd503a71"
 dependencies = [
  "generic-array",
+]
+
+[[package]]
+name = "block-buffer"
+version = "0.12.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cdd35008169921d80bc60d3d0ab416eecb028c4cd653352907921d95084790be"
+dependencies = [
+ "hybrid-array",
 ]
 
 [[package]]
@@ -286,6 +313,12 @@ name = "bumpalo"
 version = "3.20.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "72f5acc6cb2ba439de613abc23857ec3d78374d8ed5ac84e9d11336e87da8649"
+
+[[package]]
+name = "byteorder"
+version = "1.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1fd0f2584146f6f2ef48085050886acf353beff7305ebd1ae69500e27c67f64b"
 
 [[package]]
 name = "bytes"
@@ -308,6 +341,17 @@ name = "cfg-if"
 version = "1.0.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9330f8b2ff13f34540b44e946ef35111825727b38d33286ef986142615121801"
+
+[[package]]
+name = "chacha20"
+version = "0.10.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6f8d983286843e49675a4b7a2d174efe136dc93a18d69130dd18198a6c167601"
+dependencies = [
+ "cfg-if",
+ "cpufeatures 0.3.0",
+ "rand_core 0.10.1",
+]
 
 [[package]]
 name = "chrono"
@@ -364,10 +408,25 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c8d4a3bb8b1e0c1050499d1815f5ab16d04f0959b233085fb31653fbfc9d98f9"
 
 [[package]]
+name = "cmov"
+version = "0.5.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3f88a43d011fc4a6876cb7344703e297c71dda42494fee094d5f7c76bf13f746"
+
+[[package]]
 name = "colorchoice"
 version = "1.0.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1d07550c9036bf2ae0c684c4297d503f838287c83c53686d05370d0e139ae570"
+
+[[package]]
+name = "concurrent-queue"
+version = "2.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4ca0197aee26d1ae37445ee532fefce43251d24cc7c166799f4d46817f1d3973"
+dependencies = [
+ "crossbeam-utils",
+]
 
 [[package]]
 name = "console"
@@ -407,6 +466,30 @@ dependencies = [
 ]
 
 [[package]]
+name = "cpufeatures"
+version = "0.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8b2a41393f66f16b0823bb79094d54ac5fbd34ab292ddafb9a0456ac9f87d201"
+dependencies = [
+ "libc",
+]
+
+[[package]]
+name = "crc"
+version = "3.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5eb8a2a1cd12ab0d987a5d5e825195d372001a4094a0376319d5a0ad71c1ba0d"
+dependencies = [
+ "crc-catalog",
+]
+
+[[package]]
+name = "crc-catalog"
+version = "2.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "217698eaf96b4a3f0bc4f3662aaa55bdf913cd54d7204591faa790070c6d0853"
+
+[[package]]
 name = "crossbeam-deque"
 version = "0.8.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -426,6 +509,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "crossbeam-queue"
+version = "0.3.12"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0f58bbc28f91df819d0aa2a2c00cd19754769c2fad90579b3592b1c9ba7a3115"
+dependencies = [
+ "crossbeam-utils",
+]
+
+[[package]]
 name = "crossbeam-utils"
 version = "0.8.21"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -439,6 +531,24 @@ checksum = "78c8292055d1c1df0cce5d180393dc8cce0abec0a7102adb6c7b1eef6016d60a"
 dependencies = [
  "generic-array",
  "typenum",
+]
+
+[[package]]
+name = "crypto-common"
+version = "0.2.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ce6e4c961d6cd6c9a86db418387425e8bdeaf05b3c8bc1411e6dca4c252f1453"
+dependencies = [
+ "hybrid-array",
+]
+
+[[package]]
+name = "ctutils"
+version = "0.4.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7d5515a3834141de9eafb9717ad39eea8247b5674e6066c404e8c4b365d2a29e"
+dependencies = [
+ "cmov",
 ]
 
 [[package]]
@@ -468,8 +578,19 @@ version = "0.10.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9ed9a281f7bc9b7576e61468ba615a66a5c8cfdff42420a70aa82701a3b1e292"
 dependencies = [
- "block-buffer",
- "crypto-common",
+ "block-buffer 0.10.4",
+ "crypto-common 0.1.7",
+]
+
+[[package]]
+name = "digest"
+version = "0.11.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f1dd6dbb5841937940781866fa1281a1ff7bd3bf827091440879f9994983d5c2"
+dependencies = [
+ "block-buffer 0.12.0",
+ "crypto-common 0.2.2",
+ "ctutils",
 ]
 
 [[package]]
@@ -481,6 +602,21 @@ dependencies = [
  "proc-macro2",
  "quote",
  "syn",
+]
+
+[[package]]
+name = "dotenvy"
+version = "0.15.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1aaf95b3e5c8f23aa320147307562d361db0ae0d51242340f558153b4eb2439b"
+
+[[package]]
+name = "either"
+version = "1.16.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "91622ff5e7162018101f2fea40d6ebf4a78bbe5a49736a2020649edf9693679e"
+dependencies = [
+ "serde",
 ]
 
 [[package]]
@@ -503,6 +639,27 @@ checksum = "39cab71617ae0d63f51a36d69f866391735b51691dbda63cf6f96d042b63efeb"
 dependencies = [
  "libc",
  "windows-sys",
+]
+
+[[package]]
+name = "etcetera"
+version = "0.11.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "de48cc4d1c1d97a20fd819def54b890cadde72ed3ad0c614822a0a433361be96"
+dependencies = [
+ "cfg-if",
+ "windows-sys",
+]
+
+[[package]]
+name = "event-listener"
+version = "5.4.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e13b66accf52311f30a0db42147dadea9850cb48cd070028831ae5f5d4b856ab"
+dependencies = [
+ "concurrent-queue",
+ "parking",
+ "pin-project-lite",
 ]
 
 [[package]]
@@ -558,7 +715,7 @@ version = "0.14.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d6b1dac7e7f07f8a60aa844f616bede13deeffaf24e9e35ae9e4979a7dac4a5c"
 dependencies = [
- "flume",
+ "flume 0.11.1",
  "ignore",
  "proc-macro2",
  "quote",
@@ -576,7 +733,7 @@ dependencies = [
  "fluent-langneg",
  "fluent-syntax",
  "fluent-template-macros",
- "flume",
+ "flume 0.11.1",
  "ignore",
  "intl-memoizer",
  "log",
@@ -594,10 +751,27 @@ dependencies = [
 ]
 
 [[package]]
+name = "flume"
+version = "0.12.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5e139bc46ca777eb5efaf62df0ab8cc5fd400866427e56c68b22e414e53bd3be"
+dependencies = [
+ "futures-core",
+ "futures-sink",
+ "spin",
+]
+
+[[package]]
 name = "foldhash"
 version = "0.1.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d9c4f5dac5e15c24eb999c26181a6ca40b39fe946cbe4c263c7209467bc83af2"
+
+[[package]]
+name = "foldhash"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "77ce24cb58228fbb8aa041425bb1050850ac19177686ea6e0f41a70416f56fdb"
 
 [[package]]
 name = "form_urlencoded"
@@ -615,6 +789,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "07bbe89c50d7a535e539b8c17bc0b49bdb77747034daa8087407d655f3f7cc1d"
 dependencies = [
  "futures-core",
+ "futures-sink",
 ]
 
 [[package]]
@@ -622,6 +797,34 @@ name = "futures-core"
 version = "0.3.32"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7e3450815272ef58cec6d564423f6e755e25379b217b0bc688e295ba24df6b1d"
+
+[[package]]
+name = "futures-executor"
+version = "0.3.32"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "baf29c38818342a3b26b5b923639e7b1f4a61fc5e76102d4b1981c6dc7a7579d"
+dependencies = [
+ "futures-core",
+ "futures-task",
+ "futures-util",
+]
+
+[[package]]
+name = "futures-intrusive"
+version = "0.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1d930c203dd0b6ff06e0201a4a2fe9149b43c684fd4420555b26d21b1a02956f"
+dependencies = [
+ "futures-core",
+ "lock_api",
+ "parking_lot",
+]
+
+[[package]]
+name = "futures-io"
+version = "0.3.32"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cecba35d7ad927e23624b22ad55235f2239cfa44fd10428eecbeba6d6a717718"
 
 [[package]]
 name = "futures-macro"
@@ -653,9 +856,11 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "389ca41296e6190b48053de0321d02a77f32f8a5d2461dd38762c0593805c6d6"
 dependencies = [
  "futures-core",
+ "futures-io",
  "futures-macro",
  "futures-sink",
  "futures-task",
+ "memchr",
  "pin-project-lite",
  "slab",
 ]
@@ -691,6 +896,7 @@ dependencies = [
  "cfg-if",
  "libc",
  "r-efi 6.0.0",
+ "rand_core 0.10.1",
  "wasip2",
  "wasip3",
 ]
@@ -720,7 +926,18 @@ version = "0.15.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9229cfe53dfd69f0609a49f65461bd93001ea1ef889cd5529dd176593f5338a1"
 dependencies = [
- "foldhash",
+ "foldhash 0.1.5",
+]
+
+[[package]]
+name = "hashbrown"
+version = "0.16.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "841d1cc9bed7f9236f321df977030373f4a4163ae1a7dbfe1a51a2c1a51d9100"
+dependencies = [
+ "allocator-api2",
+ "equivalent",
+ "foldhash 0.2.0",
 ]
 
 [[package]]
@@ -730,10 +947,43 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ed5909b6e89a2db4456e54cd5f673791d7eca6732202bbf2a9cc504fe2f9b84a"
 
 [[package]]
+name = "hashlink"
+version = "0.11.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ea0b22561a9c04a7cb1a302c013e0259cd3b4bb619f145b32f72b8b4bcbed230"
+dependencies = [
+ "hashbrown 0.16.1",
+]
+
+[[package]]
 name = "heck"
 version = "0.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2304e00983f87ffb38b55b444b5e3b60a884b5d30c0fca7d82fe33449bbe55ea"
+
+[[package]]
+name = "hex"
+version = "0.4.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7f24254aa9a54b5c858eaee2f5bccdb46aaf0e486a595ed5fd8f86ba55232a70"
+
+[[package]]
+name = "hkdf"
+version = "0.13.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4aaa26c720c68b866f2c96ef5c1264b3e6f473fe5d4ce61cd44bbe913e553018"
+dependencies = [
+ "hmac",
+]
+
+[[package]]
+name = "hmac"
+version = "0.13.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6303bc9732ae41b04cb554b844a762b4115a61bfaa81e3e83050991eeb56863f"
+dependencies = [
+ "digest 0.11.3",
+]
 
 [[package]]
 name = "http"
@@ -785,6 +1035,15 @@ name = "httpdate"
 version = "1.0.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "df3b46402a9d5adb4c86a0cf463f42e19994e3ee891101b1841f30a545cb49a9"
+
+[[package]]
+name = "hybrid-array"
+version = "0.4.12"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9155a582abd142abc056962c29e3ce5ff2ad5469f4246b537ed42c5deba857da"
+dependencies = [
+ "typenum",
+]
 
 [[package]]
 name = "hyper"
@@ -846,10 +1105,113 @@ dependencies = [
 ]
 
 [[package]]
+name = "icu_collections"
+version = "2.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2984d1cd16c883d7935b9e07e44071dca8d917fd52ecc02c04d5fa0b5a3f191c"
+dependencies = [
+ "displaydoc",
+ "potential_utf",
+ "utf8_iter",
+ "yoke",
+ "zerofrom",
+ "zerovec",
+]
+
+[[package]]
+name = "icu_locale_core"
+version = "2.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "92219b62b3e2b4d88ac5119f8904c10f8f61bf7e95b640d25ba3075e6cac2c29"
+dependencies = [
+ "displaydoc",
+ "litemap",
+ "tinystr",
+ "writeable",
+ "zerovec",
+]
+
+[[package]]
+name = "icu_normalizer"
+version = "2.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c56e5ee99d6e3d33bd91c5d85458b6005a22140021cc324cea84dd0e72cff3b4"
+dependencies = [
+ "icu_collections",
+ "icu_normalizer_data",
+ "icu_properties",
+ "icu_provider",
+ "smallvec",
+ "zerovec",
+]
+
+[[package]]
+name = "icu_normalizer_data"
+version = "2.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "da3be0ae77ea334f4da67c12f149704f19f81d1adf7c51cf482943e84a2bad38"
+
+[[package]]
+name = "icu_properties"
+version = "2.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bee3b67d0ea5c2cca5003417989af8996f8604e34fb9ddf96208a033901e70de"
+dependencies = [
+ "icu_collections",
+ "icu_locale_core",
+ "icu_properties_data",
+ "icu_provider",
+ "zerotrie",
+ "zerovec",
+]
+
+[[package]]
+name = "icu_properties_data"
+version = "2.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8e2bbb201e0c04f7b4b3e14382af113e17ba4f63e2c9d2ee626b720cbce54a14"
+
+[[package]]
+name = "icu_provider"
+version = "2.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "139c4cf31c8b5f33d7e199446eff9c1e02decfc2f0eec2c8d71f65befa45b421"
+dependencies = [
+ "displaydoc",
+ "icu_locale_core",
+ "writeable",
+ "yoke",
+ "zerofrom",
+ "zerotrie",
+ "zerovec",
+]
+
+[[package]]
 name = "id-arena"
 version = "2.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3d3067d79b975e8844ca9eb072e16b31c3c1c36928edf9c6789548c524d0d954"
+
+[[package]]
+name = "idna"
+version = "1.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3b0875f23caa03898994f6ddc501886a45c7d3d62d04d2d90788d47be1b1e4de"
+dependencies = [
+ "idna_adapter",
+ "smallvec",
+ "utf8_iter",
+]
+
+[[package]]
+name = "idna_adapter"
+version = "1.2.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cb68373c0d6620ef8105e855e7745e18b0d00d3bdb07fb532e434244cdb9a714"
+dependencies = [
+ "icu_normalizer",
+ "icu_properties",
+]
 
 [[package]]
 name = "ignore"
@@ -973,10 +1335,27 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "68ab91017fe16c622486840e4c83c9a37afeff978bd239b5293d61ece587de66"
 
 [[package]]
+name = "libsqlite3-sys"
+version = "0.37.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b1f111c8c41e7c61a49cd34e44c7619462967221a6443b0ec299e0ac30cfb9b1"
+dependencies = [
+ "cc",
+ "pkg-config",
+ "vcpkg",
+]
+
+[[package]]
 name = "linux-raw-sys"
 version = "0.12.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "32a66949e030da00e8c7d4434b251670a91556f4144941d37452769c25d58a53"
+
+[[package]]
+name = "litemap"
+version = "0.8.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "92daf443525c4cce67b150400bc2316076100ce0b3686209eb8cf3c31612e6f0"
 
 [[package]]
 name = "lock_api"
@@ -1007,6 +1386,16 @@ name = "matchit"
 version = "0.8.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "47e1ffaa40ddd1f3ed91f717a33c8c0ee23fff369e3aa8772b9605cc1d22f4c3"
+
+[[package]]
+name = "md-5"
+version = "0.11.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "69b6441f590336821bb897fb28fc622898ccceb1d6cea3fde5ea86b090c4de98"
+dependencies = [
+ "cfg-if",
+ "digest 0.11.3",
+]
 
 [[package]]
 name = "memchr"
@@ -1089,6 +1478,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "parking"
+version = "2.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f38d5652c16fde515bb1ecef450ab0f6a219d619a7274976324d5e377f7dceba"
+
+[[package]]
 name = "parking_lot"
 version = "0.12.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1122,6 +1517,21 @@ name = "pin-project-lite"
 version = "0.2.17"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a89322df9ebe1c1578d689c92318e070967d1042b512afbe49518723f4e6d5cd"
+
+[[package]]
+name = "pkg-config"
+version = "0.3.33"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "19f132c84eca552bf34cab8ec81f1c1dcc229b811638f9d283dceabe58c5569e"
+
+[[package]]
+name = "potential_utf"
+version = "0.1.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0103b1cef7ec0cf76490e969665504990193874ea05c85ff9bab8b911d0a0564"
+dependencies = [
+ "zerovec",
+]
 
 [[package]]
 name = "powerfmt"
@@ -1215,6 +1625,17 @@ dependencies = [
 ]
 
 [[package]]
+name = "rand"
+version = "0.10.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d2e8e8bcc7961af1fdac401278c6a831614941f6164ee3bf4ce61b7edb162207"
+dependencies = [
+ "chacha20",
+ "getrandom 0.4.2",
+ "rand_core 0.10.1",
+]
+
+[[package]]
 name = "rand_chacha"
 version = "0.9.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1241,6 +1662,12 @@ checksum = "76afc826de14238e6e8c374ddcc1fa19e374fd8dd986b0d2af0d02377261d83c"
 dependencies = [
  "getrandom 0.3.4",
 ]
+
+[[package]]
+name = "rand_core"
+version = "0.10.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "63b8176103e19a2643978565ca18b50549f6101881c443590420e4dc998a3c69"
 
 [[package]]
 name = "redox_syscall"
@@ -1300,6 +1727,7 @@ dependencies = [
  "ruscker-core",
  "serde",
  "serde_json",
+ "sqlx",
  "thiserror",
  "tokio",
  "tower",
@@ -1514,8 +1942,41 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e3bf829a2d51ab4a5ddf1352d8470c140cadc8301b2ae1789db023f01cedd6ba"
 dependencies = [
  "cfg-if",
- "cpufeatures",
- "digest",
+ "cpufeatures 0.2.17",
+ "digest 0.10.7",
+]
+
+[[package]]
+name = "sha1"
+version = "0.11.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "aacc4cc499359472b4abe1bf11d0b12e688af9a805fa5e3016f9a386dc2d0214"
+dependencies = [
+ "cfg-if",
+ "cpufeatures 0.3.0",
+ "digest 0.11.3",
+]
+
+[[package]]
+name = "sha2"
+version = "0.10.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a7507d819769d01a365ab707794a4084392c824f54a7a6a7862f8c3d0892b283"
+dependencies = [
+ "cfg-if",
+ "cpufeatures 0.2.17",
+ "digest 0.10.7",
+]
+
+[[package]]
+name = "sha2"
+version = "0.11.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "446ba717509524cb3f22f17ecc096f10f4822d76ab5c0b9822c5f9c284e825f4"
+dependencies = [
+ "cfg-if",
+ "cpufeatures 0.3.0",
+ "digest 0.11.3",
 ]
 
 [[package]]
@@ -1560,6 +2021,9 @@ name = "smallvec"
 version = "1.15.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "67b1b7a3b5fe4f1376887184045fcf45c69e92af734b7aaddc05fb777b6fbd03"
+dependencies = [
+ "serde",
+]
 
 [[package]]
 name = "socket2"
@@ -1578,6 +2042,202 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6980e8d7511241f8acf4aebddbb1ff938df5eebe98691418c4468d0b72a96a67"
 dependencies = [
  "lock_api",
+]
+
+[[package]]
+name = "sqlx"
+version = "0.9.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "378620ccc25c62c89d8be1c819e76a88d59bdcc3304733330788948e619bfd71"
+dependencies = [
+ "sqlx-core",
+ "sqlx-macros",
+ "sqlx-mysql",
+ "sqlx-postgres",
+ "sqlx-sqlite",
+]
+
+[[package]]
+name = "sqlx-core"
+version = "0.9.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "05b44e85bf579a8eeb4ceaa77a3a523baf2bf0e9bac7e40f405d537b5d2d5ccb"
+dependencies = [
+ "base64",
+ "bytes",
+ "cfg-if",
+ "chrono",
+ "crc",
+ "crossbeam-queue",
+ "either",
+ "event-listener",
+ "futures-core",
+ "futures-intrusive",
+ "futures-io",
+ "futures-util",
+ "hashbrown 0.16.1",
+ "hashlink",
+ "indexmap",
+ "log",
+ "memchr",
+ "percent-encoding",
+ "serde",
+ "serde_json",
+ "sha2 0.10.9",
+ "smallvec",
+ "thiserror",
+ "tokio",
+ "tokio-stream",
+ "tracing",
+ "url",
+ "uuid",
+]
+
+[[package]]
+name = "sqlx-macros"
+version = "0.9.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bd2b84f2bc39a5705ef27ec785a11c934a41bbd4a24941e257927cddc26b60bf"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "sqlx-core",
+ "sqlx-macros-core",
+ "syn",
+]
+
+[[package]]
+name = "sqlx-macros-core"
+version = "0.9.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fb8d96de5fdc85a5c4ec813432b523ec637e80ba98f046555f75f7908ddac7c3"
+dependencies = [
+ "cfg-if",
+ "dotenvy",
+ "either",
+ "heck",
+ "hex",
+ "proc-macro2",
+ "quote",
+ "serde",
+ "serde_json",
+ "sha2 0.10.9",
+ "sqlx-core",
+ "sqlx-mysql",
+ "sqlx-postgres",
+ "sqlx-sqlite",
+ "syn",
+ "thiserror",
+ "tokio",
+ "url",
+]
+
+[[package]]
+name = "sqlx-mysql"
+version = "0.9.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "90b8020fe17c5f2c245bfa2505d7ef59c5604839527c740266ad2214acebea27"
+dependencies = [
+ "bitflags",
+ "byteorder",
+ "bytes",
+ "chrono",
+ "crc",
+ "digest 0.11.3",
+ "dotenvy",
+ "either",
+ "futures-core",
+ "futures-util",
+ "generic-array",
+ "log",
+ "percent-encoding",
+ "serde",
+ "sha1 0.11.0",
+ "sha2 0.11.0",
+ "sqlx-core",
+ "thiserror",
+ "tracing",
+ "uuid",
+]
+
+[[package]]
+name = "sqlx-postgres"
+version = "0.9.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "87a2bdd6e83f6b3ea525ca9fee568030508b58355a43d0b2c1674d5f79dcd65e"
+dependencies = [
+ "atoi",
+ "base64",
+ "bitflags",
+ "byteorder",
+ "chrono",
+ "crc",
+ "dotenvy",
+ "etcetera",
+ "futures-channel",
+ "futures-core",
+ "futures-util",
+ "hex",
+ "hkdf",
+ "hmac",
+ "itoa",
+ "log",
+ "md-5",
+ "memchr",
+ "rand 0.10.1",
+ "serde",
+ "serde_json",
+ "sha2 0.11.0",
+ "smallvec",
+ "sqlx-core",
+ "stringprep",
+ "thiserror",
+ "tracing",
+ "uuid",
+ "whoami",
+]
+
+[[package]]
+name = "sqlx-sqlite"
+version = "0.9.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "488e99c397a62007e4229aec669a179816339afc6d2620ca6fa420dbee2e982c"
+dependencies = [
+ "atoi",
+ "chrono",
+ "flume 0.12.0",
+ "form_urlencoded",
+ "futures-channel",
+ "futures-core",
+ "futures-executor",
+ "futures-intrusive",
+ "futures-util",
+ "libsqlite3-sys",
+ "log",
+ "percent-encoding",
+ "serde",
+ "sqlx-core",
+ "thiserror",
+ "tracing",
+ "url",
+ "uuid",
+]
+
+[[package]]
+name = "stable_deref_trait"
+version = "1.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6ce2be8dc25455e1f91df71bfa12ad37d7af1092ae736f3a6cd0e37bc7810596"
+
+[[package]]
+name = "stringprep"
+version = "0.1.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7b4df3d392d81bd458a8a621b8bffbd2302a12ffe288a9d931670948749463b1"
+dependencies = [
+ "unicode-bidi",
+ "unicode-normalization",
+ "unicode-properties",
 ]
 
 [[package]]
@@ -1602,6 +2262,17 @@ name = "sync_wrapper"
 version = "1.0.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0bf256ce5efdfa370213c1dabab5935a12e49f2c58d15e9eac2870d3b4f27263"
+
+[[package]]
+name = "synstructure"
+version = "0.13.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "728a70f3dbaf5bab7f0c4b1ac8d7ae5ea60a4b5549c8a5914361c99147a709d2"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
+]
 
 [[package]]
 name = "tempfile"
@@ -1688,6 +2359,21 @@ dependencies = [
 ]
 
 [[package]]
+name = "tinyvec"
+version = "1.11.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3e61e67053d25a4e82c844e8424039d9745781b3fc4f32b8d55ed50f5f667ef3"
+dependencies = [
+ "tinyvec_macros",
+]
+
+[[package]]
+name = "tinyvec_macros"
+version = "0.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1f3ccbac311fea05f86f61904b462b55fb3df8837a366dfc601a0161d0532f20"
+
+[[package]]
 name = "tokio"
 version = "1.52.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1713,6 +2399,17 @@ dependencies = [
  "proc-macro2",
  "quote",
  "syn",
+]
+
+[[package]]
+name = "tokio-stream"
+version = "0.1.18"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "32da49809aab5c3bc678af03902d4ccddea2a87d028d86392a4b1560c6906c70"
+dependencies = [
+ "futures-core",
+ "pin-project-lite",
+ "tokio",
 ]
 
 [[package]]
@@ -1884,7 +2581,7 @@ dependencies = [
  "httparse",
  "log",
  "rand 0.9.4",
- "sha1",
+ "sha1 0.10.6",
  "thiserror",
 ]
 
@@ -1953,10 +2650,31 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "dbc4bc3a9f746d862c45cb89d705aa10f187bb96c76001afab07a0d35ce60142"
 
 [[package]]
+name = "unicode-bidi"
+version = "0.3.18"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5c1cb5db39152898a79168971543b1cb5020dff7fe43c8dc468b0885f5e29df5"
+
+[[package]]
 name = "unicode-ident"
 version = "1.0.24"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e6e4313cd5fcd3dad5cafa179702e2b244f760991f45397d14d4ebf38247da75"
+
+[[package]]
+name = "unicode-normalization"
+version = "0.1.25"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5fd4f6878c9cb28d874b009da9e8d183b5abc80117c40bbd187a1fde336be6e8"
+dependencies = [
+ "tinyvec",
+]
+
+[[package]]
+name = "unicode-properties"
+version = "0.1.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7df058c713841ad818f1dc5d3fd88063241cc61f49f5fbea4b951e8cf5a8d71d"
 
 [[package]]
 name = "unicode-xid"
@@ -1969,6 +2687,24 @@ name = "unsafe-libyaml"
 version = "0.2.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "673aac59facbab8a9007c7f6108d11f63b603f7cabff99fabf650fea5c32b861"
+
+[[package]]
+name = "url"
+version = "2.5.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ff67a8a4397373c3ef660812acab3268222035010ab8680ec4215f38ba3d0eed"
+dependencies = [
+ "form_urlencoded",
+ "idna",
+ "percent-encoding",
+ "serde",
+]
+
+[[package]]
+name = "utf8_iter"
+version = "1.0.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b6c140620e7ffbb22c2dee59cafe6084a59b5ffc27a8859a5f0d494b5d52b6be"
 
 [[package]]
 name = "utf8parse"
@@ -1993,6 +2729,12 @@ name = "valuable"
 version = "0.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ba73ea9cf16a25df0c8caa16c51acb937d5712a8429db78a3ee29d5dcacd3a65"
+
+[[package]]
+name = "vcpkg"
+version = "0.2.15"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "accd4ea62f7bb7a82fe23066fb0957d48ef677f6eeb8215f372f52e48bb32426"
 
 [[package]]
 name = "version_check"
@@ -2112,6 +2854,12 @@ dependencies = [
  "indexmap",
  "semver",
 ]
+
+[[package]]
+name = "whoami"
+version = "2.1.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "998767ef88740d1f5b0682a9c53c24431453923962269c2db68ee43788c5a40d"
 
 [[package]]
 name = "winapi-util"
@@ -2294,10 +3042,39 @@ dependencies = [
 ]
 
 [[package]]
+name = "writeable"
+version = "0.6.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1ffae5123b2d3fc086436f8834ae3ab053a283cfac8fe0a0b8eaae044768a4c4"
+
+[[package]]
 name = "yansi"
 version = "1.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "cfe53a6657fd280eaa890a3bc59152892ffa3e30101319d168b781ed6529b049"
+
+[[package]]
+name = "yoke"
+version = "0.8.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "abe8c5fda708d9ca3df187cae8bfb9ceda00dd96231bed36e445a1a48e66f9ca"
+dependencies = [
+ "stable_deref_trait",
+ "yoke-derive",
+ "zerofrom",
+]
+
+[[package]]
+name = "yoke-derive"
+version = "0.8.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "de844c262c8848816172cef550288e7dc6c7b7814b4ee56b3e1553f275f1858e"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
+ "synstructure",
+]
 
 [[package]]
 name = "zerocopy"
@@ -2324,6 +3101,32 @@ name = "zerofrom"
 version = "0.1.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0ec05a11813ea801ff6d75110ad09cd0824ddba17dfe17128ea0d5f68e6c5272"
+dependencies = [
+ "zerofrom-derive",
+]
+
+[[package]]
+name = "zerofrom-derive"
+version = "0.1.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "11532158c46691caf0f2593ea8358fed6bbf68a0315e80aae9bd41fbade684a1"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
+ "synstructure",
+]
+
+[[package]]
+name = "zerotrie"
+version = "0.2.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0f9152d31db0792fa83f70fb2f83148effb5c1f5b8c7686c3459e361d9bc20bf"
+dependencies = [
+ "displaydoc",
+ "yoke",
+ "zerofrom",
+]
 
 [[package]]
 name = "zerovec"
@@ -2332,7 +3135,20 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "90f911cbc359ab6af17377d242225f4d75119aec87ea711a880987b18cd7b239"
 dependencies = [
  "serde",
+ "yoke",
  "zerofrom",
+ "zerovec-derive",
+]
+
+[[package]]
+name = "zerovec-derive"
+version = "0.11.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "625dc425cab0dca6dc3c3319506e6593dcb08a9f387ea3b284dbd52a92c40555"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
 ]
 
 [[package]]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3,12 +3,36 @@
 version = 4
 
 [[package]]
+name = "adler2"
+version = "2.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "320119579fcad9c21884f5c4861d16174d0e06250625266f50fe6898340abefa"
+
+[[package]]
 name = "aho-corasick"
 version = "1.1.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ddd31a130427c27518df266943a5308ed92d4b226cc639f5a8f1002816174301"
 dependencies = [
  "memchr",
+]
+
+[[package]]
+name = "aligned"
+version = "0.4.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ee4508988c62edf04abd8d92897fca0c2995d907ce1dfeaf369dac3716a40685"
+dependencies = [
+ "as-slice",
+]
+
+[[package]]
+name = "aligned-vec"
+version = "0.6.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "dc890384c8602f339876ded803c97ad529f3842aba97f6392b3dba0dd171769b"
+dependencies = [
+ "equator",
 ]
 
 [[package]]
@@ -81,6 +105,38 @@ name = "anyhow"
 version = "1.0.102"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7f202df86484c868dbad7eaa557ef785d5c66295e41b460ef922eca0723b842c"
+
+[[package]]
+name = "arbitrary"
+version = "1.4.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c3d036a3c4ab069c7b410a2ce876bd74808d2d0888a82667669f8e783a898bf1"
+
+[[package]]
+name = "arg_enum_proc_macro"
+version = "0.3.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0ae92a5119aa49cdbcf6b9f893fe4e1d98b04ccbf82ee0584ad948a44a734dea"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
+]
+
+[[package]]
+name = "arrayvec"
+version = "0.7.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7c02d123df017efcdfbd739ef81735b36c5ba83ec3c59c80a9d7ecc718f92e50"
+
+[[package]]
+name = "as-slice"
+version = "0.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "516b6b4f0e40d50dcda9365d53964ec74560ad4284da2e7fc97122cd83174516"
+dependencies = [
+ "stable_deref_trait",
+]
 
 [[package]]
 name = "askama"
@@ -168,6 +224,49 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f2032f911046de80f0a198e0901378627c33f59ea0ac00e363d481118bd70a53"
 
 [[package]]
+name = "av-scenechange"
+version = "0.14.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0f321d77c20e19b92c39e7471cf986812cbb46659d2af674adc4331ef3f18394"
+dependencies = [
+ "aligned",
+ "anyhow",
+ "arg_enum_proc_macro",
+ "arrayvec",
+ "log",
+ "num-rational",
+ "num-traits",
+ "pastey",
+ "rayon",
+ "thiserror",
+ "v_frame",
+ "y4m",
+]
+
+[[package]]
+name = "av1-grain"
+version = "0.2.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8cfddb07216410377231960af4fcab838eaa12e013417781b78bd95ee22077f8"
+dependencies = [
+ "anyhow",
+ "arrayvec",
+ "log",
+ "nom",
+ "num-rational",
+ "v_frame",
+]
+
+[[package]]
+name = "avif-serialize"
+version = "0.8.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e7178fe5f7d460b13895ebb9dcb28a3a6216d2df2574a0806cb51b555d297f38"
+dependencies = [
+ "arrayvec",
+]
+
+[[package]]
 name = "axum"
 version = "0.8.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -188,6 +287,7 @@ dependencies = [
  "matchit",
  "memchr",
  "mime",
+ "multer",
  "percent-encoding",
  "pin-project-lite",
  "serde_core",
@@ -272,12 +372,27 @@ dependencies = [
 ]
 
 [[package]]
+name = "bit_field"
+version = "0.10.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1e4b40c7323adcfc0a41c4b88143ed58346ff65a288fc144329c5c45e05d70c6"
+
+[[package]]
 name = "bitflags"
 version = "2.11.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c4512299f36f043ab09a583e57bceb5a5aab7a73db1805848e8fef3c9e8c78b3"
 dependencies = [
  "serde_core",
+]
+
+[[package]]
+name = "bitstream-io"
+version = "4.10.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7eff00be299a18769011411c9def0d827e8f2d7bf0c3dbf53633147a8867fd1f"
+dependencies = [
+ "no_std_io2",
 ]
 
 [[package]]
@@ -309,16 +424,34 @@ dependencies = [
 ]
 
 [[package]]
+name = "built"
+version = "0.8.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5c0e531d93d39c34eef561e929e8a7f86d77a5af08aac4f6d6e39976c51858e9"
+
+[[package]]
 name = "bumpalo"
 version = "3.20.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "72f5acc6cb2ba439de613abc23857ec3d78374d8ed5ac84e9d11336e87da8649"
 
 [[package]]
+name = "bytemuck"
+version = "1.25.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c8efb64bd706a16a1bdde310ae86b351e4d21550d98d056f22f8a7f7a2183fec"
+
+[[package]]
 name = "byteorder"
 version = "1.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1fd0f2584146f6f2ef48085050886acf353beff7305ebd1ae69500e27c67f64b"
+
+[[package]]
+name = "byteorder-lite"
+version = "0.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8f1fe948ff07f4bd06c30984e69f5b4899c516a3ef74f34df92a2df2ab535495"
 
 [[package]]
 name = "bytes"
@@ -333,7 +466,20 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a1dce859f0832a7d088c4f1119888ab94ef4b5d6795d1ce05afb7fe159d79f98"
 dependencies = [
  "find-msvc-tools",
+ "jobserver",
+ "libc",
  "shlex",
+]
+
+[[package]]
+name = "cfb"
+version = "0.7.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d38f2da7a0a2c4ccf0065be06397cc26a81f4e528be095826eee9d4adbb8c60f"
+dependencies = [
+ "byteorder",
+ "fnv",
+ "uuid",
 ]
 
 [[package]]
@@ -490,6 +636,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "217698eaf96b4a3f0bc4f3662aaa55bdf913cd54d7204591faa790070c6d0853"
 
 [[package]]
+name = "crc32fast"
+version = "1.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9481c1c90cbf2ac953f07c8d4a58aa3945c425b7185c9154d67a65e4230da511"
+dependencies = [
+ "cfg-if",
+]
+
+[[package]]
 name = "crossbeam-deque"
 version = "0.8.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -522,6 +677,12 @@ name = "crossbeam-utils"
 version = "0.8.21"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d0a5c400df2834b80a4c3327b3aad3a4c4cd4de0629063962b03235697506a28"
+
+[[package]]
+name = "crunchy"
+version = "0.2.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "460fbee9c2c2f33933d720630a6a0bac33ba7053db5344fac858d4b8952d77d5"
 
 [[package]]
 name = "crypto-common"
@@ -626,6 +787,35 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "34aa73646ffb006b8f5147f3dc182bd4bcb190227ce861fc4a4844bf8e3cb2c0"
 
 [[package]]
+name = "encoding_rs"
+version = "0.8.35"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "75030f3c4f45dafd7586dd6780965a8c7e8e285a5ecb86713e63a79c5b2766f3"
+dependencies = [
+ "cfg-if",
+]
+
+[[package]]
+name = "equator"
+version = "0.4.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4711b213838dfee0117e3be6ac926007d7f433d7bbe33595975d4190cb07e6fc"
+dependencies = [
+ "equator-macro",
+]
+
+[[package]]
+name = "equator-macro"
+version = "0.4.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "44f23cf4b44bfce11a86ace86f8a73ffdec849c9fd00a386a53d278bd9e81fb3"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
+]
+
+[[package]]
 name = "equivalent"
 version = "1.0.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -663,16 +853,50 @@ dependencies = [
 ]
 
 [[package]]
+name = "exr"
+version = "1.74.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4300e043a56aa2cb633c01af81ca8f699a321879a7854d3896a0ba89056363be"
+dependencies = [
+ "bit_field",
+ "half",
+ "lebe",
+ "miniz_oxide",
+ "rayon-core",
+ "smallvec",
+ "zune-inflate",
+]
+
+[[package]]
 name = "fastrand"
 version = "2.4.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9f1f227452a390804cdb637b74a86990f2a7d7ba4b7d5693aac9b4dd6defd8d6"
 
 [[package]]
+name = "fdeflate"
+version = "0.3.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1e6853b52649d4ac5c0bd02320cddc5ba956bdb407c4b75a2c6b75bf51500f8c"
+dependencies = [
+ "simd-adler32",
+]
+
+[[package]]
 name = "find-msvc-tools"
 version = "0.1.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5baebc0774151f905a1a2cc41989300b1e6fbb29aff0ceffa1064fdd3088d582"
+
+[[package]]
+name = "flate2"
+version = "1.1.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "843fba2746e448b37e26a819579957415c8cef339bf08564fe8b7ddbd959573c"
+dependencies = [
+ "crc32fast",
+ "miniz_oxide",
+]
 
 [[package]]
 name = "fluent-bundle"
@@ -760,6 +984,12 @@ dependencies = [
  "futures-sink",
  "spin",
 ]
+
+[[package]]
+name = "fnv"
+version = "1.0.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3f9eec918d3f24069decb9af1554cad7c880e2da24a9afd88aca000531ab82c1"
 
 [[package]]
 name = "foldhash"
@@ -918,6 +1148,17 @@ dependencies = [
  "log",
  "regex-automata",
  "regex-syntax",
+]
+
+[[package]]
+name = "half"
+version = "2.7.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6ea2d84b969582b4b1864a92dc5d27cd2b77b622a8d79306834f1be5ba20d84b"
+dependencies = [
+ "cfg-if",
+ "crunchy",
+ "zerocopy",
 ]
 
 [[package]]
@@ -1230,6 +1471,41 @@ dependencies = [
 ]
 
 [[package]]
+name = "image"
+version = "0.25.10"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "85ab80394333c02fe689eaf900ab500fbd0c2213da414687ebf995a65d5a6104"
+dependencies = [
+ "bytemuck",
+ "byteorder-lite",
+ "exr",
+ "image-webp",
+ "moxcms",
+ "num-traits",
+ "png",
+ "ravif",
+ "rayon",
+ "zune-core",
+ "zune-jpeg",
+]
+
+[[package]]
+name = "image-webp"
+version = "0.2.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "525e9ff3e1a4be2fbea1fdf0e98686a6d98b4d8f937e1bf7402245af1909e8c3"
+dependencies = [
+ "byteorder-lite",
+ "quick-error",
+]
+
+[[package]]
+name = "imgref"
+version = "1.12.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "40fac9d56ed6437b198fddba683305e8e2d651aa42647f00f5ae542e7f5c94a2"
+
+[[package]]
 name = "include_dir"
 version = "0.7.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1261,6 +1537,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "infer"
+version = "0.19.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a588916bfdfd92e71cacef98a63d9b1f0d74d6599980d11894290e7ddefffcf7"
+dependencies = [
+ "cfb",
+]
+
+[[package]]
 name = "insta"
 version = "1.47.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1271,6 +1556,17 @@ dependencies = [
  "serde",
  "similar",
  "tempfile",
+]
+
+[[package]]
+name = "interpolate_name"
+version = "0.2.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c34819042dc3d3971c46c2190835914dfbe0c3c13f61449b2997f4e9722dfa60"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
 ]
 
 [[package]]
@@ -1299,10 +1595,29 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a6cb138bb79a146c1bd460005623e142ef0181e3d0219cb493e02f7d08a35695"
 
 [[package]]
+name = "itertools"
+version = "0.14.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2b192c782037fadd9cfa75548310488aabdbf3d2da73885b31bd0abd03351285"
+dependencies = [
+ "either",
+]
+
+[[package]]
 name = "itoa"
 version = "1.0.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8f42a60cbdf9a97f5d2305f08a87dc4e09308d1276d28c869c684d7777685682"
+
+[[package]]
+name = "jobserver"
+version = "0.1.34"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9afb3de4395d6b3e67a780b6de64b51c978ecf11cb9a462c66be7d4ca9039d33"
+dependencies = [
+ "getrandom 0.3.4",
+ "libc",
+]
 
 [[package]]
 name = "js-sys"
@@ -1329,10 +1644,26 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "09edd9e8b54e49e587e4f6295a7d29c3ea94d469cb40ab8ca70b288248a81db2"
 
 [[package]]
+name = "lebe"
+version = "0.5.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7a79a3332a6609480d7d0c9eab957bca6b455b91bb84e66d19f5ff66294b85b8"
+
+[[package]]
 name = "libc"
 version = "0.2.186"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "68ab91017fe16c622486840e4c83c9a37afeff978bd239b5293d61ece587de66"
+
+[[package]]
+name = "libfuzzer-sys"
+version = "0.4.12"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f12a681b7dd8ce12bff52488013ba614b869148d54dd79836ab85aafdd53f08d"
+dependencies = [
+ "arbitrary",
+ "cc",
+]
 
 [[package]]
 name = "libsqlite3-sys"
@@ -1373,6 +1704,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5e5032e24019045c762d3c0f28f5b6b8bbf38563a65908389bf7978758920897"
 
 [[package]]
+name = "loop9"
+version = "0.1.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0fae87c125b03c1d2c0150c90365d7d6bcc53fb73a9acaef207d2d065860f062"
+dependencies = [
+ "imgref",
+]
+
+[[package]]
 name = "matchers"
 version = "0.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1386,6 +1726,16 @@ name = "matchit"
 version = "0.8.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "47e1ffaa40ddd1f3ed91f717a33c8c0ee23fff369e3aa8772b9605cc1d22f4c3"
+
+[[package]]
+name = "maybe-rayon"
+version = "0.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8ea1f30cedd69f0a2954655f7188c6a834246d2bcf1e315e2ac40c4b24dc9519"
+dependencies = [
+ "cfg-if",
+ "rayon",
+]
 
 [[package]]
 name = "md-5"
@@ -1420,6 +1770,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "miniz_oxide"
+version = "0.8.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1fa76a2c86f704bdb222d66965fb3d63269ce38518b83cb0575fca855ebb6316"
+dependencies = [
+ "adler2",
+ "simd-adler32",
+]
+
+[[package]]
 name = "mio"
 version = "1.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1431,6 +1791,63 @@ dependencies = [
 ]
 
 [[package]]
+name = "moxcms"
+version = "0.8.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bb85c154ba489f01b25c0d36ae69a87e4a1c73a72631fc6c0eb6dde34a73e44b"
+dependencies = [
+ "num-traits",
+ "pxfm",
+]
+
+[[package]]
+name = "multer"
+version = "3.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "83e87776546dc87511aa5ee218730c92b666d7264ab6ed41f9d215af9cd5224b"
+dependencies = [
+ "bytes",
+ "encoding_rs",
+ "futures-util",
+ "http",
+ "httparse",
+ "memchr",
+ "mime",
+ "spin",
+ "version_check",
+]
+
+[[package]]
+name = "new_debug_unreachable"
+version = "1.0.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "650eef8c711430f1a879fdd01d4745a7deea475becfb90269c06775983bbf086"
+
+[[package]]
+name = "no_std_io2"
+version = "0.9.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "418abd1b6d34fbf6cae440dc874771b0525a604428704c76e48b29a5e67b8003"
+dependencies = [
+ "memchr",
+]
+
+[[package]]
+name = "nom"
+version = "8.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "df9761775871bdef83bee530e60050f7e54b1105350d6884eb0fb4f46c2f9405"
+dependencies = [
+ "memchr",
+]
+
+[[package]]
+name = "noop_proc_macro"
+version = "0.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0676bb32a98c1a483ce53e500a81ad9c3d5b3f7c920c28c24e9cb0980d0b5bc8"
+
+[[package]]
 name = "nu-ansi-term"
 version = "0.50.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1440,10 +1857,51 @@ dependencies = [
 ]
 
 [[package]]
+name = "num-bigint"
+version = "0.4.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a5e44f723f1133c9deac646763579fdb3ac745e418f2a7af9cd0c431da1f20b9"
+dependencies = [
+ "num-integer",
+ "num-traits",
+]
+
+[[package]]
 name = "num-conv"
 version = "0.2.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "521739c6d2bac4aa25192232afe6841231376b2b26d4d9fae5ecf8ca5772e441"
+
+[[package]]
+name = "num-derive"
+version = "0.4.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ed3955f1a9c7c0c15e092f9c887db08b1fc683305fdf6eb6684f22555355e202"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
+]
+
+[[package]]
+name = "num-integer"
+version = "0.1.46"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7969661fd2958a5cb096e56c8e1ad0444ac2bbcd0061bd28660485a44879858f"
+dependencies = [
+ "num-traits",
+]
+
+[[package]]
+name = "num-rational"
+version = "0.4.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f83d14da390562dca69fc84082e73e548e1ad308d24accdedd2720017cb37824"
+dependencies = [
+ "num-bigint",
+ "num-integer",
+ "num-traits",
+]
 
 [[package]]
 name = "num-traits"
@@ -1507,6 +1965,18 @@ dependencies = [
 ]
 
 [[package]]
+name = "paste"
+version = "1.0.15"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "57c0d7b74b563b49d38dae00a0c37d4d6de9b432382b2892f0574ddcae73fd0a"
+
+[[package]]
+name = "pastey"
+version = "0.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "35fb2e5f958ec131621fdd531e9fc186ed768cbe395337403ae56c17a74c68ec"
+
+[[package]]
 name = "percent-encoding"
 version = "2.3.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1523,6 +1993,19 @@ name = "pkg-config"
 version = "0.3.33"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "19f132c84eca552bf34cab8ec81f1c1dcc229b811638f9d283dceabe58c5569e"
+
+[[package]]
+name = "png"
+version = "0.18.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "60769b8b31b2a9f263dae2776c37b1b28ae246943cf719eb6946a1db05128a61"
+dependencies = [
+ "bitflags",
+ "crc32fast",
+ "fdeflate",
+ "flate2",
+ "miniz_oxide",
+]
 
 [[package]]
 name = "potential_utf"
@@ -1582,6 +2065,37 @@ checksum = "8fd00f0bb2e90d81d1044c2b32617f68fcb9fa3bb7640c23e9c748e53fb30934"
 dependencies = [
  "unicode-ident",
 ]
+
+[[package]]
+name = "profiling"
+version = "1.0.18"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3d595e54a326bc53c1c197b32d295e14b169e3cfeaa8dc82b529f947fba6bcf5"
+dependencies = [
+ "profiling-procmacros",
+]
+
+[[package]]
+name = "profiling-procmacros"
+version = "1.0.18"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4488a4a36b9a4ba6b9334a32a39971f77c1436ec82c38707bce707699cc3bbcb"
+dependencies = [
+ "quote",
+ "syn",
+]
+
+[[package]]
+name = "pxfm"
+version = "0.1.29"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e0c5ccf5294c6ccd63a74f1565028353830a9c2f5eb0c682c355c471726a6e3f"
+
+[[package]]
+name = "quick-error"
+version = "2.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a993555f31e5a609f617c12db6250dedcac1b0a85076912c436e6fc9b2c8e6a3"
 
 [[package]]
 name = "quote"
@@ -1670,6 +2184,76 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "63b8176103e19a2643978565ca18b50549f6101881c443590420e4dc998a3c69"
 
 [[package]]
+name = "rav1e"
+version = "0.8.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "43b6dd56e85d9483277cde964fd1bdb0428de4fec5ebba7540995639a21cb32b"
+dependencies = [
+ "aligned-vec",
+ "arbitrary",
+ "arg_enum_proc_macro",
+ "arrayvec",
+ "av-scenechange",
+ "av1-grain",
+ "bitstream-io",
+ "built",
+ "cfg-if",
+ "interpolate_name",
+ "itertools",
+ "libc",
+ "libfuzzer-sys",
+ "log",
+ "maybe-rayon",
+ "new_debug_unreachable",
+ "noop_proc_macro",
+ "num-derive",
+ "num-traits",
+ "paste",
+ "profiling",
+ "rand 0.9.4",
+ "rand_chacha",
+ "simd_helpers",
+ "thiserror",
+ "v_frame",
+ "wasm-bindgen",
+]
+
+[[package]]
+name = "ravif"
+version = "0.13.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e52310197d971b0f5be7fe6b57530dcd27beb35c1b013f29d66c1ad73fbbcc45"
+dependencies = [
+ "avif-serialize",
+ "imgref",
+ "loop9",
+ "quick-error",
+ "rav1e",
+ "rayon",
+ "rgb",
+]
+
+[[package]]
+name = "rayon"
+version = "1.12.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fb39b166781f92d482534ef4b4b1b2568f42613b53e5b6c160e24cfbfa30926d"
+dependencies = [
+ "either",
+ "rayon-core",
+]
+
+[[package]]
+name = "rayon-core"
+version = "1.13.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "22e18b0f0062d30d4230b2e85ff77fdfe4326feb054b9783a3460d8435c8ab91"
+dependencies = [
+ "crossbeam-deque",
+ "crossbeam-utils",
+]
+
+[[package]]
 name = "redox_syscall"
 version = "0.5.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1708,6 +2292,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "dc897dd8d9e8bd1ed8cdad82b5966c3e0ecae09fb1907d58efaa013543185d0a"
 
 [[package]]
+name = "rgb"
+version = "0.8.53"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "47b34b781b31e5d73e9fbc8689c70551fd1ade9a19e3e28cfec8580a79290cc4"
+
+[[package]]
 name = "ruscker-admin"
 version = "0.1.0"
 dependencies = [
@@ -1719,7 +2309,9 @@ dependencies = [
  "fluent-bundle",
  "fluent-templates",
  "hyper",
+ "image",
  "include_dir",
+ "infer",
  "insta",
  "pretty_assertions",
  "regex",
@@ -1736,6 +2328,7 @@ dependencies = [
  "tower-http",
  "tracing",
  "unic-langid",
+ "uuid",
 ]
 
 [[package]]
@@ -2004,6 +2597,21 @@ checksum = "c4db69cba1110affc0e9f7bcd48bbf87b3f4fc7c61fc9155afd4c469eb3d6c1b"
 dependencies = [
  "errno",
  "libc",
+]
+
+[[package]]
+name = "simd-adler32"
+version = "0.3.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "703d5c7ef118737c72f1af64ad2f6f8c5e1921f818cdcb97b8fe6fc69bf66214"
+
+[[package]]
+name = "simd_helpers"
+version = "0.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "95890f873bec569a0362c235787f3aca6e1e887302ba4840839bcc6459c42da6"
+dependencies = [
+ "quote",
 ]
 
 [[package]]
@@ -2727,6 +3335,17 @@ dependencies = [
 ]
 
 [[package]]
+name = "v_frame"
+version = "0.3.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "666b7727c8875d6ab5db9533418d7c764233ac9c0cff1d469aec8fa127597be2"
+dependencies = [
+ "aligned-vec",
+ "num-traits",
+ "wasm-bindgen",
+]
+
+[[package]]
 name = "valuable"
 version = "0.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3050,6 +3669,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1ffae5123b2d3fc086436f8834ae3ab053a283cfac8fe0a0b8eaae044768a4c4"
 
 [[package]]
+name = "y4m"
+version = "0.8.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7a5a4b21e1a62b67a2970e6831bc091d7b87e119e7f9791aef9702e3bef04448"
+
+[[package]]
 name = "yansi"
 version = "1.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3158,3 +3783,27 @@ name = "zmij"
 version = "1.0.21"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b8848ee67ecc8aedbaf3e4122217aff892639231befc6a1b58d29fff4c2cabaa"
+
+[[package]]
+name = "zune-core"
+version = "0.5.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cb8a0807f7c01457d0379ba880ba6322660448ddebc890ce29bb64da71fb40f9"
+
+[[package]]
+name = "zune-inflate"
+version = "0.2.54"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "73ab332fe2f6680068f3582b16a24f90ad7096d5d39b974d1c0aff0125116f02"
+dependencies = [
+ "simd-adler32",
+]
+
+[[package]]
+name = "zune-jpeg"
+version = "0.5.15"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "27bc9d5b815bc103f142aa054f561d9187d191692ec7c2d1e2b4737f8dbd7296"
+dependencies = [
+ "zune-core",
+]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -9,6 +9,41 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "320119579fcad9c21884f5c4861d16174d0e06250625266f50fe6898340abefa"
 
 [[package]]
+name = "aead"
+version = "0.5.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d122413f284cf2d62fb1b7db97e02edb8cda96d769b16e443a4f6195e35662b0"
+dependencies = [
+ "crypto-common 0.1.7",
+ "generic-array",
+]
+
+[[package]]
+name = "aes"
+version = "0.8.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b169f7a6d4742236a0a00c541b845991d0ac43e546831af1249753ab4c3aa3a0"
+dependencies = [
+ "cfg-if",
+ "cipher",
+ "cpufeatures 0.2.17",
+]
+
+[[package]]
+name = "aes-gcm"
+version = "0.10.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "831010a0f742e1209b3bcea8fab6a8e149051ba6099432c8cb2cc117dec3ead1"
+dependencies = [
+ "aead",
+ "aes",
+ "cipher",
+ "ctr",
+ "ghash",
+ "subtle",
+]
+
+[[package]]
 name = "aho-corasick"
 version = "1.1.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -514,6 +549,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "cipher"
+version = "0.4.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "773f3b9af64447d2ce9850330c473515014aa235e6a783b02db81ff39e4a3dad"
+dependencies = [
+ "crypto-common 0.1.7",
+ "inout",
+]
+
+[[package]]
 name = "clap"
 version = "4.6.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -691,6 +736,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "78c8292055d1c1df0cce5d180393dc8cce0abec0a7102adb6c7b1eef6016d60a"
 dependencies = [
  "generic-array",
+ "rand_core 0.6.4",
  "typenum",
 ]
 
@@ -701,6 +747,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ce6e4c961d6cd6c9a86db418387425e8bdeaf05b3c8bc1411e6dca4c252f1453"
 dependencies = [
  "hybrid-array",
+]
+
+[[package]]
+name = "ctr"
+version = "0.9.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0369ee1ad671834580515889b80f2ea915f23b8be8d0daa4bbaf2ac5c7590835"
+dependencies = [
+ "cipher",
 ]
 
 [[package]]
@@ -1107,6 +1162,17 @@ dependencies = [
 
 [[package]]
 name = "getrandom"
+version = "0.2.17"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ff2abc00be7fca6ebc474524697ae276ad847ad0a6b3faa4bcb027e9a4614ad0"
+dependencies = [
+ "cfg-if",
+ "libc",
+ "wasi",
+]
+
+[[package]]
+name = "getrandom"
 version = "0.3.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "899def5c37c4fd7b2664648c28120ecec138e4d395b459e5ca34f9cce2dd77fd"
@@ -1129,6 +1195,16 @@ dependencies = [
  "rand_core 0.10.1",
  "wasip2",
  "wasip3",
+]
+
+[[package]]
+name = "ghash"
+version = "0.5.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f0d8a4362ccb29cb0b265253fb0a2728f592895ee6854fd9bc13f2ffda266ff1"
+dependencies = [
+ "opaque-debug",
+ "polyval",
 ]
 
 [[package]]
@@ -1546,6 +1622,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "inout"
+version = "0.1.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "879f10e63c20629ecabbb64a8010319738c66a5cd0c29b02d63d272b03751d01"
+dependencies = [
+ "generic-array",
+]
+
+[[package]]
 name = "insta"
 version = "1.47.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1925,6 +2010,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "384b8ab6d37215f3c5301a95a4accb5d64aa607f1fcb26a11b5303878451b4fe"
 
 [[package]]
+name = "opaque-debug"
+version = "0.3.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c08d65885ee38876c4f86fa503fb49d7b507c2b62552df7c70b2fce627e06381"
+
+[[package]]
 name = "ordered-float"
 version = "5.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2005,6 +2096,18 @@ dependencies = [
  "fdeflate",
  "flate2",
  "miniz_oxide",
+]
+
+[[package]]
+name = "polyval"
+version = "0.6.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9d1fe60d06143b2430aa532c94cfe9e29783047f06c0d7fd359a9a51b729fa25"
+dependencies = [
+ "cfg-if",
+ "cpufeatures 0.2.17",
+ "opaque-debug",
+ "universal-hash",
 ]
 
 [[package]]
@@ -2165,6 +2268,7 @@ version = "0.6.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ec0be4795e2f6a28069bec0b5ff3e2ac9bafc99e6a9a7dc3547996c5c816922c"
 dependencies = [
+ "getrandom 0.2.17",
  "serde",
 ]
 
@@ -2301,13 +2405,16 @@ checksum = "47b34b781b31e5d73e9fbc8689c70551fd1ade9a19e3e28cfec8580a79290cc4"
 name = "ruscker-admin"
 version = "0.1.0"
 dependencies = [
+ "aes-gcm",
  "anyhow",
  "askama",
  "axum",
  "axum-extra",
+ "base64",
  "chrono",
  "fluent-bundle",
  "fluent-templates",
+ "hex",
  "hyper",
  "image",
  "include_dir",
@@ -2329,6 +2436,7 @@ dependencies = [
  "tracing",
  "unic-langid",
  "uuid",
+ "zeroize",
 ]
 
 [[package]]
@@ -2857,6 +2965,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7da8b5736845d9f2fcb837ea5d9e2628564b3b043a70948a3f0b778838c5fb4f"
 
 [[package]]
+name = "subtle"
+version = "2.6.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "13c2bddecc57b384dee18652358fb23172facb8a2c51ccc10d74c157bdea3292"
+
+[[package]]
 name = "syn"
 version = "2.0.117"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3291,6 +3405,16 @@ name = "unicode-xid"
 version = "0.2.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ebc1c04c71510c7f702b52b7c350734c9ff1295c464a03335b00bb84fc54f853"
+
+[[package]]
+name = "universal-hash"
+version = "0.5.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fc1de2c688dc15305988b563c3854064043356019f97a4b46276fe734c4f07ea"
+dependencies = [
+ "crypto-common 0.1.7",
+ "subtle",
+]
 
 [[package]]
 name = "unsafe-libyaml"
@@ -3743,6 +3867,12 @@ dependencies = [
  "syn",
  "synstructure",
 ]
+
+[[package]]
+name = "zeroize"
+version = "1.8.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b97154e67e32c85465826e8bcc1c59429aaaf107c1e4a9e53c8d8ccd5eff88d0"
 
 [[package]]
 name = "zerotrie"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -28,7 +28,7 @@ tokio = { version = "1.52", features = ["full"] }
 async-trait = "0.1.89"
 
 # Web framework
-axum = { version = "0.8", features = ["ws", "macros"] }
+axum = { version = "0.8", features = ["ws", "macros", "multipart"] }
 axum-extra = { version = "0.12", features = ["cookie"] }
 tower = "0.5"
 tower-http = { version = "0.6", features = ["trace", "fs", "cors"] }
@@ -66,6 +66,12 @@ fluent-templates = "0.14"
 fluent-bundle = "0.16"
 unic-langid = "0.9"
 include_dir = "0.7"
+
+# Image processing (Phase 2 image library). default-features=false so
+# we avoid pulling AVIF/EXR/HDR/TIFF/...  we only need PNG/JPEG/WebP.
+image = { version = "0.25", default-features = false, features = ["png", "jpeg", "webp", "rayon"] }
+# Sniff MIME from magic bytes; client Content-Type can lie.
+infer = "0.19"
 
 # Database (SQLite via sqlx)
 sqlx = { version = "0.9", features = ["runtime-tokio", "sqlite", "macros", "chrono", "uuid"] }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -82,6 +82,9 @@ bollard = "0.21"
 # Cryptography
 ring = "0.17.14"
 base64 = "0.22"
+aes-gcm = "0.10"
+zeroize = "1.8"
+hex = "0.4"
 
 # Testing
 pretty_assertions = "1.4"

--- a/crates/ruscker-admin/Cargo.toml
+++ b/crates/ruscker-admin/Cargo.toml
@@ -41,9 +41,14 @@ serde_json = { workspace = true }
 serde_yaml_ng = { workspace = true }
 chrono = { workspace = true }
 regex = { workspace = true }
+uuid = { workspace = true }
 
 # Persistence (Phase 2)
 sqlx = { workspace = true }
+
+# Image library (Phase 2)
+image = { workspace = true }
+infer = { workspace = true }
 
 [dev-dependencies]
 pretty_assertions = { workspace = true }

--- a/crates/ruscker-admin/Cargo.toml
+++ b/crates/ruscker-admin/Cargo.toml
@@ -38,6 +38,7 @@ tracing = { workspace = true }
 # Misc
 serde = { workspace = true }
 serde_json = { workspace = true }
+serde_yaml_ng = { workspace = true }
 chrono = { workspace = true }
 regex = { workspace = true }
 

--- a/crates/ruscker-admin/Cargo.toml
+++ b/crates/ruscker-admin/Cargo.toml
@@ -50,6 +50,12 @@ sqlx = { workspace = true }
 image = { workspace = true }
 infer = { workspace = true }
 
+# Credentials store (Phase 2)
+aes-gcm = { workspace = true }
+zeroize = { workspace = true }
+hex = { workspace = true }
+base64 = { workspace = true }
+
 [dev-dependencies]
 pretty_assertions = { workspace = true }
 insta = { workspace = true }

--- a/crates/ruscker-admin/Cargo.toml
+++ b/crates/ruscker-admin/Cargo.toml
@@ -41,6 +41,9 @@ serde_json = { workspace = true }
 chrono = { workspace = true }
 regex = { workspace = true }
 
+# Persistence (Phase 2)
+sqlx = { workspace = true }
+
 [dev-dependencies]
 pretty_assertions = { workspace = true }
 insta = { workspace = true }

--- a/crates/ruscker-admin/assets/i18n/en/landing.ftl
+++ b/crates/ruscker-admin/assets/i18n/en/landing.ftl
@@ -118,6 +118,28 @@ admin-images-empty = No images yet. Upload the first one above.
 admin-images-delete = Delete
 admin-images-delete-confirm = Delete this image? Specs referencing the filename will fall back to the tinted cover.
 
+# Admin credentials
+admin-creds-title = Registry credentials
+admin-creds-subtitle = Passwords are encrypted at rest with AES-256-GCM. They never appear in the YAML or in the panel after saving.
+admin-creds-form-title = Add / update credential
+admin-creds-name = Name
+admin-creds-name-help = Unique identifier. Use the same name in your specs.
+admin-creds-registry = Registry
+admin-creds-username = Username
+admin-creds-password = Password / token
+admin-creds-password-help = Encrypted on save and never echoed back.
+admin-creds-save = Save credential
+admin-creds-saved = Credential saved:
+admin-creds-empty = No credentials stored yet.
+admin-creds-delete = Delete
+admin-creds-delete-confirm = Delete this credential?
+admin-creds-col-name = Name
+admin-creds-col-registry = Registry
+admin-creds-col-username = Username
+admin-creds-col-created = Created
+admin-creds-key-missing-title = RUSCKER_MASTER_KEY is not configured
+admin-creds-key-missing-help = The credentials store needs a 32-byte key as hex (64 chars) or base64 (44 chars). Generate one with:
+
 card-cta-open = Open
 card-cta-link = Visit
 card-cta-open-app = Open app

--- a/crates/ruscker-admin/assets/i18n/en/landing.ftl
+++ b/crates/ruscker-admin/assets/i18n/en/landing.ftl
@@ -140,6 +140,33 @@ admin-creds-col-created = Created
 admin-creds-key-missing-title = RUSCKER_MASTER_KEY is not configured
 admin-creds-key-missing-help = The credentials store needs a 32-byte key as hex (64 chars) or base64 (44 chars). Generate one with:
 
+# Admin landing editor
+admin-landing-title = Landing editor
+admin-landing-crumb = Settings · Landing page
+admin-landing-subtitle = Customize the public portal. Changes take effect on the visitor's next refresh.
+admin-landing-open-portal = Open portal
+admin-landing-save = Save
+admin-landing-saved = Settings saved. Reload the public portal to see them.
+admin-landing-colors = Header colors
+admin-landing-header-bg = Background color
+admin-landing-bg-help = Empty = use the theme's default (light/dark).
+admin-landing-header-fg = Text color
+admin-landing-clear = Clear
+admin-landing-intro = Intro text (default)
+admin-landing-intro-default = Default (fallback for all languages)
+admin-landing-intro-default-placeholder = Welcome to the portal…
+admin-landing-intro-help = Rendered between the header and the filters. Empty = no text.
+admin-landing-intro-locales = Intro text per language
+admin-landing-intro-pt = Portuguese
+admin-landing-intro-en = English
+admin-landing-intro-es = Spanish
+admin-landing-intro-fr = French
+admin-landing-preview = Portal preview
+admin-landing-preview-help = Approximate look of the header and intro. Cards and filters appear as on the real landing.
+admin-landing-preview-empty = (no intro text)
+admin-landing-future-title = Coming soon
+admin-landing-future-help = Logo editor, section reordering, custom HTML blocks, SEO/analytics and meta tags. For now those fields follow the YAML.
+
 card-cta-open = Open
 card-cta-link = Visit
 card-cta-open-app = Open app

--- a/crates/ruscker-admin/assets/i18n/en/landing.ftl
+++ b/crates/ruscker-admin/assets/i18n/en/landing.ftl
@@ -23,6 +23,42 @@ type-package-abbr = PKG
 type-api-abbr = API
 type-link-abbr = LNK
 
+# Admin shell
+admin-nav-apps = Apps
+admin-nav-images = Images
+admin-nav-credentials = Credentials
+admin-nav-landing = Portal
+admin-nav-audit = Audit log
+admin-nav-portal = Back to portal
+admin-nav-logout = Sign out
+
+# Admin login
+admin-login-title = Admin sign in
+admin-login-help = Enter the admin token defined in RUSCKER_ADMIN_TOKEN.
+admin-login-token-label = Token
+admin-login-token-placeholder = Paste the token here
+admin-login-submit = Sign in
+admin-login-error-wrong = Wrong token. Please try again.
+admin-login-back-portal = ← public portal
+
+# Apps list
+admin-specs-title = Apps
+admin-specs-subtitle = Spec catalog stored in the database
+admin-specs-empty = No apps yet. Use { $cmd } to import from a YAML.
+admin-specs-add = Add app
+admin-specs-col-id = ID
+admin-specs-col-name = Name
+admin-specs-col-kind = Kind
+admin-specs-col-state = State
+admin-specs-col-updated = Updated
+admin-specs-col-version = Version
+admin-specs-col-actions = Actions
+admin-specs-filter-search = Search by id or name…
+admin-specs-filter-kind-all = All kinds
+admin-specs-filter-state-all = Active and inactive
+admin-specs-edit = Edit
+admin-specs-delete = Delete
+
 card-cta-open = Open
 card-cta-link = Visit
 card-cta-open-app = Open app

--- a/crates/ruscker-admin/assets/i18n/en/landing.ftl
+++ b/crates/ruscker-admin/assets/i18n/en/landing.ftl
@@ -59,6 +59,54 @@ admin-specs-filter-state-all = Active and inactive
 admin-specs-edit = Edit
 admin-specs-delete = Delete
 
+# Spec form (new / edit)
+spec-form-title-new = New app
+spec-form-crumb-new = New
+spec-form-crumb-edit = Edit
+spec-form-cancel = Cancel
+spec-form-save = Save changes
+spec-form-kind = Kind
+spec-form-kind-app = App container
+spec-form-kind-talk = Presentation
+spec-form-kind-report = Report
+spec-form-kind-package = Package
+spec-form-kind-api = API
+spec-form-kind-link = External link
+spec-form-identity = Identity
+spec-form-id = ID
+spec-form-id-help-new = Operator-chosen. Appears at /app/<id>/.
+spec-form-id-help-edit = ID is immutable once created.
+spec-form-name = Display name
+spec-form-desc = Description
+spec-form-visual = Visual
+spec-form-logo = Card logo
+spec-form-logo-help = URL or /assets/img/foo.png path. See docs/IMAGES.md.
+spec-form-access = Access
+spec-form-state = State
+spec-form-state-active = Active
+spec-form-state-inactive = Inactive
+spec-form-tema = Theme
+spec-form-container = Container
+spec-form-image = Docker image
+spec-form-seats = Sessions/container
+spec-form-lifetime = Max lifetime (min)
+spec-form-lifetime-help = 360 = 6 hours
+spec-form-link-section = External link
+spec-form-link = Target URL
+spec-form-meta = Metadata
+spec-form-updated = Updated on
+spec-form-updated-help = Leave empty to use today's date.
+spec-form-preview = Card preview
+spec-form-preview-help = Updates live as you edit.
+spec-form-actions = Actions
+spec-form-delete = Delete app
+spec-form-delete-confirm = Are you sure? This cannot be undone.
+
+spec-form-error-id-required = ID is required.
+spec-form-error-id-shape = ID must start with a letter and contain only letters, digits, "_" and "-".
+spec-form-error-id-duplicate = An app with that ID already exists.
+spec-form-error-name-required = Display name is required.
+
 card-cta-open = Open
 card-cta-link = Visit
 card-cta-open-app = Open app

--- a/crates/ruscker-admin/assets/i18n/en/landing.ftl
+++ b/crates/ruscker-admin/assets/i18n/en/landing.ftl
@@ -107,6 +107,17 @@ spec-form-error-id-shape = ID must start with a letter and contain only letters,
 spec-form-error-id-duplicate = An app with that ID already exists.
 spec-form-error-name-required = Display name is required.
 
+# Admin image library
+admin-images-title = Image library
+admin-images-subtitle = PNG, JPEG and WebP are converted to WebP. SVG passes through.
+admin-images-drop-here = Click to pick a file
+admin-images-formats = PNG · JPEG · WebP · SVG · up to 10 MB
+admin-images-upload = Upload
+admin-images-uploaded = Image uploaded:
+admin-images-empty = No images yet. Upload the first one above.
+admin-images-delete = Delete
+admin-images-delete-confirm = Delete this image? Specs referencing the filename will fall back to the tinted cover.
+
 card-cta-open = Open
 card-cta-link = Visit
 card-cta-open-app = Open app

--- a/crates/ruscker-admin/assets/i18n/en/landing.ftl
+++ b/crates/ruscker-admin/assets/i18n/en/landing.ftl
@@ -167,6 +167,22 @@ admin-landing-preview-empty = (no intro text)
 admin-landing-future-title = Coming soon
 admin-landing-future-help = Logo editor, section reordering, custom HTML blocks, SEO/analytics and meta tags. For now those fields follow the YAML.
 
+# Admin audit log
+admin-audit-title = Audit log
+admin-audit-subtitle = Every admin change, newest first. Capped at 100 events per query.
+admin-audit-family = Family
+admin-audit-family-all = All actions
+admin-audit-family-spec = Apps
+admin-audit-family-image = Images
+admin-audit-family-credential = Credentials
+admin-audit-family-landing = Portal
+admin-audit-actor = Actor
+admin-audit-actor-all = All actors
+admin-audit-target-placeholder = Search target (e.g. spec:auroraprime)
+admin-audit-apply = Apply
+admin-audit-empty = No changes yet — or the filter matches nothing.
+admin-audit-limit-hint = Showing the 100 most recent matches. Tighten the filter to refine.
+
 card-cta-open = Open
 card-cta-link = Visit
 card-cta-open-app = Open app

--- a/crates/ruscker-admin/assets/i18n/es/landing.ftl
+++ b/crates/ruscker-admin/assets/i18n/es/landing.ftl
@@ -167,6 +167,22 @@ admin-landing-preview-empty = (sin texto de introducción)
 admin-landing-future-title = Próximamente
 admin-landing-future-help = Editor de logos, reordenación de secciones, bloques HTML custom, SEO/analytics y meta tags. Por ahora siguen el YAML.
 
+# Admin audit log
+admin-audit-title = Auditoría
+admin-audit-subtitle = Todos los cambios del admin, del más reciente al más antiguo. Tope de 100 eventos por consulta.
+admin-audit-family = Familia
+admin-audit-family-all = Todas las acciones
+admin-audit-family-spec = Aplicaciones
+admin-audit-family-image = Imágenes
+admin-audit-family-credential = Credenciales
+admin-audit-family-landing = Portal
+admin-audit-actor = Autor
+admin-audit-actor-all = Todos los autores
+admin-audit-target-placeholder = Buscar destino (ej: spec:auroraprime)
+admin-audit-apply = Aplicar
+admin-audit-empty = Aún no hay cambios — o el filtro no coincide con nada.
+admin-audit-limit-hint = Mostrando los 100 más recientes. Afine el filtro para reducir.
+
 card-cta-open = Abrir
 card-cta-link = Visitar
 card-cta-open-app = Abrir aplicación

--- a/crates/ruscker-admin/assets/i18n/es/landing.ftl
+++ b/crates/ruscker-admin/assets/i18n/es/landing.ftl
@@ -107,6 +107,17 @@ spec-form-error-id-shape = El ID debe empezar con una letra y contener solo letr
 spec-form-error-id-duplicate = Ya existe una aplicación con ese ID.
 spec-form-error-name-required = El nombre visible es obligatorio.
 
+# Admin image library
+admin-images-title = Biblioteca de imágenes
+admin-images-subtitle = PNG, JPEG y WebP se convierten a WebP. SVG pasa directo.
+admin-images-drop-here = Haga clic para elegir un archivo
+admin-images-formats = PNG · JPEG · WebP · SVG · hasta 10 MB
+admin-images-upload = Subir
+admin-images-uploaded = Imagen subida:
+admin-images-empty = Aún no hay imágenes. Suba la primera arriba.
+admin-images-delete = Eliminar
+admin-images-delete-confirm = ¿Eliminar esta imagen? Las specs que referencian el archivo mostrarán el cover tintado.
+
 card-cta-open = Abrir
 card-cta-link = Visitar
 card-cta-open-app = Abrir aplicación

--- a/crates/ruscker-admin/assets/i18n/es/landing.ftl
+++ b/crates/ruscker-admin/assets/i18n/es/landing.ftl
@@ -59,6 +59,54 @@ admin-specs-filter-state-all = Activos e inactivos
 admin-specs-edit = Editar
 admin-specs-delete = Borrar
 
+# Spec form (new / edit)
+spec-form-title-new = Nueva aplicación
+spec-form-crumb-new = Nueva
+spec-form-crumb-edit = Editar
+spec-form-cancel = Cancelar
+spec-form-save = Guardar cambios
+spec-form-kind = Tipo
+spec-form-kind-app = App contenedor
+spec-form-kind-talk = Presentación
+spec-form-kind-report = Informe
+spec-form-kind-package = Paquete
+spec-form-kind-api = API
+spec-form-kind-link = Enlace externo
+spec-form-identity = Identidad
+spec-form-id = ID
+spec-form-id-help-new = Elegido por el operador. Aparece en /app/<id>/.
+spec-form-id-help-edit = El ID es inmutable después de creado.
+spec-form-name = Nombre visible
+spec-form-desc = Descripción
+spec-form-visual = Visual
+spec-form-logo = Logo del card
+spec-form-logo-help = URL o ruta /assets/img/foo.png. Ver docs/IMAGES.md.
+spec-form-access = Acceso
+spec-form-state = Estado
+spec-form-state-active = Activo
+spec-form-state-inactive = Inactivo
+spec-form-tema = Tema
+spec-form-container = Contenedor
+spec-form-image = Imagen Docker
+spec-form-seats = Sesiones/contenedor
+spec-form-lifetime = Vida máx. (min)
+spec-form-lifetime-help = 360 = 6 horas
+spec-form-link-section = Enlace externo
+spec-form-link = URL destino
+spec-form-meta = Metadatos
+spec-form-updated = Actualizado el
+spec-form-updated-help = Vacío para usar la fecha de hoy.
+spec-form-preview = Vista previa
+spec-form-preview-help = Se actualiza en vivo.
+spec-form-actions = Acciones
+spec-form-delete = Eliminar aplicación
+spec-form-delete-confirm = ¿Está seguro? Esto no se puede deshacer.
+
+spec-form-error-id-required = El ID es obligatorio.
+spec-form-error-id-shape = El ID debe empezar con una letra y contener solo letras, números, "_" y "-".
+spec-form-error-id-duplicate = Ya existe una aplicación con ese ID.
+spec-form-error-name-required = El nombre visible es obligatorio.
+
 card-cta-open = Abrir
 card-cta-link = Visitar
 card-cta-open-app = Abrir aplicación

--- a/crates/ruscker-admin/assets/i18n/es/landing.ftl
+++ b/crates/ruscker-admin/assets/i18n/es/landing.ftl
@@ -23,6 +23,42 @@ type-package-abbr = PKG
 type-api-abbr = API
 type-link-abbr = LNK
 
+# Admin shell
+admin-nav-apps = Aplicaciones
+admin-nav-images = Imágenes
+admin-nav-credentials = Credenciales
+admin-nav-landing = Portal
+admin-nav-audit = Auditoría
+admin-nav-portal = Volver al portal
+admin-nav-logout = Salir
+
+# Admin login
+admin-login-title = Acceso admin
+admin-login-help = Ingrese el token de admin definido en RUSCKER_ADMIN_TOKEN.
+admin-login-token-label = Token
+admin-login-token-placeholder = Pegue el token aquí
+admin-login-submit = Entrar
+admin-login-error-wrong = Token incorrecto. Intente de nuevo.
+admin-login-back-portal = ← portal público
+
+# Apps list
+admin-specs-title = Aplicaciones
+admin-specs-subtitle = Catálogo de specs en la base de datos
+admin-specs-empty = Aún no hay aplicaciones. Use { $cmd } para importar desde YAML.
+admin-specs-add = Añadir aplicación
+admin-specs-col-id = ID
+admin-specs-col-name = Nombre
+admin-specs-col-kind = Tipo
+admin-specs-col-state = Estado
+admin-specs-col-updated = Actualizado
+admin-specs-col-version = Versión
+admin-specs-col-actions = Acciones
+admin-specs-filter-search = Buscar por id o nombre…
+admin-specs-filter-kind-all = Todos los tipos
+admin-specs-filter-state-all = Activos e inactivos
+admin-specs-edit = Editar
+admin-specs-delete = Borrar
+
 card-cta-open = Abrir
 card-cta-link = Visitar
 card-cta-open-app = Abrir aplicación

--- a/crates/ruscker-admin/assets/i18n/es/landing.ftl
+++ b/crates/ruscker-admin/assets/i18n/es/landing.ftl
@@ -140,6 +140,33 @@ admin-creds-col-created = Creada
 admin-creds-key-missing-title = RUSCKER_MASTER_KEY no está configurada
 admin-creds-key-missing-help = El store de credenciales necesita una clave de 32 bytes en hex (64 chars) o base64 (44 chars). Genere una con:
 
+# Admin landing editor
+admin-landing-title = Editor del portal
+admin-landing-crumb = Ajustes · Landing page
+admin-landing-subtitle = Personalice el portal público. Los cambios surten efecto al refrescar.
+admin-landing-open-portal = Abrir portal
+admin-landing-save = Guardar
+admin-landing-saved = Ajustes guardados. Recargue el portal para ver los cambios.
+admin-landing-colors = Colores del encabezado
+admin-landing-header-bg = Color de fondo
+admin-landing-bg-help = Vacío = usa el color predeterminado del tema (claro/oscuro).
+admin-landing-header-fg = Color del texto
+admin-landing-clear = Limpiar
+admin-landing-intro = Texto de introducción (predeterminado)
+admin-landing-intro-default = Predeterminado (fallback para todos los idiomas)
+admin-landing-intro-default-placeholder = Bienvenido al portal…
+admin-landing-intro-help = Se muestra entre el encabezado y los filtros. Vacío = sin texto.
+admin-landing-intro-locales = Texto de introducción por idioma
+admin-landing-intro-pt = Portugués
+admin-landing-intro-en = Inglés
+admin-landing-intro-es = Español
+admin-landing-intro-fr = Francés
+admin-landing-preview = Vista previa
+admin-landing-preview-help = Aproximación visual del encabezado y la introducción. Cards y filtros como en la landing real.
+admin-landing-preview-empty = (sin texto de introducción)
+admin-landing-future-title = Próximamente
+admin-landing-future-help = Editor de logos, reordenación de secciones, bloques HTML custom, SEO/analytics y meta tags. Por ahora siguen el YAML.
+
 card-cta-open = Abrir
 card-cta-link = Visitar
 card-cta-open-app = Abrir aplicación

--- a/crates/ruscker-admin/assets/i18n/es/landing.ftl
+++ b/crates/ruscker-admin/assets/i18n/es/landing.ftl
@@ -118,6 +118,28 @@ admin-images-empty = Aún no hay imágenes. Suba la primera arriba.
 admin-images-delete = Eliminar
 admin-images-delete-confirm = ¿Eliminar esta imagen? Las specs que referencian el archivo mostrarán el cover tintado.
 
+# Admin credentials
+admin-creds-title = Credenciales del registry
+admin-creds-subtitle = Las contraseñas se cifran en reposo con AES-256-GCM. Nunca aparecen en el YAML ni en el panel después de guardarlas.
+admin-creds-form-title = Añadir / actualizar credencial
+admin-creds-name = Nombre
+admin-creds-name-help = Identificador único. Use el mismo nombre en sus specs.
+admin-creds-registry = Registry
+admin-creds-username = Usuario
+admin-creds-password = Contraseña / token
+admin-creds-password-help = Cifrada al guardar; no se muestra de nuevo.
+admin-creds-save = Guardar credencial
+admin-creds-saved = Credencial guardada:
+admin-creds-empty = No hay credenciales aún.
+admin-creds-delete = Borrar
+admin-creds-delete-confirm = ¿Borrar esta credencial?
+admin-creds-col-name = Nombre
+admin-creds-col-registry = Registry
+admin-creds-col-username = Usuario
+admin-creds-col-created = Creada
+admin-creds-key-missing-title = RUSCKER_MASTER_KEY no está configurada
+admin-creds-key-missing-help = El store de credenciales necesita una clave de 32 bytes en hex (64 chars) o base64 (44 chars). Genere una con:
+
 card-cta-open = Abrir
 card-cta-link = Visitar
 card-cta-open-app = Abrir aplicación

--- a/crates/ruscker-admin/assets/i18n/fr/landing.ftl
+++ b/crates/ruscker-admin/assets/i18n/fr/landing.ftl
@@ -140,6 +140,33 @@ admin-creds-col-created = Créé le
 admin-creds-key-missing-title = RUSCKER_MASTER_KEY n'est pas configurée
 admin-creds-key-missing-help = Le store d'identifiants a besoin d'une clé de 32 octets en hex (64 chars) ou base64 (44 chars). Générez-en une avec :
 
+# Admin landing editor
+admin-landing-title = Éditeur du portail
+admin-landing-crumb = Paramètres · Page d'accueil
+admin-landing-subtitle = Personnalisez le portail public. Les modifications s'appliquent au prochain rafraîchissement du visiteur.
+admin-landing-open-portal = Ouvrir le portail
+admin-landing-save = Enregistrer
+admin-landing-saved = Paramètres enregistrés. Rechargez le portail public pour voir.
+admin-landing-colors = Couleurs de l'en-tête
+admin-landing-header-bg = Couleur de fond
+admin-landing-bg-help = Vide = utilise la couleur par défaut du thème (clair/sombre).
+admin-landing-header-fg = Couleur du texte
+admin-landing-clear = Effacer
+admin-landing-intro = Texte d'introduction (par défaut)
+admin-landing-intro-default = Par défaut (fallback pour toutes les langues)
+admin-landing-intro-default-placeholder = Bienvenue sur le portail…
+admin-landing-intro-help = Affiché entre l'en-tête et les filtres. Vide = pas de texte.
+admin-landing-intro-locales = Texte d'introduction par langue
+admin-landing-intro-pt = Portugais
+admin-landing-intro-en = Anglais
+admin-landing-intro-es = Espagnol
+admin-landing-intro-fr = Français
+admin-landing-preview = Aperçu du portail
+admin-landing-preview-help = Approximation visuelle de l'en-tête et de l'intro. Les cartes et filtres ressemblent au portail réel.
+admin-landing-preview-empty = (pas de texte d'introduction)
+admin-landing-future-title = Bientôt
+admin-landing-future-help = Éditeur de logos, réorganisation des sections, blocs HTML personnalisés, SEO/analytics et meta tags. Pour l'instant ces champs suivent le YAML.
+
 card-cta-open = Ouvrir
 card-cta-link = Accéder
 card-cta-open-app = Ouvrir l'application

--- a/crates/ruscker-admin/assets/i18n/fr/landing.ftl
+++ b/crates/ruscker-admin/assets/i18n/fr/landing.ftl
@@ -167,6 +167,22 @@ admin-landing-preview-empty = (pas de texte d'introduction)
 admin-landing-future-title = Bientôt
 admin-landing-future-help = Éditeur de logos, réorganisation des sections, blocs HTML personnalisés, SEO/analytics et meta tags. Pour l'instant ces champs suivent le YAML.
 
+# Admin audit log
+admin-audit-title = Journal d'audit
+admin-audit-subtitle = Tous les changements admin, du plus récent au plus ancien. Limité à 100 événements par requête.
+admin-audit-family = Famille
+admin-audit-family-all = Toutes les actions
+admin-audit-family-spec = Applications
+admin-audit-family-image = Images
+admin-audit-family-credential = Identifiants
+admin-audit-family-landing = Portail
+admin-audit-actor = Auteur
+admin-audit-actor-all = Tous les auteurs
+admin-audit-target-placeholder = Rechercher une cible (ex : spec:auroraprime)
+admin-audit-apply = Appliquer
+admin-audit-empty = Aucun changement — ou le filtre ne correspond à rien.
+admin-audit-limit-hint = Affichage des 100 plus récents. Affinez le filtre pour réduire.
+
 card-cta-open = Ouvrir
 card-cta-link = Accéder
 card-cta-open-app = Ouvrir l'application

--- a/crates/ruscker-admin/assets/i18n/fr/landing.ftl
+++ b/crates/ruscker-admin/assets/i18n/fr/landing.ftl
@@ -107,6 +107,17 @@ spec-form-error-id-shape = L'ID doit commencer par une lettre et contenir unique
 spec-form-error-id-duplicate = Une application avec cet ID existe déjà.
 spec-form-error-name-required = Le nom d'affichage est obligatoire.
 
+# Admin image library
+admin-images-title = Bibliothèque d'images
+admin-images-subtitle = PNG, JPEG et WebP sont convertis en WebP. Le SVG passe tel quel.
+admin-images-drop-here = Cliquez pour choisir un fichier
+admin-images-formats = PNG · JPEG · WebP · SVG · jusqu'à 10 Mo
+admin-images-upload = Envoyer
+admin-images-uploaded = Image envoyée :
+admin-images-empty = Aucune image. Envoyez la première ci-dessus.
+admin-images-delete = Supprimer
+admin-images-delete-confirm = Supprimer cette image ? Les specs qui référencent le fichier afficheront le cover teinté.
+
 card-cta-open = Ouvrir
 card-cta-link = Accéder
 card-cta-open-app = Ouvrir l'application

--- a/crates/ruscker-admin/assets/i18n/fr/landing.ftl
+++ b/crates/ruscker-admin/assets/i18n/fr/landing.ftl
@@ -59,6 +59,54 @@ admin-specs-filter-state-all = Actifs et inactifs
 admin-specs-edit = Modifier
 admin-specs-delete = Supprimer
 
+# Spec form (new / edit)
+spec-form-title-new = Nouvelle application
+spec-form-crumb-new = Nouvelle
+spec-form-crumb-edit = Modifier
+spec-form-cancel = Annuler
+spec-form-save = Enregistrer
+spec-form-kind = Type
+spec-form-kind-app = App conteneur
+spec-form-kind-talk = Présentation
+spec-form-kind-report = Rapport
+spec-form-kind-package = Paquet
+spec-form-kind-api = API
+spec-form-kind-link = Lien externe
+spec-form-identity = Identité
+spec-form-id = ID
+spec-form-id-help-new = Choisi par l'opérateur. Apparaît à /app/<id>/.
+spec-form-id-help-edit = L'ID est immuable une fois créé.
+spec-form-name = Nom d'affichage
+spec-form-desc = Description
+spec-form-visual = Visuel
+spec-form-logo = Logo de la carte
+spec-form-logo-help = URL ou chemin /assets/img/foo.png. Voir docs/IMAGES.md.
+spec-form-access = Accès
+spec-form-state = État
+spec-form-state-active = Actif
+spec-form-state-inactive = Inactif
+spec-form-tema = Thème
+spec-form-container = Conteneur
+spec-form-image = Image Docker
+spec-form-seats = Sessions/conteneur
+spec-form-lifetime = Durée max. (min)
+spec-form-lifetime-help = 360 = 6 heures
+spec-form-link-section = Lien externe
+spec-form-link = URL cible
+spec-form-meta = Métadonnées
+spec-form-updated = Mis à jour le
+spec-form-updated-help = Vide pour utiliser la date d'aujourd'hui.
+spec-form-preview = Aperçu de la carte
+spec-form-preview-help = Mise à jour en direct.
+spec-form-actions = Actions
+spec-form-delete = Supprimer l'application
+spec-form-delete-confirm = Êtes-vous sûr ? Cette action est irréversible.
+
+spec-form-error-id-required = L'ID est obligatoire.
+spec-form-error-id-shape = L'ID doit commencer par une lettre et contenir uniquement lettres, chiffres, "_" et "-".
+spec-form-error-id-duplicate = Une application avec cet ID existe déjà.
+spec-form-error-name-required = Le nom d'affichage est obligatoire.
+
 card-cta-open = Ouvrir
 card-cta-link = Accéder
 card-cta-open-app = Ouvrir l'application

--- a/crates/ruscker-admin/assets/i18n/fr/landing.ftl
+++ b/crates/ruscker-admin/assets/i18n/fr/landing.ftl
@@ -23,6 +23,42 @@ type-package-abbr = PKG
 type-api-abbr = API
 type-link-abbr = LNK
 
+# Admin shell
+admin-nav-apps = Applications
+admin-nav-images = Images
+admin-nav-credentials = Identifiants
+admin-nav-landing = Portail
+admin-nav-audit = Journal
+admin-nav-portal = Retour au portail
+admin-nav-logout = Déconnexion
+
+# Admin login
+admin-login-title = Accès admin
+admin-login-help = Saisissez le jeton admin défini dans RUSCKER_ADMIN_TOKEN.
+admin-login-token-label = Jeton
+admin-login-token-placeholder = Collez le jeton ici
+admin-login-submit = Se connecter
+admin-login-error-wrong = Jeton incorrect. Réessayez.
+admin-login-back-portal = ← portail public
+
+# Apps list
+admin-specs-title = Applications
+admin-specs-subtitle = Catalogue de specs dans la base
+admin-specs-empty = Aucune application. Utilisez { $cmd } pour importer un YAML.
+admin-specs-add = Ajouter une application
+admin-specs-col-id = ID
+admin-specs-col-name = Nom
+admin-specs-col-kind = Type
+admin-specs-col-state = État
+admin-specs-col-updated = Mis à jour
+admin-specs-col-version = Version
+admin-specs-col-actions = Actions
+admin-specs-filter-search = Rechercher par id ou nom…
+admin-specs-filter-kind-all = Tous les types
+admin-specs-filter-state-all = Actifs et inactifs
+admin-specs-edit = Modifier
+admin-specs-delete = Supprimer
+
 card-cta-open = Ouvrir
 card-cta-link = Accéder
 card-cta-open-app = Ouvrir l'application

--- a/crates/ruscker-admin/assets/i18n/fr/landing.ftl
+++ b/crates/ruscker-admin/assets/i18n/fr/landing.ftl
@@ -118,6 +118,28 @@ admin-images-empty = Aucune image. Envoyez la première ci-dessus.
 admin-images-delete = Supprimer
 admin-images-delete-confirm = Supprimer cette image ? Les specs qui référencent le fichier afficheront le cover teinté.
 
+# Admin credentials
+admin-creds-title = Identifiants registry
+admin-creds-subtitle = Les mots de passe sont chiffrés au repos avec AES-256-GCM. Ils n'apparaissent jamais dans le YAML ni dans le panneau après sauvegarde.
+admin-creds-form-title = Ajouter / mettre à jour
+admin-creds-name = Nom
+admin-creds-name-help = Identifiant unique. Utilisez le même nom dans vos specs.
+admin-creds-registry = Registry
+admin-creds-username = Nom d'utilisateur
+admin-creds-password = Mot de passe / jeton
+admin-creds-password-help = Chiffré à l'enregistrement, jamais réaffiché.
+admin-creds-save = Enregistrer
+admin-creds-saved = Identifiant enregistré :
+admin-creds-empty = Aucun identifiant enregistré.
+admin-creds-delete = Supprimer
+admin-creds-delete-confirm = Supprimer cet identifiant ?
+admin-creds-col-name = Nom
+admin-creds-col-registry = Registry
+admin-creds-col-username = Utilisateur
+admin-creds-col-created = Créé le
+admin-creds-key-missing-title = RUSCKER_MASTER_KEY n'est pas configurée
+admin-creds-key-missing-help = Le store d'identifiants a besoin d'une clé de 32 octets en hex (64 chars) ou base64 (44 chars). Générez-en une avec :
+
 card-cta-open = Ouvrir
 card-cta-link = Accéder
 card-cta-open-app = Ouvrir l'application

--- a/crates/ruscker-admin/assets/i18n/pt/landing.ftl
+++ b/crates/ruscker-admin/assets/i18n/pt/landing.ftl
@@ -144,6 +144,33 @@ admin-creds-col-created = Criada em
 admin-creds-key-missing-title = RUSCKER_MASTER_KEY não está configurada
 admin-creds-key-missing-help = O store de credenciais precisa de uma chave de 32 bytes em hex (64 chars) ou base64 (44 chars). Gere uma assim:
 
+# Admin landing editor
+admin-landing-title = Editor da landing
+admin-landing-crumb = Configurações · Landing page
+admin-landing-subtitle = Personalize o portal público. Mudanças entram em vigor no próximo refresh do visitante.
+admin-landing-open-portal = Abrir portal
+admin-landing-save = Salvar
+admin-landing-saved = Configurações salvas. Recarregue o portal público para ver.
+admin-landing-colors = Cores do cabeçalho
+admin-landing-header-bg = Cor de fundo
+admin-landing-bg-help = Vazio = usa a cor padrão do tema (claro/escuro).
+admin-landing-header-fg = Cor do texto
+admin-landing-clear = Limpar
+admin-landing-intro = Texto introdutório (padrão)
+admin-landing-intro-default = Padrão (fallback para todos os idiomas)
+admin-landing-intro-default-placeholder = Bem-vindo ao portal…
+admin-landing-intro-help = Texto exibido entre o cabeçalho e os filtros. Vazio = sem texto.
+admin-landing-intro-locales = Texto introdutório por idioma
+admin-landing-intro-pt = Português
+admin-landing-intro-en = Inglês
+admin-landing-intro-es = Espanhol
+admin-landing-intro-fr = Francês
+admin-landing-preview = Prévia do portal
+admin-landing-preview-help = Aproximação visual do cabeçalho e texto. Cards e filtros ficam como na landing real.
+admin-landing-preview-empty = (sem texto introdutório)
+admin-landing-future-title = Em breve
+admin-landing-future-help = Editor de logos, reordenação de seções, blocos HTML customizados, SEO/analytics e meta tags. Por enquanto, esses campos seguem o YAML.
+
 card-cta-open = Abrir
 card-cta-link = Acessar
 card-cta-open-app = Abrir aplicativo

--- a/crates/ruscker-admin/assets/i18n/pt/landing.ftl
+++ b/crates/ruscker-admin/assets/i18n/pt/landing.ftl
@@ -27,6 +27,42 @@ type-package-abbr = PCT
 type-api-abbr = API
 type-link-abbr = LNK
 
+# Admin shell
+admin-nav-apps = Aplicações
+admin-nav-images = Imagens
+admin-nav-credentials = Credenciais
+admin-nav-landing = Portal
+admin-nav-audit = Auditoria
+admin-nav-portal = Voltar ao portal
+admin-nav-logout = Sair
+
+# Admin login
+admin-login-title = Acesso ao admin
+admin-login-help = Digite o token de admin definido em RUSCKER_ADMIN_TOKEN.
+admin-login-token-label = Token
+admin-login-token-placeholder = Cole o token aqui
+admin-login-submit = Entrar
+admin-login-error-wrong = Token incorreto. Tente de novo.
+admin-login-back-portal = ← portal público
+
+# Apps list
+admin-specs-title = Aplicações
+admin-specs-subtitle = Catálogo de specs no banco
+admin-specs-empty = Nenhuma aplicação ainda. Use { $cmd } para importar de um YAML.
+admin-specs-add = Adicionar aplicação
+admin-specs-col-id = ID
+admin-specs-col-name = Nome
+admin-specs-col-kind = Tipo
+admin-specs-col-state = Estado
+admin-specs-col-updated = Atualizado
+admin-specs-col-version = Versão
+admin-specs-col-actions = Ações
+admin-specs-filter-search = Buscar por id ou nome…
+admin-specs-filter-kind-all = Todos os tipos
+admin-specs-filter-state-all = Ativos e inativos
+admin-specs-edit = Editar
+admin-specs-delete = Apagar
+
 card-cta-open = Abrir
 card-cta-link = Acessar
 card-cta-open-app = Abrir aplicativo

--- a/crates/ruscker-admin/assets/i18n/pt/landing.ftl
+++ b/crates/ruscker-admin/assets/i18n/pt/landing.ftl
@@ -63,6 +63,54 @@ admin-specs-filter-state-all = Ativos e inativos
 admin-specs-edit = Editar
 admin-specs-delete = Apagar
 
+# Spec form (new / edit)
+spec-form-title-new = Nova aplicação
+spec-form-crumb-new = Nova
+spec-form-crumb-edit = Editar
+spec-form-cancel = Cancelar
+spec-form-save = Salvar alterações
+spec-form-kind = Tipo
+spec-form-kind-app = App container
+spec-form-kind-talk = Apresentação
+spec-form-kind-report = Relatório
+spec-form-kind-package = Pacote
+spec-form-kind-api = API
+spec-form-kind-link = Link externo
+spec-form-identity = Identidade
+spec-form-id = ID
+spec-form-id-help-new = Gerado pelo operador. Aparece em /app/<id>/.
+spec-form-id-help-edit = ID é imutável depois de criado.
+spec-form-name = Nome de exibição
+spec-form-desc = Descrição
+spec-form-visual = Visual
+spec-form-logo = Logo do card
+spec-form-logo-help = URL ou caminho /assets/img/foo.png. Veja docs/IMAGES.md.
+spec-form-access = Acesso
+spec-form-state = Estado
+spec-form-state-active = Ativo
+spec-form-state-inactive = Inativo
+spec-form-tema = Tema
+spec-form-container = Container
+spec-form-image = Imagem Docker
+spec-form-seats = Sessões/container
+spec-form-lifetime = Vida máx. (min)
+spec-form-lifetime-help = 360 = 6 horas
+spec-form-link-section = Link externo
+spec-form-link = URL de destino
+spec-form-meta = Metadados
+spec-form-updated = Atualizado em
+spec-form-updated-help = Vazio para usar a data de hoje.
+spec-form-preview = Prévia do card
+spec-form-preview-help = Atualiza ao vivo conforme você edita.
+spec-form-actions = Ações
+spec-form-delete = Excluir aplicação
+spec-form-delete-confirm = Tem certeza? Esta ação não pode ser desfeita.
+
+spec-form-error-id-required = ID é obrigatório.
+spec-form-error-id-shape = ID deve começar com letra e conter apenas letras, números, "_" e "-".
+spec-form-error-id-duplicate = Já existe uma aplicação com esse ID.
+spec-form-error-name-required = Nome de exibição é obrigatório.
+
 card-cta-open = Abrir
 card-cta-link = Acessar
 card-cta-open-app = Abrir aplicativo

--- a/crates/ruscker-admin/assets/i18n/pt/landing.ftl
+++ b/crates/ruscker-admin/assets/i18n/pt/landing.ftl
@@ -171,6 +171,22 @@ admin-landing-preview-empty = (sem texto introdutório)
 admin-landing-future-title = Em breve
 admin-landing-future-help = Editor de logos, reordenação de seções, blocos HTML customizados, SEO/analytics e meta tags. Por enquanto, esses campos seguem o YAML.
 
+# Admin audit log
+admin-audit-title = Auditoria
+admin-audit-subtitle = Todas as alterações administrativas, do mais recente para o mais antigo. Limite de 100 eventos por consulta.
+admin-audit-family = Família
+admin-audit-family-all = Todas as ações
+admin-audit-family-spec = Aplicações
+admin-audit-family-image = Imagens
+admin-audit-family-credential = Credenciais
+admin-audit-family-landing = Portal
+admin-audit-actor = Autor
+admin-audit-actor-all = Todos os autores
+admin-audit-target-placeholder = Buscar por alvo (ex: spec:auroraprime)
+admin-audit-apply = Aplicar
+admin-audit-empty = Nenhuma alteração ainda — ou o filtro não bate em nada.
+admin-audit-limit-hint = Mostrando os 100 mais recentes que batem com o filtro. Ajuste os filtros para refinar.
+
 card-cta-open = Abrir
 card-cta-link = Acessar
 card-cta-open-app = Abrir aplicativo

--- a/crates/ruscker-admin/assets/i18n/pt/landing.ftl
+++ b/crates/ruscker-admin/assets/i18n/pt/landing.ftl
@@ -111,6 +111,17 @@ spec-form-error-id-shape = ID deve começar com letra e conter apenas letras, n�
 spec-form-error-id-duplicate = Já existe uma aplicação com esse ID.
 spec-form-error-name-required = Nome de exibição é obrigatório.
 
+# Admin image library
+admin-images-title = Biblioteca de imagens
+admin-images-subtitle = PNG, JPEG e WebP são convertidos para WebP. SVG passa direto.
+admin-images-drop-here = Clique para escolher um arquivo
+admin-images-formats = PNG · JPEG · WebP · SVG · até 10 MB
+admin-images-upload = Enviar
+admin-images-uploaded = Imagem enviada:
+admin-images-empty = Nenhuma imagem ainda. Envie a primeira acima.
+admin-images-delete = Excluir
+admin-images-delete-confirm = Excluir essa imagem? Specs que referenciam o arquivo passarão a mostrar o cover tintado.
+
 card-cta-open = Abrir
 card-cta-link = Acessar
 card-cta-open-app = Abrir aplicativo

--- a/crates/ruscker-admin/assets/i18n/pt/landing.ftl
+++ b/crates/ruscker-admin/assets/i18n/pt/landing.ftl
@@ -122,6 +122,28 @@ admin-images-empty = Nenhuma imagem ainda. Envie a primeira acima.
 admin-images-delete = Excluir
 admin-images-delete-confirm = Excluir essa imagem? Specs que referenciam o arquivo passarão a mostrar o cover tintado.
 
+# Admin credentials
+admin-creds-title = Credenciais do registry
+admin-creds-subtitle = Senhas criptografadas em repouso com AES-256-GCM. Nunca aparecem no YAML nem no painel depois de salvas.
+admin-creds-form-title = Adicionar / atualizar credencial
+admin-creds-name = Nome
+admin-creds-name-help = Identificador único. Use o mesmo nome nas specs.
+admin-creds-registry = Registry
+admin-creds-username = Usuário
+admin-creds-password = Senha / token
+admin-creds-password-help = Será criptografada e nunca será exibida novamente.
+admin-creds-save = Salvar credencial
+admin-creds-saved = Credencial salva:
+admin-creds-empty = Nenhuma credencial cadastrada.
+admin-creds-delete = Excluir
+admin-creds-delete-confirm = Apagar essa credencial?
+admin-creds-col-name = Nome
+admin-creds-col-registry = Registry
+admin-creds-col-username = Usuário
+admin-creds-col-created = Criada em
+admin-creds-key-missing-title = RUSCKER_MASTER_KEY não está configurada
+admin-creds-key-missing-help = O store de credenciais precisa de uma chave de 32 bytes em hex (64 chars) ou base64 (44 chars). Gere uma assim:
+
 card-cta-open = Abrir
 card-cta-link = Acessar
 card-cta-open-app = Abrir aplicativo

--- a/crates/ruscker-admin/assets/tailwind/input.css
+++ b/crates/ruscker-admin/assets/tailwind/input.css
@@ -803,6 +803,29 @@ textarea.spec-form-input { resize: vertical; min-height: 64px; }
 .image-tile:hover .image-tile-delete { opacity: 1; }
 .image-tile-delete:hover { background: var(--color-lock); }
 
+/* ─── Credentials store ───────────────────────────────────────── */
+.creds-form {
+  background: var(--surface);
+  border: 0.5px solid var(--border);
+  border-radius: 10px;
+  padding: 16px 18px;
+}
+.creds-form-section-title {
+  font-size: 11px; font-weight: 500;
+  color: var(--text-muted);
+  text-transform: uppercase;
+  letter-spacing: 0.05em;
+  margin-bottom: 12px;
+}
+.creds-form input:disabled {
+  opacity: 0.45;
+  cursor: not-allowed;
+}
+.creds-form button:disabled {
+  opacity: 0.45;
+  cursor: not-allowed;
+}
+
 /* ─── Brand lockup (footer) ──────────────────────────────────────
  *
  * Inline mark + wordmark text. Wordmark is always lowercase,

--- a/crates/ruscker-admin/assets/tailwind/input.css
+++ b/crates/ruscker-admin/assets/tailwind/input.css
@@ -914,6 +914,116 @@ textarea.spec-form-input { resize: vertical; min-height: 64px; }
   border-radius: 4px;
 }
 
+/* ─── Audit log viewer ───────────────────────────────────────── */
+.audit-filter-bar {
+  display: flex; flex-wrap: wrap; align-items: center; gap: 8px;
+  padding: 10px 12px;
+  background: var(--surface);
+  border: 0.5px solid var(--border);
+  border-radius: 8px;
+  margin-bottom: 12px;
+}
+
+.audit-list {
+  list-style: none;
+  background: var(--surface);
+  border: 0.5px solid var(--border);
+  border-radius: 8px;
+  overflow: hidden;
+  padding: 0; margin: 0;
+}
+.audit-row {
+  border-bottom: 0.5px solid var(--border-soft);
+}
+.audit-row:last-child { border-bottom: none; }
+
+.audit-row-summary {
+  display: flex; align-items: center; gap: 8px;
+  width: 100%;
+  padding: 8px 12px;
+  background: transparent;
+  border: none;
+  text-align: left;
+  font-family: inherit;
+  font-size: 12px;
+  cursor: pointer;
+  color: var(--text);
+  transition: background 0.1s;
+}
+.audit-row-summary:hover { background: var(--surface-soft); }
+
+.audit-row-icon {
+  font-size: 14px;
+  flex-shrink: 0;
+  width: 18px;
+}
+.audit-row-action {
+  font-family: ui-monospace, SFMono-Regular, Menlo, monospace;
+  font-size: 11px;
+  padding: 1px 7px;
+  border-radius: 4px;
+  font-weight: 500;
+  white-space: nowrap;
+}
+.tone-create  .audit-row-action,
+.tone-create  .audit-row-icon { color: #047857; }
+.tone-create  .audit-row-action { background: rgba(16, 185, 129, 0.12); }
+
+.tone-update  .audit-row-action,
+.tone-update  .audit-row-icon { color: #1d4ed8; }
+.tone-update  .audit-row-action { background: rgba(59, 130, 246, 0.12); }
+
+.tone-delete  .audit-row-action,
+.tone-delete  .audit-row-icon { color: #b91c1c; }
+.tone-delete  .audit-row-action { background: rgba(239, 68, 68, 0.12); }
+
+.tone-import  .audit-row-action,
+.tone-import  .audit-row-icon { color: var(--color-teal-800); }
+.tone-import  .audit-row-action { background: rgba(15, 110, 86, 0.12); }
+
+.tone-other   .audit-row-action { background: var(--surface-soft); color: var(--text-muted); }
+
+.audit-row-target {
+  color: var(--text-muted);
+  font-size: 11px;
+  white-space: nowrap;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  max-width: 280px;
+}
+.audit-row-spacer { flex: 1; }
+.audit-row-actor {
+  font-family: ui-monospace, SFMono-Regular, Menlo, monospace;
+  font-size: 10px;
+  color: var(--text-faint);
+  padding: 1px 6px;
+  background: var(--surface-soft);
+  border-radius: 4px;
+}
+.audit-row-time {
+  font-family: ui-monospace, SFMono-Regular, Menlo, monospace;
+  font-size: 10px;
+  color: var(--text-faint);
+  white-space: nowrap;
+}
+.audit-row-chev {
+  font-size: 13px;
+  color: var(--text-faint);
+  width: 14px;
+  text-align: center;
+}
+.audit-row-diff {
+  background: var(--surface-soft);
+  border-top: 0.5px solid var(--border-soft);
+  padding: 10px 14px 10px 38px;
+  font-family: ui-monospace, SFMono-Regular, Menlo, monospace;
+  font-size: 11px;
+  color: var(--text-muted);
+  white-space: pre-wrap;
+  margin: 0;
+  overflow-x: auto;
+}
+
 /* ─── Brand lockup (footer) ──────────────────────────────────────
  *
  * Inline mark + wordmark text. Wordmark is always lowercase,

--- a/crates/ruscker-admin/assets/tailwind/input.css
+++ b/crates/ruscker-admin/assets/tailwind/input.css
@@ -408,6 +408,179 @@ body {
 /* Hide cards filtered out by Alpine without layout shift */
 [x-cloak] { display: none !important; }
 
+/* ─── Admin shell ─────────────────────────────────────────────── */
+.admin-navbar {
+  display: flex; align-items: center; gap: 16px;
+  padding: 10px 18px;
+  border-bottom: 0.5px solid var(--border);
+  background: var(--surface);
+  flex-wrap: wrap;
+}
+.admin-brand {
+  display: inline-flex; align-items: center; gap: 8px;
+  font-family: var(--font-display);
+  font-weight: 500; font-size: 14px;
+  color: var(--text); text-decoration: none;
+  letter-spacing: -0.01em;
+  margin-right: 8px;
+}
+.admin-nav-links { display: flex; align-items: center; gap: 2px; }
+.admin-nav-actions {
+  margin-left: auto;
+  display: flex; align-items: center; gap: 2px;
+}
+.admin-nav-link {
+  display: inline-flex; align-items: center; gap: 6px;
+  padding: 6px 10px;
+  font-size: 12px; color: var(--text-muted);
+  border-radius: 6px;
+  text-decoration: none;
+  border: none; background: transparent;
+  font-family: inherit; cursor: pointer;
+  transition: background 0.15s, color 0.15s;
+}
+.admin-nav-link:hover {
+  background: var(--surface-soft);
+  color: var(--text);
+}
+.admin-nav-link.is-active {
+  background: var(--text);
+  color: var(--bg);
+}
+.admin-nav-link i { font-size: 14px; }
+.admin-nav-link--logout { color: var(--color-lock); }
+.admin-nav-link--logout:hover { background: var(--color-lock); color: #fff; }
+
+/* ─── Admin login card ───────────────────────────────────────── */
+.admin-login-card {
+  background: var(--surface);
+  border: 0.5px solid var(--border);
+  border-radius: 12px;
+  padding: 28px 32px;
+  width: 100%;
+  max-width: 360px;
+  display: flex; flex-direction: column; gap: 14px;
+  box-shadow: 0 4px 24px rgba(0, 0, 0, 0.06);
+}
+.admin-login-brand {
+  display: flex; align-items: center; gap: 10px;
+  margin-bottom: 8px;
+}
+.admin-login-field {
+  display: flex; flex-direction: column; gap: 4px;
+  margin-top: 4px;
+}
+.admin-login-label {
+  font-size: 11px;
+  color: var(--text-muted);
+  text-transform: uppercase;
+  letter-spacing: 0.05em;
+}
+.admin-login-field input {
+  appearance: none;
+  background: var(--bg);
+  border: 0.5px solid var(--border);
+  border-radius: 6px;
+  padding: 10px 12px;
+  font-size: 13px;
+  font-family: ui-monospace, SFMono-Regular, Menlo, monospace;
+  color: var(--text);
+}
+.admin-login-field input:focus {
+  outline: none;
+  border-color: var(--color-teal-600);
+  box-shadow: 0 0 0 2px rgba(15, 110, 86, 0.15);
+}
+.admin-login-btn {
+  display: inline-flex; align-items: center; justify-content: center; gap: 6px;
+  background: var(--color-teal-600);
+  color: #fff;
+  font-family: inherit; font-size: 13px; font-weight: 500;
+  border: none; border-radius: 6px;
+  padding: 10px 12px; cursor: pointer;
+  transition: background 0.15s;
+}
+.admin-login-btn:hover { background: var(--color-teal-800); }
+.admin-login-btn i { font-size: 14px; }
+.admin-login-error {
+  display: flex; align-items: center; gap: 8px;
+  background: rgba(239, 68, 68, 0.08);
+  border: 0.5px solid rgba(239, 68, 68, 0.3);
+  color: #b91c1c;
+  border-radius: 6px;
+  padding: 8px 12px;
+  font-size: 12px;
+}
+.admin-login-error i { font-size: 14px; }
+.admin-login-footer {
+  display: flex; align-items: center; justify-content: space-between;
+  font-size: 11px;
+  margin-top: 4px;
+}
+.admin-login-footer a { color: var(--text-muted); text-decoration: none; }
+.admin-login-footer a:hover { color: var(--text); }
+.admin-login-locale {
+  background: transparent; border: none;
+  font-family: inherit; font-size: 10px;
+  color: var(--text-muted);
+  padding: 2px 5px; border-radius: 4px;
+  cursor: pointer; letter-spacing: 0.05em;
+}
+.admin-login-locale.is-active {
+  background: var(--text); color: var(--bg);
+}
+
+/* ─── Admin apps table ───────────────────────────────────────── */
+.admin-table {
+  width: 100%;
+  border-collapse: collapse;
+  background: var(--surface);
+  border: 0.5px solid var(--border);
+  border-radius: 10px;
+  overflow: hidden;
+  font-size: 12px;
+}
+.admin-table th {
+  text-align: left;
+  font-weight: 500;
+  font-size: 10px;
+  text-transform: uppercase;
+  letter-spacing: 0.05em;
+  color: var(--text-muted);
+  padding: 10px 12px;
+  border-bottom: 0.5px solid var(--border);
+  background: var(--surface-soft);
+}
+.admin-table td {
+  padding: 10px 12px;
+  border-bottom: 0.5px solid var(--border-soft);
+  vertical-align: middle;
+}
+.admin-table tr:last-child td { border-bottom: none; }
+.admin-table tr:hover td { background: var(--surface-soft); }
+.admin-table .id-cell {
+  font-family: ui-monospace, SFMono-Regular, Menlo, monospace;
+  color: var(--text-muted);
+}
+.admin-table .actions-cell {
+  text-align: right;
+  white-space: nowrap;
+}
+.pill {
+  display: inline-flex; align-items: center;
+  padding: 2px 8px;
+  font-size: 10px;
+  border-radius: 999px;
+  letter-spacing: 0.04em;
+  text-transform: uppercase;
+}
+.pill-state-active   { background: rgba(16, 185, 129, 0.12); color: #047857; }
+.pill-state-inactive { background: rgba(156, 163, 175, 0.18); color: #4b5563; }
+.pill-kind-shiny       { background: rgba(6, 214, 160, 0.18); color: #04553f; }
+.pill-kind-interactive { background: rgba(6, 214, 160, 0.18); color: #04553f; }
+.pill-kind-api         { background: rgba(6, 182, 212, 0.18); color: #083344; }
+.pill-kind-external    { background: rgba(38, 84, 124, 0.15); color: #26547c; }
+
 /* ─── Brand lockup (footer) ──────────────────────────────────────
  *
  * Inline mark + wordmark text. Wordmark is always lowercase,

--- a/crates/ruscker-admin/assets/tailwind/input.css
+++ b/crates/ruscker-admin/assets/tailwind/input.css
@@ -581,6 +581,131 @@ body {
 .pill-kind-api         { background: rgba(6, 182, 212, 0.18); color: #083344; }
 .pill-kind-external    { background: rgba(38, 84, 124, 0.15); color: #26547c; }
 
+/* ─── Spec form (admin/spec_form.html) ───────────────────────── */
+.spec-form-layout {
+  display: grid;
+  grid-template-columns: minmax(0, 1.5fr) minmax(0, 1fr);
+  gap: 24px;
+}
+@media (max-width: 900px) {
+  .spec-form-layout { grid-template-columns: 1fr; }
+}
+.spec-form-fields { min-width: 0; }
+.spec-form-preview {
+  position: sticky; top: 16px; align-self: start;
+  max-width: 320px;
+}
+.spec-form-section { margin-bottom: 16px; }
+.spec-form-section-title {
+  font-size: 11px; font-weight: 500;
+  color: var(--text-muted);
+  text-transform: uppercase;
+  letter-spacing: 0.06em;
+  margin: 20px 0 10px;
+}
+.spec-form-field { margin-bottom: 12px; }
+.spec-form-label {
+  font-size: 12px;
+  color: var(--text);
+  display: block;
+  margin-bottom: 4px;
+}
+.spec-form-help {
+  font-size: 10.5px;
+  color: var(--text-faint);
+  margin-top: 3px;
+  line-height: 1.4;
+}
+.spec-form-input {
+  width: 100%;
+  background: var(--surface);
+  border: 0.5px solid var(--border);
+  border-radius: 6px;
+  padding: 7px 10px;
+  font-size: 12.5px;
+  font-family: inherit;
+  color: var(--text);
+  appearance: none;
+}
+.spec-form-input:focus {
+  outline: none;
+  border-color: var(--color-teal-600);
+  box-shadow: 0 0 0 2px rgba(15, 110, 86, 0.15);
+}
+.spec-form-input:read-only {
+  background: var(--surface-soft);
+  color: var(--text-muted);
+}
+.spec-form-input--mono {
+  font-family: ui-monospace, SFMono-Regular, Menlo, monospace;
+  font-size: 12px;
+}
+textarea.spec-form-input { resize: vertical; min-height: 64px; }
+
+/* Type picker — 6 cards, equal columns */
+.kind-picker {
+  display: grid;
+  grid-template-columns: repeat(6, 1fr);
+  gap: 6px;
+}
+@media (max-width: 720px) {
+  .kind-picker { grid-template-columns: repeat(3, 1fr); }
+}
+.kind-picker-card {
+  display: flex; flex-direction: column; align-items: center; gap: 4px;
+  padding: 10px 4px;
+  border: 0.5px solid var(--border);
+  border-radius: 8px;
+  cursor: pointer;
+  font-size: 11px;
+  color: var(--text-muted);
+  transition: all 0.15s;
+  text-align: center;
+}
+.kind-picker-card i { font-size: 18px; }
+.kind-picker-card:hover { border-color: var(--border-strong); color: var(--text); }
+.kind-picker-card.is-active {
+  border: 2px solid var(--color-teal-600);
+  background: rgba(15, 110, 86, 0.06);
+  color: var(--color-teal-800);
+  padding: 9px 3px;  /* compensate the extra 1px border */
+}
+.sr-only {
+  position: absolute; width: 1px; height: 1px;
+  padding: 0; margin: -1px;
+  overflow: hidden; clip: rect(0,0,0,0);
+  border: 0;
+}
+
+.spec-form-actions-box {
+  margin-top: 18px;
+  padding: 12px;
+  border: 0.5px solid var(--border);
+  border-radius: 8px;
+}
+.spec-form-actions-title {
+  font-size: 11px; font-weight: 500;
+  color: var(--text-muted);
+  text-transform: uppercase;
+  letter-spacing: 0.05em;
+  margin-bottom: 8px;
+}
+.spec-form-delete {
+  display: inline-flex; align-items: center; gap: 6px;
+  background: transparent;
+  border: 0.5px solid rgba(239, 68, 68, 0.4);
+  border-radius: 6px;
+  padding: 6px 10px;
+  font-size: 12px;
+  color: var(--color-lock);
+  font-family: inherit;
+  cursor: pointer;
+  transition: background 0.15s;
+}
+.spec-form-delete:hover {
+  background: rgba(239, 68, 68, 0.08);
+}
+
 /* ─── Brand lockup (footer) ──────────────────────────────────────
  *
  * Inline mark + wordmark text. Wordmark is always lowercase,

--- a/crates/ruscker-admin/assets/tailwind/input.css
+++ b/crates/ruscker-admin/assets/tailwind/input.css
@@ -706,6 +706,103 @@ textarea.spec-form-input { resize: vertical; min-height: 64px; }
   background: rgba(239, 68, 68, 0.08);
 }
 
+/* ─── Admin image library ────────────────────────────────────── */
+.admin-flash-ok {
+  display: flex; align-items: center; gap: 8px;
+  background: rgba(16, 185, 129, 0.08);
+  border: 0.5px solid rgba(16, 185, 129, 0.3);
+  color: #047857;
+  border-radius: 6px;
+  padding: 8px 12px;
+  font-size: 12px;
+}
+.admin-flash-ok code {
+  font-family: ui-monospace, SFMono-Regular, Menlo, monospace;
+  background: rgba(16, 185, 129, 0.12);
+  padding: 1px 6px;
+  border-radius: 3px;
+  font-size: 11px;
+}
+
+.image-upload-zone {
+  display: flex; align-items: center; gap: 14px;
+  padding: 16px 20px;
+  border: 1px dashed var(--border-strong);
+  border-radius: 10px;
+  background: var(--surface-soft);
+}
+.image-upload-zone input[type="file"] {
+  position: absolute;
+  width: 1px; height: 1px; padding: 0; margin: -1px;
+  overflow: hidden; clip: rect(0,0,0,0);
+}
+.image-upload-label {
+  display: flex; flex-direction: column; align-items: flex-start;
+  cursor: pointer;
+  font-size: 12px;
+  color: var(--text-muted);
+  flex: 1;
+}
+.image-upload-label > span:first-of-type {
+  color: var(--text);
+  display: flex; align-items: center; gap: 6px;
+  margin-bottom: 2px;
+}
+.image-upload-label i { font-size: 16px; color: var(--color-teal-600); }
+
+.image-gallery {
+  display: grid;
+  grid-template-columns: repeat(auto-fill, minmax(180px, 1fr));
+  gap: 12px;
+  margin-top: 16px;
+}
+.image-tile {
+  position: relative;
+  background: var(--surface);
+  border: 0.5px solid var(--border);
+  border-radius: 8px;
+  overflow: hidden;
+  display: flex; flex-direction: column;
+}
+.image-tile-frame {
+  display: block;
+  height: 120px;
+  background: var(--surface-soft);
+  border-bottom: 0.5px solid var(--border);
+  overflow: hidden;
+}
+.image-tile-frame img {
+  width: 100%; height: 100%;
+  object-fit: contain;
+  padding: 6px;
+}
+.image-tile-meta {
+  padding: 8px 10px;
+  font-size: 11px;
+}
+.image-tile-name {
+  font-family: ui-monospace, SFMono-Regular, Menlo, monospace;
+  font-size: 11px;
+  white-space: nowrap; overflow: hidden; text-overflow: ellipsis;
+  margin-bottom: 3px;
+}
+.image-tile-sub {
+  display: flex; gap: 4px; flex-wrap: wrap;
+  font-size: 10px;
+  color: var(--text-faint);
+}
+.image-tile-delete {
+  position: absolute; top: 6px; right: 6px;
+  background: rgba(0, 0, 0, 0.6); color: white;
+  border: none; border-radius: 4px;
+  width: 22px; height: 22px;
+  cursor: pointer; display: flex; align-items: center; justify-content: center;
+  opacity: 0; transition: opacity 0.15s;
+}
+.image-tile-delete i { font-size: 13px; }
+.image-tile:hover .image-tile-delete { opacity: 1; }
+.image-tile-delete:hover { background: var(--color-lock); }
+
 /* ─── Brand lockup (footer) ──────────────────────────────────────
  *
  * Inline mark + wordmark text. Wordmark is always lowercase,

--- a/crates/ruscker-admin/assets/tailwind/input.css
+++ b/crates/ruscker-admin/assets/tailwind/input.css
@@ -826,6 +826,94 @@ textarea.spec-form-input { resize: vertical; min-height: 64px; }
   cursor: not-allowed;
 }
 
+/* ─── Landing editor ─────────────────────────────────────────── */
+.color-input {
+  display: flex; align-items: center; gap: 6px;
+}
+.color-input input[type="color"] {
+  width: 36px; height: 36px;
+  border: 0.5px solid var(--border);
+  border-radius: 6px;
+  background: transparent;
+  cursor: pointer;
+  padding: 2px;
+}
+.color-input input[type="text"] {
+  flex: 1;
+}
+
+.info-box {
+  display: flex; gap: 10px;
+  background: var(--surface-soft);
+  border: 0.5px solid var(--border);
+  border-radius: 8px;
+  padding: 10px 12px;
+  font-size: 12px;
+  color: var(--text-muted);
+  margin-top: 16px;
+}
+.info-box i {
+  font-size: 14px;
+  color: var(--color-teal-600);
+  flex-shrink: 0;
+  margin-top: 1px;
+}
+
+.landing-preview-frame {
+  width: 100%;
+  background: var(--bg);
+  border: 0.5px solid var(--border);
+  border-radius: 8px;
+  overflow: hidden;
+  box-shadow: 0 1px 2px rgba(0,0,0,0.04);
+}
+.landing-preview-header {
+  background: var(--bg);
+  color: var(--text);
+  border-bottom: 0.5px solid var(--border);
+}
+.landing-preview-header-inner {
+  display: flex; align-items: flex-end; justify-content: space-between;
+  padding: 10px 12px;
+}
+.landing-preview-title {
+  font-size: 13px; font-weight: 500;
+  letter-spacing: -0.02em;
+}
+.landing-preview-sub {
+  font-size: 9px; opacity: 0.75; margin-top: 2px;
+}
+.landing-preview-count {
+  font-size: 9px; opacity: 0.7;
+}
+.landing-preview-body {
+  padding: 10px 12px;
+  display: flex; flex-direction: column; gap: 8px;
+}
+.landing-preview-intro {
+  font-size: 10px;
+  line-height: 1.4;
+  color: var(--text-muted);
+  margin: 0;
+}
+.landing-preview-mockfilter {
+  height: 22px;
+  background: var(--surface);
+  border: 0.5px solid var(--border);
+  border-radius: 999px;
+}
+.landing-preview-mockgrid {
+  display: grid;
+  grid-template-columns: repeat(2, 1fr);
+  gap: 4px;
+}
+.landing-preview-mockgrid > div {
+  height: 36px;
+  background: var(--surface);
+  border: 0.5px solid var(--border);
+  border-radius: 4px;
+}
+
 /* ─── Brand lockup (footer) ──────────────────────────────────────
  *
  * Inline mark + wordmark text. Wordmark is always lowercase,

--- a/crates/ruscker-admin/migrations/0001_initial.sql
+++ b/crates/ruscker-admin/migrations/0001_initial.sql
@@ -1,0 +1,124 @@
+-- Initial schema for Ruscker admin DB.
+--
+-- See docs/adr/0002-sqlite-source-of-truth.md and
+-- crates/ruscker-admin/CLAUDE.md for the rationale. Short version:
+-- SQLite holds the live spec catalog, images, credentials and
+-- audit log. YAML stays as an import/export format.
+--
+-- Conventions:
+--   * Timestamps: TIMESTAMP (sqlx maps to chrono::DateTime).
+--     All write paths set them explicitly — no DEFAULT triggers,
+--     so the application is the single source of "now()".
+--   * JSON columns: TEXT NOT NULL. Validated by serde at write
+--     time; reads parse with `serde_json::from_str`.
+--   * `state` enums: TEXT NOT NULL, value space documented per
+--     column. SQLite has no native enums; values are checked in
+--     the application layer.
+--   * Foreign keys are enabled at connection time via
+--     `PRAGMA foreign_keys = ON`.
+
+CREATE TABLE specs (
+    id              TEXT    PRIMARY KEY,
+    display_name    TEXT,
+    description     TEXT,
+    -- 'shiny' | 'interactive' | 'api' | 'external' (DisplayType / SpecKind)
+    kind            TEXT    NOT NULL,
+    container_image TEXT,
+    -- The full Spec serialized as JSON for round-trip fidelity.
+    -- Schema-known fields live in their own columns above so we
+    -- can index/query them without parsing JSON; this column is
+    -- the authoritative record for everything else.
+    config_json     TEXT    NOT NULL,
+    -- 'active' | 'inactive'. Inactive specs are hidden from the
+    -- public landing by default.
+    state           TEXT    NOT NULL DEFAULT 'active',
+    created_at      TIMESTAMP NOT NULL,
+    updated_at      TIMESTAMP NOT NULL,
+    -- Monotonic counter incremented on every UPDATE. spec_versions
+    -- carries the historical JSON for each value of `version`.
+    version         INTEGER NOT NULL DEFAULT 1
+);
+
+CREATE INDEX specs_state_idx ON specs (state);
+CREATE INDEX specs_kind_idx ON specs (kind);
+
+-- History table — one row per (spec, version) capturing the JSON
+-- that was current at that version. Lets the admin show "undo
+-- last change" and the audit log link to actual diffs.
+CREATE TABLE spec_versions (
+    spec_id     TEXT    NOT NULL REFERENCES specs(id) ON DELETE CASCADE,
+    version     INTEGER NOT NULL,
+    config_json TEXT    NOT NULL,
+    changed_at  TIMESTAMP NOT NULL,
+    -- Who made the change. NULL for imports (no logged-in user).
+    changed_by  TEXT,
+    PRIMARY KEY (spec_id, version)
+);
+
+-- Operator-uploaded card images. Phase 2 stores blobs in SQLite
+-- (~MB-sized files, hundreds of them) — simpler ops than a
+-- separate filesystem path. Switching to object storage is a
+-- migration when individual installs cross 1 GB.
+CREATE TABLE images (
+    id           TEXT    PRIMARY KEY,
+    -- Human filename for the admin UI (uploads/auroraprime.png).
+    filename     TEXT    NOT NULL,
+    -- image/webp, image/png, image/svg+xml.
+    mime_type    TEXT    NOT NULL,
+    size_bytes   INTEGER NOT NULL,
+    blob         BLOB    NOT NULL,
+    width        INTEGER,
+    height       INTEGER,
+    uploaded_at  TIMESTAMP NOT NULL
+);
+
+CREATE INDEX images_filename_idx ON images (filename);
+
+-- Registry / API credentials. Password ciphertext is AES-GCM-
+-- encrypted with a master key supplied via the RUSCKER_MASTER_KEY
+-- env var. The DB never sees the plaintext.
+CREATE TABLE credentials (
+    name         TEXT    PRIMARY KEY,
+    registry     TEXT    NOT NULL,
+    username     TEXT    NOT NULL,
+    password_enc BLOB    NOT NULL,
+    -- Nonce used during AES-GCM encryption — required for decryption.
+    nonce        BLOB    NOT NULL,
+    created_at   TIMESTAMP NOT NULL
+);
+
+-- Visual customization of the public landing. Matches the
+-- LandingCustomization YAML block 1:1 so import/export round-trip
+-- works without schema gymnastics.
+CREATE TABLE landing_customization (
+    id           INTEGER PRIMARY KEY CHECK (id = 1), -- singleton row
+    header_bg    TEXT,
+    header_fg    TEXT,
+    intro        TEXT,
+    -- JSON object: { "pt": "...", "en": "...", ... }
+    intro_locales_json TEXT NOT NULL DEFAULT '{}',
+    updated_at   TIMESTAMP NOT NULL
+);
+
+INSERT INTO landing_customization (id, intro_locales_json, updated_at)
+VALUES (1, '{}', CURRENT_TIMESTAMP);
+
+-- Append-only history of operator actions. Every admin write
+-- inserts here so we can answer "who changed what when".
+CREATE TABLE audit_log (
+    id          INTEGER PRIMARY KEY AUTOINCREMENT,
+    -- NULL for system events (imports, scheduled tasks).
+    actor       TEXT,
+    -- 'spec.create' | 'spec.update' | 'spec.delete' | 'image.upload' | …
+    action      TEXT NOT NULL,
+    -- Foreign-key-ish reference to the affected entity, e.g.
+    -- 'spec:auroraprime', 'image:abc-123'. Not enforced as a FK
+    -- because the target may have been deleted.
+    target      TEXT,
+    -- JSON diff (old/new). NULL for events without a diff.
+    diff_json   TEXT,
+    occurred_at TIMESTAMP NOT NULL
+);
+
+CREATE INDEX audit_log_target_idx ON audit_log (target);
+CREATE INDEX audit_log_action_idx ON audit_log (action);

--- a/crates/ruscker-admin/migrations/0002_config_meta.sql
+++ b/crates/ruscker-admin/migrations/0002_config_meta.sql
@@ -1,0 +1,17 @@
+-- Catch-all for the YAML sections that don't have dedicated
+-- tables yet: top-level `server`, `logging`, and the rest of the
+-- `proxy` block (everything except `specs` and
+-- `landing-customization`, which live in their own tables).
+--
+-- Stored as JSON blobs keyed by section name. When a Phase 2+ UI
+-- needs to surface a specific field, we extract it to a column
+-- and migrate the data out of here. Until then, the importer and
+-- exporter just round-trip the JSON unchanged so YAML edits aren't
+-- lost on import → export → reimport.
+
+CREATE TABLE config_meta (
+    -- 'proxy' | 'server' | 'logging'
+    key         TEXT PRIMARY KEY,
+    value_json  TEXT NOT NULL,
+    updated_at  TIMESTAMP NOT NULL
+);

--- a/crates/ruscker-admin/src/auth.rs
+++ b/crates/ruscker-admin/src/auth.rs
@@ -1,0 +1,140 @@
+//! Admin authentication — MVP env-var token model.
+//!
+//! Threat model for Phase 2: the operator runs Ruscker on a
+//! private network (or behind a reverse proxy with mTLS).
+//! `RUSCKER_ADMIN_TOKEN` is a long random secret the operator
+//! enters once on `/admin/login`; the server matches it in
+//! constant time and issues an HttpOnly + Strict-SameSite cookie.
+//!
+//! Real auth (OIDC, SAML, role-based ACL) lands in Phase 8. Until
+//! then the model is "one token = full admin"; suitable for a
+//! single-operator install, not for shared teams.
+//!
+//! Cookie storage choice: the cookie value IS the token literal.
+//! Server-side sessions are a Phase 2.5 refinement once we have a
+//! session store; today the cookie is bound by `HttpOnly`,
+//! `Secure` (when TLS terminated), and `SameSite=Strict`.
+
+use anyhow::Result;
+use axum::extract::FromRequestParts;
+use axum::http::request::Parts;
+use axum::http::StatusCode;
+use axum::response::{IntoResponse, Redirect, Response};
+use std::convert::Infallible;
+use std::sync::Arc;
+use tower_cookies::Cookies;
+
+/// Cookie name. Distinct prefix `ruscker_admin_` keeps it from
+/// colliding with the locale/theme cookies and makes it easier to
+/// audit in DevTools.
+pub const COOKIE_NAME: &str = "ruscker_admin_session";
+
+/// Held in `AppState`. `None` means admin routes are disabled —
+/// they will 503 with a hint to set `RUSCKER_ADMIN_TOKEN`. The
+/// token is wrapped in `Arc<str>` so cloning [`AppState`] (per
+/// request) doesn't copy the string.
+#[derive(Clone, Debug, Default)]
+pub struct AdminAuth {
+    pub token: Option<Arc<str>>,
+}
+
+impl AdminAuth {
+    pub fn from_env() -> Self {
+        let token = std::env::var("RUSCKER_ADMIN_TOKEN").ok().filter(|s| !s.is_empty());
+        Self {
+            token: token.map(Arc::from),
+        }
+    }
+
+    pub fn with_token(token: impl Into<String>) -> Self {
+        Self {
+            token: Some(Arc::from(token.into())),
+        }
+    }
+
+    pub fn is_configured(&self) -> bool {
+        self.token.is_some()
+    }
+
+    /// Constant-time compare. Mismatched lengths return false
+    /// without iterating — the length leak is intentional and
+    /// matches every well-known constant-time API. The XOR-fold
+    /// over the body is loop-bounded by `a.len()`, so the time
+    /// depends only on the (public) length, not on the bytes.
+    pub fn matches(&self, candidate: &str) -> bool {
+        let Some(expected) = self.token.as_deref() else {
+            return false;
+        };
+        ct_eq(expected.as_bytes(), candidate.as_bytes())
+    }
+}
+
+fn ct_eq(a: &[u8], b: &[u8]) -> bool {
+    if a.len() != b.len() {
+        return false;
+    }
+    let mut diff: u8 = 0;
+    for (x, y) in a.iter().zip(b.iter()) {
+        diff |= x ^ y;
+    }
+    diff == 0
+}
+
+/// Marker extracted by admin routes to assert that the request is
+/// authenticated. Absence of a valid session redirects to the
+/// login form (303 See Other so re-POST isn't suggested by
+/// browsers).
+///
+/// When the server has NO admin token configured at all, the
+/// extractor returns 503 — admin routes simply cannot work
+/// without a token to compare against.
+pub struct AdminSession;
+
+impl FromRequestParts<crate::AppState> for AdminSession {
+    type Rejection = Response;
+
+    async fn from_request_parts(
+        parts: &mut Parts,
+        state: &crate::AppState,
+    ) -> Result<Self, Self::Rejection> {
+        if !state.admin_auth.is_configured() {
+            return Err((
+                StatusCode::SERVICE_UNAVAILABLE,
+                "RUSCKER_ADMIN_TOKEN is not set — admin disabled",
+            )
+                .into_response());
+        }
+
+        // Cookies extractor is infallible (always Some) when the
+        // CookieManagerLayer is in the stack — which it is, see
+        // router().
+        let cookies = match Cookies::from_request_parts(parts, state).await {
+            Ok(c) => c,
+            Err(_) => return Err(Redirect::to("/admin/login").into_response()),
+        };
+        let candidate = cookies.get(COOKIE_NAME).map(|c| c.value().to_string());
+        match candidate {
+            Some(c) if state.admin_auth.matches(&c) => Ok(AdminSession),
+            _ => Err(Redirect::to("/admin/login").into_response()),
+        }
+    }
+}
+
+/// Convenience extractor for routes that want to know whether the
+/// caller is authenticated without rejecting — useful for the
+/// `_layout.html` so the navbar can show/hide a "logout" link.
+pub struct MaybeAdminSession(pub bool);
+
+impl FromRequestParts<crate::AppState> for MaybeAdminSession {
+    type Rejection = Infallible;
+
+    async fn from_request_parts(
+        parts: &mut Parts,
+        state: &crate::AppState,
+    ) -> Result<Self, Self::Rejection> {
+        match AdminSession::from_request_parts(parts, state).await {
+            Ok(_) => Ok(MaybeAdminSession(true)),
+            Err(_) => Ok(MaybeAdminSession(false)),
+        }
+    }
+}

--- a/crates/ruscker-admin/src/crypto.rs
+++ b/crates/ruscker-admin/src/crypto.rs
@@ -1,0 +1,233 @@
+//! Cryptographic primitives for the credentials store.
+//!
+//! Operators supply a 32-byte master key in `RUSCKER_MASTER_KEY`
+//! as either:
+//!
+//! - 64 lowercase hex chars (e.g. `b5e3...c1`)
+//! - 44-char base64 (with or without `=` padding)
+//!
+//! Generate one with `openssl rand -hex 32` or
+//! `openssl rand -base64 32`.
+//!
+//! The key encrypts every credential password using AES-256-GCM
+//! with a fresh 12-byte nonce per row. The nonce is stored
+//! alongside the ciphertext (it's not secret — it just has to be
+//! unique per (key, plaintext) pair, which a CSPRNG guarantees
+//! with overwhelming probability).
+//!
+//! If the master key is rotated, every prior credential becomes
+//! unreadable. Re-entry is the only recovery — by design; that's
+//! also the property that limits the blast radius if the env var
+//! leaks but the DB doesn't.
+
+use aes_gcm::aead::{Aead, AeadCore, KeyInit, OsRng};
+use aes_gcm::{Aes256Gcm, Key, Nonce};
+use anyhow::{anyhow, Context, Result};
+use base64::Engine;
+use std::sync::Arc;
+use zeroize::Zeroizing;
+
+/// The 32-byte AES-256-GCM key, derived from `RUSCKER_MASTER_KEY`.
+///
+/// Wrapped in `Arc` because `AppState` is cloned per request and we
+/// don't want to copy the secret 31 times per landing render. The
+/// underlying buffer is `Zeroizing<[u8; 32]>` — when the last `Arc`
+/// drops the bytes are wiped from memory.
+#[derive(Clone, Debug, Default)]
+pub struct MasterKey {
+    inner: Option<Arc<Zeroizing<[u8; 32]>>>,
+}
+
+impl MasterKey {
+    pub fn from_env() -> Result<Self> {
+        let Ok(raw) = std::env::var("RUSCKER_MASTER_KEY") else {
+            return Ok(Self::default());
+        };
+        if raw.is_empty() {
+            return Ok(Self::default());
+        }
+        Self::from_str(&raw)
+    }
+
+    pub fn from_str(raw: &str) -> Result<Self> {
+        let bytes = decode_key_material(raw)?;
+        Ok(Self {
+            inner: Some(Arc::new(Zeroizing::new(bytes))),
+        })
+    }
+
+    pub fn is_configured(&self) -> bool {
+        self.inner.is_some()
+    }
+
+    /// Encrypt `plaintext` with a fresh random nonce. Returns
+    /// `(ciphertext, nonce)`; the caller persists both.
+    pub fn encrypt(&self, plaintext: &[u8]) -> Result<(Vec<u8>, Vec<u8>)> {
+        let key = self.cipher_key()?;
+        let cipher = Aes256Gcm::new(key);
+        let nonce = Aes256Gcm::generate_nonce(&mut OsRng);
+        let ciphertext = cipher
+            .encrypt(&nonce, plaintext)
+            .map_err(|e| anyhow!("AES-GCM encrypt failed: {e}"))?;
+        Ok((ciphertext, nonce.to_vec()))
+    }
+
+    /// Decrypt `ciphertext` with the supplied `nonce`. Returns the
+    /// plaintext bytes inside a `Zeroizing` wrapper so callers
+    /// don't accidentally leave it lying in memory.
+    pub fn decrypt(
+        &self,
+        ciphertext: &[u8],
+        nonce_bytes: &[u8],
+    ) -> Result<Zeroizing<Vec<u8>>> {
+        if nonce_bytes.len() != 12 {
+            return Err(anyhow!(
+                "AES-GCM nonce must be 12 bytes, got {}",
+                nonce_bytes.len()
+            ));
+        }
+        let key = self.cipher_key()?;
+        let cipher = Aes256Gcm::new(key);
+        let nonce = Nonce::from_slice(nonce_bytes);
+        let plaintext = cipher
+            .decrypt(nonce, ciphertext)
+            .map_err(|e| anyhow!("AES-GCM decrypt failed: {e}"))?;
+        Ok(Zeroizing::new(plaintext))
+    }
+
+    fn cipher_key(&self) -> Result<&Key<Aes256Gcm>> {
+        let inner = self
+            .inner
+            .as_ref()
+            .ok_or_else(|| anyhow!("master key not configured (RUSCKER_MASTER_KEY)"))?;
+        // Aes256Gcm::Key is a transparent newtype over [u8; 32].
+        Ok(Key::<Aes256Gcm>::from_slice(inner.as_ref().as_slice()))
+    }
+}
+
+/// Accept hex (64 chars), base64 (44 chars with padding), or
+/// base64-no-pad (43 chars). Anything else is an error.
+fn decode_key_material(raw: &str) -> Result<[u8; 32]> {
+    let raw = raw.trim();
+    // Hex check first — unambiguous (64 lowercase hex chars).
+    if raw.len() == 64 && raw.chars().all(|c| c.is_ascii_hexdigit()) {
+        let v = hex::decode(raw).context("decode master key as hex")?;
+        return v
+            .try_into()
+            .map_err(|_| anyhow!("hex key must decode to 32 bytes"));
+    }
+    // Else try base64. We attempt all four common variants
+    // (standard ± padding, URL-safe ± padding) inline, because
+    // base64::Engine isn't dyn-compatible (its methods are
+    // generic) so we can't loop over `&dyn Engine`.
+    let try_decode = |bytes: Result<Vec<u8>, _>| -> Option<[u8; 32]> {
+        bytes.ok().and_then(|v| {
+            (v.len() == 32).then(|| {
+                let mut out = [0u8; 32];
+                out.copy_from_slice(&v);
+                out
+            })
+        })
+    };
+    use base64::engine::general_purpose::{
+        STANDARD, STANDARD_NO_PAD, URL_SAFE, URL_SAFE_NO_PAD,
+    };
+    if let Some(b) = try_decode(STANDARD.decode(raw)) {
+        return Ok(b);
+    }
+    if let Some(b) = try_decode(STANDARD_NO_PAD.decode(raw)) {
+        return Ok(b);
+    }
+    if let Some(b) = try_decode(URL_SAFE.decode(raw)) {
+        return Ok(b);
+    }
+    if let Some(b) = try_decode(URL_SAFE_NO_PAD.decode(raw)) {
+        return Ok(b);
+    }
+    Err(anyhow!(
+        "RUSCKER_MASTER_KEY must be 32 bytes encoded as 64-hex or 44-base64 (try `openssl rand -hex 32`)"
+    ))
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn fixed_key() -> MasterKey {
+        // 32 bytes of zeroes — fine for tests. Real deployments
+        // use `openssl rand -hex 32`.
+        MasterKey::from_str("0000000000000000000000000000000000000000000000000000000000000000").unwrap()
+    }
+
+    #[test]
+    fn from_env_returns_unconfigured_when_missing() {
+        // Snapshot+restore env, in case CI exports it.
+        let prior = std::env::var("RUSCKER_MASTER_KEY").ok();
+        std::env::remove_var("RUSCKER_MASTER_KEY");
+        let k = MasterKey::from_env().unwrap();
+        assert!(!k.is_configured());
+        if let Some(p) = prior {
+            std::env::set_var("RUSCKER_MASTER_KEY", p);
+        }
+    }
+
+    #[test]
+    fn accepts_hex_64() {
+        let k = MasterKey::from_str(&"ab".repeat(32)).unwrap();
+        assert!(k.is_configured());
+    }
+
+    #[test]
+    fn accepts_base64() {
+        // 32 bytes of 0x42 → fixed base64
+        let b64 = base64::engine::general_purpose::STANDARD.encode([0x42u8; 32]);
+        assert_eq!(b64.len(), 44);
+        let k = MasterKey::from_str(&b64).unwrap();
+        assert!(k.is_configured());
+    }
+
+    #[test]
+    fn rejects_short_input() {
+        assert!(MasterKey::from_str("too-short").is_err());
+    }
+
+    #[test]
+    fn encrypt_then_decrypt_roundtrip() {
+        let k = fixed_key();
+        let (ct, nonce) = k.encrypt(b"hunter2-the-password").unwrap();
+        let pt = k.decrypt(&ct, &nonce).unwrap();
+        assert_eq!(pt.as_slice(), b"hunter2-the-password");
+    }
+
+    #[test]
+    fn ciphertexts_differ_per_call() {
+        let k = fixed_key();
+        let (ct1, _) = k.encrypt(b"same plaintext").unwrap();
+        let (ct2, _) = k.encrypt(b"same plaintext").unwrap();
+        assert_ne!(ct1, ct2, "fresh nonce ⇒ different ciphertext each call");
+    }
+
+    #[test]
+    fn decrypt_with_wrong_nonce_fails() {
+        let k = fixed_key();
+        let (ct, _nonce) = k.encrypt(b"data").unwrap();
+        let bad_nonce = vec![0u8; 12];
+        assert!(k.decrypt(&ct, &bad_nonce).is_err());
+    }
+
+    #[test]
+    fn decrypt_with_tampered_ciphertext_fails() {
+        let k = fixed_key();
+        let (mut ct, nonce) = k.encrypt(b"data").unwrap();
+        let last = ct.len() - 1;
+        ct[last] ^= 1;
+        assert!(k.decrypt(&ct, &nonce).is_err());
+    }
+
+    #[test]
+    fn unconfigured_key_refuses_to_encrypt() {
+        let k = MasterKey::default();
+        assert!(!k.is_configured());
+        assert!(k.encrypt(b"hi").is_err());
+    }
+}

--- a/crates/ruscker-admin/src/db.rs
+++ b/crates/ruscker-admin/src/db.rs
@@ -73,6 +73,7 @@ pub async fn open_memory() -> Result<SqlitePool> {
     Ok(pool)
 }
 
+pub mod audit;
 pub mod credentials;
 pub mod export;
 pub mod images;

--- a/crates/ruscker-admin/src/db.rs
+++ b/crates/ruscker-admin/src/db.rs
@@ -73,4 +73,5 @@ pub async fn open_memory() -> Result<SqlitePool> {
     Ok(pool)
 }
 
+pub mod export;
 pub mod specs;

--- a/crates/ruscker-admin/src/db.rs
+++ b/crates/ruscker-admin/src/db.rs
@@ -76,4 +76,5 @@ pub async fn open_memory() -> Result<SqlitePool> {
 pub mod credentials;
 pub mod export;
 pub mod images;
+pub mod landing;
 pub mod specs;

--- a/crates/ruscker-admin/src/db.rs
+++ b/crates/ruscker-admin/src/db.rs
@@ -74,4 +74,5 @@ pub async fn open_memory() -> Result<SqlitePool> {
 }
 
 pub mod export;
+pub mod images;
 pub mod specs;

--- a/crates/ruscker-admin/src/db.rs
+++ b/crates/ruscker-admin/src/db.rs
@@ -1,0 +1,76 @@
+//! SQLite persistence — connection pool, migrations, repositories.
+//!
+//! Phase 2 introduces SQLite as the source of truth for spec
+//! configurations, images, credentials, landing customization,
+//! and the audit log. YAML stays around as an import/export
+//! format only (see `ruscker import` / `ruscker export`).
+//!
+//! Conventions:
+//!
+//! - All write paths go through transactions, even single-row
+//!   updates, so we can attach an `audit_log` insert atomically.
+//! - The application is the single source of "now()"; no DB-level
+//!   `DEFAULT CURRENT_TIMESTAMP` triggers. Keeps tests
+//!   deterministic and lets imports preserve historical
+//!   `created_at` values.
+//! - Foreign keys are enabled per-connection via PRAGMA — SQLite
+//!   defaults to off for legacy reasons.
+
+use anyhow::{Context, Result};
+use sqlx::sqlite::{SqliteConnectOptions, SqlitePoolOptions};
+use sqlx::SqlitePool;
+use std::path::Path;
+use std::str::FromStr;
+
+/// Built-in migrations directory. The `sqlx::migrate!` macro
+/// embeds every `.sql` file under `migrations/` at compile time —
+/// no separate deployment needed.
+pub static MIGRATIONS: sqlx::migrate::Migrator = sqlx::migrate!("./migrations");
+
+/// Open the SQLite database at `path`, creating the file if
+/// missing, and apply any pending migrations. Returns the pool
+/// ready for use.
+pub async fn open(path: impl AsRef<Path>) -> Result<SqlitePool> {
+    let path = path.as_ref();
+    let url = format!("sqlite://{}", path.display());
+    let opts = SqliteConnectOptions::from_str(&url)
+        .with_context(|| format!("invalid SQLite URL `{url}`"))?
+        .create_if_missing(true)
+        .foreign_keys(true)
+        .journal_mode(sqlx::sqlite::SqliteJournalMode::Wal)
+        // BUSY_TIMEOUT prevents `database is locked` errors under
+        // concurrent writes (importer + admin write paths).
+        .busy_timeout(std::time::Duration::from_secs(5));
+
+    let pool = SqlitePoolOptions::new()
+        // SQLite is single-writer; more than a handful of conns
+        // just serializes longer. 5 readers is plenty for the
+        // admin's expected load.
+        .max_connections(5)
+        .connect_with(opts)
+        .await
+        .with_context(|| format!("open SQLite at {}", path.display()))?;
+
+    MIGRATIONS
+        .run(&pool)
+        .await
+        .context("apply migrations")?;
+
+    Ok(pool)
+}
+
+/// Open an in-memory database for tests. Migrations applied.
+#[cfg(test)]
+pub async fn open_memory() -> Result<SqlitePool> {
+    let opts = SqliteConnectOptions::from_str("sqlite::memory:")?
+        .create_if_missing(true)
+        .foreign_keys(true);
+    let pool = SqlitePoolOptions::new()
+        .max_connections(1)
+        .connect_with(opts)
+        .await?;
+    MIGRATIONS.run(&pool).await?;
+    Ok(pool)
+}
+
+pub mod specs;

--- a/crates/ruscker-admin/src/db.rs
+++ b/crates/ruscker-admin/src/db.rs
@@ -73,6 +73,7 @@ pub async fn open_memory() -> Result<SqlitePool> {
     Ok(pool)
 }
 
+pub mod credentials;
 pub mod export;
 pub mod images;
 pub mod specs;

--- a/crates/ruscker-admin/src/db/audit.rs
+++ b/crates/ruscker-admin/src/db/audit.rs
@@ -1,0 +1,219 @@
+//! Audit log read API.
+//!
+//! Writes happen across the codebase — every repository method
+//! that mutates state inserts an `audit_log` row in the same
+//! transaction as the change. This module is read-only and powers
+//! the `/admin/audit` page.
+//!
+//! Filtering is intentionally permissive: every field on
+//! [`AuditFilter`] is `Option`, and `None` means "don't restrict
+//! on this dimension". Combined with pagination, this is enough
+//! for the MVP. A full-text search over `diff_json` is a Phase
+//! 2.5+ refinement.
+
+use anyhow::{Context, Result};
+use chrono::{DateTime, Utc};
+use sqlx::SqlitePool;
+
+/// One row of `audit_log`, with `diff_json` parsed when valid.
+#[derive(Debug, Clone)]
+pub struct AuditEntry {
+    pub id: i64,
+    pub actor: Option<String>,
+    /// e.g. `spec.update`, `image.upload`, `credential.delete`.
+    pub action: String,
+    /// e.g. `spec:auroraprime`, `image:abc-123`. `None` for
+    /// global events (system imports).
+    pub target: Option<String>,
+    /// Parsed `diff_json`. `None` when the column was NULL or
+    /// the JSON was unparseable (we don't fail the listing for
+    /// one bad row; the operator gets `<malformed>` in the UI).
+    pub diff: Option<serde_json::Value>,
+    pub occurred_at: DateTime<Utc>,
+}
+
+/// Top-level action category. Maps to the prefix before the dot
+/// in `audit_log.action` (e.g. `spec.*` → `Spec`). Used by the
+/// page's filter dropdown so operators don't have to know exact
+/// action names.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum ActionFamily {
+    Spec,
+    Image,
+    Credential,
+    Landing,
+}
+
+impl ActionFamily {
+    pub fn parse(s: &str) -> Option<Self> {
+        Some(match s {
+            "spec" => Self::Spec,
+            "image" => Self::Image,
+            "credential" => Self::Credential,
+            "landing" => Self::Landing,
+            _ => return None,
+        })
+    }
+    pub fn as_prefix(self) -> &'static str {
+        match self {
+            Self::Spec => "spec.",
+            Self::Image => "image.",
+            Self::Credential => "credential.",
+            Self::Landing => "landing.",
+        }
+    }
+}
+
+#[derive(Debug, Default, Clone)]
+pub struct AuditFilter {
+    pub family: Option<ActionFamily>,
+    pub target_contains: Option<String>,
+    pub actor: Option<String>,
+    pub limit: i64,
+}
+
+impl AuditFilter {
+    pub fn new() -> Self {
+        Self {
+            limit: 100,
+            ..Default::default()
+        }
+    }
+}
+
+/// List rows matching `filter`, newest first.
+///
+/// Dynamic WHERE built via [`sqlx::QueryBuilder`] (the typed
+/// `query_as` family takes `&'static str` only). All values are
+/// bound through `push_bind`; no string interpolation, no SQL
+/// injection.
+pub async fn list(pool: &SqlitePool, filter: &AuditFilter) -> Result<Vec<AuditEntry>> {
+    let mut qb: sqlx::QueryBuilder<sqlx::Sqlite> = sqlx::QueryBuilder::new(
+        "SELECT id, actor, action, target, diff_json, occurred_at FROM audit_log WHERE 1=1",
+    );
+    if let Some(family) = filter.family {
+        qb.push(" AND action LIKE ");
+        qb.push_bind(format!("{}%", family.as_prefix()));
+    }
+    if let Some(t) = &filter.target_contains {
+        qb.push(" AND target LIKE ");
+        qb.push_bind(format!("%{}%", t));
+    }
+    if let Some(a) = &filter.actor {
+        qb.push(" AND actor = ");
+        qb.push_bind(a.clone());
+    }
+    qb.push(" ORDER BY id DESC LIMIT ");
+    qb.push_bind(filter.limit.max(1).min(1000));
+
+    let rows: Vec<(i64, Option<String>, String, Option<String>, Option<String>, DateTime<Utc>)> =
+        qb.build_query_as()
+            .fetch_all(pool)
+            .await
+            .context("list audit_log")?;
+
+    Ok(rows
+        .into_iter()
+        .map(|(id, actor, action, target, diff_json, occurred_at)| AuditEntry {
+            id,
+            actor,
+            action,
+            target,
+            diff: diff_json
+                .as_deref()
+                .and_then(|s| serde_json::from_str(s).ok()),
+            occurred_at,
+        })
+        .collect())
+}
+
+/// Distinct values of `action` currently in the table — used to
+/// populate the filter dropdown so the UI doesn't enumerate
+/// actions that have never fired in this install.
+pub async fn distinct_actions(pool: &SqlitePool) -> Result<Vec<String>> {
+    let rows: Vec<(String,)> =
+        sqlx::query_as("SELECT DISTINCT action FROM audit_log ORDER BY action ASC")
+            .fetch_all(pool)
+            .await
+            .context("distinct actions")?;
+    Ok(rows.into_iter().map(|(a,)| a).collect())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::db::open_memory;
+    use chrono::Utc;
+
+    async fn seed(pool: &SqlitePool, action: &str, target: Option<&str>, actor: Option<&str>) {
+        sqlx::query(
+            "INSERT INTO audit_log (actor, action, target, diff_json, occurred_at)
+             VALUES (?, ?, ?, NULL, ?)",
+        )
+        .bind(actor)
+        .bind(action)
+        .bind(target)
+        .bind(Utc::now())
+        .execute(pool)
+        .await
+        .unwrap();
+    }
+
+    #[tokio::test]
+    async fn list_returns_newest_first() {
+        let pool = open_memory().await.unwrap();
+        seed(&pool, "spec.create", Some("spec:a"), None).await;
+        seed(&pool, "spec.update", Some("spec:a"), None).await;
+        seed(&pool, "spec.delete", Some("spec:a"), None).await;
+
+        let v = list(&pool, &AuditFilter::new()).await.unwrap();
+        assert_eq!(v.len(), 3);
+        assert_eq!(v[0].action, "spec.delete");
+        assert_eq!(v[2].action, "spec.create");
+    }
+
+    #[tokio::test]
+    async fn family_filter_narrows_by_prefix() {
+        let pool = open_memory().await.unwrap();
+        seed(&pool, "spec.create", Some("spec:a"), None).await;
+        seed(&pool, "image.upload", Some("image:1"), None).await;
+        seed(&pool, "credential.create", Some("credential:dh"), None).await;
+
+        let f = AuditFilter {
+            family: Some(ActionFamily::Image),
+            ..AuditFilter::new()
+        };
+        let v = list(&pool, &f).await.unwrap();
+        assert_eq!(v.len(), 1);
+        assert_eq!(v[0].action, "image.upload");
+    }
+
+    #[tokio::test]
+    async fn target_substring_filter() {
+        let pool = open_memory().await.unwrap();
+        seed(&pool, "spec.update", Some("spec:auroraprime"), None).await;
+        seed(&pool, "spec.update", Some("spec:creches"), None).await;
+
+        let f = AuditFilter {
+            target_contains: Some("aurora".into()),
+            ..AuditFilter::new()
+        };
+        let v = list(&pool, &f).await.unwrap();
+        assert_eq!(v.len(), 1);
+        assert_eq!(v[0].target.as_deref(), Some("spec:auroraprime"));
+    }
+
+    #[tokio::test]
+    async fn limit_caps_returned_rows() {
+        let pool = open_memory().await.unwrap();
+        for i in 0..10 {
+            seed(&pool, "spec.create", Some(&format!("spec:{i}")), None).await;
+        }
+        let f = AuditFilter {
+            limit: 3,
+            ..AuditFilter::new()
+        };
+        let v = list(&pool, &f).await.unwrap();
+        assert_eq!(v.len(), 3);
+    }
+}

--- a/crates/ruscker-admin/src/db/credentials.rs
+++ b/crates/ruscker-admin/src/db/credentials.rs
@@ -1,0 +1,216 @@
+//! Registry credentials — the encrypted-at-rest password store.
+//!
+//! Plaintext passwords never touch the disk. The
+//! [`MasterKey`](crate::crypto::MasterKey) encrypts on insert,
+//! decrypts on fetch. The admin UI lists names + usernames only;
+//! the actual password is fetched by the runtime when it needs to
+//! pull an image (and never echoed back to the operator's
+//! browser).
+
+use anyhow::{Context, Result};
+use chrono::{DateTime, Utc};
+use sqlx::SqlitePool;
+use zeroize::Zeroizing;
+
+use crate::crypto::MasterKey;
+
+/// Public-facing summary — no secrets. What the gallery sees.
+#[derive(Debug, Clone)]
+pub struct CredentialMeta {
+    pub name: String,
+    pub registry: String,
+    pub username: String,
+    pub created_at: DateTime<Utc>,
+}
+
+/// Insert (or replace) a credential. Encrypts the password under
+/// the master key with a fresh nonce. Audit entry tagged with
+/// `actor`. Returns `true` if a prior row was replaced.
+pub async fn upsert(
+    pool: &SqlitePool,
+    key: &MasterKey,
+    name: &str,
+    registry: &str,
+    username: &str,
+    password: &str,
+    actor: Option<&str>,
+) -> Result<bool> {
+    let now = Utc::now();
+    let (ciphertext, nonce) = key.encrypt(password.as_bytes())?;
+
+    let mut tx = pool.begin().await.context("begin credential tx")?;
+
+    let existing: Option<(i64,)> =
+        sqlx::query_as("SELECT 1 FROM credentials WHERE name = ?")
+            .bind(name)
+            .fetch_optional(&mut *tx)
+            .await
+            .with_context(|| format!("lookup credential {name}"))?;
+    let replaced = existing.is_some();
+
+    sqlx::query(
+        "INSERT INTO credentials
+           (name, registry, username, password_enc, nonce, created_at)
+         VALUES (?, ?, ?, ?, ?, ?)
+         ON CONFLICT(name) DO UPDATE SET
+           registry = excluded.registry,
+           username = excluded.username,
+           password_enc = excluded.password_enc,
+           nonce = excluded.nonce",
+    )
+    .bind(name)
+    .bind(registry)
+    .bind(username)
+    .bind(&ciphertext)
+    .bind(&nonce)
+    .bind(now)
+    .execute(&mut *tx)
+    .await
+    .with_context(|| format!("insert credential {name}"))?;
+
+    sqlx::query(
+        "INSERT INTO audit_log (actor, action, target, diff_json, occurred_at)
+         VALUES (?, ?, ?, ?, ?)",
+    )
+    .bind(actor)
+    .bind(if replaced { "credential.update" } else { "credential.create" })
+    .bind(format!("credential:{name}"))
+    .bind(serde_json::to_string(&serde_json::json!({
+        "registry": registry,
+        "username": username,
+    }))?)
+    .bind(now)
+    .execute(&mut *tx)
+    .await
+    .context("audit credential upsert")?;
+
+    tx.commit().await.context("commit credential tx")?;
+    Ok(replaced)
+}
+
+/// List every credential — names, usernames, registries only.
+pub async fn list_all(pool: &SqlitePool) -> Result<Vec<CredentialMeta>> {
+    let rows: Vec<(String, String, String, DateTime<Utc>)> = sqlx::query_as(
+        "SELECT name, registry, username, created_at
+           FROM credentials
+          ORDER BY name ASC",
+    )
+    .fetch_all(pool)
+    .await
+    .context("list credentials")?;
+    Ok(rows
+        .into_iter()
+        .map(|(name, registry, username, created_at)| CredentialMeta {
+            name,
+            registry,
+            username,
+            created_at,
+        })
+        .collect())
+}
+
+/// Decrypt the password for a single credential. Used by the
+/// runtime when pulling an image; **not** exposed in the UI.
+/// Returns `None` if the name doesn't exist.
+pub async fn fetch_password(
+    pool: &SqlitePool,
+    key: &MasterKey,
+    name: &str,
+) -> Result<Option<Zeroizing<String>>> {
+    let row: Option<(Vec<u8>, Vec<u8>)> =
+        sqlx::query_as("SELECT password_enc, nonce FROM credentials WHERE name = ?")
+            .bind(name)
+            .fetch_optional(pool)
+            .await
+            .with_context(|| format!("fetch credential {name}"))?;
+    match row {
+        None => Ok(None),
+        Some((enc, nonce)) => {
+            let pt = key.decrypt(&enc, &nonce)?;
+            let s = String::from_utf8(pt.to_vec())
+                .context("decrypted password is not valid UTF-8")?;
+            Ok(Some(Zeroizing::new(s)))
+        }
+    }
+}
+
+pub async fn delete_one(pool: &SqlitePool, name: &str, actor: Option<&str>) -> Result<bool> {
+    let now = Utc::now();
+    let mut tx = pool.begin().await.context("begin credential delete tx")?;
+    let rows = sqlx::query("DELETE FROM credentials WHERE name = ?")
+        .bind(name)
+        .execute(&mut *tx)
+        .await
+        .with_context(|| format!("delete credential {name}"))?;
+    let removed = rows.rows_affected() > 0;
+    if removed {
+        sqlx::query(
+            "INSERT INTO audit_log (actor, action, target, diff_json, occurred_at)
+             VALUES (?, 'credential.delete', ?, '{}', ?)",
+        )
+        .bind(actor)
+        .bind(format!("credential:{name}"))
+        .bind(now)
+        .execute(&mut *tx)
+        .await
+        .context("audit credential.delete")?;
+    }
+    tx.commit().await.context("commit credential delete")?;
+    Ok(removed)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::db::open_memory;
+
+    fn fixed_key() -> MasterKey {
+        MasterKey::from_str(&"ab".repeat(32)).unwrap()
+    }
+
+    #[tokio::test]
+    async fn upsert_then_fetch_round_trip() {
+        let pool = open_memory().await.unwrap();
+        let key = fixed_key();
+        upsert(&pool, &key, "docker-hub", "docker.io", "milkway", "hunter2", Some("admin"))
+            .await
+            .unwrap();
+        let pw = fetch_password(&pool, &key, "docker-hub").await.unwrap();
+        assert_eq!(pw.unwrap().as_str(), "hunter2");
+    }
+
+    #[tokio::test]
+    async fn list_does_not_contain_passwords() {
+        let pool = open_memory().await.unwrap();
+        let key = fixed_key();
+        upsert(&pool, &key, "dh", "docker.io", "milkway", "topsecret", None)
+            .await
+            .unwrap();
+        let metas = list_all(&pool).await.unwrap();
+        assert_eq!(metas.len(), 1);
+        assert_eq!(metas[0].name, "dh");
+        assert_eq!(metas[0].username, "milkway");
+        // (No way to access the password field — CredentialMeta
+        // doesn't have one. Compile-time guarantee.)
+    }
+
+    #[tokio::test]
+    async fn upsert_replaces_password() {
+        let pool = open_memory().await.unwrap();
+        let key = fixed_key();
+        upsert(&pool, &key, "dh", "docker.io", "milkway", "old", None).await.unwrap();
+        let replaced = upsert(&pool, &key, "dh", "docker.io", "milkway", "new", None).await.unwrap();
+        assert!(replaced);
+        let pw = fetch_password(&pool, &key, "dh").await.unwrap().unwrap();
+        assert_eq!(pw.as_str(), "new");
+    }
+
+    #[tokio::test]
+    async fn delete_then_fetch_returns_none() {
+        let pool = open_memory().await.unwrap();
+        let key = fixed_key();
+        upsert(&pool, &key, "dh", "docker.io", "milkway", "x", None).await.unwrap();
+        assert!(delete_one(&pool, "dh", None).await.unwrap());
+        assert!(fetch_password(&pool, &key, "dh").await.unwrap().is_none());
+    }
+}

--- a/crates/ruscker-admin/src/db/export.rs
+++ b/crates/ruscker-admin/src/db/export.rs
@@ -1,0 +1,169 @@
+//! Export the DB back to a `ruscker_config::Config` ready for YAML
+//! serialization. Mirror of `import_all`: every byte the importer
+//! persisted comes back, modulo whitespace/comments which YAML
+//! can't preserve.
+//!
+//! Round-trip invariant (covered by tests): for any `Config c`,
+//! `import_all(pool, c)` followed by `reconstruct_config(pool)`
+//! returns a value that, when re-imported, reports
+//! `unchanged = total_specs` and `updated = 0`.
+
+use anyhow::{Context, Result};
+use ruscker_config::{Config, LandingCustomization, Logging, Proxy, Server, Spec};
+use sqlx::SqlitePool;
+
+/// Rebuild a full [`Config`] from everything currently in the
+/// database: spec rows, the landing-customization singleton, and
+/// the `config_meta` key/value entries for the rest of
+/// proxy/server/logging.
+pub async fn reconstruct_config(pool: &SqlitePool) -> Result<Config> {
+    // 1. Specs — read in stable order (id ASC) so YAML output is
+    //    deterministic across runs.
+    let spec_rows: Vec<(String,)> =
+        sqlx::query_as("SELECT config_json FROM specs ORDER BY id ASC")
+            .fetch_all(pool)
+            .await
+            .context("load specs")?;
+    let mut specs: Vec<Spec> = Vec::with_capacity(spec_rows.len());
+    for (json,) in spec_rows {
+        let s: Spec = serde_json::from_str(&json).context("deserialize spec row")?;
+        specs.push(s);
+    }
+
+    // 2. Landing customization singleton.
+    let lc_row: Option<(Option<String>, Option<String>, Option<String>, String)> =
+        sqlx::query_as(
+            "SELECT header_bg, header_fg, intro, intro_locales_json
+               FROM landing_customization WHERE id = 1",
+        )
+        .fetch_optional(pool)
+        .await
+        .context("load landing_customization")?;
+    let landing_customization = match lc_row {
+        Some((bg, fg, intro, locales_json)) => LandingCustomization {
+            header_bg: bg,
+            header_fg: fg,
+            intro,
+            intro_locales: serde_json::from_str(&locales_json)
+                .context("parse intro_locales_json")?,
+        },
+        None => LandingCustomization::default(),
+    };
+
+    // 3. config_meta sections — start with default structs and let
+    //    serde_json overlay whatever the import persisted. Falling
+    //    back to default-when-missing means a DB with no
+    //    config_meta row still gives a sensible Config.
+    let proxy_meta = load_meta(pool, "proxy").await?;
+    let server_value = load_meta(pool, "server").await?;
+    let logging_value = load_meta(pool, "logging").await?;
+
+    let mut proxy: Proxy = match proxy_meta {
+        Some(v) => serde_json::from_value(v).context("deserialize proxy meta")?,
+        None => Proxy::default(),
+    };
+    let server: Server = match server_value {
+        Some(v) => serde_json::from_value(v).context("deserialize server meta")?,
+        None => Server::default(),
+    };
+    let logging: Logging = match logging_value {
+        Some(v) => serde_json::from_value(v).context("deserialize logging meta")?,
+        None => Logging::default(),
+    };
+
+    // 4. Splice specs + landing-customization back onto proxy.
+    proxy.specs = specs;
+    proxy.landing_customization = landing_customization;
+
+    Ok(Config {
+        server,
+        proxy,
+        logging,
+        raw_warnings: Vec::new(),
+    })
+}
+
+async fn load_meta(pool: &SqlitePool, key: &str) -> Result<Option<serde_json::Value>> {
+    let row: Option<(String,)> =
+        sqlx::query_as("SELECT value_json FROM config_meta WHERE key = ?")
+            .bind(key)
+            .fetch_optional(pool)
+            .await
+            .with_context(|| format!("load config_meta[{key}]"))?;
+    match row {
+        None => Ok(None),
+        Some((json,)) => Ok(Some(serde_json::from_str(&json)?)),
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::db::{open_memory, specs::import_all};
+
+    fn fixture_yaml() -> String {
+        std::env::set_var("DOCKER_REGISTRY_PASSWORD", "test");
+        std::fs::read_to_string("../../examples/application.yml").unwrap()
+    }
+
+    #[tokio::test]
+    async fn round_trip_preserves_specs_count() {
+        let pool = open_memory().await.unwrap();
+        let cfg_in = Config::from_yaml(&fixture_yaml()).unwrap();
+        import_all(&pool, &cfg_in).await.unwrap();
+
+        let cfg_out = reconstruct_config(&pool).await.unwrap();
+        assert_eq!(cfg_out.proxy.specs.len(), cfg_in.proxy.specs.len());
+    }
+
+    #[tokio::test]
+    async fn round_trip_then_reimport_is_unchanged() {
+        let pool = open_memory().await.unwrap();
+        let cfg_in = Config::from_yaml(&fixture_yaml()).unwrap();
+        import_all(&pool, &cfg_in).await.unwrap();
+
+        let cfg_out = reconstruct_config(&pool).await.unwrap();
+
+        // Re-import the exported Config into a fresh DB — every
+        // spec should land as Created.
+        let pool2 = open_memory().await.unwrap();
+        let r = import_all(&pool2, &cfg_out).await.unwrap();
+        assert_eq!(r.created, cfg_in.proxy.specs.len());
+
+        // And re-import the same Config into the SAME DB — every
+        // spec unchanged.
+        let r2 = import_all(&pool2, &cfg_out).await.unwrap();
+        assert_eq!(r2.unchanged, cfg_in.proxy.specs.len());
+        assert_eq!(r2.updated, 0);
+    }
+
+    #[tokio::test]
+    async fn round_trip_preserves_landing_customization() {
+        let pool = open_memory().await.unwrap();
+        let cfg_in = Config::from_yaml(&fixture_yaml()).unwrap();
+        import_all(&pool, &cfg_in).await.unwrap();
+        let cfg_out = reconstruct_config(&pool).await.unwrap();
+
+        assert_eq!(
+            cfg_out.proxy.landing_customization.header_bg,
+            cfg_in.proxy.landing_customization.header_bg
+        );
+        assert_eq!(
+            cfg_out.proxy.landing_customization.intro_locales,
+            cfg_in.proxy.landing_customization.intro_locales
+        );
+    }
+
+    #[tokio::test]
+    async fn round_trip_preserves_proxy_settings() {
+        let pool = open_memory().await.unwrap();
+        let cfg_in = Config::from_yaml(&fixture_yaml()).unwrap();
+        import_all(&pool, &cfg_in).await.unwrap();
+        let cfg_out = reconstruct_config(&pool).await.unwrap();
+
+        assert_eq!(cfg_out.proxy.title, cfg_in.proxy.title);
+        assert_eq!(cfg_out.proxy.port, cfg_in.proxy.port);
+        assert_eq!(cfg_out.proxy.bind_address, cfg_in.proxy.bind_address);
+        assert_eq!(cfg_out.proxy.heartbeat_rate, cfg_in.proxy.heartbeat_rate);
+    }
+}

--- a/crates/ruscker-admin/src/db/images.rs
+++ b/crates/ruscker-admin/src/db/images.rs
@@ -1,0 +1,173 @@
+//! Image library repository — uploads and reads against the
+//! `images` table.
+//!
+//! Storage choice: blobs live in SQLite. The expected scale is
+//! tens to low hundreds of images per install at ~10-100 KB each
+//! (WebP-encoded), totaling a few MB; well within SQLite's
+//! comfort zone and gone-with-the-DB-file in backups.
+//!
+//! Switching to object storage is a Phase 2.5+ migration when an
+//! install crosses ~1 GB of images or someone wants to share a
+//! gallery across multiple Ruscker instances.
+
+use anyhow::{Context, Result};
+use chrono::{DateTime, Utc};
+use sqlx::SqlitePool;
+use uuid::Uuid;
+
+use crate::images::Processed;
+
+/// Soft limit warned about (not enforced) on encoded image size.
+/// Anything above this is technically allowed but produces a
+/// startup warning so operators see oversize uploads pile up.
+pub const SOFT_SIZE_LIMIT_BYTES: i64 = 500 * 1024;
+
+/// Row of `images` minus the blob — for the gallery list.
+#[derive(Debug, Clone)]
+pub struct ImageMeta {
+    pub id: String,
+    pub filename: String,
+    pub mime_type: String,
+    pub size_bytes: i64,
+    pub width: Option<i64>,
+    pub height: Option<i64>,
+    pub uploaded_at: DateTime<Utc>,
+}
+
+/// Insert a processed image. Returns the freshly assigned id.
+/// Idempotent on filename: re-uploading the same filename
+/// **replaces** the existing row (and the prior bytes are gone —
+/// we don't keep image history, only spec history).
+pub async fn insert(pool: &SqlitePool, processed: Processed, actor: Option<&str>) -> Result<String> {
+    let now = Utc::now();
+    let mut tx = pool.begin().await.context("begin image insert tx")?;
+
+    // Remove any prior row with the same filename so the new
+    // upload wins. We could UPSERT with the same id but reusing
+    // ids across content is worse for cache headers downstream.
+    sqlx::query("DELETE FROM images WHERE filename = ?")
+        .bind(&processed.filename)
+        .execute(&mut *tx)
+        .await
+        .with_context(|| format!("delete prior image {}", processed.filename))?;
+
+    let id = Uuid::new_v4().to_string();
+    sqlx::query(
+        "INSERT INTO images
+           (id, filename, mime_type, size_bytes, blob, width, height, uploaded_at)
+         VALUES (?, ?, ?, ?, ?, ?, ?, ?)",
+    )
+    .bind(&id)
+    .bind(&processed.filename)
+    .bind(&processed.mime_type)
+    .bind(processed.bytes.len() as i64)
+    .bind(&processed.bytes)
+    .bind(processed.width.map(|n| n as i64))
+    .bind(processed.height.map(|n| n as i64))
+    .bind(now)
+    .execute(&mut *tx)
+    .await
+    .with_context(|| format!("insert image {}", processed.filename))?;
+
+    sqlx::query(
+        "INSERT INTO audit_log (actor, action, target, diff_json, occurred_at)
+         VALUES (?, 'image.upload', ?, ?, ?)",
+    )
+    .bind(actor)
+    .bind(format!("image:{id}"))
+    .bind(serde_json::to_string(&serde_json::json!({
+        "filename": processed.filename,
+        "mime": processed.mime_type,
+        "size": processed.bytes.len(),
+    }))?)
+    .bind(now)
+    .execute(&mut *tx)
+    .await
+    .context("audit image.upload")?;
+
+    tx.commit().await.context("commit image insert")?;
+    Ok(id)
+}
+
+/// Fetch the bytes + MIME of an image by **filename**. This is the
+/// public lookup hit by `GET /assets/img/<filename>`.
+pub async fn fetch_by_filename(
+    pool: &SqlitePool,
+    filename: &str,
+) -> Result<Option<(String, Vec<u8>)>> {
+    let row: Option<(String, Vec<u8>)> =
+        sqlx::query_as("SELECT mime_type, blob FROM images WHERE filename = ?")
+            .bind(filename)
+            .fetch_optional(pool)
+            .await
+            .with_context(|| format!("fetch image {filename}"))?;
+    Ok(row)
+}
+
+/// Gallery listing — every uploaded image, newest first.
+pub async fn list_all(pool: &SqlitePool) -> Result<Vec<ImageMeta>> {
+    let rows: Vec<(String, String, String, i64, Option<i64>, Option<i64>, DateTime<Utc>)> =
+        sqlx::query_as(
+            "SELECT id, filename, mime_type, size_bytes, width, height, uploaded_at
+               FROM images
+              ORDER BY uploaded_at DESC, filename ASC",
+        )
+        .fetch_all(pool)
+        .await
+        .context("list images")?;
+    Ok(rows
+        .into_iter()
+        .map(|(id, filename, mime_type, size_bytes, width, height, uploaded_at)| {
+            ImageMeta {
+                id,
+                filename,
+                mime_type,
+                size_bytes,
+                width,
+                height,
+                uploaded_at,
+            }
+        })
+        .collect())
+}
+
+/// Delete by id. Returns true if a row was removed. Audit row is
+/// written on either branch (an attempted delete is an event).
+pub async fn delete_one(pool: &SqlitePool, id: &str, actor: Option<&str>) -> Result<bool> {
+    let now = Utc::now();
+    let mut tx = pool.begin().await.context("begin image delete tx")?;
+
+    // Capture filename for the audit diff before deletion.
+    let filename: Option<(String,)> = sqlx::query_as("SELECT filename FROM images WHERE id = ?")
+        .bind(id)
+        .fetch_optional(&mut *tx)
+        .await
+        .context("lookup image for delete")?;
+
+    let rows = sqlx::query("DELETE FROM images WHERE id = ?")
+        .bind(id)
+        .execute(&mut *tx)
+        .await
+        .with_context(|| format!("delete image {id}"))?;
+    let removed = rows.rows_affected() > 0;
+
+    if removed {
+        let diff = filename
+            .as_ref()
+            .map(|(f,)| serde_json::json!({ "filename": f }))
+            .unwrap_or_else(|| serde_json::json!({}));
+        sqlx::query(
+            "INSERT INTO audit_log (actor, action, target, diff_json, occurred_at)
+             VALUES (?, 'image.delete', ?, ?, ?)",
+        )
+        .bind(actor)
+        .bind(format!("image:{id}"))
+        .bind(serde_json::to_string(&diff)?)
+        .bind(now)
+        .execute(&mut *tx)
+        .await
+        .context("audit image.delete")?;
+    }
+    tx.commit().await.context("commit image delete")?;
+    Ok(removed)
+}

--- a/crates/ruscker-admin/src/db/landing.rs
+++ b/crates/ruscker-admin/src/db/landing.rs
@@ -1,0 +1,144 @@
+//! Landing-page customization repository.
+//!
+//! Wraps the `landing_customization` singleton (id=1) — header
+//! bg/fg, default intro paragraph, and per-locale intro overrides.
+//! The same shape as [`ruscker_config::LandingCustomization`] so
+//! import/export round-trip without translation gymnastics.
+
+use anyhow::{Context, Result};
+use chrono::Utc;
+use ruscker_config::LandingCustomization;
+use sqlx::SqlitePool;
+
+/// Read the singleton row. Returns the default
+/// [`LandingCustomization`] when the row hasn't been initialized
+/// yet (which shouldn't normally happen — migration 0001 inserts
+/// it — but defensive code keeps tests with a fresh DB happy).
+pub async fn fetch(pool: &SqlitePool) -> Result<LandingCustomization> {
+    let row: Option<(Option<String>, Option<String>, Option<String>, String)> =
+        sqlx::query_as(
+            "SELECT header_bg, header_fg, intro, intro_locales_json
+               FROM landing_customization WHERE id = 1",
+        )
+        .fetch_optional(pool)
+        .await
+        .context("load landing_customization")?;
+    match row {
+        None => Ok(LandingCustomization::default()),
+        Some((bg, fg, intro, locales_json)) => {
+            let intro_locales =
+                serde_json::from_str(&locales_json).context("parse intro_locales_json")?;
+            Ok(LandingCustomization {
+                header_bg: bg,
+                header_fg: fg,
+                intro,
+                intro_locales,
+            })
+        }
+    }
+}
+
+/// Replace the singleton with `lc`. Empty strings on the form
+/// arrive as `Some("")` from axum's Form extractor; this helper
+/// collapses them to `None` so empty values disappear from the
+/// exported YAML rather than serializing as `""`.
+pub async fn update(
+    pool: &SqlitePool,
+    lc: &LandingCustomization,
+    actor: Option<&str>,
+) -> Result<()> {
+    let now = Utc::now();
+    let intro_locales_json =
+        serde_json::to_string(&lc.intro_locales).context("serialize intro_locales")?;
+
+    let mut tx = pool.begin().await.context("begin landing update tx")?;
+
+    sqlx::query(
+        "UPDATE landing_customization
+            SET header_bg = ?, header_fg = ?, intro = ?,
+                intro_locales_json = ?, updated_at = ?
+          WHERE id = 1",
+    )
+    .bind(none_if_empty(&lc.header_bg))
+    .bind(none_if_empty(&lc.header_fg))
+    .bind(none_if_empty(&lc.intro))
+    .bind(&intro_locales_json)
+    .bind(now)
+    .execute(&mut *tx)
+    .await
+    .context("update landing_customization")?;
+
+    sqlx::query(
+        "INSERT INTO audit_log (actor, action, target, diff_json, occurred_at)
+         VALUES (?, 'landing.update', 'landing:customization', NULL, ?)",
+    )
+    .bind(actor)
+    .bind(now)
+    .execute(&mut *tx)
+    .await
+    .context("audit landing.update")?;
+
+    tx.commit().await.context("commit landing update")?;
+    Ok(())
+}
+
+fn none_if_empty(s: &Option<String>) -> Option<&str> {
+    s.as_deref().and_then(|x| {
+        let t = x.trim();
+        if t.is_empty() { None } else { Some(t) }
+    })
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::db::open_memory;
+
+    #[tokio::test]
+    async fn defaults_on_fresh_db() {
+        let pool = open_memory().await.unwrap();
+        let lc = fetch(&pool).await.unwrap();
+        assert!(lc.header_bg.is_none());
+        assert!(lc.intro.is_none());
+        assert!(lc.intro_locales.is_empty());
+    }
+
+    #[tokio::test]
+    async fn update_then_fetch_roundtrip() {
+        let pool = open_memory().await.unwrap();
+        let mut lc = LandingCustomization::default();
+        lc.header_bg = Some("#0f6e56".into());
+        lc.header_fg = Some("#ffffff".into());
+        lc.intro = Some("Welcome".into());
+        lc.intro_locales.insert("pt".into(), "Bem-vindo".into());
+        lc.intro_locales.insert("en".into(), "Welcome".into());
+
+        update(&pool, &lc, Some("admin")).await.unwrap();
+        let got = fetch(&pool).await.unwrap();
+        assert_eq!(got.header_bg.as_deref(), Some("#0f6e56"));
+        assert_eq!(got.header_fg.as_deref(), Some("#ffffff"));
+        assert_eq!(got.intro.as_deref(), Some("Welcome"));
+        assert_eq!(got.intro_locales.get("pt").map(String::as_str), Some("Bem-vindo"));
+        assert_eq!(got.intro_locales.get("en").map(String::as_str), Some("Welcome"));
+
+        // audit captured the event
+        let (n,): (i64,) =
+            sqlx::query_as("SELECT COUNT(*) FROM audit_log WHERE action='landing.update'")
+                .fetch_one(&pool)
+                .await
+                .unwrap();
+        assert_eq!(n, 1);
+    }
+
+    #[tokio::test]
+    async fn empty_strings_collapse_to_none() {
+        let pool = open_memory().await.unwrap();
+        let mut lc = LandingCustomization::default();
+        lc.header_bg = Some("   ".into()); // whitespace only
+        lc.intro = Some("".into());
+        update(&pool, &lc, None).await.unwrap();
+        let got = fetch(&pool).await.unwrap();
+        assert!(got.header_bg.is_none(), "whitespace-only becomes None");
+        assert!(got.intro.is_none());
+    }
+}

--- a/crates/ruscker-admin/src/db/specs.rs
+++ b/crates/ruscker-admin/src/db/specs.rs
@@ -64,6 +64,16 @@ pub async fn import_all(pool: &SqlitePool, config: &Config) -> Result<ImportRepo
     .await
     .context("update landing_customization")?;
 
+    // Persist the rest of `proxy` (everything except specs and
+    // landing-customization) + the top-level server / logging
+    // blocks as JSON blobs in config_meta. Lets export reconstruct
+    // a byte-equivalent (mod whitespace) YAML without inventing
+    // schema for every field the admin UI doesn't expose yet.
+    let proxy_meta = proxy_meta_value(&config.proxy)?;
+    upsert_meta(&mut tx, "proxy", &proxy_meta, now).await?;
+    upsert_meta(&mut tx, "server", &serde_json::to_value(&config.server)?, now).await?;
+    upsert_meta(&mut tx, "logging", &serde_json::to_value(&config.logging)?, now).await?;
+
     // System-level audit entry for the import.
     sqlx::query(
         "INSERT INTO audit_log (actor, action, target, diff_json, occurred_at)
@@ -200,6 +210,41 @@ async fn upsert_in_tx(
 fn canonical_json(spec: &Spec) -> Result<String> {
     let v = serde_json::to_value(spec)?;
     Ok(serde_json::to_string(&v)?)
+}
+
+/// Strip specs + landing-customization from a serialized Proxy so
+/// what lands in `config_meta` is just the "settings" parts. Those
+/// two fields have their own tables and would otherwise be stored
+/// twice with risk of drift.
+fn proxy_meta_value(proxy: &ruscker_config::Proxy) -> Result<serde_json::Value> {
+    let mut v = serde_json::to_value(proxy).context("serialize proxy")?;
+    if let Some(obj) = v.as_object_mut() {
+        obj.remove("specs");
+        obj.remove("landing-customization");
+    }
+    Ok(v)
+}
+
+/// INSERT-or-REPLACE a row in `config_meta`. Helper so the import
+/// flow reads cleanly.
+async fn upsert_meta(
+    tx: &mut sqlx::Transaction<'_, sqlx::Sqlite>,
+    key: &str,
+    value: &serde_json::Value,
+    now: DateTime<Utc>,
+) -> Result<()> {
+    let json = serde_json::to_string(value)?;
+    sqlx::query(
+        "INSERT OR REPLACE INTO config_meta (key, value_json, updated_at)
+         VALUES (?, ?, ?)",
+    )
+    .bind(key)
+    .bind(&json)
+    .bind(now)
+    .execute(&mut **tx)
+    .await
+    .with_context(|| format!("upsert config_meta[{key}]"))?;
+    Ok(())
 }
 
 fn kind_str(spec: &Spec) -> &'static str {

--- a/crates/ruscker-admin/src/db/specs.rs
+++ b/crates/ruscker-admin/src/db/specs.rs
@@ -1,0 +1,299 @@
+//! Spec repository — bulk import, single-row CRUD, version history.
+//!
+//! Reads/writes happen through these functions rather than ad-hoc
+//! SQL throughout the codebase. Keeps the schema's invariants
+//! (audit log + version bump on update) in one place.
+
+use anyhow::{Context, Result};
+use chrono::{DateTime, Utc};
+use ruscker_config::{Config, Spec};
+use sqlx::SqlitePool;
+
+/// What happened during [`import_all`].
+#[derive(Debug, Default, Clone)]
+pub struct ImportReport {
+    /// Specs newly inserted on this run.
+    pub created: usize,
+    /// Specs that already existed and were updated to a new version.
+    pub updated: usize,
+    /// Specs that existed unchanged (config_json identical).
+    pub unchanged: usize,
+}
+
+/// Import every spec from a parsed [`Config`] into the database.
+///
+/// Idempotent: re-running with the same YAML produces zero updates
+/// (specs with identical `config_json` are left alone). Modified
+/// specs bump their `version` counter and append a row to
+/// `spec_versions`. Specs present in the DB but **not** in the
+/// incoming config are NOT deleted — that's a separate operator
+/// action (no surprise destruction).
+///
+/// The whole import runs in a single transaction.
+pub async fn import_all(pool: &SqlitePool, config: &Config) -> Result<ImportReport> {
+    let now = Utc::now();
+    let mut tx = pool.begin().await.context("begin import tx")?;
+
+    let mut report = ImportReport::default();
+
+    for spec in &config.proxy.specs {
+        let outcome = upsert_in_tx(&mut tx, spec, now).await?;
+        match outcome {
+            UpsertOutcome::Created => report.created += 1,
+            UpsertOutcome::Updated => report.updated += 1,
+            UpsertOutcome::Unchanged => report.unchanged += 1,
+        }
+    }
+
+    // Landing customization is a singleton — replace it whole.
+    let lc = &config.proxy.landing_customization;
+    let intro_locales_json = serde_json::to_string(&lc.intro_locales)
+        .context("serialize intro_locales")?;
+    sqlx::query(
+        "UPDATE landing_customization
+            SET header_bg = ?, header_fg = ?, intro = ?,
+                intro_locales_json = ?, updated_at = ?
+          WHERE id = 1",
+    )
+    .bind(&lc.header_bg)
+    .bind(&lc.header_fg)
+    .bind(&lc.intro)
+    .bind(&intro_locales_json)
+    .bind(now)
+    .execute(&mut *tx)
+    .await
+    .context("update landing_customization")?;
+
+    // System-level audit entry for the import.
+    sqlx::query(
+        "INSERT INTO audit_log (actor, action, target, diff_json, occurred_at)
+         VALUES (NULL, 'spec.import', NULL, ?, ?)",
+    )
+    .bind(serde_json::to_string(&serde_json::json!({
+        "created": report.created,
+        "updated": report.updated,
+        "unchanged": report.unchanged,
+    }))?)
+    .bind(now)
+    .execute(&mut *tx)
+    .await
+    .context("audit import")?;
+
+    tx.commit().await.context("commit import tx")?;
+    Ok(report)
+}
+
+#[derive(Debug, PartialEq, Eq)]
+enum UpsertOutcome {
+    Created,
+    Updated,
+    Unchanged,
+}
+
+async fn upsert_in_tx(
+    tx: &mut sqlx::Transaction<'_, sqlx::Sqlite>,
+    spec: &Spec,
+    now: DateTime<Utc>,
+) -> Result<UpsertOutcome> {
+    let config_json = canonical_json(spec)
+        .with_context(|| format!("serialize spec {}", spec.id))?;
+    let kind = kind_str(spec);
+    let state = if spec.template_properties.is_active() { "active" } else { "inactive" };
+
+    // Check existing
+    let existing: Option<(String, i64)> = sqlx::query_as(
+        "SELECT config_json, version FROM specs WHERE id = ?",
+    )
+    .bind(&spec.id)
+    .fetch_optional(&mut **tx)
+    .await
+    .with_context(|| format!("lookup spec {}", spec.id))?;
+
+    match existing {
+        None => {
+            sqlx::query(
+                "INSERT INTO specs (id, display_name, description, kind,
+                                    container_image, config_json, state,
+                                    created_at, updated_at, version)
+                 VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, 1)",
+            )
+            .bind(&spec.id)
+            .bind(spec.display_name.as_deref())
+            .bind(spec.description.as_deref())
+            .bind(kind)
+            .bind(spec.container_image.as_deref())
+            .bind(&config_json)
+            .bind(state)
+            .bind(now)
+            .bind(now)
+            .execute(&mut **tx)
+            .await
+            .with_context(|| format!("insert spec {}", spec.id))?;
+
+            sqlx::query(
+                "INSERT INTO spec_versions (spec_id, version, config_json, changed_at, changed_by)
+                 VALUES (?, 1, ?, ?, NULL)",
+            )
+            .bind(&spec.id)
+            .bind(&config_json)
+            .bind(now)
+            .execute(&mut **tx)
+            .await
+            .with_context(|| format!("insert v1 history for {}", spec.id))?;
+
+            Ok(UpsertOutcome::Created)
+        }
+        Some((existing_json, version)) => {
+            if existing_json == config_json {
+                return Ok(UpsertOutcome::Unchanged);
+            }
+            let next_version = version + 1;
+            sqlx::query(
+                "UPDATE specs
+                    SET display_name = ?, description = ?, kind = ?,
+                        container_image = ?, config_json = ?, state = ?,
+                        updated_at = ?, version = ?
+                  WHERE id = ?",
+            )
+            .bind(spec.display_name.as_deref())
+            .bind(spec.description.as_deref())
+            .bind(kind)
+            .bind(spec.container_image.as_deref())
+            .bind(&config_json)
+            .bind(state)
+            .bind(now)
+            .bind(next_version)
+            .bind(&spec.id)
+            .execute(&mut **tx)
+            .await
+            .with_context(|| format!("update spec {}", spec.id))?;
+
+            sqlx::query(
+                "INSERT INTO spec_versions (spec_id, version, config_json, changed_at, changed_by)
+                 VALUES (?, ?, ?, ?, NULL)",
+            )
+            .bind(&spec.id)
+            .bind(next_version)
+            .bind(&config_json)
+            .bind(now)
+            .execute(&mut **tx)
+            .await
+            .with_context(|| format!("history v{next_version} for {}", spec.id))?;
+
+            Ok(UpsertOutcome::Updated)
+        }
+    }
+}
+
+/// Serialize a `Spec` to canonical (alphabetically sorted) JSON.
+///
+/// Plain `serde_json::to_string(spec)` is NOT deterministic across
+/// parses of the same YAML, because [`TemplateProperties`] wraps a
+/// `HashMap` whose iteration order is randomized per-process. The
+/// importer relies on byte-equal JSON to detect "unchanged" specs;
+/// without canonicalization every re-import marks every spec as
+/// updated and pollutes spec_versions with phantom history.
+///
+/// Round-tripping through `serde_json::Value` normalizes objects
+/// to `serde_json::Map`, which is BTreeMap-backed and therefore
+/// alphabetically sorted on serialization.
+fn canonical_json(spec: &Spec) -> Result<String> {
+    let v = serde_json::to_value(spec)?;
+    Ok(serde_json::to_string(&v)?)
+}
+
+fn kind_str(spec: &Spec) -> &'static str {
+    use ruscker_config::SpecKind;
+    match spec.kind() {
+        SpecKind::Shiny => "shiny",
+        SpecKind::InteractiveApp => "interactive",
+        SpecKind::Api => "api",
+        SpecKind::External => "external",
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::db::open_memory;
+
+    fn fixture_yaml() -> String {
+        std::env::set_var("DOCKER_REGISTRY_PASSWORD", "test");
+        std::fs::read_to_string("../../examples/application.yml").unwrap()
+    }
+
+    #[tokio::test]
+    async fn imports_31_specs_then_roundtrip_is_unchanged() {
+        let pool = open_memory().await.unwrap();
+        let cfg = Config::from_yaml(&fixture_yaml()).unwrap();
+
+        let r1 = import_all(&pool, &cfg).await.unwrap();
+        assert_eq!(r1.created, 31, "first import inserts all");
+        assert_eq!(r1.updated, 0);
+        assert_eq!(r1.unchanged, 0);
+
+        let r2 = import_all(&pool, &cfg).await.unwrap();
+        assert_eq!(r2.created, 0, "second import sees them as existing");
+        assert_eq!(r2.updated, 0, "no changes → no version bumps");
+        assert_eq!(r2.unchanged, 31);
+
+        // Audit log got both import events.
+        let audit_count: (i64,) = sqlx::query_as(
+            "SELECT COUNT(*) FROM audit_log WHERE action = 'spec.import'",
+        )
+        .fetch_one(&pool)
+        .await
+        .unwrap();
+        assert_eq!(audit_count.0, 2);
+    }
+
+    #[tokio::test]
+    async fn modifying_a_spec_bumps_version() {
+        let pool = open_memory().await.unwrap();
+        let mut cfg = Config::from_yaml(&fixture_yaml()).unwrap();
+        import_all(&pool, &cfg).await.unwrap();
+
+        // Tweak one spec's description and re-import.
+        cfg.proxy.specs[0].description = Some("Updated description".to_string());
+        let r = import_all(&pool, &cfg).await.unwrap();
+        assert_eq!(r.updated, 1);
+        assert_eq!(r.unchanged, 30);
+
+        let (version,): (i64,) = sqlx::query_as("SELECT version FROM specs WHERE id = ?")
+            .bind(&cfg.proxy.specs[0].id)
+            .fetch_one(&pool)
+            .await
+            .unwrap();
+        assert_eq!(version, 2);
+
+        let (history_count,): (i64,) = sqlx::query_as(
+            "SELECT COUNT(*) FROM spec_versions WHERE spec_id = ?",
+        )
+        .bind(&cfg.proxy.specs[0].id)
+        .fetch_one(&pool)
+        .await
+        .unwrap();
+        assert_eq!(history_count, 2, "v1 + v2 in history");
+    }
+
+    #[tokio::test]
+    async fn landing_customization_round_trips() {
+        let pool = open_memory().await.unwrap();
+        let cfg = Config::from_yaml(&fixture_yaml()).unwrap();
+        import_all(&pool, &cfg).await.unwrap();
+
+        let row: (Option<String>, Option<String>, Option<String>, String) = sqlx::query_as(
+            "SELECT header_bg, header_fg, intro, intro_locales_json
+               FROM landing_customization WHERE id = 1",
+        )
+        .fetch_one(&pool)
+        .await
+        .unwrap();
+        // examples/application.yml has header-bg=#0f6e56 and intro-locales for all 4 langs
+        assert_eq!(row.0.as_deref(), Some("#0f6e56"));
+        let parsed: std::collections::HashMap<String, String> =
+            serde_json::from_str(&row.3).unwrap();
+        assert!(parsed.contains_key("pt"));
+        assert!(parsed.contains_key("en"));
+    }
+}

--- a/crates/ruscker-admin/src/db/specs.rs
+++ b/crates/ruscker-admin/src/db/specs.rs
@@ -94,10 +94,92 @@ pub async fn import_all(pool: &SqlitePool, config: &Config) -> Result<ImportRepo
 }
 
 #[derive(Debug, PartialEq, Eq)]
-enum UpsertOutcome {
+pub enum UpsertOutcome {
     Created,
     Updated,
     Unchanged,
+}
+
+/// Fetch a single spec by id, deserializing `config_json` back to
+/// a [`Spec`]. Returns `None` if no row matches.
+pub async fn fetch_one(pool: &SqlitePool, id: &str) -> Result<Option<Spec>> {
+    let row: Option<(String,)> =
+        sqlx::query_as("SELECT config_json FROM specs WHERE id = ?")
+            .bind(id)
+            .fetch_optional(pool)
+            .await
+            .with_context(|| format!("fetch spec {id}"))?;
+    match row {
+        None => Ok(None),
+        Some((json,)) => {
+            let s: Spec = serde_json::from_str(&json)
+                .with_context(|| format!("deserialize spec {id}"))?;
+            Ok(Some(s))
+        }
+    }
+}
+
+/// Upsert a single spec — used by the admin form. Wraps the same
+/// logic as `import_all`'s per-row path in its own transaction
+/// (with an audit-log entry tagged with `actor` if provided).
+pub async fn upsert_one(
+    pool: &SqlitePool,
+    spec: &Spec,
+    actor: Option<&str>,
+) -> Result<UpsertOutcome> {
+    let now = Utc::now();
+    let mut tx = pool.begin().await.context("begin upsert tx")?;
+    let outcome = upsert_in_tx(&mut tx, spec, now).await?;
+    if outcome != UpsertOutcome::Unchanged {
+        let action = if outcome == UpsertOutcome::Created {
+            "spec.create"
+        } else {
+            "spec.update"
+        };
+        sqlx::query(
+            "INSERT INTO audit_log (actor, action, target, diff_json, occurred_at)
+             VALUES (?, ?, ?, NULL, ?)",
+        )
+        .bind(actor)
+        .bind(action)
+        .bind(format!("spec:{}", spec.id))
+        .bind(now)
+        .execute(&mut *tx)
+        .await
+        .context("audit upsert_one")?;
+    }
+    tx.commit().await.context("commit upsert_one tx")?;
+    Ok(outcome)
+}
+
+/// Delete a spec and all its history. Returns `true` if a row was
+/// actually removed (false if the id didn't exist). Audit log
+/// records the action either way.
+pub async fn delete_one(pool: &SqlitePool, id: &str, actor: Option<&str>) -> Result<bool> {
+    let now = Utc::now();
+    let mut tx = pool.begin().await.context("begin delete tx")?;
+    // ON DELETE CASCADE handles spec_versions; we still need to
+    // delete the specs row itself.
+    let rows = sqlx::query("DELETE FROM specs WHERE id = ?")
+        .bind(id)
+        .execute(&mut *tx)
+        .await
+        .with_context(|| format!("delete spec {id}"))?;
+    let removed = rows.rows_affected() > 0;
+    if removed {
+        sqlx::query(
+            "INSERT INTO audit_log (actor, action, target, diff_json, occurred_at)
+             VALUES (?, 'spec.delete', ?, NULL, ?)",
+        )
+        .bind(actor)
+        .bind(format!("spec:{id}"))
+        .bind(now)
+        .execute(&mut *tx)
+        .await
+        .context("audit delete")?;
+    }
+    tx.commit().await.context("commit delete tx")?;
+    Ok(removed)
 }
 
 async fn upsert_in_tx(

--- a/crates/ruscker-admin/src/images.rs
+++ b/crates/ruscker-admin/src/images.rs
@@ -1,0 +1,222 @@
+//! Image processing — MIME sniffing, decode, WebP re-encoding.
+//!
+//! Operators can upload PNG/JPEG/SVG/WebP. PNG and JPEG are
+//! re-encoded to WebP at quality 80 (best size/visual trade-off
+//! for screenshots and logos). SVG is passed through unchanged
+//! since vector logos shouldn't be rasterized; the MIME stays
+//! `image/svg+xml`. WebP uploads are passed through as-is.
+//!
+//! Returned [`Processed`] carries everything `db::images::insert`
+//! needs to write a row. No DB code lives here so this module
+//! stays pure / unit-testable.
+
+use anyhow::{anyhow, Context, Result};
+use image::ImageReader;
+use std::io::Cursor;
+
+/// Maximum source upload size accepted. Anything bigger is
+/// rejected before decoding — protects against
+/// decompression-bomb-style memory attacks.
+pub const MAX_UPLOAD_BYTES: usize = 10 * 1024 * 1024;
+
+/// Soft target after re-encoding. Larger uploads still go through
+/// but produce a `tracing::warn`. Used by callers to surface a UI
+/// warning.
+pub const SOFT_TARGET_BYTES: usize = 500 * 1024;
+
+/// Output of [`process_upload`] — everything `db::images::insert`
+/// needs and nothing it doesn't.
+pub struct Processed {
+    pub filename: String,
+    pub mime_type: String,
+    pub bytes: Vec<u8>,
+    pub width: Option<u32>,
+    pub height: Option<u32>,
+}
+
+/// Accepted MIME categories.
+#[derive(Debug, PartialEq, Eq)]
+pub enum SourceKind {
+    Png,
+    Jpeg,
+    Webp,
+    Svg,
+}
+
+impl SourceKind {
+    /// Sniff bytes (preferred) and fall back to the operator-
+    /// supplied content-type. Returns `None` for anything outside
+    /// the allowlist.
+    pub fn detect(bytes: &[u8], supplied_mime: Option<&str>) -> Option<Self> {
+        // 1. Magic-byte sniff — fast and lie-proof for the raster
+        //    formats. We only act on positive raster matches here;
+        //    a "yes that's XML" answer from infer doesn't help us
+        //    distinguish SVG from any other XML.
+        if let Some(kind) = infer::get(bytes) {
+            match kind.mime_type() {
+                "image/png" => return Some(Self::Png),
+                "image/jpeg" => return Some(Self::Jpeg),
+                "image/webp" => return Some(Self::Webp),
+                _ => {} // fall through
+            }
+        }
+        // 2. SVG: text-sniff because it's plain XML.
+        if looks_like_svg(bytes) {
+            return Some(Self::Svg);
+        }
+        // 3. Last resort: trust the client-declared MIME.
+        match supplied_mime? {
+            "image/svg+xml" => Some(Self::Svg),
+            "image/png" => Some(Self::Png),
+            "image/jpeg" => Some(Self::Jpeg),
+            "image/webp" => Some(Self::Webp),
+            _ => None,
+        }
+    }
+}
+
+fn looks_like_svg(bytes: &[u8]) -> bool {
+    let prefix = std::str::from_utf8(&bytes[..bytes.len().min(512)]).unwrap_or("");
+    let prefix = prefix.trim_start();
+    prefix.starts_with("<?xml") && prefix.contains("<svg")
+        || prefix.starts_with("<svg")
+}
+
+/// Decode + re-encode the upload. Returns `Err` on unsupported
+/// MIME, decompression-bomb-sized inputs, or decode failures.
+///
+/// Filenames are normalized: any path components stripped, then
+/// the extension rewritten to `.webp` for PNG/JPEG conversions.
+/// SVG keeps `.svg`. WebP keeps `.webp`.
+pub fn process_upload(
+    raw_filename: &str,
+    supplied_mime: Option<&str>,
+    bytes: Vec<u8>,
+) -> Result<Processed> {
+    if bytes.len() > MAX_UPLOAD_BYTES {
+        return Err(anyhow!(
+            "upload exceeds {} MB cap",
+            MAX_UPLOAD_BYTES / 1024 / 1024
+        ));
+    }
+    let kind = SourceKind::detect(&bytes, supplied_mime)
+        .ok_or_else(|| anyhow!("unsupported MIME (PNG/JPEG/WebP/SVG only)"))?;
+
+    let base = sanitize_basename(raw_filename);
+    if base.is_empty() {
+        return Err(anyhow!("filename cannot be empty"));
+    }
+
+    match kind {
+        SourceKind::Png | SourceKind::Jpeg => {
+            let (webp_bytes, w, h) = encode_to_webp(&bytes).context("convert to WebP")?;
+            let filename = rewrite_extension(&base, "webp");
+            if webp_bytes.len() > SOFT_TARGET_BYTES {
+                tracing::warn!(
+                    filename = %filename,
+                    bytes = webp_bytes.len(),
+                    "image larger than {} KB after WebP encoding",
+                    SOFT_TARGET_BYTES / 1024
+                );
+            }
+            Ok(Processed {
+                filename,
+                mime_type: "image/webp".into(),
+                bytes: webp_bytes,
+                width: Some(w),
+                height: Some(h),
+            })
+        }
+        SourceKind::Webp => {
+            let dims = decode_dimensions(&bytes).ok();
+            Ok(Processed {
+                filename: rewrite_extension(&base, "webp"),
+                mime_type: "image/webp".into(),
+                bytes,
+                width: dims.map(|(w, _)| w),
+                height: dims.map(|(_, h)| h),
+            })
+        }
+        SourceKind::Svg => Ok(Processed {
+            filename: rewrite_extension(&base, "svg"),
+            mime_type: "image/svg+xml".into(),
+            bytes,
+            width: None,
+            height: None,
+        }),
+    }
+}
+
+/// Strip any directory components and any leading dots, lowercase
+/// the result. Prevents path-traversal via crafted filenames.
+fn sanitize_basename(name: &str) -> String {
+    let basename = std::path::Path::new(name)
+        .file_name()
+        .and_then(|s| s.to_str())
+        .unwrap_or("");
+    basename
+        .trim_start_matches('.')
+        .chars()
+        .filter(|c| c.is_ascii_alphanumeric() || matches!(c, '.' | '-' | '_'))
+        .collect::<String>()
+        .to_ascii_lowercase()
+}
+
+fn rewrite_extension(name: &str, new_ext: &str) -> String {
+    let stem = name.rsplit_once('.').map(|(s, _)| s).unwrap_or(name);
+    format!("{stem}.{new_ext}")
+}
+
+fn encode_to_webp(bytes: &[u8]) -> Result<(Vec<u8>, u32, u32)> {
+    let img = ImageReader::new(Cursor::new(bytes))
+        .with_guessed_format()
+        .context("guess format")?
+        .decode()
+        .context("decode source image")?;
+
+    let (w, h) = (img.width(), img.height());
+    let mut out: Vec<u8> = Vec::with_capacity(bytes.len() / 2);
+    img.write_to(&mut Cursor::new(&mut out), image::ImageFormat::WebP)
+        .context("write WebP")?;
+    Ok((out, w, h))
+}
+
+fn decode_dimensions(bytes: &[u8]) -> Result<(u32, u32)> {
+    let img = ImageReader::new(Cursor::new(bytes))
+        .with_guessed_format()?
+        .decode()?;
+    Ok((img.width(), img.height()))
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn sanitize_strips_paths_and_normalizes() {
+        assert_eq!(sanitize_basename("../../etc/passwd"), "passwd");
+        assert_eq!(sanitize_basename("foo bar.png"), "foobar.png");
+        assert_eq!(sanitize_basename("CAPS.PNG"), "caps.png");
+        assert_eq!(sanitize_basename(".hidden"), "hidden");
+    }
+
+    #[test]
+    fn detects_svg_text() {
+        let svg = br#"<?xml version="1.0"?><svg xmlns="http://www.w3.org/2000/svg"/>"#;
+        assert_eq!(SourceKind::detect(svg, None), Some(SourceKind::Svg));
+        let bare = br#"<svg xmlns="http://www.w3.org/2000/svg"/>"#;
+        assert_eq!(SourceKind::detect(bare, None), Some(SourceKind::Svg));
+    }
+
+    #[test]
+    fn rejects_unknown_mime() {
+        let junk = b"this is not an image at all";
+        assert!(SourceKind::detect(junk, None).is_none());
+    }
+
+    #[test]
+    fn process_rejects_oversize() {
+        let bytes = vec![0u8; MAX_UPLOAD_BYTES + 1];
+        assert!(process_upload("x.png", Some("image/png"), bytes).is_err());
+    }
+}

--- a/crates/ruscker-admin/src/lib.rs
+++ b/crates/ruscker-admin/src/lib.rs
@@ -24,17 +24,24 @@ use tower_cookies::CookieManagerLayer;
 use tower_http::services::ServeDir;
 use tracing::info;
 
+pub mod auth;
 pub mod db;
 pub mod i18n;
 pub mod routes;
 pub mod theme;
 pub mod view_model;
 
+use sqlx::SqlitePool;
+
 /// Shared state injected into every request.
 #[derive(Clone)]
 pub struct AppState {
     pub config: Arc<Config>,
     pub locales: Arc<i18n::Locales>,
+    pub admin_auth: auth::AdminAuth,
+    /// Optional SQLite pool. `None` ⇒ admin CRUD routes 503
+    /// because they have no source of truth to read or write.
+    pub db: Option<SqlitePool>,
 }
 
 /// HTTP server hosting the landing and (later) the admin panel.
@@ -60,6 +67,8 @@ impl AdminServer {
         let state = AppState {
             config: Arc::new(config),
             locales: Arc::new(locales),
+            admin_auth: auth::AdminAuth::from_env(),
+            db: None,
         };
         Ok(Self {
             addr,
@@ -73,6 +82,23 @@ impl AdminServer {
     /// responds 404 for missing files, never directory-lists.
     pub fn with_images_dir(mut self, dir: impl AsRef<Path>) -> Self {
         self.images_dir = Some(dir.as_ref().to_path_buf());
+        self
+    }
+
+    /// Override the admin token (default: pulled from
+    /// `RUSCKER_ADMIN_TOKEN` env var). Useful for tests that need
+    /// a known token without touching the process environment.
+    pub fn with_admin_token(mut self, token: impl Into<String>) -> Self {
+        self.state.admin_auth = auth::AdminAuth::with_token(token);
+        self
+    }
+
+    /// Attach a SQLite pool. Required for the `/admin/*` routes
+    /// that read or write the spec catalog. The pool is shared
+    /// across all requests — sqlx handles the connection
+    /// multiplexing.
+    pub fn with_db(mut self, pool: SqlitePool) -> Self {
+        self.state.db = Some(pool);
         self
     }
 
@@ -102,7 +128,8 @@ pub fn router_with_images(state: AppState, images_dir: Option<&Path>) -> Router 
     let mut r = Router::new()
         .merge(routes::landing::routes())
         .merge(routes::assets::routes())
-        .merge(routes::prefs::routes());
+        .merge(routes::prefs::routes())
+        .merge(routes::admin::routes());
     if let Some(dir) = images_dir {
         // ServeDir handles 404, content-type sniffing, and range
         // requests. Specific routes in routes::assets (e.g.

--- a/crates/ruscker-admin/src/lib.rs
+++ b/crates/ruscker-admin/src/lib.rs
@@ -24,6 +24,7 @@ use tower_cookies::CookieManagerLayer;
 use tower_http::services::ServeDir;
 use tracing::info;
 
+pub mod db;
 pub mod i18n;
 pub mod routes;
 pub mod theme;

--- a/crates/ruscker-admin/src/lib.rs
+++ b/crates/ruscker-admin/src/lib.rs
@@ -21,12 +21,12 @@ use std::path::{Path, PathBuf};
 use std::sync::Arc;
 use tokio::net::TcpListener;
 use tower_cookies::CookieManagerLayer;
-use tower_http::services::ServeDir;
 use tracing::info;
 
 pub mod auth;
 pub mod db;
 pub mod i18n;
+pub mod images;
 pub mod routes;
 pub mod theme;
 pub mod view_model;
@@ -42,6 +42,11 @@ pub struct AppState {
     /// Optional SQLite pool. `None` ⇒ admin CRUD routes 503
     /// because they have no source of truth to read or write.
     pub db: Option<SqlitePool>,
+    /// On-disk fallback directory for `/assets/img/<file>`. When
+    /// the DB lookup misses (or `db` is `None`), the assets route
+    /// falls through to this directory before 404'ing. `None`
+    /// disables the disk fallback entirely.
+    pub images_dir: Option<Arc<Path>>,
 }
 
 /// HTTP server hosting the landing and (later) the admin panel.
@@ -69,6 +74,7 @@ impl AdminServer {
             locales: Arc::new(locales),
             admin_auth: auth::AdminAuth::from_env(),
             db: None,
+            images_dir: None,
         };
         Ok(Self {
             addr,
@@ -77,11 +83,15 @@ impl AdminServer {
         })
     }
 
-    /// Set the on-disk directory served at `/assets/img/`. Files
-    /// must already exist when the server starts — `ServeDir`
-    /// responds 404 for missing files, never directory-lists.
+    /// Set the on-disk fallback directory for `/assets/img/<file>`.
+    /// When the DB image library has the filename it wins; otherwise
+    /// the handler reads from this directory. `None` disables the
+    /// fallback (DB-only mode).
     pub fn with_images_dir(mut self, dir: impl AsRef<Path>) -> Self {
-        self.images_dir = Some(dir.as_ref().to_path_buf());
+        let pathbuf = dir.as_ref().to_path_buf();
+        let arc: Arc<Path> = Arc::from(pathbuf.clone().into_boxed_path());
+        self.images_dir = Some(pathbuf);
+        self.state.images_dir = Some(arc);
         self
     }
 
@@ -122,20 +132,15 @@ pub fn router(state: AppState) -> Router {
     router_with_images(state, None)
 }
 
-/// Same as [`router`], but also mounts `images_dir` at
-/// `/assets/img/` via [`ServeDir`]. `None` skips the mount entirely.
-pub fn router_with_images(state: AppState, images_dir: Option<&Path>) -> Router {
-    let mut r = Router::new()
+/// Deprecated alias kept for the CLI's call site — the
+/// `images_dir` argument is now ignored because state carries the
+/// fallback directory itself (set via [`AdminServer::with_images_dir`]).
+pub fn router_with_images(state: AppState, _images_dir: Option<&Path>) -> Router {
+    Router::new()
         .merge(routes::landing::routes())
         .merge(routes::assets::routes())
         .merge(routes::prefs::routes())
-        .merge(routes::admin::routes());
-    if let Some(dir) = images_dir {
-        // ServeDir handles 404, content-type sniffing, and range
-        // requests. Specific routes in routes::assets (e.g.
-        // /assets/styles.css) take precedence — only the `img`
-        // subtree is delegated to disk.
-        r = r.nest_service("/assets/img", ServeDir::new(dir));
-    }
-    r.layer(CookieManagerLayer::new()).with_state(state)
+        .merge(routes::admin::routes())
+        .layer(CookieManagerLayer::new())
+        .with_state(state)
 }

--- a/crates/ruscker-admin/src/lib.rs
+++ b/crates/ruscker-admin/src/lib.rs
@@ -24,6 +24,7 @@ use tower_cookies::CookieManagerLayer;
 use tracing::info;
 
 pub mod auth;
+pub mod crypto;
 pub mod db;
 pub mod i18n;
 pub mod images;
@@ -47,6 +48,10 @@ pub struct AppState {
     /// falls through to this directory before 404'ing. `None`
     /// disables the disk fallback entirely.
     pub images_dir: Option<Arc<Path>>,
+    /// Master key for the credentials store. When unset, the
+    /// `/admin/credentials` route 503s with a hint to set
+    /// `RUSCKER_MASTER_KEY`.
+    pub master_key: crypto::MasterKey,
 }
 
 /// HTTP server hosting the landing and (later) the admin panel.
@@ -75,6 +80,7 @@ impl AdminServer {
             admin_auth: auth::AdminAuth::from_env(),
             db: None,
             images_dir: None,
+            master_key: crypto::MasterKey::from_env().context("load master key")?,
         };
         Ok(Self {
             addr,
@@ -101,6 +107,13 @@ impl AdminServer {
     pub fn with_admin_token(mut self, token: impl Into<String>) -> Self {
         self.state.admin_auth = auth::AdminAuth::with_token(token);
         self
+    }
+
+    /// Override the credentials master key (default: pulled from
+    /// `RUSCKER_MASTER_KEY`). Accepts hex (64ch) or base64 (44ch).
+    pub fn with_master_key(mut self, raw: impl AsRef<str>) -> Result<Self> {
+        self.state.master_key = crypto::MasterKey::from_str(raw.as_ref())?;
+        Ok(self)
     }
 
     /// Attach a SQLite pool. Required for the `/admin/*` routes

--- a/crates/ruscker-admin/src/routes/admin.rs
+++ b/crates/ruscker-admin/src/routes/admin.rs
@@ -23,6 +23,7 @@ use crate::AppState;
 
 pub mod credentials;
 pub mod images;
+pub mod landing;
 pub mod spec_form;
 pub mod specs;
 
@@ -35,6 +36,7 @@ pub fn routes() -> Router<AppState> {
         .merge(spec_form::routes())
         .merge(images::routes())
         .merge(credentials::routes())
+        .merge(landing::routes())
 }
 
 // ── Templates ────────────────────────────────────────────────────

--- a/crates/ruscker-admin/src/routes/admin.rs
+++ b/crates/ruscker-admin/src/routes/admin.rs
@@ -21,6 +21,7 @@ use crate::i18n::{Locale, Locales};
 use crate::theme::Theme;
 use crate::AppState;
 
+pub mod images;
 pub mod spec_form;
 pub mod specs;
 
@@ -31,6 +32,7 @@ pub fn routes() -> Router<AppState> {
         .route("/admin/logout", post(logout))
         .merge(specs::routes())
         .merge(spec_form::routes())
+        .merge(images::routes())
 }
 
 // ── Templates ────────────────────────────────────────────────────

--- a/crates/ruscker-admin/src/routes/admin.rs
+++ b/crates/ruscker-admin/src/routes/admin.rs
@@ -21,6 +21,7 @@ use crate::i18n::{Locale, Locales};
 use crate::theme::Theme;
 use crate::AppState;
 
+pub mod credentials;
 pub mod images;
 pub mod spec_form;
 pub mod specs;
@@ -33,6 +34,7 @@ pub fn routes() -> Router<AppState> {
         .merge(specs::routes())
         .merge(spec_form::routes())
         .merge(images::routes())
+        .merge(credentials::routes())
 }
 
 // ── Templates ────────────────────────────────────────────────────

--- a/crates/ruscker-admin/src/routes/admin.rs
+++ b/crates/ruscker-admin/src/routes/admin.rs
@@ -21,6 +21,7 @@ use crate::i18n::{Locale, Locales};
 use crate::theme::Theme;
 use crate::AppState;
 
+pub mod audit;
 pub mod credentials;
 pub mod images;
 pub mod landing;
@@ -37,6 +38,7 @@ pub fn routes() -> Router<AppState> {
         .merge(images::routes())
         .merge(credentials::routes())
         .merge(landing::routes())
+        .merge(audit::routes())
 }
 
 // ── Templates ────────────────────────────────────────────────────

--- a/crates/ruscker-admin/src/routes/admin.rs
+++ b/crates/ruscker-admin/src/routes/admin.rs
@@ -1,0 +1,158 @@
+//! Admin routes — login, logout, and the `/admin/*` subtree.
+//!
+//! All routes here either render the login form or assume an
+//! authenticated session (via [`crate::auth::AdminSession`]). The
+//! login form does NOT require auth; everything else does.
+
+use askama::Template;
+use axum::{
+    extract::{Form, State},
+    http::{header::REFERER, HeaderMap, StatusCode},
+    response::{Html, IntoResponse, Redirect, Response},
+    routing::{get, post},
+    Router,
+};
+use serde::Deserialize;
+use tower_cookies::cookie::time::Duration;
+use tower_cookies::{Cookie, Cookies};
+
+use crate::auth::{AdminSession, MaybeAdminSession, COOKIE_NAME};
+use crate::i18n::{Locale, Locales};
+use crate::theme::Theme;
+use crate::AppState;
+
+pub mod specs;
+
+pub fn routes() -> Router<AppState> {
+    Router::new()
+        .route("/admin", get(redirect_to_specs))
+        .route("/admin/login", get(login_form).post(login_submit))
+        .route("/admin/logout", post(logout))
+        .merge(specs::routes())
+}
+
+// ── Templates ────────────────────────────────────────────────────
+
+#[derive(Template)]
+#[template(path = "admin/login.html")]
+struct LoginPage<'a> {
+    locale: Locale,
+    theme: Theme,
+    locales: &'a Locales,
+    locales_all: &'static [Locale],
+    /// "wrong-token" when the previous submit failed, otherwise empty.
+    /// Drives the inline error banner.
+    error: &'static str,
+}
+
+impl LoginPage<'_> {
+    fn t(&self, key: &str) -> String {
+        self.locales.t(self.locale, key, None)
+    }
+}
+
+// ── Handlers ─────────────────────────────────────────────────────
+
+async fn redirect_to_specs(_: AdminSession) -> Redirect {
+    Redirect::to("/admin/specs")
+}
+
+async fn login_form(
+    State(state): State<AppState>,
+    loc: Locale,
+    theme: Theme,
+) -> Response {
+    let page = LoginPage {
+        locale: loc,
+        theme,
+        locales: &state.locales,
+        locales_all: &Locale::ALL,
+        error: "",
+    };
+    render(&page)
+}
+
+#[derive(Debug, Deserialize)]
+pub struct LoginForm {
+    pub token: String,
+}
+
+async fn login_submit(
+    State(state): State<AppState>,
+    cookies: Cookies,
+    loc: Locale,
+    theme: Theme,
+    headers: HeaderMap,
+    Form(form): Form<LoginForm>,
+) -> Response {
+    if !state.admin_auth.is_configured() {
+        return (
+            StatusCode::SERVICE_UNAVAILABLE,
+            "RUSCKER_ADMIN_TOKEN is not set — admin disabled",
+        )
+            .into_response();
+    }
+
+    if !state.admin_auth.matches(&form.token) {
+        // Re-render the form with the error banner. 401 status so
+        // CLI clients / tests can distinguish.
+        let page = LoginPage {
+            locale: loc,
+            theme,
+            locales: &state.locales,
+            locales_all: &Locale::ALL,
+            error: "wrong-token",
+        };
+        let body = match page.render() {
+            Ok(s) => s,
+            Err(_) => return (StatusCode::INTERNAL_SERVER_ERROR, "render").into_response(),
+        };
+        let mut resp = (StatusCode::UNAUTHORIZED, Html(body)).into_response();
+        // Failed login also clears any stale cookie.
+        cookies.remove(Cookie::new(COOKIE_NAME, ""));
+        // 401 keeps the URL at /admin/login so the user can retry.
+        resp.headers_mut()
+            .insert("X-Ruscker-Login", "failed".parse().unwrap());
+        return resp;
+    }
+
+    // Success — set the cookie. 24h lifetime; re-login required
+    // after that. Long enough that operators don't have to log in
+    // multiple times per day, short enough that a left-open tab on
+    // a shared device expires within a workday.
+    let mut c = Cookie::new(COOKIE_NAME, form.token);
+    c.set_path("/");
+    c.set_http_only(true);
+    c.set_same_site(tower_cookies::cookie::SameSite::Strict);
+    c.set_max_age(Duration::hours(24));
+    cookies.add(c);
+
+    // Redirect to the page the operator was trying to reach. The
+    // login form preserves the destination in a `?next=` param —
+    // not implemented yet, so default to /admin/specs.
+    let target = headers
+        .get(REFERER)
+        .and_then(|v| v.to_str().ok())
+        .filter(|r| r.contains("/admin/") && !r.contains("/admin/login"))
+        .unwrap_or("/admin/specs");
+    Redirect::to(target).into_response()
+}
+
+async fn logout(_: MaybeAdminSession, cookies: Cookies) -> Redirect {
+    // Remove sets an expired cookie with the same name+path.
+    let mut c = Cookie::new(COOKIE_NAME, "");
+    c.set_path("/");
+    cookies.remove(c);
+    Redirect::to("/admin/login")
+}
+
+/// Shared `Template → Response` (matches what landing.rs uses).
+pub(crate) fn render<T: Template>(t: &T) -> Response {
+    match t.render() {
+        Ok(html) => Html(html).into_response(),
+        Err(err) => {
+            tracing::error!(error = ?err, "admin template render failed");
+            (StatusCode::INTERNAL_SERVER_ERROR, "template error").into_response()
+        }
+    }
+}

--- a/crates/ruscker-admin/src/routes/admin.rs
+++ b/crates/ruscker-admin/src/routes/admin.rs
@@ -21,6 +21,7 @@ use crate::i18n::{Locale, Locales};
 use crate::theme::Theme;
 use crate::AppState;
 
+pub mod spec_form;
 pub mod specs;
 
 pub fn routes() -> Router<AppState> {
@@ -29,6 +30,7 @@ pub fn routes() -> Router<AppState> {
         .route("/admin/login", get(login_form).post(login_submit))
         .route("/admin/logout", post(logout))
         .merge(specs::routes())
+        .merge(spec_form::routes())
 }
 
 // ── Templates ────────────────────────────────────────────────────

--- a/crates/ruscker-admin/src/routes/admin/audit.rs
+++ b/crates/ruscker-admin/src/routes/admin/audit.rs
@@ -1,0 +1,157 @@
+//! Admin > Audit log viewer.
+//!
+//! Read-only listing of the `audit_log` table with a handful of
+//! filters (action family, target substring, actor). Rows expand
+//! to show `diff_json` pretty-printed. No mutation routes — this
+//! is a forensic surface, not an editor.
+
+use askama::Template;
+use axum::{
+    extract::{Query, State},
+    http::StatusCode,
+    response::{IntoResponse, Response},
+    routing::get,
+    Router,
+};
+use serde::Deserialize;
+
+use crate::auth::AdminSession;
+use crate::db;
+use crate::db::audit::{ActionFamily, AuditEntry, AuditFilter};
+use crate::i18n::{Locale, Locales};
+use crate::theme::Theme;
+use crate::AppState;
+
+pub fn routes() -> Router<AppState> {
+    Router::new().route("/admin/audit", get(index))
+}
+
+#[derive(Debug, Deserialize, Default)]
+pub struct AuditQuery {
+    /// "spec" | "image" | "credential" | "landing" | "" (all)
+    #[serde(default)]
+    pub family: String,
+    /// Substring match against target (`spec:auroraprime`,
+    /// `image:abc-123`, …).
+    #[serde(default)]
+    pub target: String,
+    /// Exact match against actor column.
+    #[serde(default)]
+    pub actor: String,
+}
+
+#[derive(Template)]
+#[template(path = "admin/audit.html")]
+struct AuditPage<'a> {
+    locale: Locale,
+    theme: Theme,
+    locales: &'a Locales,
+    locales_all: &'static [Locale],
+    nav_section: &'static str,
+    entries: Vec<AuditEntry>,
+    filter: AuditQuery,
+    /// Distinct actors ever seen — populates the actor select.
+    /// Empty in the typical single-operator install.
+    distinct_actors: Vec<String>,
+}
+
+impl<'a> AuditPage<'a> {
+    fn t(&self, key: &str) -> String {
+        self.locales.t(self.locale, key, None)
+    }
+
+    /// Pretty-printed JSON for the expanded row. Returns "" when
+    /// the entry had no diff_json (so the template can `{% if %}`
+    /// it out without complicating the helper signature).
+    fn pretty_diff(&self, e: &AuditEntry) -> String {
+        match &e.diff {
+            Some(v) => serde_json::to_string_pretty(v).unwrap_or_default(),
+            None => String::new(),
+        }
+    }
+
+    /// `spec.create` → "spec.create", with a Tabler icon name
+    /// keyed to the family. Used by the row badge.
+    fn action_icon(&self, action: &str) -> &'static str {
+        match action.split_once('.').map(|(f, _)| f) {
+            Some("spec") => "ti-app-window",
+            Some("image") => "ti-photo",
+            Some("credential") => "ti-key",
+            Some("landing") => "ti-layout",
+            _ => "ti-history",
+        }
+    }
+
+    /// Color hint for the action verb (suffix after the dot).
+    /// create=green, update=blue, delete=red, import=teal.
+    fn action_tone(&self, action: &str) -> &'static str {
+        match action.rsplit('.').next() {
+            Some("create") | Some("upload") => "tone-create",
+            Some("update") => "tone-update",
+            Some("delete") => "tone-delete",
+            Some("import") => "tone-import",
+            _ => "tone-other",
+        }
+    }
+}
+
+async fn index(
+    _: AdminSession,
+    State(state): State<AppState>,
+    loc: Locale,
+    theme: Theme,
+    Query(q): Query<AuditQuery>,
+) -> Response {
+    let Some(pool) = state.db.as_ref() else {
+        return (StatusCode::SERVICE_UNAVAILABLE, "no db").into_response();
+    };
+
+    let filter = AuditFilter {
+        family: ActionFamily::parse(&q.family),
+        target_contains: empty_to_none(&q.target),
+        actor: empty_to_none(&q.actor),
+        ..AuditFilter::new()
+    };
+
+    let entries = match db::audit::list(pool, &filter).await {
+        Ok(v) => v,
+        Err(err) => {
+            tracing::error!(error = ?err, "audit list failed");
+            return (StatusCode::INTERNAL_SERVER_ERROR, "db error").into_response();
+        }
+    };
+
+    // Distinct actors only worth showing when there are at least
+    // two — single-operator installs leak no information by
+    // omitting the select.
+    let distinct_actors: Vec<String> = match sqlx::query_as::<_, (String,)>(
+        "SELECT DISTINCT actor FROM audit_log WHERE actor IS NOT NULL ORDER BY actor ASC",
+    )
+    .fetch_all(pool)
+    .await
+    {
+        Ok(rows) => rows.into_iter().map(|(s,)| s).collect(),
+        Err(_) => Vec::new(),
+    };
+
+    let page = AuditPage {
+        locale: loc,
+        theme,
+        locales: &state.locales,
+        locales_all: &Locale::ALL,
+        nav_section: "audit",
+        entries,
+        filter: q,
+        distinct_actors,
+    };
+    super::render(&page)
+}
+
+fn empty_to_none(s: &str) -> Option<String> {
+    let t = s.trim();
+    if t.is_empty() {
+        None
+    } else {
+        Some(t.to_string())
+    }
+}

--- a/crates/ruscker-admin/src/routes/admin/credentials.rs
+++ b/crates/ruscker-admin/src/routes/admin/credentials.rs
@@ -1,0 +1,175 @@
+//! Admin > Registry credentials.
+//!
+//! List + create-or-update + delete on a single page. The list
+//! shows names, registries and usernames; passwords never leave
+//! the server. The form does both create (new name) and update
+//! (existing name) via the same `upsert` repository call.
+
+use askama::Template;
+use axum::{
+    extract::{Form, Path, State},
+    http::StatusCode,
+    response::{IntoResponse, Redirect, Response},
+    routing::{get, post},
+    Router,
+};
+use serde::Deserialize;
+
+use crate::auth::AdminSession;
+use crate::db;
+use crate::i18n::{Locale, Locales};
+use crate::theme::Theme;
+use crate::AppState;
+
+pub fn routes() -> Router<AppState> {
+    Router::new()
+        .route("/admin/credentials", get(index).post(create_or_update))
+        .route("/admin/credentials/{name}/delete", post(delete))
+}
+
+#[derive(Template)]
+#[template(path = "admin/credentials.html")]
+struct CredentialsPage<'a> {
+    locale: Locale,
+    theme: Theme,
+    locales: &'a Locales,
+    locales_all: &'static [Locale],
+    nav_section: &'static str,
+    credentials: Vec<db::credentials::CredentialMeta>,
+    /// Banner shown when the master key isn't configured. When
+    /// true, the form is disabled and a hint is rendered.
+    key_missing: bool,
+    flash_saved: Option<String>,
+    flash_error: Option<String>,
+}
+
+impl<'a> CredentialsPage<'a> {
+    fn t(&self, key: &str) -> String {
+        self.locales.t(self.locale, key, None)
+    }
+}
+
+async fn index(
+    _: AdminSession,
+    State(state): State<AppState>,
+    loc: Locale,
+    theme: Theme,
+) -> Response {
+    render_index(&state, loc, theme, None, None).await
+}
+
+async fn render_index(
+    state: &AppState,
+    loc: Locale,
+    theme: Theme,
+    flash_saved: Option<String>,
+    flash_error: Option<String>,
+) -> Response {
+    let Some(pool) = state.db.as_ref() else {
+        return (StatusCode::SERVICE_UNAVAILABLE, "no db").into_response();
+    };
+    let credentials = match db::credentials::list_all(pool).await {
+        Ok(v) => v,
+        Err(err) => {
+            tracing::error!(error = ?err, "list credentials failed");
+            return (StatusCode::INTERNAL_SERVER_ERROR, "db error").into_response();
+        }
+    };
+    let page = CredentialsPage {
+        locale: loc,
+        theme,
+        locales: &state.locales,
+        locales_all: &Locale::ALL,
+        nav_section: "credentials",
+        credentials,
+        key_missing: !state.master_key.is_configured(),
+        flash_saved,
+        flash_error,
+    };
+    super::render(&page)
+}
+
+#[derive(Debug, Deserialize)]
+pub struct CredentialForm {
+    pub name: String,
+    pub registry: String,
+    pub username: String,
+    pub password: String,
+}
+
+async fn create_or_update(
+    _: AdminSession,
+    State(state): State<AppState>,
+    loc: Locale,
+    theme: Theme,
+    Form(form): Form<CredentialForm>,
+) -> Response {
+    let Some(pool) = state.db.as_ref() else {
+        return (StatusCode::SERVICE_UNAVAILABLE, "no db").into_response();
+    };
+    if !state.master_key.is_configured() {
+        return render_index(
+            &state,
+            loc,
+            theme,
+            None,
+            Some("RUSCKER_MASTER_KEY is not set".into()),
+        )
+        .await;
+    }
+
+    if form.name.trim().is_empty()
+        || form.username.trim().is_empty()
+        || form.password.is_empty()
+    {
+        return render_index(
+            &state,
+            loc,
+            theme,
+            None,
+            Some("name, username and password are required".into()),
+        )
+        .await;
+    }
+
+    let registry = if form.registry.trim().is_empty() {
+        "docker.io".to_string()
+    } else {
+        form.registry.trim().to_string()
+    };
+
+    match db::credentials::upsert(
+        pool,
+        &state.master_key,
+        form.name.trim(),
+        &registry,
+        form.username.trim(),
+        &form.password,
+        Some("admin"),
+    )
+    .await
+    {
+        Ok(_) => render_index(&state, loc, theme, Some(form.name.trim().to_string()), None).await,
+        Err(err) => {
+            tracing::error!(error = ?err, "credential upsert failed");
+            render_index(&state, loc, theme, None, Some(err.to_string())).await
+        }
+    }
+}
+
+async fn delete(
+    _: AdminSession,
+    State(state): State<AppState>,
+    Path(name): Path<String>,
+) -> Response {
+    let Some(pool) = state.db.as_ref() else {
+        return (StatusCode::SERVICE_UNAVAILABLE, "no db").into_response();
+    };
+    match db::credentials::delete_one(pool, &name, Some("admin")).await {
+        Ok(_) => Redirect::to("/admin/credentials").into_response(),
+        Err(err) => {
+            tracing::error!(error = ?err, name, "credential delete failed");
+            (StatusCode::INTERNAL_SERVER_ERROR, "delete failed").into_response()
+        }
+    }
+}

--- a/crates/ruscker-admin/src/routes/admin/images.rs
+++ b/crates/ruscker-admin/src/routes/admin/images.rs
@@ -1,0 +1,196 @@
+//! Admin > image library — gallery, upload, delete.
+//!
+//! Upload pipeline:
+//!   1. axum::Multipart streams the form field
+//!   2. `images::process_upload` sniffs MIME, decodes,
+//!      re-encodes PNG/JPEG to WebP (SVG passes through)
+//!   3. `db::images::insert` writes the BLOB + audit row
+//!   4. Redirect back to /admin/images
+//!
+//! Body cap of 12 MB applied per route — slightly above the
+//! 10 MB cap inside `process_upload` to account for multipart
+//! framing overhead.
+
+use askama::Template;
+use axum::{
+    extract::{DefaultBodyLimit, Multipart, Path, State},
+    http::StatusCode,
+    response::{IntoResponse, Redirect, Response},
+    routing::{get, post},
+    Router,
+};
+
+use crate::auth::AdminSession;
+use crate::db;
+use crate::i18n::{Locale, Locales};
+use crate::images;
+use crate::theme::Theme;
+use crate::AppState;
+
+const UPLOAD_BODY_LIMIT: usize = 12 * 1024 * 1024;
+
+pub fn routes() -> Router<AppState> {
+    Router::new()
+        .route("/admin/images", get(index).post(upload))
+        .route("/admin/images/{id}/delete", post(delete))
+        .layer(DefaultBodyLimit::max(UPLOAD_BODY_LIMIT))
+}
+
+#[derive(Template)]
+#[template(path = "admin/images.html")]
+struct ImagesPage<'a> {
+    locale: Locale,
+    theme: Theme,
+    locales: &'a Locales,
+    locales_all: &'static [Locale],
+    nav_section: &'static str,
+    images: Vec<db::images::ImageMeta>,
+    /// Set on successful upload — drives a one-shot toast.
+    flash_uploaded: Option<String>,
+    flash_error: Option<String>,
+}
+
+impl<'a> ImagesPage<'a> {
+    fn t(&self, key: &str) -> String {
+        self.locales.t(self.locale, key, None)
+    }
+
+    /// "12.3 KB" / "1.4 MB" — for the size column. Takes `&i64`
+    /// so the template can pass the borrowed field straight in
+    /// without writing `*img.size_bytes`.
+    fn fmt_size(&self, bytes: &i64) -> String {
+        let b = *bytes;
+        if b < 1024 {
+            format!("{} B", b)
+        } else if b < 1024 * 1024 {
+            format!("{:.1} KB", b as f64 / 1024.0)
+        } else {
+            format!("{:.1} MB", b as f64 / 1024.0 / 1024.0)
+        }
+    }
+}
+
+async fn index(
+    _: AdminSession,
+    State(state): State<AppState>,
+    loc: Locale,
+    theme: Theme,
+) -> Response {
+    render_index(&state, loc, theme, None, None).await
+}
+
+async fn render_index(
+    state: &AppState,
+    loc: Locale,
+    theme: Theme,
+    flash_uploaded: Option<String>,
+    flash_error: Option<String>,
+) -> Response {
+    let Some(pool) = state.db.as_ref() else {
+        return (
+            StatusCode::SERVICE_UNAVAILABLE,
+            "database not attached — start with --db <path>",
+        )
+            .into_response();
+    };
+    let images = match db::images::list_all(pool).await {
+        Ok(v) => v,
+        Err(err) => {
+            tracing::error!(error = ?err, "list images failed");
+            return (StatusCode::INTERNAL_SERVER_ERROR, "db error").into_response();
+        }
+    };
+    let page = ImagesPage {
+        locale: loc,
+        theme,
+        locales: &state.locales,
+        locales_all: &Locale::ALL,
+        nav_section: "images",
+        images,
+        flash_uploaded,
+        flash_error,
+    };
+    super::render(&page)
+}
+
+async fn upload(
+    _: AdminSession,
+    State(state): State<AppState>,
+    loc: Locale,
+    theme: Theme,
+    mut multipart: Multipart,
+) -> Response {
+    let Some(pool) = state.db.as_ref() else {
+        return (StatusCode::SERVICE_UNAVAILABLE, "no db").into_response();
+    };
+
+    // The form has a single file field named `file`. We iterate
+    // through everything and pick the first one whose field_name
+    // matches; other fields (CSRF token, etc.) are ignored.
+    let mut last_uploaded_name: Option<String> = None;
+    let mut last_error: Option<String> = None;
+
+    loop {
+        let field = match multipart.next_field().await {
+            Ok(Some(f)) => f,
+            Ok(None) => break,
+            Err(err) => {
+                last_error = Some(format!("multipart parse error: {err}"));
+                break;
+            }
+        };
+        if field.name() != Some("file") {
+            continue;
+        }
+        let filename = field.file_name().unwrap_or("upload").to_string();
+        let mime = field.content_type().map(|s| s.to_string());
+        let bytes = match field.bytes().await {
+            Ok(b) => b.to_vec(),
+            Err(err) => {
+                last_error = Some(format!("read upload: {err}"));
+                continue;
+            }
+        };
+        if bytes.is_empty() {
+            continue; // empty file input — nothing chosen
+        }
+
+        let processed = match images::process_upload(&filename, mime.as_deref(), bytes) {
+            Ok(p) => p,
+            Err(err) => {
+                tracing::warn!(error = ?err, filename, "rejecting upload");
+                last_error = Some(err.to_string());
+                continue;
+            }
+        };
+        let stored_name = processed.filename.clone();
+        match db::images::insert(pool, processed, Some("admin")).await {
+            Ok(_id) => {
+                last_uploaded_name = Some(stored_name);
+            }
+            Err(err) => {
+                tracing::error!(error = ?err, "image insert failed");
+                last_error = Some(format!("save: {err}"));
+            }
+        }
+    }
+
+    render_index(&state, loc, theme, last_uploaded_name, last_error).await
+}
+
+async fn delete(
+    _: AdminSession,
+    State(state): State<AppState>,
+    Path(id): Path<String>,
+) -> Response {
+    let Some(pool) = state.db.as_ref() else {
+        return (StatusCode::SERVICE_UNAVAILABLE, "no db").into_response();
+    };
+    match db::images::delete_one(pool, &id, Some("admin")).await {
+        Ok(_) => Redirect::to("/admin/images").into_response(),
+        Err(err) => {
+            tracing::error!(error = ?err, id, "image delete failed");
+            (StatusCode::INTERNAL_SERVER_ERROR, "delete failed").into_response()
+        }
+    }
+}

--- a/crates/ruscker-admin/src/routes/admin/landing.rs
+++ b/crates/ruscker-admin/src/routes/admin/landing.rs
@@ -1,0 +1,191 @@
+//! Admin > Landing-page editor.
+//!
+//! MVP scope (matches what `LandingCustomization` already
+//! supports): header background + foreground colors, fallback
+//! intro paragraph, and per-locale intro overrides for the four
+//! shipped languages.
+//!
+//! The mockup `docs/mockups/admin-landing-editor.html` shows a
+//! bigger vision: drag-to-reorder sections, custom HTML blocks,
+//! analytics, OG tags. Those need schema additions and ship in
+//! later slices on this branch.
+
+use askama::Template;
+use axum::{
+    extract::{Form, State},
+    http::StatusCode,
+    response::{IntoResponse, Response},
+    routing::get,
+    Router,
+};
+use ruscker_config::LandingCustomization;
+use serde::Deserialize;
+use std::collections::HashMap;
+
+use crate::auth::AdminSession;
+use crate::db;
+use crate::i18n::{Locale, Locales};
+use crate::theme::Theme;
+use crate::AppState;
+
+pub fn routes() -> Router<AppState> {
+    Router::new().route("/admin/landing", get(index).post(save))
+}
+
+#[derive(Template)]
+#[template(path = "admin/landing.html")]
+struct LandingPage<'a> {
+    locale: Locale,
+    theme: Theme,
+    locales: &'a Locales,
+    locales_all: &'static [Locale],
+    nav_section: &'static str,
+    form: LandingForm,
+    flash_saved: bool,
+    flash_error: Option<String>,
+    /// The portal title (read from config — operator can't change
+    /// it through this form yet; it's set in the YAML).
+    portal_title: String,
+}
+
+impl<'a> LandingPage<'a> {
+    fn t(&self, key: &str) -> String {
+        self.locales.t(self.locale, key, None)
+    }
+
+    /// JSON literal for Alpine x-data. Same trick as the spec
+    /// form: don't `|safe` it — Askama auto-escape turns quotes
+    /// into `&quot;` so the attribute parses cleanly.
+    fn form_initial_json(&self) -> String {
+        serde_json::to_string(&self.form).unwrap_or_else(|_| "{}".into())
+    }
+}
+
+/// Flat form structure mirroring the customization fields. The
+/// 4 named per-locale intros keep the form simple instead of
+/// pushing a dynamic key/value table; if a fifth language ever
+/// ships, this struct and the template add one field each.
+#[derive(Debug, Default, serde::Serialize, Deserialize)]
+#[serde(default)]
+pub struct LandingForm {
+    pub header_bg: String,
+    pub header_fg: String,
+    pub intro: String,
+    pub intro_pt: String,
+    pub intro_en: String,
+    pub intro_es: String,
+    pub intro_fr: String,
+}
+
+impl LandingForm {
+    pub fn from_customization(lc: &LandingCustomization) -> Self {
+        let g = |code: &str| lc.intro_locales.get(code).cloned().unwrap_or_default();
+        Self {
+            header_bg: lc.header_bg.clone().unwrap_or_default(),
+            header_fg: lc.header_fg.clone().unwrap_or_default(),
+            intro: lc.intro.clone().unwrap_or_default(),
+            intro_pt: g("pt"),
+            intro_en: g("en"),
+            intro_es: g("es"),
+            intro_fr: g("fr"),
+        }
+    }
+
+    pub fn into_customization(self) -> LandingCustomization {
+        let mut intro_locales: HashMap<String, String> = HashMap::new();
+        for (code, val) in [
+            ("pt", self.intro_pt),
+            ("en", self.intro_en),
+            ("es", self.intro_es),
+            ("fr", self.intro_fr),
+        ] {
+            let trimmed = val.trim();
+            if !trimmed.is_empty() {
+                intro_locales.insert(code.into(), trimmed.to_string());
+            }
+        }
+        LandingCustomization {
+            header_bg: empty_to_none(self.header_bg),
+            header_fg: empty_to_none(self.header_fg),
+            intro: empty_to_none(self.intro),
+            intro_locales,
+        }
+    }
+}
+
+fn empty_to_none(s: String) -> Option<String> {
+    let t = s.trim();
+    if t.is_empty() { None } else { Some(t.to_string()) }
+}
+
+async fn index(
+    _: AdminSession,
+    State(state): State<AppState>,
+    loc: Locale,
+    theme: Theme,
+) -> Response {
+    render(&state, loc, theme, None, false, None).await
+}
+
+async fn save(
+    _: AdminSession,
+    State(state): State<AppState>,
+    loc: Locale,
+    theme: Theme,
+    Form(form): Form<LandingForm>,
+) -> Response {
+    let Some(pool) = state.db.as_ref() else {
+        return (StatusCode::SERVICE_UNAVAILABLE, "no db").into_response();
+    };
+    let lc = form.into_customization();
+    match db::landing::update(pool, &lc, Some("admin")).await {
+        Ok(_) => render(&state, loc, theme, Some(LandingForm::from_customization(&lc)), true, None).await,
+        Err(err) => {
+            tracing::error!(error = ?err, "landing update failed");
+            render(
+                &state,
+                loc,
+                theme,
+                Some(LandingForm::from_customization(&lc)),
+                false,
+                Some(err.to_string()),
+            )
+            .await
+        }
+    }
+}
+
+async fn render(
+    state: &AppState,
+    loc: Locale,
+    theme: Theme,
+    preset_form: Option<LandingForm>,
+    flash_saved: bool,
+    flash_error: Option<String>,
+) -> Response {
+    let Some(pool) = state.db.as_ref() else {
+        return (StatusCode::SERVICE_UNAVAILABLE, "no db").into_response();
+    };
+    let form = match preset_form {
+        Some(f) => f,
+        None => match db::landing::fetch(pool).await {
+            Ok(lc) => LandingForm::from_customization(&lc),
+            Err(err) => {
+                tracing::error!(error = ?err, "landing fetch failed");
+                return (StatusCode::INTERNAL_SERVER_ERROR, "db error").into_response();
+            }
+        },
+    };
+    let page = LandingPage {
+        locale: loc,
+        theme,
+        locales: &state.locales,
+        locales_all: &Locale::ALL,
+        nav_section: "landing",
+        form,
+        flash_saved,
+        flash_error,
+        portal_title: state.config.proxy.title.trim().to_string(),
+    };
+    super::render(&page)
+}

--- a/crates/ruscker-admin/src/routes/admin/spec_form.rs
+++ b/crates/ruscker-admin/src/routes/admin/spec_form.rs
@@ -1,0 +1,457 @@
+//! Admin > Add/Edit spec form.
+//!
+//! Single template (`templates/admin/spec_form.html`) used for both
+//! New and Edit, parameterized by `mode`. On submit, the form posts
+//! to `/admin/specs` (create) or `/admin/specs/:id` (update); on
+//! delete, to `/admin/specs/:id/delete`.
+//!
+//! Field scope covers what the SEPE YAML actually uses today
+//! (~80% of specs). Phase 2.5 adds advanced fields (replicas,
+//! scaling, env vars, volumes) behind a collapsible section.
+
+use anyhow::Result;
+use askama::Template;
+use axum::{
+    extract::{Form, Path, State},
+    http::StatusCode,
+    response::{IntoResponse, Redirect, Response},
+    routing::{get, post},
+    Router,
+};
+use chrono::Utc;
+use ruscker_config::{Spec, SpecKindOverride, TemplateProperties};
+use serde::{Deserialize, Serialize};
+use serde_yaml_ng::Value as YamlValue;
+use std::collections::HashMap;
+
+use crate::auth::AdminSession;
+use crate::db;
+use crate::i18n::{Locale, Locales};
+use crate::theme::Theme;
+use crate::view_model::DisplayType;
+use crate::AppState;
+
+pub fn routes() -> Router<AppState> {
+    Router::new()
+        .route("/admin/specs/new", get(new_form))
+        .route("/admin/specs", post(create))
+        .route(
+            "/admin/specs/{id}/edit",
+            get(edit_form),
+        )
+        .route("/admin/specs/{id}", post(update))
+        .route("/admin/specs/{id}/delete", post(delete))
+}
+
+// ── Form payload ────────────────────────────────────────────────
+
+/// Mirror of the form fields. Strings are unconditional so empty
+/// inputs round-trip as `""` rather than disappearing; conversion
+/// to [`Spec`] handles "empty means None".
+#[derive(Debug, Default, Serialize, Deserialize)]
+#[serde(default)]
+pub struct SpecForm {
+    pub id: String,
+    pub display_name: String,
+    pub description: String,
+    /// "app" | "talk" | "report" | "package" | "api" | "link"
+    pub display_type: String,
+    pub container_image: String,
+    /// "active" | "inactive"
+    pub state: String,
+    /// "lock" (restricted) | "lock_open" (public)
+    pub access: String,
+    pub tema: String,
+    pub logo: String,
+    /// Updated date in DD/MM/YYYY. Empty ⇒ stamp with today.
+    pub updated: String,
+    /// External link target (for type=link/package).
+    pub link: String,
+    pub seats_per_container: String,
+    pub max_lifetime: String,
+}
+
+impl SpecForm {
+    /// Build a form pre-filled from an existing [`Spec`] for the
+    /// edit view.
+    pub fn from_spec(spec: &Spec) -> Self {
+        let tp = &spec.template_properties;
+        let dt = DisplayType::from_spec(spec);
+        Self {
+            id: spec.id.clone(),
+            display_name: spec.display_name.clone().unwrap_or_default(),
+            description: spec.description.clone().unwrap_or_default(),
+            display_type: dt.key().to_string(),
+            container_image: spec.container_image.clone().unwrap_or_default(),
+            state: tp
+                .get_str("state")
+                .map(str::to_string)
+                .unwrap_or_else(|| "active".into()),
+            access: tp
+                .get_str("icon")
+                .map(str::to_string)
+                .unwrap_or_else(|| "lock".into()),
+            tema: tp.get_str("tema").map(str::to_string).unwrap_or_default(),
+            logo: tp.get_str("logo").map(str::to_string).unwrap_or_default(),
+            updated: tp.get_str("updated").map(str::to_string).unwrap_or_default(),
+            link: tp.get_str("link").map(str::to_string).unwrap_or_default(),
+            seats_per_container: spec
+                .seats_per_container
+                .map(|n| n.to_string())
+                .unwrap_or_default(),
+            max_lifetime: spec.max_lifetime.map(|n| n.to_string()).unwrap_or_default(),
+        }
+    }
+
+    /// Build a fresh [`Spec`] from the submitted form values.
+    /// Empty optional strings become `None`. Numeric strings parse
+    /// optimistically; non-parseable values fall back to None
+    /// (operator gets a 400 from `validate` before reaching here).
+    pub fn into_spec(self) -> Result<Spec> {
+        let dt = DisplayType::parse(&self.display_type).unwrap_or(DisplayType::App);
+        let kind_override = match dt {
+            DisplayType::App => Some(SpecKindOverride::Shiny),
+            DisplayType::Talk | DisplayType::Report => None, // these are visual
+            DisplayType::Package | DisplayType::Link => Some(SpecKindOverride::External),
+            DisplayType::Api => Some(SpecKindOverride::Api),
+        };
+
+        let updated = if self.updated.trim().is_empty() {
+            Utc::now().format("%d/%m/%Y").to_string()
+        } else {
+            self.updated.trim().to_string()
+        };
+
+        let mut tp_map: HashMap<String, YamlValue> = HashMap::new();
+        // type, state, icon are always set so chips/filters render
+        tp_map.insert("type".into(), YamlValue::String(dt.key().to_string()));
+        tp_map.insert("state".into(), YamlValue::String(self.state.clone()));
+        tp_map.insert("icon".into(), YamlValue::String(self.access.clone()));
+        tp_map.insert("updated".into(), YamlValue::String(updated));
+
+        if !self.tema.trim().is_empty() {
+            tp_map.insert(
+                "tema".into(),
+                YamlValue::String(self.tema.trim().to_string()),
+            );
+        }
+        if !self.logo.trim().is_empty() {
+            tp_map.insert(
+                "logo".into(),
+                YamlValue::String(self.logo.trim().to_string()),
+            );
+        }
+        if !self.link.trim().is_empty() {
+            tp_map.insert(
+                "link".into(),
+                YamlValue::String(self.link.trim().to_string()),
+            );
+        }
+
+        let container_image = match dt {
+            DisplayType::Package | DisplayType::Link => None,
+            _ => empty_to_none(&self.container_image),
+        };
+
+        Ok(Spec {
+            id: self.id.trim().to_string(),
+            display_name: empty_to_none(&self.display_name),
+            description: empty_to_none(&self.description),
+            container_image,
+            seats_per_container: parse_opt(&self.seats_per_container),
+            max_lifetime: parse_opt(&self.max_lifetime),
+            container_lifetime: None,
+            heartbeat_timeout: None,
+            stop_on_logout: None,
+            docker_registry_username: None,
+            docker_registry_password: None,
+            docker_registry_domain: None,
+            template_properties: TemplateProperties(tp_map),
+            kind_override,
+            api: None,
+            min_replicas: None,
+            max_replicas: None,
+            scale_up_threshold: None,
+            scale_down_threshold: None,
+            scale_down_grace: None,
+            drain_timeout: None,
+            routing_strategy: None,
+            concurrent_requests_per_replica: None,
+        })
+    }
+
+    /// Server-side validation. Returns a list of fluent message
+    /// keys describing each problem; empty list = OK.
+    pub fn validate(&self, mode: FormMode) -> Vec<&'static str> {
+        let mut errs = Vec::new();
+        if self.id.trim().is_empty() {
+            errs.push("spec-form-error-id-required");
+        } else if !is_kebab_id(self.id.trim()) {
+            errs.push("spec-form-error-id-shape");
+        }
+        if self.display_name.trim().is_empty() {
+            errs.push("spec-form-error-name-required");
+        }
+        if matches!(mode, FormMode::New) && self.id.trim().is_empty() {
+            // duplicate-id check happens later (needs DB access)
+        }
+        errs
+    }
+}
+
+fn empty_to_none(s: &str) -> Option<String> {
+    let t = s.trim();
+    if t.is_empty() { None } else { Some(t.to_string()) }
+}
+fn parse_opt<T: std::str::FromStr>(s: &str) -> Option<T> {
+    s.trim().parse().ok()
+}
+fn is_kebab_id(s: &str) -> bool {
+    !s.is_empty()
+        && s.chars().all(|c| c.is_ascii_alphanumeric() || c == '_' || c == '-')
+        && s.chars()
+            .next()
+            .map(|c| c.is_ascii_alphabetic())
+            .unwrap_or(false)
+}
+
+// ── Template ────────────────────────────────────────────────────
+
+#[derive(Debug, Copy, Clone, PartialEq, Eq)]
+pub enum FormMode {
+    New,
+    Edit,
+}
+impl FormMode {
+    pub fn is_new(self) -> bool {
+        matches!(self, FormMode::New)
+    }
+    pub fn is_edit(self) -> bool {
+        matches!(self, FormMode::Edit)
+    }
+}
+
+#[derive(Template)]
+#[template(path = "admin/spec_form.html")]
+struct SpecFormPage<'a> {
+    locale: Locale,
+    theme: Theme,
+    locales: &'a Locales,
+    locales_all: &'static [Locale],
+    nav_section: &'static str,
+    mode: FormMode,
+    form: SpecForm,
+    /// Pre-validation errors (Fluent keys) shown above the form.
+    errors: Vec<&'static str>,
+}
+
+impl<'a> SpecFormPage<'a> {
+    fn t(&self, key: &str) -> String {
+        self.locales.t(self.locale, key, None)
+    }
+
+    /// JSON-encoded initial form values, ready to drop into the
+    /// `x-data` attribute of the live-preview Alpine component.
+    fn form_initial_json(&self) -> String {
+        serde_json::to_string(&self.form).unwrap_or_else(|_| "{}".into())
+    }
+
+    /// Options for the kind picker: (key, label-fluent-key, tabler-icon).
+    /// Order intentional — mirrors the public landing chip order.
+    fn display_type_options(&self) -> &'static [(&'static str, &'static str, &'static str)] {
+        &[
+            ("app", "spec-form-kind-app", "app-window"),
+            ("talk", "spec-form-kind-talk", "presentation"),
+            ("report", "spec-form-kind-report", "file-text"),
+            ("package", "spec-form-kind-package", "package"),
+            ("api", "spec-form-kind-api", "api"),
+            ("link", "spec-form-kind-link", "external-link"),
+        ]
+    }
+}
+
+// ── Handlers ─────────────────────────────────────────────────────
+
+async fn new_form(
+    _: AdminSession,
+    State(state): State<AppState>,
+    loc: Locale,
+    theme: Theme,
+) -> Response {
+    let page = SpecFormPage {
+        locale: loc,
+        theme,
+        locales: &state.locales,
+        locales_all: &Locale::ALL,
+        nav_section: "specs",
+        mode: FormMode::New,
+        form: SpecForm {
+            // Sensible defaults for a new app
+            display_type: "app".into(),
+            state: "active".into(),
+            access: "lock".into(),
+            ..Default::default()
+        },
+        errors: Vec::new(),
+    };
+    super::render(&page)
+}
+
+async fn edit_form(
+    _: AdminSession,
+    State(state): State<AppState>,
+    loc: Locale,
+    theme: Theme,
+    Path(id): Path<String>,
+) -> Response {
+    let Some(pool) = state.db.as_ref() else {
+        return (StatusCode::SERVICE_UNAVAILABLE, "no db").into_response();
+    };
+    let spec = match db::specs::fetch_one(pool, &id).await {
+        Ok(Some(s)) => s,
+        Ok(None) => return (StatusCode::NOT_FOUND, "spec not found").into_response(),
+        Err(e) => {
+            tracing::error!(error = ?e, id, "fetch spec failed");
+            return (StatusCode::INTERNAL_SERVER_ERROR, "db error").into_response();
+        }
+    };
+    let page = SpecFormPage {
+        locale: loc,
+        theme,
+        locales: &state.locales,
+        locales_all: &Locale::ALL,
+        nav_section: "specs",
+        mode: FormMode::Edit,
+        form: SpecForm::from_spec(&spec),
+        errors: Vec::new(),
+    };
+    super::render(&page)
+}
+
+async fn create(
+    _: AdminSession,
+    State(state): State<AppState>,
+    loc: Locale,
+    theme: Theme,
+    Form(form): Form<SpecForm>,
+) -> Response {
+    let Some(pool) = state.db.as_ref() else {
+        return (StatusCode::SERVICE_UNAVAILABLE, "no db").into_response();
+    };
+
+    let mut errors = form.validate(FormMode::New);
+
+    // Uniqueness check
+    if errors.is_empty() {
+        match db::specs::fetch_one(pool, form.id.trim()).await {
+            Ok(Some(_)) => errors.push("spec-form-error-id-duplicate"),
+            Ok(None) => {}
+            Err(e) => {
+                tracing::error!(error = ?e, "duplicate-check failed");
+                return (StatusCode::INTERNAL_SERVER_ERROR, "db error").into_response();
+            }
+        }
+    }
+
+    if !errors.is_empty() {
+        return render_form_with_errors(&state, loc, theme, FormMode::New, form, errors);
+    }
+
+    let id = form.id.trim().to_string();
+    let spec = match form.into_spec() {
+        Ok(s) => s,
+        Err(e) => {
+            tracing::error!(error = ?e, "form → spec failed");
+            return (StatusCode::BAD_REQUEST, "invalid form data").into_response();
+        }
+    };
+
+    match db::specs::upsert_one(pool, &spec, Some("admin")).await {
+        Ok(_) => Redirect::to(&format!("/admin/specs/{}/edit", id)).into_response(),
+        Err(e) => {
+            tracing::error!(error = ?e, "save failed");
+            (StatusCode::INTERNAL_SERVER_ERROR, "save failed").into_response()
+        }
+    }
+}
+
+async fn update(
+    _: AdminSession,
+    State(state): State<AppState>,
+    loc: Locale,
+    theme: Theme,
+    Path(id): Path<String>,
+    Form(mut form): Form<SpecForm>,
+) -> Response {
+    let Some(pool) = state.db.as_ref() else {
+        return (StatusCode::SERVICE_UNAVAILABLE, "no db").into_response();
+    };
+
+    // The URL id wins over the form id — operators don't get to
+    // rename specs through the form (it would orphan the audit
+    // log target). Renaming is a separate planned action.
+    form.id = id.clone();
+
+    let errors = form.validate(FormMode::Edit);
+    if !errors.is_empty() {
+        return render_form_with_errors(&state, loc, theme, FormMode::Edit, form, errors);
+    }
+
+    let spec = match form.into_spec() {
+        Ok(s) => s,
+        Err(e) => {
+            tracing::error!(error = ?e, "form → spec failed");
+            return (StatusCode::BAD_REQUEST, "invalid form data").into_response();
+        }
+    };
+
+    match db::specs::upsert_one(pool, &spec, Some("admin")).await {
+        Ok(_) => Redirect::to(&format!("/admin/specs/{}/edit", id)).into_response(),
+        Err(e) => {
+            tracing::error!(error = ?e, "save failed");
+            (StatusCode::INTERNAL_SERVER_ERROR, "save failed").into_response()
+        }
+    }
+}
+
+async fn delete(
+    _: AdminSession,
+    State(state): State<AppState>,
+    Path(id): Path<String>,
+) -> Response {
+    let Some(pool) = state.db.as_ref() else {
+        return (StatusCode::SERVICE_UNAVAILABLE, "no db").into_response();
+    };
+    match db::specs::delete_one(pool, &id, Some("admin")).await {
+        Ok(_) => Redirect::to("/admin/specs").into_response(),
+        Err(e) => {
+            tracing::error!(error = ?e, id, "delete failed");
+            (StatusCode::INTERNAL_SERVER_ERROR, "delete failed").into_response()
+        }
+    }
+}
+
+fn render_form_with_errors(
+    state: &AppState,
+    loc: Locale,
+    theme: Theme,
+    mode: FormMode,
+    form: SpecForm,
+    errors: Vec<&'static str>,
+) -> Response {
+    let page = SpecFormPage {
+        locale: loc,
+        theme,
+        locales: &state.locales,
+        locales_all: &Locale::ALL,
+        nav_section: "specs",
+        mode,
+        form,
+        errors,
+    };
+    let body = match page.render() {
+        Ok(s) => s,
+        Err(_) => return (StatusCode::INTERNAL_SERVER_ERROR, "render").into_response(),
+    };
+    (StatusCode::UNPROCESSABLE_ENTITY, axum::response::Html(body)).into_response()
+}

--- a/crates/ruscker-admin/src/routes/admin/specs.rs
+++ b/crates/ruscker-admin/src/routes/admin/specs.rs
@@ -1,0 +1,95 @@
+//! Admin > Apps list page.
+//!
+//! Read-only for now: lists every spec in the DB with kind, state,
+//! version, updated_at. Edit/delete buttons are placeholders until
+//! the spec form lands in the next slice.
+
+use askama::Template;
+use axum::{
+    extract::State,
+    http::StatusCode,
+    response::{IntoResponse, Response},
+    routing::get,
+    Router,
+};
+use chrono::{DateTime, Utc};
+use sqlx::FromRow;
+
+use crate::auth::AdminSession;
+use crate::i18n::{Locale, Locales};
+use crate::theme::Theme;
+use crate::AppState;
+
+pub fn routes() -> Router<AppState> {
+    Router::new().route("/admin/specs", get(index))
+}
+
+/// One row out of the `specs` table, picked for the list view.
+/// Distinct from `Spec` (the YAML model) so we don't need to
+/// deserialize `config_json` just to render a table.
+#[derive(Debug, FromRow)]
+pub struct SpecRow {
+    pub id: String,
+    pub display_name: Option<String>,
+    pub kind: String,
+    pub state: String,
+    pub updated_at: DateTime<Utc>,
+    pub version: i64,
+}
+
+#[derive(Template)]
+#[template(path = "admin/specs.html")]
+struct SpecsPage<'a> {
+    locale: Locale,
+    theme: Theme,
+    locales: &'a Locales,
+    locales_all: &'static [Locale],
+    nav_section: &'static str,
+    specs: Vec<SpecRow>,
+}
+
+impl<'a> SpecsPage<'a> {
+    fn t(&self, key: &str) -> String {
+        self.locales.t(self.locale, key, None)
+    }
+}
+
+async fn index(
+    _: AdminSession,
+    State(state): State<AppState>,
+    loc: Locale,
+    theme: Theme,
+) -> Response {
+    let Some(pool) = state.db.as_ref() else {
+        return (
+            StatusCode::SERVICE_UNAVAILABLE,
+            "database not attached — start with --db <path>",
+        )
+            .into_response();
+    };
+
+    let specs: Vec<SpecRow> = match sqlx::query_as(
+        "SELECT id, display_name, kind, state, updated_at, version
+           FROM specs
+           ORDER BY updated_at DESC, id ASC",
+    )
+    .fetch_all(pool)
+    .await
+    {
+        Ok(rows) => rows,
+        Err(err) => {
+            tracing::error!(error = ?err, "load specs failed");
+            return (StatusCode::INTERNAL_SERVER_ERROR, "db error").into_response();
+        }
+    };
+
+    let page = SpecsPage {
+        locale: loc,
+        theme,
+        locales: &state.locales,
+        locales_all: &Locale::ALL,
+        nav_section: "specs",
+        specs,
+    };
+    super::render(&page)
+}

--- a/crates/ruscker-admin/src/routes/assets.rs
+++ b/crates/ruscker-admin/src/routes/assets.rs
@@ -13,6 +13,7 @@
 //! `cache-control: immutable` header — safe to cache aggressively.
 
 use axum::{
+    extract::{Path as AxumPath, State},
     http::{header, HeaderMap, HeaderValue, StatusCode},
     response::{IntoResponse, Response},
     routing::get,
@@ -90,6 +91,70 @@ pub fn routes() -> Router<AppState> {
         // Conventional well-known browser hooks.
         .route("/favicon.svg", get(|| serve(BRAND_MARK_FLAT, SVG)))
         .route("/apple-touch-icon.png", get(|| serve(BRAND_APP_ICON, SVG)))
+        // Operator-uploaded card images. DB first (Phase 2 image
+        // library); on miss, fall back to the on-disk `images_dir`
+        // (Phase 1 deploy that uses a static folder of files).
+        .route("/assets/img/{filename}", get(serve_card_image))
+}
+
+async fn serve_card_image(
+    State(state): State<AppState>,
+    AxumPath(filename): AxumPath<String>,
+) -> Response {
+    // Don't allow `../` or directory components — Axum's path
+    // extractor already collapses path segments per route, but
+    // we double-check before any FS read.
+    if filename.contains('/') || filename.contains("..") {
+        return StatusCode::BAD_REQUEST.into_response();
+    }
+
+    // 1. DB lookup
+    if let Some(pool) = state.db.as_ref() {
+        match crate::db::images::fetch_by_filename(pool, &filename).await {
+            Ok(Some((mime, bytes))) => return serve_dynamic(bytes, &mime),
+            Ok(None) => {}
+            Err(err) => {
+                tracing::error!(error = ?err, filename, "image DB lookup failed");
+            }
+        }
+    }
+
+    // 2. Disk fallback
+    if let Some(dir) = state.images_dir.as_ref() {
+        let candidate = dir.join(&filename);
+        if let Ok(bytes) = tokio::fs::read(&candidate).await {
+            let mime = mime_from_extension(&filename);
+            return serve_dynamic(bytes, mime);
+        }
+    }
+
+    StatusCode::NOT_FOUND.into_response()
+}
+
+fn mime_from_extension(name: &str) -> &'static str {
+    match name.rsplit_once('.').map(|(_, ext)| ext.to_ascii_lowercase()) {
+        Some(ref e) if e == "webp" => "image/webp",
+        Some(ref e) if e == "png" => "image/png",
+        Some(ref e) if e == "jpg" || e == "jpeg" => "image/jpeg",
+        Some(ref e) if e == "svg" => "image/svg+xml",
+        Some(ref e) if e == "gif" => "image/gif",
+        _ => "application/octet-stream",
+    }
+}
+
+/// Like [`serve`] but takes owned bytes (DB blob / FS read) and
+/// short-cache headers (these images can change without a binary
+/// rebuild so `immutable` would be wrong here).
+fn serve_dynamic(body: Vec<u8>, content_type: &str) -> Response {
+    let mut headers = HeaderMap::new();
+    if let Ok(ct) = HeaderValue::from_str(content_type) {
+        headers.insert(header::CONTENT_TYPE, ct);
+    }
+    headers.insert(
+        header::CACHE_CONTROL,
+        HeaderValue::from_static("public, max-age=60, must-revalidate"),
+    );
+    (StatusCode::OK, headers, body).into_response()
 }
 
 // ── Helpers ───────────────────────────────────────────────────────

--- a/crates/ruscker-admin/src/routes/landing.rs
+++ b/crates/ruscker-admin/src/routes/landing.rs
@@ -80,8 +80,18 @@ async fn index(State(state): State<AppState>, loc: Locale, theme: Theme) -> Resp
         total: cards.iter().filter(|c| c.active).count(),
     };
 
-    // Landing customization: header background + per-locale intro.
-    let lc = &state.config.proxy.landing_customization;
+    // Landing customization: read from DB when available
+    // (admin-editable), fall back to the YAML-derived value
+    // otherwise (Phase 1 / no-DB deployments).
+    let lc = match state.db.as_ref() {
+        Some(pool) => crate::db::landing::fetch(pool)
+            .await
+            .unwrap_or_else(|err| {
+                tracing::warn!(error = ?err, "landing customization fetch failed; using YAML");
+                state.config.proxy.landing_customization.clone()
+            }),
+        None => state.config.proxy.landing_customization.clone(),
+    };
     let header_style = match (&lc.header_bg, &lc.header_fg) {
         (Some(bg), Some(fg)) => format!("background: {}; color: {};", bg, fg),
         (Some(bg), None) => format!("background: {};", bg),

--- a/crates/ruscker-admin/src/routes/mod.rs
+++ b/crates/ruscker-admin/src/routes/mod.rs
@@ -1,5 +1,6 @@
 //! HTTP route handlers, one module per resource family.
 
+pub mod admin;
 pub mod assets;
 pub mod landing;
 pub mod prefs;

--- a/crates/ruscker-admin/templates/admin/_layout.html
+++ b/crates/ruscker-admin/templates/admin/_layout.html
@@ -1,0 +1,76 @@
+<!doctype html>
+<html lang="{{ locale.code() }}"{% match theme.data_attr() %}{% when Some with (t) %} data-theme="{{ t }}"{% when None %}{% endmatch %}>
+<head>
+<meta charset="utf-8">
+<meta name="viewport" content="width=device-width,initial-scale=1">
+<meta name="theme-color" content="#0f6e56">
+<meta name="application-name" content="Ruscker">
+<meta name="robots" content="noindex,nofollow">
+<title>{% block title %}Admin · Ruscker{% endblock %}</title>
+
+<link rel="icon" type="image/svg+xml" href="/favicon.svg">
+<link rel="mask-icon" href="/assets/brand/mark.svg" color="#0f6e56">
+<link rel="apple-touch-icon" href="/apple-touch-icon.png">
+
+<link rel="preload" href="/assets/fonts/jost-latin-400-normal.woff2" as="font" type="font/woff2" crossorigin>
+<link rel="preload" href="/assets/fonts/jost-latin-500-normal.woff2" as="font" type="font/woff2" crossorigin>
+<link rel="stylesheet" href="/assets/styles.css">
+<link rel="stylesheet" href="/assets/icons/tabler-icons.min.css">
+</head>
+<body class="min-h-screen flex flex-col">
+
+{% block navbar %}
+<nav class="admin-navbar">
+  <a href="/admin" class="admin-brand">
+    <svg viewBox="0 0 80 80" width="22" height="22" aria-hidden="true">
+      <polygon points="14,52 40,40 66,52 40,64" fill="#0F6E56"/>
+      <polygon points="14,40 40,28 66,40 40,52" fill="#1D9E75"/>
+      <polygon points="14,28 40,16 66,28 40,40" fill="#5DCAA5"/>
+    </svg>
+    <span>ruscker · admin</span>
+  </a>
+
+  <div class="admin-nav-links">
+    <a href="/admin/specs" class="admin-nav-link {% if nav_section == "specs" %}is-active{% endif %}">
+      <i class="ti ti-apps" aria-hidden="true"></i>
+      <span>{{ self.t("admin-nav-apps") }}</span>
+    </a>
+    <a href="/admin/images" class="admin-nav-link {% if nav_section == "images" %}is-active{% endif %}">
+      <i class="ti ti-photo" aria-hidden="true"></i>
+      <span>{{ self.t("admin-nav-images") }}</span>
+    </a>
+    <a href="/admin/credentials" class="admin-nav-link {% if nav_section == "credentials" %}is-active{% endif %}">
+      <i class="ti ti-key" aria-hidden="true"></i>
+      <span>{{ self.t("admin-nav-credentials") }}</span>
+    </a>
+    <a href="/admin/landing" class="admin-nav-link {% if nav_section == "landing" %}is-active{% endif %}">
+      <i class="ti ti-layout" aria-hidden="true"></i>
+      <span>{{ self.t("admin-nav-landing") }}</span>
+    </a>
+    <a href="/admin/audit" class="admin-nav-link {% if nav_section == "audit" %}is-active{% endif %}">
+      <i class="ti ti-history" aria-hidden="true"></i>
+      <span>{{ self.t("admin-nav-audit") }}</span>
+    </a>
+  </div>
+
+  <div class="admin-nav-actions">
+    <a href="/" class="admin-nav-link" title="{{ self.t("admin-nav-portal") }}">
+      <i class="ti ti-arrow-back-up" aria-hidden="true"></i>
+      <span>{{ self.t("admin-nav-portal") }}</span>
+    </a>
+    <form method="post" action="/admin/logout" class="contents">
+      <button type="submit" class="admin-nav-link admin-nav-link--logout">
+        <i class="ti ti-logout" aria-hidden="true"></i>
+        <span>{{ self.t("admin-nav-logout") }}</span>
+      </button>
+    </form>
+  </div>
+</nav>
+{% endblock %}
+
+<main class="flex-1 px-6 py-6 max-w-7xl mx-auto w-full">
+  {% block content %}{% endblock %}
+</main>
+
+</body>
+</html>

--- a/crates/ruscker-admin/templates/admin/audit.html
+++ b/crates/ruscker-admin/templates/admin/audit.html
@@ -1,0 +1,120 @@
+{% extends "admin/_layout.html" %}
+
+{% block title %}{{ self.t("admin-audit-title") }} · Ruscker{% endblock %}
+
+{% block content %}
+
+<div x-data="ruscker.audit()" x-cloak>
+
+  <div class="flex items-end justify-between mb-5">
+    <div>
+      <h1 class="text-xl font-medium tracking-tight">{{ self.t("admin-audit-title") }}</h1>
+      <p class="text-xs text-[color:var(--text-muted)] mt-1">{{ self.t("admin-audit-subtitle") }}</p>
+    </div>
+    <div class="text-xs text-[color:var(--text-faint)]">{{ entries.len() }}</div>
+  </div>
+
+  {# ── Filter bar ───────────────────────────────────────────── #}
+  <form method="get" action="/admin/audit"
+        class="audit-filter-bar">
+    <div class="select-wrap" :class="'{{ filter.family }}' !== '' ? 'is-active' : ''">
+      <select name="family" class="theme-select" onchange="this.form.submit()"
+              aria-label="{{ self.t("admin-audit-family") }}">
+        <option value="" {% if filter.family.is_empty() %}selected{% endif %}>{{ self.t("admin-audit-family-all") }}</option>
+        <option value="spec"       {% if filter.family == "spec" %}selected{% endif %}>{{ self.t("admin-audit-family-spec") }}</option>
+        <option value="image"      {% if filter.family == "image" %}selected{% endif %}>{{ self.t("admin-audit-family-image") }}</option>
+        <option value="credential" {% if filter.family == "credential" %}selected{% endif %}>{{ self.t("admin-audit-family-credential") }}</option>
+        <option value="landing"    {% if filter.family == "landing" %}selected{% endif %}>{{ self.t("admin-audit-family-landing") }}</option>
+      </select>
+      <i class="ti ti-chevron-down select-chevron" aria-hidden="true"></i>
+    </div>
+
+    <label class="search-pill flex-1 min-w-[180px]">
+      <i class="ti ti-search text-[14px] text-[color:var(--text-faint)]" aria-hidden="true"></i>
+      <input type="search" name="target"
+             value="{{ filter.target }}"
+             placeholder="{{ self.t("admin-audit-target-placeholder") }}">
+    </label>
+
+    {% if distinct_actors.len() > 1 %}
+      <div class="select-wrap" :class="'{{ filter.actor }}' !== '' ? 'is-active' : ''">
+        <select name="actor" class="theme-select" onchange="this.form.submit()"
+                aria-label="{{ self.t("admin-audit-actor") }}">
+          <option value="" {% if filter.actor.is_empty() %}selected{% endif %}>{{ self.t("admin-audit-actor-all") }}</option>
+          {% for a in distinct_actors %}
+            <option value="{{ a }}" {% if filter.actor == *a %}selected{% endif %}>{{ a }}</option>
+          {% endfor %}
+        </select>
+        <i class="ti ti-chevron-down select-chevron" aria-hidden="true"></i>
+      </div>
+    {% endif %}
+
+    <button type="submit" class="sort-btn">
+      <i class="ti ti-filter" aria-hidden="true"></i>
+      <span>{{ self.t("admin-audit-apply") }}</span>
+    </button>
+
+    {% if !filter.family.is_empty() || !filter.target.is_empty() || !filter.actor.is_empty() %}
+      <a href="/admin/audit" class="text-[11px] text-[color:var(--text-faint)] underline hover:text-[color:var(--text)] ml-1">
+        {{ self.t("filter-clear") }}
+      </a>
+    {% endif %}
+  </form>
+
+  {# ── Entries ──────────────────────────────────────────────── #}
+  {% if entries.is_empty() %}
+    <div class="card-surface rounded-lg p-12 text-center text-sm text-[color:var(--text-muted)] mt-4">
+      {{ self.t("admin-audit-empty") }}
+    </div>
+  {% else %}
+    <ul class="audit-list mt-4">
+      {% for e in entries %}
+        <li class="audit-row">
+          <button class="audit-row-summary {{ self.action_tone(e.action.as_str()) }}"
+                  type="button"
+                  @click="toggle({{ e.id }})">
+            <i class="ti {{ self.action_icon(e.action.as_str()) }} audit-row-icon" aria-hidden="true"></i>
+            <span class="audit-row-action">{{ e.action }}</span>
+            {% match e.target %}{% when Some with (t) %}
+              <span class="audit-row-target id-cell">{{ t }}</span>
+            {% when None %}
+              <span class="audit-row-target opacity-50">—</span>
+            {% endmatch %}
+            <span class="audit-row-spacer"></span>
+            {% match e.actor %}{% when Some with (a) %}
+              <span class="audit-row-actor">{{ a }}</span>
+            {% when None %}
+              <span class="audit-row-actor opacity-50">system</span>
+            {% endmatch %}
+            <time class="audit-row-time">{{ e.occurred_at.format("%d/%m/%Y %H:%M:%S") }}</time>
+            {% if e.diff.is_some() %}
+              <i class="ti audit-row-chev" :class="open === {{ e.id }} ? 'ti-chevron-down' : 'ti-chevron-right'" aria-hidden="true"></i>
+            {% else %}
+              <span class="audit-row-chev opacity-30">·</span>
+            {% endif %}
+          </button>
+          {% if e.diff.is_some() %}
+            <pre x-show="open === {{ e.id }}" class="audit-row-diff" x-transition.opacity>{{ self.pretty_diff(e) }}</pre>
+          {% endif %}
+        </li>
+      {% endfor %}
+    </ul>
+    {% if entries.len() >= 100 %}
+      <p class="text-[11px] text-[color:var(--text-faint)] text-center mt-3">
+        {{ self.t("admin-audit-limit-hint") }}
+      </p>
+    {% endif %}
+  {% endif %}
+
+</div>
+
+<script src="/assets/js/alpine.min.js" defer></script>
+<script>
+window.ruscker = window.ruscker || {};
+window.ruscker.audit = () => ({
+  open: null,
+  toggle(id) { this.open = this.open === id ? null : id; },
+});
+</script>
+
+{% endblock %}

--- a/crates/ruscker-admin/templates/admin/credentials.html
+++ b/crates/ruscker-admin/templates/admin/credentials.html
@@ -1,0 +1,128 @@
+{% extends "admin/_layout.html" %}
+
+{% block title %}{{ self.t("admin-creds-title") }} · Ruscker{% endblock %}
+
+{% block content %}
+
+<div class="flex items-end justify-between mb-5">
+  <div>
+    <h1 class="text-xl font-medium tracking-tight">{{ self.t("admin-creds-title") }}</h1>
+    <p class="text-xs text-[color:var(--text-muted)] mt-1">{{ self.t("admin-creds-subtitle") }}</p>
+  </div>
+  <div class="text-xs text-[color:var(--text-faint)]">{{ credentials.len() }}</div>
+</div>
+
+{% if key_missing %}
+  <div class="admin-login-error mb-4" role="alert">
+    <i class="ti ti-alert-circle" aria-hidden="true"></i>
+    <div>
+      <strong>{{ self.t("admin-creds-key-missing-title") }}</strong>
+      <div class="text-[11px] opacity-80 mt-1">{{ self.t("admin-creds-key-missing-help") }}</div>
+      <pre class="text-[10px] mt-2 bg-[color:var(--surface-soft)] p-2 rounded inline-block">openssl rand -hex 32</pre>
+    </div>
+  </div>
+{% endif %}
+
+{% match flash_error %}{% when Some with (msg) %}
+  <div class="admin-login-error mb-4" role="alert">
+    <i class="ti ti-alert-circle" aria-hidden="true"></i>
+    {{ msg }}
+  </div>
+{% when None %}{% endmatch %}
+
+{% match flash_saved %}{% when Some with (name) %}
+  <div class="admin-flash-ok mb-4" role="status">
+    <i class="ti ti-check" aria-hidden="true"></i>
+    {{ self.t("admin-creds-saved") }} <code>{{ name }}</code>
+  </div>
+{% when None %}{% endmatch %}
+
+{# ── Add/Update form ──────────────────────────────────────── #}
+<form method="post" action="/admin/credentials" class="creds-form" autocomplete="off">
+  <div class="creds-form-section-title">{{ self.t("admin-creds-form-title") }}</div>
+
+  <div class="grid grid-cols-2 gap-3">
+    <div class="spec-form-field">
+      <label class="spec-form-label">{{ self.t("admin-creds-name") }}</label>
+      <input type="text" name="name" required
+             placeholder="docker-hub"
+             {% if key_missing %}disabled{% endif %}
+             class="spec-form-input spec-form-input--mono">
+      <div class="spec-form-help">{{ self.t("admin-creds-name-help") }}</div>
+    </div>
+    <div class="spec-form-field">
+      <label class="spec-form-label">{{ self.t("admin-creds-registry") }}</label>
+      <input type="text" name="registry"
+             placeholder="docker.io"
+             {% if key_missing %}disabled{% endif %}
+             class="spec-form-input spec-form-input--mono">
+    </div>
+  </div>
+
+  <div class="grid grid-cols-2 gap-3">
+    <div class="spec-form-field">
+      <label class="spec-form-label">{{ self.t("admin-creds-username") }}</label>
+      <input type="text" name="username" required
+             {% if key_missing %}disabled{% endif %}
+             class="spec-form-input">
+    </div>
+    <div class="spec-form-field">
+      <label class="spec-form-label">{{ self.t("admin-creds-password") }}</label>
+      <input type="password" name="password" required
+             autocomplete="new-password"
+             {% if key_missing %}disabled{% endif %}
+             class="spec-form-input spec-form-input--mono">
+      <div class="spec-form-help">{{ self.t("admin-creds-password-help") }}</div>
+    </div>
+  </div>
+
+  <div class="flex justify-end gap-2 mt-2">
+    <button type="submit" class="admin-login-btn"
+            style="padding:8px 14px;font-size:12px"
+            {% if key_missing %}disabled{% endif %}>
+      <i class="ti ti-device-floppy" aria-hidden="true"></i>
+      {{ self.t("admin-creds-save") }}
+    </button>
+  </div>
+</form>
+
+{# ── Stored credentials list ──────────────────────────────── #}
+{% if credentials.is_empty() %}
+  <div class="card-surface rounded-lg p-12 text-center text-sm text-[color:var(--text-muted)] mt-6">
+    {{ self.t("admin-creds-empty") }}
+  </div>
+{% else %}
+  <table class="admin-table mt-6">
+    <thead>
+      <tr>
+        <th>{{ self.t("admin-creds-col-name") }}</th>
+        <th>{{ self.t("admin-creds-col-registry") }}</th>
+        <th>{{ self.t("admin-creds-col-username") }}</th>
+        <th>{{ self.t("admin-creds-col-created") }}</th>
+        <th class="actions-cell">{{ self.t("admin-specs-col-actions") }}</th>
+      </tr>
+    </thead>
+    <tbody>
+      {% for c in credentials %}
+        <tr>
+          <td class="id-cell">{{ c.name }}</td>
+          <td class="text-[color:var(--text-muted)]">{{ c.registry }}</td>
+          <td>{{ c.username }}</td>
+          <td class="text-[color:var(--text-muted)]">{{ c.created_at.format("%d/%m/%Y") }}</td>
+          <td class="actions-cell">
+            <form method="post" action="/admin/credentials/{{ c.name }}/delete"
+                  onsubmit="return confirm('{{ self.t("admin-creds-delete-confirm") }}');"
+                  class="inline">
+              <button type="submit" class="admin-nav-link" style="color:var(--color-lock)"
+                      title="{{ self.t("admin-creds-delete") }}">
+                <i class="ti ti-trash" aria-hidden="true"></i>
+              </button>
+            </form>
+          </td>
+        </tr>
+      {% endfor %}
+    </tbody>
+  </table>
+{% endif %}
+
+{% endblock %}

--- a/crates/ruscker-admin/templates/admin/images.html
+++ b/crates/ruscker-admin/templates/admin/images.html
@@ -1,0 +1,80 @@
+{% extends "admin/_layout.html" %}
+
+{% block title %}{{ self.t("admin-images-title") }} · Ruscker{% endblock %}
+
+{% block content %}
+
+<div class="flex items-end justify-between mb-5">
+  <div>
+    <h1 class="text-xl font-medium tracking-tight">{{ self.t("admin-images-title") }}</h1>
+    <p class="text-xs text-[color:var(--text-muted)] mt-1">{{ self.t("admin-images-subtitle") }}</p>
+  </div>
+  <div class="text-xs text-[color:var(--text-faint)]">{{ images.len() }}</div>
+</div>
+
+{% match flash_error %}{% when Some with (msg) %}
+  <div class="admin-login-error mb-4" role="alert">
+    <i class="ti ti-alert-circle" aria-hidden="true"></i>
+    {{ msg }}
+  </div>
+{% when None %}{% endmatch %}
+
+{% match flash_uploaded %}{% when Some with (name) %}
+  <div class="admin-flash-ok mb-4" role="status">
+    <i class="ti ti-check" aria-hidden="true"></i>
+    {{ self.t("admin-images-uploaded") }} <code>{{ name }}</code>
+  </div>
+{% when None %}{% endmatch %}
+
+{# ── Upload form ──────────────────────────────────────────── #}
+<form method="post" action="/admin/images" enctype="multipart/form-data"
+      class="image-upload-zone">
+  <input type="file" name="file" id="img-file" required
+         accept="image/png,image/jpeg,image/webp,image/svg+xml">
+  <label for="img-file" class="image-upload-label">
+    <i class="ti ti-cloud-upload" aria-hidden="true"></i>
+    <span>{{ self.t("admin-images-drop-here") }}</span>
+    <span class="text-[10px] text-[color:var(--text-faint)] mt-1">{{ self.t("admin-images-formats") }}</span>
+  </label>
+  <button type="submit" class="admin-login-btn" style="padding:8px 14px;font-size:12px">
+    <i class="ti ti-upload" aria-hidden="true"></i>
+    {{ self.t("admin-images-upload") }}
+  </button>
+</form>
+
+{# ── Gallery grid ─────────────────────────────────────────── #}
+{% if images.is_empty() %}
+  <div class="card-surface rounded-lg p-12 text-center text-sm text-[color:var(--text-muted)] mt-6">
+    {{ self.t("admin-images-empty") }}
+  </div>
+{% else %}
+  <section class="image-gallery">
+    {% for img in images %}
+      <div class="image-tile">
+        <a href="/assets/img/{{ img.filename }}" target="_blank" class="image-tile-frame"
+           title="{{ img.filename }}">
+          <img src="/assets/img/{{ img.filename }}" alt="" loading="lazy">
+        </a>
+        <div class="image-tile-meta">
+          <div class="image-tile-name" title="{{ img.filename }}">{{ img.filename }}</div>
+          <div class="image-tile-sub">
+            <span>{{ self.fmt_size(img.size_bytes) }}</span>
+            <span class="opacity-60">·</span>
+            <span>{{ img.mime_type }}</span>
+            {% match img.width %}{% when Some with (w) %}{% match img.height %}{% when Some with (h) %}
+              <span class="opacity-60">·</span><span>{{ w }}×{{ h }}</span>
+            {% when None %}{% endmatch %}{% when None %}{% endmatch %}
+          </div>
+        </div>
+        <form method="post" action="/admin/images/{{ img.id }}/delete"
+              onsubmit="return confirm('{{ self.t("admin-images-delete-confirm") }}');">
+          <button type="submit" class="image-tile-delete" title="{{ self.t("admin-images-delete") }}">
+            <i class="ti ti-trash" aria-hidden="true"></i>
+          </button>
+        </form>
+      </div>
+    {% endfor %}
+  </section>
+{% endif %}
+
+{% endblock %}

--- a/crates/ruscker-admin/templates/admin/landing.html
+++ b/crates/ruscker-admin/templates/admin/landing.html
@@ -1,0 +1,185 @@
+{% extends "admin/_layout.html" %}
+
+{% block title %}{{ self.t("admin-landing-title") }} · Ruscker{% endblock %}
+
+{% block content %}
+
+<div x-data="ruscker.landingForm({{ form_initial_json() }})" x-cloak>
+
+  {# ── Header ───────────────────────────────────────────────── #}
+  <div class="flex items-end justify-between mb-5 pb-3 border-b border-[color:var(--border)]">
+    <div>
+      <div class="text-[11px] text-[color:var(--text-faint)] uppercase tracking-wide">
+        {{ self.t("admin-landing-crumb") }}
+      </div>
+      <h1 class="text-xl font-medium tracking-tight">{{ self.t("admin-landing-title") }}</h1>
+      <p class="text-xs text-[color:var(--text-muted)] mt-1">{{ self.t("admin-landing-subtitle") }}</p>
+    </div>
+    <div class="flex items-center gap-2">
+      <a href="/" target="_blank" class="admin-nav-link" title="{{ self.t("admin-landing-open-portal") }}">
+        <i class="ti ti-external-link" aria-hidden="true"></i>
+        {{ self.t("admin-landing-open-portal") }}
+      </a>
+      <button type="submit" form="landing-form" class="admin-login-btn" style="padding:6px 12px;font-size:12px">
+        <i class="ti ti-device-floppy" aria-hidden="true"></i>
+        {{ self.t("admin-landing-save") }}
+      </button>
+    </div>
+  </div>
+
+  {% if flash_saved %}
+    <div class="admin-flash-ok mb-4" role="status">
+      <i class="ti ti-check" aria-hidden="true"></i>
+      {{ self.t("admin-landing-saved") }}
+    </div>
+  {% endif %}
+
+  {% match flash_error %}{% when Some with (msg) %}
+    <div class="admin-login-error mb-4" role="alert">
+      <i class="ti ti-alert-circle" aria-hidden="true"></i>
+      {{ msg }}
+    </div>
+  {% when None %}{% endmatch %}
+
+  <div class="spec-form-layout">
+
+    {# ── LEFT: form ────────────────────────────────────────── #}
+    <form id="landing-form" method="post" action="/admin/landing"
+          class="spec-form-fields" autocomplete="off">
+
+      <div class="spec-form-section-title">{{ self.t("admin-landing-colors") }}</div>
+
+      <div class="grid grid-cols-2 gap-3">
+        <div class="spec-form-field">
+          <label class="spec-form-label">{{ self.t("admin-landing-header-bg") }}</label>
+          <div class="color-input">
+            <input type="color" x-model="form.header_bg"
+                   :value="form.header_bg || '#fafaf7'">
+            <input type="text" name="header_bg" x-model="form.header_bg"
+                   placeholder="#0f6e56"
+                   class="spec-form-input spec-form-input--mono">
+            <button type="button" @click="form.header_bg = ''"
+                    class="admin-nav-link" title="{{ self.t("admin-landing-clear") }}">
+              <i class="ti ti-x" aria-hidden="true"></i>
+            </button>
+          </div>
+          <div class="spec-form-help">{{ self.t("admin-landing-bg-help") }}</div>
+        </div>
+        <div class="spec-form-field">
+          <label class="spec-form-label">{{ self.t("admin-landing-header-fg") }}</label>
+          <div class="color-input">
+            <input type="color" x-model="form.header_fg"
+                   :value="form.header_fg || '#1a1a1a'">
+            <input type="text" name="header_fg" x-model="form.header_fg"
+                   placeholder="#ffffff"
+                   class="spec-form-input spec-form-input--mono">
+            <button type="button" @click="form.header_fg = ''"
+                    class="admin-nav-link" title="{{ self.t("admin-landing-clear") }}">
+              <i class="ti ti-x" aria-hidden="true"></i>
+            </button>
+          </div>
+        </div>
+      </div>
+
+      <div class="spec-form-section-title">{{ self.t("admin-landing-intro") }}</div>
+
+      <div class="spec-form-field">
+        <label class="spec-form-label">{{ self.t("admin-landing-intro-default") }}</label>
+        <textarea name="intro" rows="2"
+                  x-model="form.intro"
+                  placeholder="{{ self.t("admin-landing-intro-default-placeholder") }}"
+                  class="spec-form-input">{{ form.intro }}</textarea>
+        <div class="spec-form-help">{{ self.t("admin-landing-intro-help") }}</div>
+      </div>
+
+      <div class="spec-form-section-title">{{ self.t("admin-landing-intro-locales") }}</div>
+
+      <div class="grid grid-cols-2 gap-3">
+        <div class="spec-form-field">
+          <label class="spec-form-label">🇧🇷 {{ self.t("admin-landing-intro-pt") }}</label>
+          <textarea name="intro_pt" rows="3"
+                    x-model="form.intro_pt"
+                    class="spec-form-input">{{ form.intro_pt }}</textarea>
+        </div>
+        <div class="spec-form-field">
+          <label class="spec-form-label">🇺🇸 {{ self.t("admin-landing-intro-en") }}</label>
+          <textarea name="intro_en" rows="3"
+                    x-model="form.intro_en"
+                    class="spec-form-input">{{ form.intro_en }}</textarea>
+        </div>
+        <div class="spec-form-field">
+          <label class="spec-form-label">🇪🇸 {{ self.t("admin-landing-intro-es") }}</label>
+          <textarea name="intro_es" rows="3"
+                    x-model="form.intro_es"
+                    class="spec-form-input">{{ form.intro_es }}</textarea>
+        </div>
+        <div class="spec-form-field">
+          <label class="spec-form-label">🇫🇷 {{ self.t("admin-landing-intro-fr") }}</label>
+          <textarea name="intro_fr" rows="3"
+                    x-model="form.intro_fr"
+                    class="spec-form-input">{{ form.intro_fr }}</textarea>
+        </div>
+      </div>
+
+      <div class="info-box">
+        <i class="ti ti-info-circle" aria-hidden="true"></i>
+        <div>
+          <strong>{{ self.t("admin-landing-future-title") }}</strong>
+          <div class="text-[11px] opacity-80 mt-1">{{ self.t("admin-landing-future-help") }}</div>
+        </div>
+      </div>
+    </form>
+
+    {# ── RIGHT: live preview ──────────────────────────────── #}
+    <aside class="spec-form-preview">
+      <div class="spec-form-section-title">{{ self.t("admin-landing-preview") }}</div>
+
+      <div class="landing-preview-frame">
+        <div class="landing-preview-header"
+             :style="(form.header_bg ? `background:${form.header_bg};` : '') + (form.header_fg ? `color:${form.header_fg};` : '')">
+          <div class="landing-preview-header-inner">
+            <div>
+              <div class="landing-preview-title">{{ portal_title }}</div>
+              <div class="landing-preview-sub">{{ self.t("landing-subtitle") }}</div>
+            </div>
+            <div class="landing-preview-count">N</div>
+          </div>
+        </div>
+
+        <div class="landing-preview-body">
+          <p class="landing-preview-intro"
+             x-text="previewIntro()"
+             :class="!previewIntro() ? 'opacity-40 italic' : ''"></p>
+          <div class="landing-preview-mockfilter"></div>
+          <div class="landing-preview-mockgrid">
+            <div></div><div></div><div></div><div></div>
+          </div>
+        </div>
+      </div>
+
+      <div class="spec-form-help" style="margin-top:8px">
+        {{ self.t("admin-landing-preview-help") }}
+      </div>
+    </aside>
+
+  </div>
+</div>
+
+<script src="/assets/js/alpine.min.js" defer></script>
+<script>
+window.ruscker = window.ruscker || {};
+window.ruscker.landingForm = (initial) => ({
+  form: initial,
+  /// Resolve the intro shown in the preview given the admin's
+  /// own locale: prefer the per-locale field, fall back to the
+  /// default. Mirrors the server-side resolution in routes/landing.rs.
+  previewIntro() {
+    const code = "{{ locale.code() }}";
+    const per = { pt: this.form.intro_pt, en: this.form.intro_en, es: this.form.intro_es, fr: this.form.intro_fr };
+    return (per[code] || this.form.intro || "").trim()
+        || "{{ self.t("admin-landing-preview-empty") }}";
+  },
+});
+</script>
+
+{% endblock %}

--- a/crates/ruscker-admin/templates/admin/login.html
+++ b/crates/ruscker-admin/templates/admin/login.html
@@ -1,0 +1,61 @@
+<!doctype html>
+<html lang="{{ locale.code() }}"{% match theme.data_attr() %}{% when Some with (t) %} data-theme="{{ t }}"{% when None %}{% endmatch %}>
+<head>
+<meta charset="utf-8">
+<meta name="viewport" content="width=device-width,initial-scale=1">
+<meta name="theme-color" content="#0f6e56">
+<meta name="robots" content="noindex,nofollow">
+<title>{{ self.t("admin-login-title") }} · Ruscker</title>
+<link rel="icon" type="image/svg+xml" href="/favicon.svg">
+<link rel="stylesheet" href="/assets/styles.css">
+<link rel="stylesheet" href="/assets/icons/tabler-icons.min.css">
+</head>
+<body class="min-h-screen flex flex-col items-center justify-center px-4">
+
+<form method="post" action="/admin/login" class="admin-login-card" autocomplete="off">
+
+  <div class="admin-login-brand">
+    <svg viewBox="0 0 80 80" width="48" height="48" aria-hidden="true">
+      <polygon points="14,52 40,40 66,52 40,64" fill="#0F6E56"/>
+      <polygon points="14,40 40,28 66,40 40,52" fill="#1D9E75"/>
+      <polygon points="14,28 40,16 66,28 40,40" fill="#5DCAA5"/>
+    </svg>
+    <div class="brand-wordmark text-base">ruscker · admin</div>
+  </div>
+
+  <h1 class="text-lg font-medium tracking-tight">{{ self.t("admin-login-title") }}</h1>
+  <p class="text-xs text-[color:var(--text-muted)]">{{ self.t("admin-login-help") }}</p>
+
+  {% if error == "wrong-token" %}
+    <div class="admin-login-error" role="alert">
+      <i class="ti ti-alert-circle" aria-hidden="true"></i>
+      {{ self.t("admin-login-error-wrong") }}
+    </div>
+  {% endif %}
+
+  <label class="admin-login-field">
+    <span class="admin-login-label">{{ self.t("admin-login-token-label") }}</span>
+    <input type="password" name="token" required autofocus
+           placeholder="{{ self.t("admin-login-token-placeholder") }}">
+  </label>
+
+  <button type="submit" class="admin-login-btn">
+    <i class="ti ti-login" aria-hidden="true"></i>
+    {{ self.t("admin-login-submit") }}
+  </button>
+
+  <div class="admin-login-footer">
+    <a href="/">{{ self.t("admin-login-back-portal") }}</a>
+    <form method="post" action="/__set/locale" class="contents">
+      {% for loc in locales_all %}
+        <button type="submit" name="locale" value="{{ loc.code() }}"
+                class="admin-login-locale {% if *loc == locale %}is-active{% endif %}">
+          {{ loc.code()|upper }}
+        </button>
+      {% endfor %}
+    </form>
+  </div>
+</form>
+
+</body>
+</html>

--- a/crates/ruscker-admin/templates/admin/spec_form.html
+++ b/crates/ruscker-admin/templates/admin/spec_form.html
@@ -1,0 +1,278 @@
+{% extends "admin/_layout.html" %}
+
+{% block title %}
+  {% if mode.is_new() %}{{ self.t("spec-form-title-new") }}{% else %}{{ form.id }} · Ruscker{% endif %}
+{% endblock %}
+
+{% block content %}
+
+<div x-data="ruscker.specForm({{ form_initial_json() }})" x-cloak>
+
+  {# ── Header ───────────────────────────────────────────────── #}
+  <div class="flex items-end justify-between mb-5 pb-3 border-b border-[color:var(--border)]">
+    <div>
+      <div class="text-[11px] text-[color:var(--text-faint)] uppercase tracking-wide">
+        <a href="/admin/specs" class="hover:underline">{{ self.t("admin-nav-apps") }}</a>
+        · {% if mode.is_new() %}{{ self.t("spec-form-crumb-new") }}{% else %}{{ self.t("spec-form-crumb-edit") }}{% endif %}
+      </div>
+      <h1 class="text-xl font-medium tracking-tight" x-text="form.display_name || form.id || '{{ self.t("spec-form-title-new") }}'"></h1>
+    </div>
+    <div class="flex items-center gap-2">
+      <a href="/admin/specs" class="admin-nav-link">{{ self.t("spec-form-cancel") }}</a>
+      <button type="submit" form="spec-form" class="admin-login-btn" style="padding:6px 12px;font-size:12px">
+        <i class="ti ti-check" aria-hidden="true"></i>
+        {{ self.t("spec-form-save") }}
+      </button>
+    </div>
+  </div>
+
+  {# ── Validation banner (server-side errors) ───────────────── #}
+  {% if !errors.is_empty() %}
+    <div class="admin-login-error mb-4" role="alert">
+      <i class="ti ti-alert-circle" aria-hidden="true"></i>
+      <ul class="m-0 p-0">
+        {% for key in errors %}
+          <li>{{ self.t(key) }}</li>
+        {% endfor %}
+      </ul>
+    </div>
+  {% endif %}
+
+  <div class="spec-form-layout">
+
+    {# ── LEFT: form ────────────────────────────────────────── #}
+    <form id="spec-form" method="post"
+          action="{% if mode.is_new() %}/admin/specs{% else %}/admin/specs/{{ form.id }}{% endif %}"
+          class="spec-form-fields"
+          autocomplete="off">
+
+      {# Type picker — 4 cards #}
+      <div class="spec-form-section">
+        <div class="spec-form-label">{{ self.t("spec-form-kind") }}</div>
+        <div class="kind-picker">
+          {% for k in display_type_options() %}
+            <label class="kind-picker-card" :class="form.display_type === '{{ k.0 }}' ? 'is-active' : ''">
+              <input type="radio" name="display_type" value="{{ k.0 }}" x-model="form.display_type" class="sr-only">
+              <i class="ti ti-{{ k.2 }}" aria-hidden="true"></i>
+              <span>{{ self.t(k.1) }}</span>
+            </label>
+          {% endfor %}
+        </div>
+      </div>
+
+      <div class="spec-form-section-title">{{ self.t("spec-form-identity") }}</div>
+
+      <div class="spec-form-field">
+        <label for="f-id" class="spec-form-label">{{ self.t("spec-form-id") }}</label>
+        <input id="f-id" type="text" name="id"
+               value="{{ form.id }}"
+               x-model="form.id"
+               required pattern="[A-Za-z][A-Za-z0-9_\-]*"
+               {% if mode.is_edit() %}readonly{% endif %}
+               class="spec-form-input spec-form-input--mono">
+        <div class="spec-form-help">
+          {% if mode.is_new() %}{{ self.t("spec-form-id-help-new") }}{% else %}{{ self.t("spec-form-id-help-edit") }}{% endif %}
+        </div>
+      </div>
+
+      <div class="spec-form-field">
+        <label for="f-name" class="spec-form-label">{{ self.t("spec-form-name") }}</label>
+        <input id="f-name" type="text" name="display_name"
+               value="{{ form.display_name }}"
+               x-model="form.display_name"
+               required
+               class="spec-form-input">
+      </div>
+
+      <div class="spec-form-field">
+        <label for="f-desc" class="spec-form-label">{{ self.t("spec-form-desc") }}</label>
+        <textarea id="f-desc" name="description"
+                  x-model="form.description"
+                  rows="3"
+                  class="spec-form-input">{{ form.description }}</textarea>
+      </div>
+
+      <div class="spec-form-section-title">{{ self.t("spec-form-visual") }}</div>
+
+      <div class="spec-form-field">
+        <label for="f-logo" class="spec-form-label">{{ self.t("spec-form-logo") }}</label>
+        <input id="f-logo" type="text" name="logo"
+               value="{{ form.logo }}"
+               x-model="form.logo"
+               placeholder="/assets/img/myapp.png"
+               class="spec-form-input spec-form-input--mono">
+        <div class="spec-form-help">{{ self.t("spec-form-logo-help") }}</div>
+      </div>
+
+      <div class="grid grid-cols-3 gap-3">
+        <div class="spec-form-field">
+          <label for="f-access" class="spec-form-label">{{ self.t("spec-form-access") }}</label>
+          <select id="f-access" name="access" x-model="form.access" class="spec-form-input">
+            <option value="lock">🔒 {{ self.t("filter-access-restricted") }}</option>
+            <option value="lock_open">🔓 {{ self.t("filter-access-public") }}</option>
+          </select>
+        </div>
+        <div class="spec-form-field">
+          <label for="f-state" class="spec-form-label">{{ self.t("spec-form-state") }}</label>
+          <select id="f-state" name="state" x-model="form.state" class="spec-form-input">
+            <option value="active">{{ self.t("spec-form-state-active") }}</option>
+            <option value="inactive">{{ self.t("spec-form-state-inactive") }}</option>
+          </select>
+        </div>
+        <div class="spec-form-field">
+          <label for="f-tema" class="spec-form-label">{{ self.t("spec-form-tema") }}</label>
+          <input id="f-tema" type="text" name="tema"
+                 value="{{ form.tema }}"
+                 x-model="form.tema"
+                 list="tema-suggestions"
+                 class="spec-form-input">
+          <datalist id="tema-suggestions">
+            <option value="Gestão"></option>
+            <option value="Infraestrutura e Mobilidade"></option>
+            <option value="Políticas Públicas"></option>
+            <option value="Saúde Pública"></option>
+            <option value="Segurança Pública"></option>
+          </datalist>
+        </div>
+      </div>
+
+      <template x-if="needsContainer()">
+        <div>
+          <div class="spec-form-section-title">{{ self.t("spec-form-container") }}</div>
+
+          <div class="spec-form-field">
+            <label for="f-img" class="spec-form-label">{{ self.t("spec-form-image") }}</label>
+            <input id="f-img" type="text" name="container_image"
+                   value="{{ form.container_image }}"
+                   x-model="form.container_image"
+                   placeholder="org/repo:tag"
+                   class="spec-form-input spec-form-input--mono">
+          </div>
+
+          <div class="grid grid-cols-2 gap-3">
+            <div class="spec-form-field">
+              <label for="f-seats" class="spec-form-label">{{ self.t("spec-form-seats") }}</label>
+              <input id="f-seats" type="number" name="seats_per_container"
+                     value="{{ form.seats_per_container }}"
+                     min="1"
+                     placeholder="10"
+                     class="spec-form-input">
+            </div>
+            <div class="spec-form-field">
+              <label for="f-lifetime" class="spec-form-label">{{ self.t("spec-form-lifetime") }}</label>
+              <input id="f-lifetime" type="number" name="max_lifetime"
+                     value="{{ form.max_lifetime }}"
+                     min="1"
+                     placeholder="360"
+                     class="spec-form-input">
+              <div class="spec-form-help">{{ self.t("spec-form-lifetime-help") }}</div>
+            </div>
+          </div>
+        </div>
+      </template>
+
+      <template x-if="needsLink()">
+        <div>
+          <div class="spec-form-section-title">{{ self.t("spec-form-link-section") }}</div>
+          <div class="spec-form-field">
+            <label for="f-link" class="spec-form-label">{{ self.t("spec-form-link") }}</label>
+            <input id="f-link" type="url" name="link"
+                   value="{{ form.link }}"
+                   x-model="form.link"
+                   placeholder="https://example.com"
+                   class="spec-form-input">
+          </div>
+        </div>
+      </template>
+
+      <div class="spec-form-section-title">{{ self.t("spec-form-meta") }}</div>
+      <div class="spec-form-field">
+        <label for="f-updated" class="spec-form-label">{{ self.t("spec-form-updated") }}</label>
+        <input id="f-updated" type="text" name="updated"
+               value="{{ form.updated }}"
+               x-model="form.updated"
+               placeholder="DD/MM/YYYY"
+               pattern="\d{2}/\d{2}/\d{4}"
+               class="spec-form-input spec-form-input--mono">
+        <div class="spec-form-help">{{ self.t("spec-form-updated-help") }}</div>
+      </div>
+    </form>
+
+    {# ── RIGHT: live preview + actions ─────────────────────── #}
+    <aside class="spec-form-preview">
+      <div class="spec-form-section-title">{{ self.t("spec-form-preview") }}</div>
+
+      <div class="rcard" style="margin:0">
+        <div class="rcover">
+          <div class="rcover-bg" :class="'tint-' + form.display_type"></div>
+          <template x-if="form.logo">
+            <img :src="form.logo" alt="" class="rcover-img">
+          </template>
+          <template x-if="!form.logo">
+            <span class="rcover-fallback" x-text="form.id || '—'"></span>
+          </template>
+          <span class="rbadge" :class="'b-' + form.display_type" x-text="badgeText()"></span>
+          <span class="rlock">
+            <i class="ti" :class="form.access === 'lock_open'
+                ? 'ti-lock-open text-[color:var(--color-lock-open)]'
+                : 'ti-lock text-[color:var(--color-lock)]'"></i>
+          </span>
+        </div>
+        <div class="rbody">
+          <div class="rtitle" x-text="form.display_name || form.id || '—'"></div>
+          <div class="rdesc" x-text="form.description || '—'"></div>
+          <div class="rmeta">
+            <span class="rmeta-left">
+              <span class="status-dot status-dot-new"></span>
+              <span x-text="form.updated ? form.updated : '—'"></span>
+            </span>
+            <i class="ti ti-arrow-right arrow-go"></i>
+          </div>
+        </div>
+      </div>
+
+      <div class="spec-form-help" style="margin-top:8px">
+        {{ self.t("spec-form-preview-help") }}
+      </div>
+
+      {% if mode.is_edit() %}
+        <div class="spec-form-actions-box">
+          <div class="spec-form-actions-title">{{ self.t("spec-form-actions") }}</div>
+          <form method="post" action="/admin/specs/{{ form.id }}/delete"
+                onsubmit="return confirm('{{ self.t("spec-form-delete-confirm") }}');">
+            <button type="submit" class="spec-form-delete">
+              <i class="ti ti-trash" aria-hidden="true"></i>
+              {{ self.t("spec-form-delete") }}
+            </button>
+          </form>
+        </div>
+      {% endif %}
+    </aside>
+
+  </div>
+</div>
+
+<script src="/assets/js/alpine.min.js" defer></script>
+<script>
+window.ruscker = window.ruscker || {};
+window.ruscker.specForm = (initial) => ({
+  form: initial,
+  needsContainer() {
+    return ['app', 'api', 'talk', 'report'].includes(this.form.display_type);
+  },
+  needsLink() {
+    return ['link', 'package'].includes(this.form.display_type);
+  },
+  badgeText() {
+    const map = {
+      // PT — matches type-*-abbr keys; localizing the preview is
+      // a polish item for the next batch.
+      app: 'APP', talk: 'APR', report: 'RLT',
+      package: 'PCT', api: 'API', link: 'LNK',
+    };
+    return map[this.form.display_type] || 'APP';
+  },
+});
+</script>
+
+{% endblock %}

--- a/crates/ruscker-admin/templates/admin/specs.html
+++ b/crates/ruscker-admin/templates/admin/specs.html
@@ -1,0 +1,66 @@
+{% extends "admin/_layout.html" %}
+
+{% block title %}{{ self.t("admin-specs-title") }} · Ruscker{% endblock %}
+
+{% block content %}
+
+<div class="flex items-end justify-between mb-5">
+  <div>
+    <h1 class="text-xl font-medium tracking-tight">{{ self.t("admin-specs-title") }}</h1>
+    <p class="text-xs text-[color:var(--text-muted)] mt-1">{{ self.t("admin-specs-subtitle") }}</p>
+  </div>
+  <div class="flex items-center gap-2">
+    <span class="text-xs text-[color:var(--text-faint)]">{{ specs.len() }}</span>
+    <a href="/admin/specs/new" class="admin-login-btn" style="padding:6px 10px;font-size:12px">
+      <i class="ti ti-plus" aria-hidden="true"></i>
+      {{ self.t("admin-specs-add") }}
+    </a>
+  </div>
+</div>
+
+{% if specs.is_empty() %}
+  <div class="card-surface rounded-lg p-12 text-center text-sm text-[color:var(--text-muted)]">
+    <p>{{ self.t("admin-specs-empty") }}</p>
+    <pre class="mt-3 inline-block text-[11px] text-left bg-[color:var(--surface-soft)] px-3 py-2 rounded">ruscker import application.yml --db &lt;path&gt;</pre>
+  </div>
+{% else %}
+  <table class="admin-table">
+    <thead>
+      <tr>
+        <th>{{ self.t("admin-specs-col-id") }}</th>
+        <th>{{ self.t("admin-specs-col-name") }}</th>
+        <th>{{ self.t("admin-specs-col-kind") }}</th>
+        <th>{{ self.t("admin-specs-col-state") }}</th>
+        <th>{{ self.t("admin-specs-col-updated") }}</th>
+        <th>{{ self.t("admin-specs-col-version") }}</th>
+        <th class="actions-cell">{{ self.t("admin-specs-col-actions") }}</th>
+      </tr>
+    </thead>
+    <tbody>
+      {% for spec in specs %}
+        <tr>
+          <td class="id-cell">{{ spec.id }}</td>
+          <td>
+            {% match spec.display_name %}
+              {% when Some with (n) %}{{ n }}
+              {% when None %}<span class="text-[color:var(--text-faint)]">—</span>
+            {% endmatch %}
+          </td>
+          <td><span class="pill pill-kind-{{ spec.kind }}">{{ spec.kind }}</span></td>
+          <td><span class="pill pill-state-{{ spec.state }}">{{ spec.state }}</span></td>
+          <td class="text-[color:var(--text-muted)]">{{ spec.updated_at.format("%d/%m/%Y %H:%M") }}</td>
+          <td class="text-[color:var(--text-muted)]">v{{ spec.version }}</td>
+          <td class="actions-cell">
+            <a href="/admin/specs/{{ spec.id }}/edit"
+               class="admin-nav-link"
+               title="{{ self.t("admin-specs-edit") }}">
+              <i class="ti ti-edit" aria-hidden="true"></i>
+            </a>
+          </td>
+        </tr>
+      {% endfor %}
+    </tbody>
+  </table>
+{% endif %}
+
+{% endblock %}

--- a/crates/ruscker-admin/tests/landing_render.rs
+++ b/crates/ruscker-admin/tests/landing_render.rs
@@ -26,6 +26,7 @@ fn app_state() -> AppState {
         locales: Arc::new(locales),
         admin_auth: Default::default(),
         db: None,
+        images_dir: None,
     }
 }
 

--- a/crates/ruscker-admin/tests/landing_render.rs
+++ b/crates/ruscker-admin/tests/landing_render.rs
@@ -24,6 +24,8 @@ fn app_state() -> AppState {
     AppState {
         config: Arc::new(config),
         locales: Arc::new(locales),
+        admin_auth: Default::default(),
+        db: None,
     }
 }
 

--- a/crates/ruscker-admin/tests/landing_render.rs
+++ b/crates/ruscker-admin/tests/landing_render.rs
@@ -27,6 +27,7 @@ fn app_state() -> AppState {
         admin_auth: Default::default(),
         db: None,
         images_dir: None,
+        master_key: Default::default(),
     }
 }
 

--- a/crates/ruscker-cli/Cargo.toml
+++ b/crates/ruscker-cli/Cargo.toml
@@ -19,6 +19,7 @@ clap = { workspace = true }
 anyhow = { workspace = true }
 serde = { workspace = true }
 serde_json = { workspace = true }
+serde_yaml_ng = { workspace = true }
 tokio = { workspace = true }
 tracing = { workspace = true }
 tracing-subscriber = { workspace = true }

--- a/crates/ruscker-cli/src/main.rs
+++ b/crates/ruscker-cli/src/main.rs
@@ -63,6 +63,20 @@ enum Command {
         path: PathBuf,
     },
 
+    /// Import a YAML configuration into a SQLite admin database.
+    /// Idempotent — re-running with unchanged YAML produces zero
+    /// writes. Specs in the DB but absent from the YAML are NOT
+    /// deleted (separate operator action).
+    Import {
+        /// Path to the source YAML.
+        path: PathBuf,
+
+        /// Path to the SQLite file. Created with the schema if
+        /// missing.
+        #[arg(long)]
+        db: PathBuf,
+    },
+
     /// Start the HTTP server (public landing in Phase 1; admin + proxy
     /// land in Phase 2+).
     Serve {
@@ -90,10 +104,43 @@ fn main() -> Result<()> {
         Command::Validate { path, json, strict } => cmd_validate(&path, json, strict),
         Command::Show { path } => cmd_show(&path),
         Command::Inspect { path } => cmd_inspect(&path),
+        Command::Import { path, db } => cmd_import(&path, &db),
         Command::Serve { config, bind, images_dir } => {
             cmd_serve(&config, bind, images_dir)
         }
     }
+}
+
+fn cmd_import(yaml_path: &PathBuf, db_path: &PathBuf) -> Result<()> {
+    let config = Config::from_file(yaml_path).with_context(|| {
+        format!("failed to load config from {}", yaml_path.display())
+    })?;
+
+    let rt = tokio::runtime::Builder::new_current_thread()
+        .enable_all()
+        .build()?;
+
+    let report = rt.block_on(async {
+        let pool = ruscker_admin::db::open(db_path).await?;
+        let r = ruscker_admin::db::specs::import_all(&pool, &config).await?;
+        pool.close().await;
+        anyhow::Ok(r)
+    })?;
+
+    println!();
+    println!("  Ruscker import");
+    println!("  ──────────────");
+    println!("  from:  {}", yaml_path.display());
+    println!("  into:  {}", db_path.display());
+    println!();
+    println!("  specs:");
+    println!("    created    {:>4}", report.created);
+    println!("    updated    {:>4}", report.updated);
+    println!("    unchanged  {:>4}", report.unchanged);
+    println!();
+    println!("  ✓ done. {} specs in the DB.",
+        report.created + report.updated + report.unchanged);
+    Ok(())
 }
 
 fn cmd_serve(

--- a/crates/ruscker-cli/src/main.rs
+++ b/crates/ruscker-cli/src/main.rs
@@ -102,6 +102,16 @@ enum Command {
         /// no image route is mounted (cards fall back to tint-only).
         #[arg(long)]
         images_dir: Option<PathBuf>,
+
+        /// Path to the SQLite admin database. Required for `/admin/*`
+        /// routes to function. Without it, those routes return 503.
+        #[arg(long)]
+        db: Option<PathBuf>,
+
+        /// Admin auth token. Overrides `RUSCKER_ADMIN_TOKEN` env var
+        /// when set. Without either, /admin/* routes return 503.
+        #[arg(long, env = "RUSCKER_ADMIN_TOKEN")]
+        admin_token: Option<String>,
     },
 }
 
@@ -115,8 +125,8 @@ fn main() -> Result<()> {
         Command::Inspect { path } => cmd_inspect(&path),
         Command::Import { path, db } => cmd_import(&path, &db),
         Command::Export { db } => cmd_export(&db),
-        Command::Serve { config, bind, images_dir } => {
-            cmd_serve(&config, bind, images_dir)
+        Command::Serve { config, bind, images_dir, db, admin_token } => {
+            cmd_serve(&config, bind, images_dir, db, admin_token)
         }
     }
 }
@@ -176,6 +186,8 @@ fn cmd_serve(
     config_path: &PathBuf,
     bind_override: Option<std::net::SocketAddr>,
     images_dir_override: Option<PathBuf>,
+    db_path: Option<PathBuf>,
+    admin_token: Option<String>,
 ) -> Result<()> {
     let config = Config::from_file(config_path).with_context(|| {
         format!("failed to load config from {}", config_path.display())
@@ -202,14 +214,24 @@ fn cmd_serve(
         candidate.is_dir().then_some(candidate)
     });
 
-    let mut server = ruscker_admin::AdminServer::new(addr, config)?;
-    if let Some(dir) = images_dir {
-        server = server.with_images_dir(dir);
-    }
-    tokio::runtime::Builder::new_multi_thread()
+    let rt = tokio::runtime::Builder::new_multi_thread()
         .enable_all()
-        .build()?
-        .block_on(server.run())
+        .build()?;
+
+    rt.block_on(async {
+        let mut server = ruscker_admin::AdminServer::new(addr, config)?;
+        if let Some(dir) = images_dir {
+            server = server.with_images_dir(dir);
+        }
+        if let Some(token) = admin_token {
+            server = server.with_admin_token(token);
+        }
+        if let Some(path) = db_path {
+            let pool = ruscker_admin::db::open(&path).await?;
+            server = server.with_db(pool);
+        }
+        server.run().await
+    })
 }
 
 fn init_tracing(verbosity: u8) {

--- a/crates/ruscker-cli/src/main.rs
+++ b/crates/ruscker-cli/src/main.rs
@@ -77,6 +77,15 @@ enum Command {
         db: PathBuf,
     },
 
+    /// Reconstruct an application.yml from a SQLite admin database
+    /// and write it to stdout. Pipes naturally into `> backup.yml`
+    /// or `| diff -u current.yml -` for change auditing.
+    Export {
+        /// Path to the SQLite file.
+        #[arg(long)]
+        db: PathBuf,
+    },
+
     /// Start the HTTP server (public landing in Phase 1; admin + proxy
     /// land in Phase 2+).
     Serve {
@@ -105,10 +114,30 @@ fn main() -> Result<()> {
         Command::Show { path } => cmd_show(&path),
         Command::Inspect { path } => cmd_inspect(&path),
         Command::Import { path, db } => cmd_import(&path, &db),
+        Command::Export { db } => cmd_export(&db),
         Command::Serve { config, bind, images_dir } => {
             cmd_serve(&config, bind, images_dir)
         }
     }
+}
+
+fn cmd_export(db_path: &PathBuf) -> Result<()> {
+    let rt = tokio::runtime::Builder::new_current_thread()
+        .enable_all()
+        .build()?;
+
+    let config = rt.block_on(async {
+        let pool = ruscker_admin::db::open(db_path).await?;
+        let c = ruscker_admin::db::export::reconstruct_config(&pool).await?;
+        pool.close().await;
+        anyhow::Ok(c)
+    })?;
+
+    // serde_yaml_ng's `to_string` emits a leading "---" document
+    // separator and trailing newline — both expected for YAML.
+    let yaml = serde_yaml_ng::to_string(&config).context("serialize Config to YAML")?;
+    print!("{yaml}");
+    Ok(())
 }
 
 fn cmd_import(yaml_path: &PathBuf, db_path: &PathBuf) -> Result<()> {

--- a/crates/ruscker-cli/src/main.rs
+++ b/crates/ruscker-cli/src/main.rs
@@ -112,6 +112,13 @@ enum Command {
         /// when set. Without either, /admin/* routes return 503.
         #[arg(long, env = "RUSCKER_ADMIN_TOKEN")]
         admin_token: Option<String>,
+
+        /// 32-byte master key for the credentials store. Accepts
+        /// hex (64 chars) or base64 (44 chars). Generate with
+        /// `openssl rand -hex 32`. Without this set,
+        /// /admin/credentials shows a hint instead of the form.
+        #[arg(long, env = "RUSCKER_MASTER_KEY")]
+        master_key: Option<String>,
     },
 }
 
@@ -125,8 +132,8 @@ fn main() -> Result<()> {
         Command::Inspect { path } => cmd_inspect(&path),
         Command::Import { path, db } => cmd_import(&path, &db),
         Command::Export { db } => cmd_export(&db),
-        Command::Serve { config, bind, images_dir, db, admin_token } => {
-            cmd_serve(&config, bind, images_dir, db, admin_token)
+        Command::Serve { config, bind, images_dir, db, admin_token, master_key } => {
+            cmd_serve(&config, bind, images_dir, db, admin_token, master_key)
         }
     }
 }
@@ -188,6 +195,7 @@ fn cmd_serve(
     images_dir_override: Option<PathBuf>,
     db_path: Option<PathBuf>,
     admin_token: Option<String>,
+    master_key: Option<String>,
 ) -> Result<()> {
     let config = Config::from_file(config_path).with_context(|| {
         format!("failed to load config from {}", config_path.display())
@@ -225,6 +233,9 @@ fn cmd_serve(
         }
         if let Some(token) = admin_token {
             server = server.with_admin_token(token);
+        }
+        if let Some(k) = master_key {
+            server = server.with_master_key(k).context("invalid --master-key")?;
         }
         if let Some(path) = db_path {
             let pool = ruscker_admin::db::open(&path).await?;

--- a/crates/ruscker-config/src/lib.rs
+++ b/crates/ruscker-config/src/lib.rs
@@ -42,8 +42,8 @@ pub mod validate;
 
 pub use error::{Error, Result};
 pub use schema::{
-    Config, LandingCustomization, Proxy, RoutingStrategy, Server, Spec, SpecKind,
-    SpecKindOverride, TemplateProperties,
+    Config, LandingCustomization, Logging, Proxy, RoutingStrategy, Server, Spec,
+    SpecKind, SpecKindOverride, TemplateProperties,
 };
 pub use validate::{ValidationReport, Warning};
 


### PR DESCRIPTION
Closes #2. Phase 2 complete: SQLite source of truth + import/export
round-trip + full admin CRUD (apps, images, credentials, landing,
audit log).

## What's in

### Persistence + round-trip
- Migration 0001: `specs`, `spec_versions`, `images`, `credentials`,
  `landing_customization`, `audit_log` (FK + WAL + 5s busy_timeout)
- Migration 0002: `config_meta` key/value for the rest of
  proxy/server/logging JSON blobs
- `ruscker import application.yml --db <path>` — idempotent
  (canonical JSON via `serde_json::Value` round-trip dodges
  HashMap nondeterminism)
- `ruscker export --db <path>` — reconstructs full Config; round-trip
  verified: import → export → reimport unchanged

### Admin
- **Auth** (env-var token, AES-256 constant-time compare, HttpOnly
  SameSite=Strict cookie 24h)
- **Apps list** `/admin/specs` — table with kind/state pills,
  filter+sort
- **Spec form** `/admin/specs/{new,:id/edit}` — kind picker, identity,
  visual, container, link, metadata; **live preview pane** updates
  card as you type; saves bump `spec_versions` + audit
- **Image library** `/admin/images` — gallery + multipart upload,
  PNG/JPEG → WebP auto-convert, SVG passes through, infer-based MIME
  sniff; serves `/assets/img/<file>` DB-first, disk fallback
- **Credentials** `/admin/credentials` — AES-256-GCM with key from
  `RUSCKER_MASTER_KEY` (hex or base64); plaintext never written;
  banner + disabled form when key absent
- **Landing editor** `/admin/landing` — color pickers (bg+fg), per-
  locale intros for pt/en/es/fr, live preview; public landing reads
  DB-first
- **Audit viewer** `/admin/audit` — filters by family/target/actor,
  color-toned pills (create=green, update=blue, delete=red,
  import=teal), expandable diff_json

### Crypto
- `crypto::MasterKey` with `Zeroizing<[u8; 32]>` behind `Arc`
- AES-256-GCM via `aes-gcm 0.10`; fresh nonce per encrypt
- Tampered ciphertext detected; unconfigured key refuses to encrypt

### Public landing changes
- Reads `LandingCustomization` from DB when attached (admin-editable),
  falls back to YAML (Phase 1 behavior preserved)
- `/assets/img/<file>` route: DB → disk → 404 (single handler
  replaces `nest_service` ServeDir)

### CLI
- `serve --db <path> --admin-token <s> --master-key <s>` (or env vars)

## i18n
+150 keys per locale across admin-nav, admin-login, admin-specs,
spec-form, admin-images, admin-creds, admin-landing, admin-audit
(pt/en/es/fr — parity enforced by scripts/i18n-check.sh).

## Tests
**71 green** across 7 crates:
- ruscker-config (15 unit + 9 shinyproxy_compat)
- ruscker-core (4)
- ruscker-admin (37 unit + 5 integration covering DB roundtrip,
  idempotent import, crypto roundtrip + tamper, image processing,
  audit filters)
- 1 doctest

## End-to-end smoke verified
- Import 31 specs from `examples/application.yml` → DB → export
  → re-import unchanged
- Admin auth flow: login wrong → 401, right → 303 + cookie
- Spec CRUD: create v=1 → update v=2 → delete; audit entries match
- Image upload: PNG 72 KB → auroraprime.webp 83 KB, 466×300, served
  from DB at /assets/img/auroraprime.webp
- Credentials: encrypted at rest (plaintext never appears literally
  in `password_enc` SQL-LIKE check); update bumps audit; delete works
- Landing: edit colors + intros, save, public landing PT/EN show
  saved values, ES falls back to default intro
- Audit: 6 events filterable by family (3 credential, 1 image, etc.)

## Out of scope (follow-up issues)
- #8 YAML import via admin modal
- #9 Rename "Imagens" tab (conflicts with Docker images)
- #10 Header gradient editor
- #11 Card cover gradient per spec

🤖 Generated with [Claude Code](https://claude.com/claude-code)