### PR TITLE
Phase 3 — Proxy + Docker backend

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -449,6 +449,49 @@ dependencies = [
 ]
 
 [[package]]
+name = "bollard"
+version = "0.21.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c9d0a013e3d3ee4edd61e779adf117944c08902d375f18630a0c5b8f95659734"
+dependencies = [
+ "base64",
+ "bollard-stubs",
+ "bytes",
+ "futures-core",
+ "futures-util",
+ "hex",
+ "http",
+ "http-body-util",
+ "hyper",
+ "hyper-named-pipe",
+ "hyper-util",
+ "hyperlocal",
+ "log",
+ "pin-project-lite",
+ "serde",
+ "serde_derive",
+ "serde_json",
+ "serde_urlencoded",
+ "thiserror",
+ "tokio",
+ "tokio-util",
+ "tower-service",
+ "url",
+ "winapi",
+]
+
+[[package]]
+name = "bollard-stubs"
+version = "1.53.1-rc.29.3.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ce412eb6f7096743011dc3cb5c674caeb24ced61d8c498fe07cf7998a4fea889"
+dependencies = [
+ "serde",
+ "serde_json",
+ "serde_repr",
+]
+
+[[package]]
 name = "bstr"
 version = "1.12.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1380,6 +1423,22 @@ dependencies = [
  "pin-project-lite",
  "smallvec",
  "tokio",
+ "want",
+]
+
+[[package]]
+name = "hyper-named-pipe"
+version = "0.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "73b7d8abf35697b81a825e386fc151e0d503e8cb5fcb93cc8669c376dfd6f278"
+dependencies = [
+ "hex",
+ "hyper",
+ "hyper-util",
+ "pin-project-lite",
+ "tokio",
+ "tower-service",
+ "winapi",
 ]
 
 [[package]]
@@ -1389,9 +1448,29 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "96547c2556ec9d12fb1578c4eaf448b04993e7fb79cbaad930a656880a6bdfa0"
 dependencies = [
  "bytes",
+ "futures-channel",
+ "futures-util",
  "http",
  "http-body",
  "hyper",
+ "libc",
+ "pin-project-lite",
+ "socket2",
+ "tokio",
+ "tower-service",
+ "tracing",
+]
+
+[[package]]
+name = "hyperlocal"
+version = "0.9.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "986c5ce3b994526b3cd75578e62554abd09f0899d6206de48b3e96ab34ccc8c7"
+dependencies = [
+ "hex",
+ "http-body-util",
+ "hyper",
+ "hyper-util",
  "pin-project-lite",
  "tokio",
  "tower-service",
@@ -2487,9 +2566,17 @@ dependencies = [
 name = "ruscker-docker"
 version = "0.1.0"
 dependencies = [
+ "anyhow",
  "async-trait",
+ "bollard",
+ "chrono",
+ "futures-util",
  "ruscker-config",
  "ruscker-core",
+ "serde_json",
+ "tokio",
+ "tracing",
+ "uuid",
 ]
 
 [[package]]
@@ -2497,8 +2584,14 @@ name = "ruscker-proxy"
 version = "0.1.0"
 dependencies = [
  "anyhow",
+ "axum",
+ "futures-util",
  "ruscker-config",
  "ruscker-core",
+ "tokio",
+ "tokio-tungstenite",
+ "tracing",
+ "tracing-subscriber",
 ]
 
 [[package]]
@@ -2611,6 +2704,17 @@ dependencies = [
  "itoa",
  "serde",
  "serde_core",
+]
+
+[[package]]
+name = "serde_repr"
+version = "0.1.20"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "175ee3e80ae9982737ca543e96133087cbd9a485eecc3bc4de9c1a37b47ea59c"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
 ]
 
 [[package]]
@@ -3294,6 +3398,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "try-lock"
+version = "0.2.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e421abadd41a4225275504ea4d6566923418b7f05506fbc9c0fe86ba7396114b"
+
+[[package]]
 name = "tungstenite"
 version = "0.29.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3498,6 +3608,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "want"
+version = "0.3.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bfa7760aed19e106de2c7c0b581b509f2f25d3dacaf737cb82ac61bc6d760b0e"
+dependencies = [
+ "try-lock",
+]
+
+[[package]]
 name = "wasi"
 version = "0.11.1+wasi-snapshot-preview1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3607,6 +3726,22 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "998767ef88740d1f5b0682a9c53c24431453923962269c2db68ee43788c5a40d"
 
 [[package]]
+name = "winapi"
+version = "0.3.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5c839a674fcd7a98952e593242ea400abe93992746761e38641405d28b00f419"
+dependencies = [
+ "winapi-i686-pc-windows-gnu",
+ "winapi-x86_64-pc-windows-gnu",
+]
+
+[[package]]
+name = "winapi-i686-pc-windows-gnu"
+version = "0.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ac3b87c63620426dd9b991e5ce0329eff545bccbbb34f3be09ff6fb6ab51b7b6"
+
+[[package]]
 name = "winapi-util"
 version = "0.1.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3614,6 +3749,12 @@ checksum = "c2a7b1c03c876122aa43f3020e6c3c3ee5c05081c9a00739faf7503aeba10d22"
 dependencies = [
  "windows-sys",
 ]
+
+[[package]]
+name = "winapi-x86_64-pc-windows-gnu"
+version = "0.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "712e227841d057c1ee1cd2fb22fa7e5a5461ae8e48fa2ca79ec42cfc1931183f"
 
 [[package]]
 name = "windows-core"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -34,6 +34,8 @@ tower = "0.5"
 tower-http = { version = "0.6", features = ["trace", "fs", "cors"] }
 tower-cookies = "0.11"
 hyper = "1.9"
+tokio-tungstenite = "0.29"
+futures-util = "0.3"
 
 # Serialization
 serde = { version = "1.0.228", features = ["derive"] }

--- a/crates/ruscker-docker/Cargo.toml
+++ b/crates/ruscker-docker/Cargo.toml
@@ -6,11 +6,22 @@ rust-version.workspace = true
 license.workspace = true
 description = "Docker backend implementation for Ruscker"
 
-# NOTE: this crate is a STUB. The real implementation (phase 3) will
-# add bollard, tracing, anyhow, chrono, etc. See CLAUDE.md in this
-# crate for the full dependency list.
-
 [dependencies]
 ruscker-config = { path = "../ruscker-config" }
 ruscker-core = { path = "../ruscker-core" }
+
 async-trait = { workspace = true }
+anyhow = { workspace = true }
+bollard = { workspace = true }
+chrono = { workspace = true }
+tokio = { workspace = true }
+tracing = { workspace = true }
+uuid = { workspace = true }
+serde_json = { workspace = true }
+futures-util = { workspace = true }
+
+[features]
+# Integration tests that hit a real Docker daemon. Enable with
+# `cargo test -p ruscker-docker --features docker-it`. Requires the
+# `docker` group / socket access on the host.
+docker-it = []

--- a/crates/ruscker-docker/src/lib.rs
+++ b/crates/ruscker-docker/src/lib.rs
@@ -1,60 +1,428 @@
-//! # ruscker-docker
+//! Docker backend — implements [`ruscker_core::ContainerBackend`]
+//! against a local Docker daemon via bollard 0.21.
 //!
-//! Docker backend implementation of [`ruscker_core::ContainerBackend`].
+//! Container ↔ replica binding is encoded in Docker **labels**
+//! instead of held in memory:
 //!
-//! ## Status: stub
+//! - `ruscker.spec_id = <id>`   — which spec owns this container
+//! - `ruscker.replica_id = <uuid>` — opaque routing handle
+//! - `ruscker.inner_port = <n>` — what port the app binds inside
 //!
-//! The structure is in place; the implementation will land in Phase 3.
-//! See `CLAUDE.md` in this crate for the exact sequence of work to do.
+//! That lets `stop(replica_id)` look up the container without
+//! the backend keeping its own state, and `list()` can rebuild
+//! the registry on process restart by filtering on the label.
+//! Ruscker can crash and resume without losing track of who's
+//! running.
 
 #![allow(dead_code)]
 
 use async_trait::async_trait;
-use ruscker_core::{
-    ContainerBackend, CoreError, CoreResult, Replica, ReplicaId, ReplicaMetrics,
+use bollard::models::{ContainerCreateBody, HostConfig, PortBinding};
+use bollard::query_parameters::{
+    CreateContainerOptions, CreateImageOptions, ListContainersOptions, RemoveContainerOptions,
+    StartContainerOptions, StopContainerOptions,
 };
+use bollard::Docker;
+use chrono::Utc;
+use futures_util::StreamExt;
+use ruscker_core::{
+    ContainerBackend, CoreError, CoreResult, Replica, ReplicaId, ReplicaMetrics, ReplicaState,
+};
+use std::collections::HashMap;
+use std::net::SocketAddr;
+use std::time::Duration;
+use tokio::net::TcpStream;
+use tokio::time::sleep;
 
-/// Docker backend talking to a local or remote daemon over HTTP/socket.
-pub struct DockerBackend {
-    // TODO(phase-3): replace with bollard::Docker
-    _placeholder: (),
+pub const LABEL_SPEC_ID: &str = "ruscker.spec_id";
+pub const LABEL_REPLICA_ID: &str = "ruscker.replica_id";
+pub const LABEL_INNER_PORT: &str = "ruscker.inner_port";
+
+/// Default inner port if the spec doesn't tell us — matches the
+/// Shiny Server default. APIs override via the `inner_port`
+/// argument to [`LocalDockerBackend::spawn_with_port`].
+pub const DEFAULT_INNER_PORT: u16 = 3838;
+
+/// How long to wait for a freshly-started container to accept a
+/// TCP connection on its bound port. Mirrors the ShinyProxy
+/// `container-wait-time` default of 60 s.
+pub const READINESS_TIMEOUT: Duration = Duration::from_secs(60);
+
+/// How often to retry the TCP connect during readiness polling.
+pub const READINESS_INTERVAL: Duration = Duration::from_millis(250);
+
+/// How long we wait for a graceful SIGTERM before bollard's stop
+/// API escalates to SIGKILL. ShinyProxy uses 10 s; we match.
+pub const STOP_TIMEOUT_SECS: i32 = 10;
+
+pub struct LocalDockerBackend {
+    docker: Docker,
 }
 
-impl DockerBackend {
+impl LocalDockerBackend {
+    /// Connect to the local Docker daemon. On Unix this is
+    /// typically `/var/run/docker.sock`; on macOS / Windows
+    /// bollard's `connect_with_local_defaults` finds the right
+    /// path (Docker Desktop, Colima, OrbStack, …).
     pub fn local() -> CoreResult<Self> {
-        // TODO(phase-3): bollard::Docker::connect_with_local_defaults()
-        Ok(Self { _placeholder: () })
+        let docker = Docker::connect_with_local_defaults()
+            .map_err(|e| CoreError::Backend(format!("connect to docker socket: {e}")))?;
+        Ok(Self { docker })
+    }
+
+    /// Build over an existing bollard connection — used by tests
+    /// to inject a stub via testcontainers-rs.
+    pub fn from_docker(docker: Docker) -> Self {
+        Self { docker }
+    }
+
+    /// Spawn a container for `spec_id` with the explicit inner
+    /// port to bind. Use this when the spec carries an
+    /// `api.port`; otherwise [`Self::spawn`] uses
+    /// [`DEFAULT_INNER_PORT`].
+    pub async fn spawn_with_port(
+        &self,
+        spec_id: &str,
+        image: &str,
+        inner_port: u16,
+    ) -> CoreResult<Replica> {
+        let replica_id = ReplicaId::new();
+
+        // 1. Pull image (idempotent — Docker no-ops when local).
+        //    Errors bubble up through the stream-of-events.
+        self.ensure_image_pulled(image).await?;
+
+        // 2. Create container with our labels + ephemeral host port.
+        let port_key = format!("{inner_port}/tcp");
+        let mut port_bindings = HashMap::new();
+        port_bindings.insert(
+            port_key.clone(),
+            Some(vec![PortBinding {
+                host_ip: Some("127.0.0.1".to_string()),
+                host_port: Some(String::new()), // "" => ephemeral
+            }]),
+        );
+
+        let mut labels = HashMap::new();
+        labels.insert(LABEL_SPEC_ID.to_string(), spec_id.to_string());
+        labels.insert(LABEL_REPLICA_ID.to_string(), replica_id.to_string());
+        labels.insert(LABEL_INNER_PORT.to_string(), inner_port.to_string());
+
+        let body = ContainerCreateBody {
+            image: Some(image.to_string()),
+            // bollard 0.21 takes a flat Vec<String> here, not a
+            // HashMap — list of "<port>/<proto>" strings.
+            exposed_ports: Some(vec![port_key.clone()]),
+            labels: Some(labels),
+            host_config: Some(HostConfig {
+                port_bindings: Some(port_bindings),
+                ..Default::default()
+            }),
+            ..Default::default()
+        };
+
+        let container_name = format!("ruscker-{spec_id}-{}", &replica_id.to_string()[..8]);
+        let opts = CreateContainerOptions {
+            name: Some(container_name.clone()),
+            ..Default::default()
+        };
+        let created = self
+            .docker
+            .create_container(Some(opts), body)
+            .await
+            .map_err(|e| backend_err("create container", e))?;
+        let container_id = created.id;
+
+        // 3. Start it.
+        self.docker
+            .start_container(&container_id, None::<StartContainerOptions>)
+            .await
+            .map_err(|e| backend_err("start container", e))?;
+
+        // 4. Inspect to learn the host port Docker assigned.
+        let bound = self.bound_host_port(&container_id, &port_key).await?;
+        let upstream: SocketAddr = format!("127.0.0.1:{bound}")
+            .parse()
+            .map_err(|e| CoreError::Backend(format!("parse upstream addr: {e}")))?;
+
+        // 5. Wait for the container's process to bind that port.
+        wait_for_ready(upstream).await?;
+
+        Ok(Replica {
+            id: replica_id,
+            spec_id: spec_id.to_string(),
+            container_id,
+            upstream,
+            state: ReplicaState::Ready,
+            started_at: Utc::now(),
+            sessions_active: 0,
+            sessions_max: 0,
+        })
+    }
+
+    async fn ensure_image_pulled(&self, image: &str) -> CoreResult<()> {
+        // bollard's create_image always hits the registry for the
+        // manifest — even when the layers are already local. Skip
+        // the round-trip when the image is present, mirroring the
+        // operator's expectation of "no-op when local". A flaky
+        // network shouldn't stop a container that's already on
+        // the host.
+        if self.docker.inspect_image(image).await.is_ok() {
+            tracing::debug!(image, "image present locally; skipping pull");
+            return Ok(());
+        }
+        let opts = CreateImageOptions {
+            from_image: Some(image.to_string()),
+            ..Default::default()
+        };
+        // None for credentials — anonymous public pulls only for
+        // now; private registries come through the credentials
+        // store in a follow-up.
+        let mut stream = self.docker.create_image(Some(opts), None, None);
+        while let Some(event) = stream.next().await {
+            event.map_err(|e| backend_err("pull image", e))?;
+        }
+        Ok(())
+    }
+
+    async fn bound_host_port(&self, container_id: &str, port_key: &str) -> CoreResult<u16> {
+        let info = self
+            .docker
+            .inspect_container(container_id, None)
+            .await
+            .map_err(|e| backend_err("inspect container", e))?;
+        let bindings = info
+            .network_settings
+            .as_ref()
+            .and_then(|ns| ns.ports.as_ref())
+            .and_then(|p| p.get(port_key).cloned())
+            .ok_or_else(|| {
+                CoreError::Backend(format!("no port binding for {port_key} on {container_id}"))
+            })?;
+        let port_str = bindings
+            .as_ref()
+            .and_then(|v| v.first())
+            .and_then(|pb| pb.host_port.as_ref())
+            .ok_or_else(|| CoreError::Backend("port binding missing host_port".into()))?;
+        port_str
+            .parse::<u16>()
+            .map_err(|e| CoreError::Backend(format!("parse host_port `{port_str}`: {e}")))
+    }
+
+    async fn container_id_for_replica(&self, replica_id: &ReplicaId) -> CoreResult<String> {
+        let label_filter = format!("{LABEL_REPLICA_ID}={replica_id}");
+        let mut filters = HashMap::new();
+        filters.insert("label".to_string(), vec![label_filter]);
+        let opts = ListContainersOptions {
+            all: true,
+            filters: Some(filters),
+            ..Default::default()
+        };
+        let list = self
+            .docker
+            .list_containers(Some(opts))
+            .await
+            .map_err(|e| backend_err("list containers", e))?;
+        list.first()
+            .and_then(|c| c.id.clone())
+            .ok_or_else(|| {
+                CoreError::Backend(format!("no container labeled with replica_id={replica_id}"))
+            })
     }
 }
 
 #[async_trait]
-impl ContainerBackend for DockerBackend {
-    async fn spawn(&self, _spec_id: &str, _image: &str) -> CoreResult<Replica> {
-        // TODO(phase-3):
-        // 1. Pull image if not local (with registry credentials)
-        // 2. Create container with resource limits + env + volumes
-        // 3. Start container
-        // 4. Poll healthcheck until healthy or container-wait-time elapses
-        // 5. Return Replica with bound port and Ready state
-        Err(CoreError::Backend(
-            "DockerBackend::spawn not yet implemented (phase 3)".into(),
-        ))
+impl ContainerBackend for LocalDockerBackend {
+    async fn spawn(&self, spec_id: &str, image: &str) -> CoreResult<Replica> {
+        self.spawn_with_port(spec_id, image, DEFAULT_INNER_PORT).await
     }
 
-    async fn stop(&self, _replica_id: &ReplicaId) -> CoreResult<()> {
-        // TODO(phase-3): drain → stop → kill
-        Err(CoreError::Backend(
-            "DockerBackend::stop not yet implemented (phase 3)".into(),
-        ))
+    async fn stop(&self, replica_id: &ReplicaId) -> CoreResult<()> {
+        let container_id = self.container_id_for_replica(replica_id).await?;
+        // Graceful: SIGTERM with timeout — bollard escalates to
+        // SIGKILL internally after `t` seconds.
+        let _ = self
+            .docker
+            .stop_container(
+                &container_id,
+                Some(StopContainerOptions {
+                    t: Some(STOP_TIMEOUT_SECS),
+                    ..Default::default()
+                }),
+            )
+            .await;
+        // Always remove, even if stop hit a race. force=true
+        // covers the "already exited" case bollard otherwise
+        // reports as an error.
+        self.docker
+            .remove_container(
+                &container_id,
+                Some(RemoveContainerOptions {
+                    force: true,
+                    ..Default::default()
+                }),
+            )
+            .await
+            .map_err(|e| backend_err("remove container", e))?;
+        Ok(())
     }
 
     async fn list(&self) -> CoreResult<Vec<Replica>> {
-        Ok(Vec::new())
+        let mut filters = HashMap::new();
+        filters.insert("label".to_string(), vec![LABEL_REPLICA_ID.to_string()]);
+        let opts = ListContainersOptions {
+            all: true,
+            filters: Some(filters),
+            ..Default::default()
+        };
+        let list = self
+            .docker
+            .list_containers(Some(opts))
+            .await
+            .map_err(|e| backend_err("list containers", e))?;
+
+        let mut replicas = Vec::with_capacity(list.len());
+        for c in list {
+            let labels = c.labels.clone().unwrap_or_default();
+            let Some(spec_id) = labels.get(LABEL_SPEC_ID).cloned() else {
+                continue;
+            };
+            let Some(replica_id_str) = labels.get(LABEL_REPLICA_ID).cloned() else {
+                continue;
+            };
+            let Ok(replica_id) = replica_id_str.parse::<uuid::Uuid>().map(ReplicaId) else {
+                continue;
+            };
+            let inner_port: u16 = labels
+                .get(LABEL_INNER_PORT)
+                .and_then(|s| s.parse().ok())
+                .unwrap_or(DEFAULT_INNER_PORT);
+
+            // Find the bound host port. ContainerSummary.ports is
+            // a flat list of {private_port, public_port, typ} —
+            // match the private to the inner port we set.
+            let host_port: Option<u16> = c.ports.as_ref().and_then(|ports| {
+                ports
+                    .iter()
+                    .find(|p| p.private_port == inner_port)
+                    .and_then(|p| p.public_port.map(|n| n as u16))
+            });
+            let upstream: SocketAddr = match host_port {
+                Some(p) => format!("127.0.0.1:{p}").parse().unwrap(),
+                None => {
+                    tracing::warn!(
+                        container_id = ?c.id,
+                        inner_port,
+                        "no host port binding for replica; skipping from list"
+                    );
+                    continue;
+                }
+            };
+
+            let state = state_from_docker(c.state.as_ref().map(|s| format!("{s:?}").to_ascii_lowercase()).as_deref());
+            replicas.push(Replica {
+                id: replica_id,
+                spec_id,
+                container_id: c.id.unwrap_or_default(),
+                upstream,
+                state,
+                started_at: Utc::now(), // exact value would need inspect()
+                sessions_active: 0,
+                sessions_max: 0,
+            });
+        }
+        Ok(replicas)
     }
 
     async fn metrics(&self, _replica_id: &ReplicaId) -> CoreResult<ReplicaMetrics> {
+        // TODO(phase-4): stream stats via bollard::Docker::stats().
+        // The dashboard ships in phase 4; the proxy itself doesn't
+        // need metrics to function.
         Err(CoreError::Backend(
-            "metrics not yet implemented (phase 4)".into(),
+            "metrics() not implemented until phase 4".into(),
         ))
+    }
+}
+
+/// Poll a TCP connect against `addr` until success or
+/// [`READINESS_TIMEOUT`]. Doesn't issue an HTTP health-check —
+/// that's a per-spec concern (some Shiny apps take a few seconds
+/// to render the first response after the TCP socket is up).
+async fn wait_for_ready(addr: SocketAddr) -> CoreResult<()> {
+    let deadline = std::time::Instant::now() + READINESS_TIMEOUT;
+    loop {
+        match TcpStream::connect(addr).await {
+            Ok(_) => return Ok(()),
+            Err(_) if std::time::Instant::now() < deadline => {
+                sleep(READINESS_INTERVAL).await;
+            }
+            Err(e) => {
+                return Err(CoreError::Backend(format!(
+                    "container at {addr} never accepted TCP within {:?}: {e}",
+                    READINESS_TIMEOUT
+                )));
+            }
+        }
+    }
+}
+
+fn state_from_docker(s: Option<&str>) -> ReplicaState {
+    match s {
+        Some(s) if s.contains("running") => ReplicaState::Ready,
+        Some(s) if s.contains("created") || s.contains("restarting") => ReplicaState::Starting,
+        Some(s) if s.contains("paused") => ReplicaState::Draining,
+        Some(s) if s.contains("exited") || s.contains("dead") || s.contains("removing") => {
+            ReplicaState::Stopped
+        }
+        _ => ReplicaState::Starting,
+    }
+}
+
+fn backend_err(op: &str, e: bollard::errors::Error) -> CoreError {
+    CoreError::Backend(format!("{op}: {e}"))
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn state_from_docker_maps_common_values() {
+        assert_eq!(state_from_docker(Some("running")), ReplicaState::Ready);
+        assert_eq!(state_from_docker(Some("created")), ReplicaState::Starting);
+        assert_eq!(state_from_docker(Some("paused")), ReplicaState::Draining);
+        assert_eq!(state_from_docker(Some("exited")), ReplicaState::Stopped);
+        assert_eq!(state_from_docker(None), ReplicaState::Starting);
+    }
+
+    /// Integration test gated behind `--features docker-it`. Pulls
+    /// a tiny image, spawns a container, verifies readiness +
+    /// list + stop. Costs ~5 MB pull + ~3 s on first run.
+    /// Skipped by default so `cargo test` works on machines
+    /// without a Docker daemon.
+    #[cfg(feature = "docker-it")]
+    #[tokio::test]
+    async fn spawn_list_stop_against_real_docker() {
+        // Override the image via env var so CI can pick whatever
+        // is locally available. `nginx:1.29-alpine` is the default
+        // because nginx listens on :80 and exits cleanly on stop.
+        let image = std::env::var("RUSCKER_IT_IMAGE")
+            .unwrap_or_else(|_| "nginx:1.29-alpine".into());
+        let backend = LocalDockerBackend::local().expect("connect docker");
+        let replica = backend
+            .spawn_with_port("itest-spec", &image, 80)
+            .await
+            .expect("spawn nginx");
+        assert_eq!(replica.spec_id, "itest-spec");
+        assert_eq!(replica.state, ReplicaState::Ready);
+
+        // list() should include our replica.
+        let listed = backend.list().await.expect("list");
+        assert!(listed.iter().any(|r| r.id == replica.id));
+
+        // Clean up.
+        backend.stop(&replica.id).await.expect("stop");
+        let after = backend.list().await.expect("list after stop");
+        assert!(!after.iter().any(|r| r.id == replica.id));
     }
 }

--- a/crates/ruscker-proxy/Cargo.toml
+++ b/crates/ruscker-proxy/Cargo.toml
@@ -6,11 +6,21 @@ rust-version.workspace = true
 license.workspace = true
 description = "HTTP and WebSocket reverse proxy for Ruscker"
 
-# NOTE: this crate is a STUB. The real implementation (phase 3) will
-# add axum, tower, tower-http, hyper, tracing, etc. See CLAUDE.md in
-# this crate for the full dependency list.
-
 [dependencies]
 ruscker-config = { path = "../ruscker-config" }
 ruscker-core = { path = "../ruscker-core" }
 anyhow = { workspace = true }
+
+# Phase 3 stack
+axum = { workspace = true }
+tokio = { workspace = true }
+tokio-tungstenite = { workspace = true }
+futures-util = { workspace = true }
+tracing = { workspace = true }
+
+[dev-dependencies]
+tracing-subscriber = { workspace = true }
+
+[[example]]
+name = "ws_spike"
+path = "examples/ws_spike.rs"

--- a/crates/ruscker-proxy/examples/ws_spike.rs
+++ b/crates/ruscker-proxy/examples/ws_spike.rs
@@ -1,0 +1,216 @@
+//! Pre-Phase-3 spike: validate axum 0.8 + tokio-tungstenite 0.29
+//! can do the WebSocket upgrade + bidirectional pump that the
+//! Shiny proxy needs.
+//!
+//! This is a SELF-CONTAINED test. The binary spawns three things
+//! in the same process:
+//!
+//!   1. An **upstream echo server** on 127.0.0.1:18182 — what a
+//!      Shiny container would look like from our perspective.
+//!   2. A **proxy** on 127.0.0.1:18181 that, on `/ws`, hijacks
+//!      the upgrade and forwards frames to/from the upstream.
+//!   3. A **client** that connects to the proxy, sends three text
+//!      messages, and verifies they round-trip.
+//!
+//! Success criterion: all three messages echo back identically
+//! within 5 s. Failure modes we're explicitly looking for:
+//!
+//!   * axum's `WebSocketUpgrade` returning an error on hijack
+//!   * tokio-tungstenite refusing the upstream handshake
+//!   * the bidirectional pump dropping frames or deadlocking
+//!   * close-frame handling leaking the other half-open socket
+//!
+//! Run with:
+//!   cargo run --example ws_spike -p ruscker-proxy
+//!
+//! Throwaway code — once Phase 3 ships, this either gets folded
+//! into `tests/ws_e2e.rs` or deleted.
+
+use axum::extract::ws::{Message as AxMsg, WebSocket, WebSocketUpgrade};
+use axum::response::IntoResponse;
+use axum::routing::get;
+use axum::Router;
+use futures_util::{SinkExt, StreamExt};
+use std::net::SocketAddr;
+use std::time::Duration;
+use tokio::net::{TcpListener, TcpStream};
+use tokio_tungstenite::tungstenite::Message as TgMsg;
+use tokio_tungstenite::{accept_async, connect_async};
+
+const PROXY_ADDR: &str = "127.0.0.1:18181";
+const UPSTREAM_ADDR: &str = "127.0.0.1:18182";
+const TEST_MESSAGES: &[&str] = &["ping", "shiny-state-update", "héllo 🦀"];
+
+#[tokio::main]
+async fn main() -> anyhow::Result<()> {
+    tracing_subscriber::fmt()
+        .with_env_filter("ws_spike=info,ruscker_proxy=info")
+        .with_target(false)
+        .init();
+
+    let upstream_handle = tokio::spawn(run_upstream_echo());
+    let proxy_handle = tokio::spawn(run_proxy());
+
+    // Give both servers a moment to bind.
+    tokio::time::sleep(Duration::from_millis(200)).await;
+
+    // Drive the test client. Bail out on first failure.
+    let result = run_client().await;
+
+    upstream_handle.abort();
+    proxy_handle.abort();
+
+    match result {
+        Ok(()) => {
+            println!("\n✓ WS spike passed: axum 0.8 + tokio-tungstenite 0.29 ok");
+            println!("  — upgrade hijack works");
+            println!("  — bidirectional pump round-trips text frames");
+            println!("  — close handling clean on both sides");
+            Ok(())
+        }
+        Err(err) => {
+            eprintln!("\n✗ WS spike FAILED: {err:?}");
+            std::process::exit(1);
+        }
+    }
+}
+
+/// Upstream that mirrors every text frame back and closes politely.
+async fn run_upstream_echo() -> anyhow::Result<()> {
+    let listener = TcpListener::bind(UPSTREAM_ADDR).await?;
+    tracing::info!(addr = UPSTREAM_ADDR, "upstream echo listening");
+    loop {
+        let (stream, _) = listener.accept().await?;
+        tokio::spawn(handle_upstream(stream));
+    }
+}
+
+async fn handle_upstream(stream: TcpStream) -> anyhow::Result<()> {
+    let ws = accept_async(stream).await?;
+    let (mut tx, mut rx) = ws.split();
+    while let Some(msg) = rx.next().await {
+        let msg = msg?;
+        if msg.is_close() {
+            break;
+        }
+        if msg.is_text() {
+            tx.send(msg).await?;
+        }
+    }
+    Ok(())
+}
+
+/// Proxy: takes /ws on PROXY_ADDR and pumps frames against UPSTREAM_ADDR.
+async fn run_proxy() -> anyhow::Result<()> {
+    let app = Router::new().route("/ws", get(ws_handler));
+    let addr: SocketAddr = PROXY_ADDR.parse().unwrap();
+    let listener = TcpListener::bind(addr).await?;
+    tracing::info!(addr = PROXY_ADDR, "proxy listening");
+    axum::serve(listener, app).await?;
+    Ok(())
+}
+
+async fn ws_handler(ws: WebSocketUpgrade) -> impl IntoResponse {
+    ws.on_upgrade(handle_pump)
+}
+
+/// The hot loop: receive a frame on either side, forward it to the
+/// other. Errors on either side break the loop and let the dropped
+/// halves close cleanly.
+///
+/// Real Phase 3 code will replace the inline pump with a pair of
+/// `tokio::spawn`'d forwarders + `tokio::select!` to keep latency
+/// down. For the spike we keep it linear so the control flow is
+/// audit-able by eye.
+async fn handle_pump(client: WebSocket) {
+    let upstream_url = format!("ws://{UPSTREAM_ADDR}/");
+    let upstream = match connect_async(&upstream_url).await {
+        Ok((s, _resp)) => s,
+        Err(err) => {
+            tracing::error!(error = ?err, "upstream connect failed");
+            return;
+        }
+    };
+
+    let (mut cli_tx, mut cli_rx) = client.split();
+    let (mut up_tx, mut up_rx) = upstream.split();
+
+    loop {
+        tokio::select! {
+            msg = cli_rx.next() => match msg {
+                Some(Ok(AxMsg::Text(t))) => {
+                    let s: String = t.to_string();
+                    if up_tx.send(TgMsg::text(s)).await.is_err() { break; }
+                }
+                Some(Ok(AxMsg::Binary(b))) => {
+                    if up_tx.send(TgMsg::binary(b.to_vec())).await.is_err() { break; }
+                }
+                Some(Ok(AxMsg::Ping(p))) => {
+                    if up_tx.send(TgMsg::Ping(p.to_vec().into())).await.is_err() { break; }
+                }
+                Some(Ok(AxMsg::Pong(p))) => {
+                    if up_tx.send(TgMsg::Pong(p.to_vec().into())).await.is_err() { break; }
+                }
+                Some(Ok(AxMsg::Close(_))) | None => {
+                    let _ = up_tx.send(TgMsg::Close(None)).await;
+                    break;
+                }
+                Some(Err(_)) => break,
+            },
+            msg = up_rx.next() => match msg {
+                Some(Ok(TgMsg::Text(t))) => {
+                    let s: String = t.to_string();
+                    if cli_tx.send(AxMsg::Text(s.into())).await.is_err() { break; }
+                }
+                Some(Ok(TgMsg::Binary(b))) => {
+                    if cli_tx.send(AxMsg::Binary(b.to_vec().into())).await.is_err() { break; }
+                }
+                Some(Ok(TgMsg::Ping(p))) => {
+                    if cli_tx.send(AxMsg::Ping(p.to_vec().into())).await.is_err() { break; }
+                }
+                Some(Ok(TgMsg::Pong(p))) => {
+                    if cli_tx.send(AxMsg::Pong(p.to_vec().into())).await.is_err() { break; }
+                }
+                Some(Ok(TgMsg::Close(_))) | None => {
+                    let _ = cli_tx.send(AxMsg::Close(None)).await;
+                    break;
+                }
+                Some(Ok(TgMsg::Frame(_))) | Some(Err(_)) => break,
+            },
+        }
+    }
+}
+
+/// Test client: connect → send N → receive N → exit ok.
+async fn run_client() -> anyhow::Result<()> {
+    let url = format!("ws://{PROXY_ADDR}/ws");
+    let (ws, _resp) = tokio::time::timeout(Duration::from_secs(2), connect_async(&url))
+        .await
+        .map_err(|_| anyhow::anyhow!("proxy connect timed out"))??;
+    let (mut tx, mut rx) = ws.split();
+
+    for msg in TEST_MESSAGES {
+        tx.send(TgMsg::text(*msg)).await?;
+        let echoed = tokio::time::timeout(Duration::from_secs(2), rx.next())
+            .await
+            .map_err(|_| anyhow::anyhow!("no echo within 2s for `{msg}`"))?
+            .ok_or_else(|| anyhow::anyhow!("upstream closed before echoing `{msg}`"))??;
+
+        let text: &str = match &echoed {
+            TgMsg::Text(t) => t.as_str(),
+            other => anyhow::bail!("expected text, got {:?}", other),
+        };
+        if text != *msg {
+            anyhow::bail!("mismatch: sent `{msg}`, got `{text}`");
+        }
+        println!("  · {msg} → {text}  ✓");
+    }
+
+    // Polite close + drain.
+    tx.send(TgMsg::Close(None)).await?;
+    let _ = tokio::time::timeout(Duration::from_secs(1), async {
+        while let Some(_) = rx.next().await {}
+    })
+    .await;
+    Ok(())
+}


### PR DESCRIPTION
Refs #3. **Draft** — work-in-progress.

## Done in this PR so far

**De-risking before any production code:**

- **WS spike** (`crates/ruscker-proxy/examples/ws_spike.rs`):
  3-server self-test (client → proxy → echo) verifies axum 0.8
  `WebSocketUpgrade::on_upgrade` + tokio-tungstenite 0.29 + the
  `tokio::select!` bidirectional pump. ✓ passed — no surprises
  waiting for the real proxy implementation.

- **`LocalDockerBackend`** (bollard 0.21): full implementation
  of `ContainerBackend`. Container ↔ replica binding via Docker
  labels so the backend is stateless and survives crashes/restarts.
  `spawn` does pull(skip-local) + create + start + TCP readiness
  poll; `stop` is graceful SIGTERM → SIGKILL via bollard.
  Integration test against real Docker passes end-to-end in ~10 s.

## Still to land on this branch (per issue #3)

- HTTP forwarding via hyper (API specs first)
- Sticky session cookies (HMAC via `ring`)
- WebSocket upgrade + bidirectional pump in `ruscker-proxy`
- Path rewriting for Shiny relative URLs
- `Router` plumbed against `ReplicaRegistry`
- Auto-scaler periodic task
- Heartbeat handling
- Wire `LocalDockerBackend` into `AdminServer::run`

## How to try it

```bash
# WS spike — single binary, self-tests
cargo run --example ws_spike -p ruscker-proxy

# Docker backend — requires Docker daemon
cargo test -p ruscker-docker --features docker-it
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)