### PR TITLE
Phase 3: session tracker + idle-expiry sweeper

### DIFF
--- a/crates/ruscker-admin/src/lib.rs
+++ b/crates/ruscker-admin/src/lib.rs
@@ -30,6 +30,7 @@ pub mod i18n;
 pub mod images;
 pub mod routes;
 pub mod scaler;
+pub mod sessions;
 pub mod theme;
 pub mod view_model;
 
@@ -80,6 +81,14 @@ pub struct AppState {
     pub spawn_locks: std::sync::Arc<
         dashmap::DashMap<String, std::sync::Arc<tokio::sync::Mutex<()>>>,
     >,
+
+    /// Per-visitor session tracker. The proxy calls
+    /// `touch_or_register` on every routed request so the
+    /// replica's `sessions_active` reflects the real number of
+    /// live visitors. A background sweeper (started from
+    /// `AdminServer::run`) evicts idle sessions after
+    /// `proxy.heartbeat_timeout` ms.
+    pub sessions: std::sync::Arc<sessions::SessionTracker>,
 }
 
 /// HTTP server hosting the landing and (later) the admin panel.
@@ -116,6 +125,7 @@ impl AdminServer {
             cookie_key: ruscker_proxy::sticky::CookieKey::from_env_or_random()
                 .context("load sticky cookie key")?,
             spawn_locks: std::sync::Arc::new(dashmap::DashMap::new()),
+            sessions: std::sync::Arc::new(sessions::SessionTracker::new()),
         };
         Ok(Self {
             addr,
@@ -201,6 +211,16 @@ impl AdminServer {
         // protocol for the scaler because every tick is idempotent.
         if self.state.backend.is_some() {
             let _ = scaler::spawn(self.state.clone(), scaler::DEFAULT_INTERVAL);
+            // Session sweeper: evicts idle sessions per the
+            // global `heartbeat-timeout`. `-1` (the ShinyProxy
+            // idiom for "never expire") becomes a no-op loop
+            // inside `sessions::spawn` so the call shape stays
+            // uniform.
+            let _ = sessions::spawn(
+                self.state.sessions.clone(),
+                self.state.replicas.clone(),
+                self.state.config.proxy.heartbeat_timeout,
+            );
         }
 
         let app = router_with_images(self.state.clone(), self.images_dir.as_deref());

--- a/crates/ruscker-admin/src/routes/proxy.rs
+++ b/crates/ruscker-admin/src/routes/proxy.rs
@@ -158,11 +158,12 @@ async fn forward(
     }
 
     // 4. Resolve the replica: sticky-first, fall back to
-    //    pick/spawn. Capture whether the cookie was honored so we
-    //    only Set-Cookie when we just minted a new session.
-    let (replica, cookie_used) =
+    //    pick/spawn. Also pin down the session_id we'll track
+    //    this visitor under so the cookie and the tracker share
+    //    the same identity.
+    let (replica, session_id, cookie_used) =
         match resolve_replica(&state, &spec, &cookies).await {
-            Ok(pair) => pair,
+            Ok(triple) => triple,
             Err(err) => {
                 tracing::error!(spec = %spec.id, error = ?err, "resolve replica failed");
                 return (
@@ -172,6 +173,17 @@ async fn forward(
                     .into_response();
             }
         };
+
+    // 4b. Heartbeat: record activity on the visitor's session.
+    //     Only matters for sticky-needed specs — API requests are
+    //     per-request, not per-session, so inflating
+    //     `sessions_active` for them would mislead the scaler.
+    if spec_kind_needs_sticky(spec.kind()) {
+        let _outcome = state
+            .sessions
+            .touch_or_register(&state.replicas, session_id, &spec.id, &replica.id)
+            .await;
+    }
 
     // 5. WebSocket branch hijacks the upgrade and pumps frames;
     //    after the upgrade response is sent, the rest of axum's
@@ -210,8 +222,16 @@ async fn forward(
 
     // 7. Issue sticky cookie when we just bound the visitor to a
     //    replica and the spec actually benefits from stickiness.
+    //    The cookie carries the exact session_id we registered
+    //    in the tracker, so subsequent requests touch the same
+    //    entry instead of registering a duplicate.
     if !cookie_used && spec_kind_needs_sticky(spec.kind()) {
-        set_sticky_cookie(&cookies, &state.cookie_key, &spec.id, &replica);
+        let session = StickySession {
+            session_id,
+            spec_id: spec.id.clone(),
+            replica_id: replica.id.clone(),
+        };
+        set_sticky_cookie(&cookies, &state.cookie_key, &session);
     }
 
     resp
@@ -225,13 +245,15 @@ fn find_spec<'a>(config: &'a ruscker_config::Config, id: &str) -> Option<&'a Spe
     config.proxy.specs.iter().find(|s| s.id == id)
 }
 
-/// Returns the chosen `Replica` and whether the sticky cookie was
-/// honored (so the caller knows whether to set a fresh one).
+/// Returns the chosen `Replica`, the session_id we'll track this
+/// visitor under (either decoded from a valid cookie or freshly
+/// minted), and whether the cookie was honored (so the caller
+/// only sets a Set-Cookie header on fresh sessions).
 async fn resolve_replica(
     state: &AppState,
     spec: &Spec,
     cookies: &Cookies,
-) -> anyhow::Result<(Replica, bool)> {
+) -> anyhow::Result<(Replica, uuid::Uuid, bool)> {
     if let Some(raw) = cookies.get(COOKIE_NAME) {
         if let Ok(session) = sticky::decode(&state.cookie_key, raw.value()) {
             // Defense in depth: a cookie for spec A must not
@@ -244,23 +266,21 @@ async fn resolve_replica(
                     .find(|r| r.id == session.replica_id)
                     .cloned();
                 if let Some(r) = alive {
-                    return Ok((r, true));
+                    return Ok((r, session.session_id, true));
                 }
             }
         }
     }
     let r = pick_or_spawn(state, spec).await?;
-    Ok((r, false))
+    Ok((r, uuid::Uuid::new_v4(), false))
 }
 
-fn set_sticky_cookie(
-    cookies: &Cookies,
-    key: &CookieKey,
-    spec_id: &str,
-    replica: &Replica,
-) {
-    let session = StickySession::new(spec_id.to_string(), replica.id.clone());
-    let value = match sticky::encode(key, &session) {
+/// Build + set the sticky cookie from an explicit `StickySession`
+/// — keeps the session_id consistent with what we tracked in the
+/// `SessionTracker` rather than minting a fresh, untracked id
+/// inside the cookie helper.
+fn set_sticky_cookie(cookies: &Cookies, key: &CookieKey, session: &StickySession) {
+    let value = match sticky::encode(key, session) {
         Ok(v) => v,
         Err(err) => {
             tracing::error!(error = ?err, "encode sticky cookie failed");
@@ -539,6 +559,7 @@ mod tests {
             replicas: StdArc::new(RwLock::new(ReplicaRegistry::new())),
             cookie_key: CookieKey::random(),
             spawn_locks: StdArc::new(dashmap::DashMap::new()),
+            sessions: StdArc::new(crate::sessions::SessionTracker::new()),
         }
     }
 

--- a/crates/ruscker-admin/src/scaler.rs
+++ b/crates/ruscker-admin/src/scaler.rs
@@ -234,6 +234,7 @@ mod tests {
             replicas: Arc::new(tokio::sync::RwLock::new(ReplicaRegistry::new())),
             cookie_key: ruscker_proxy::sticky::CookieKey::random(),
             spawn_locks: Arc::new(dashmap::DashMap::new()),
+            sessions: Arc::new(crate::sessions::SessionTracker::new()),
         }
     }
 

--- a/crates/ruscker-admin/src/sessions.rs
+++ b/crates/ruscker-admin/src/sessions.rs
@@ -1,0 +1,315 @@
+//! Per-visitor session tracking + idle-expiry sweeper.
+//!
+//! ## What a session is here
+//!
+//! A "session" is the binding between a sticky cookie's
+//! `session_id` and the replica it was routed to. The lifecycle:
+//!
+//! 1. **Registered** — first request from a visitor; we mint a
+//!    cookie, register the session, and increment the chosen
+//!    replica's `sessions_active`.
+//! 2. **Touched** — every subsequent request bumps `last_seen`.
+//!    No counter change.
+//! 3. **Expired** — the sweeper runs every
+//!    [`SWEEPER_INTERVAL`] and evicts any session whose
+//!    `now - last_seen > heartbeat_timeout`. Eviction
+//!    decrements the replica's `sessions_active`.
+//!
+//! ## Why this exists
+//!
+//! Until this module, `Replica::sessions_active` was always zero
+//! — nothing populated it. That meant `available_seats()` always
+//! returned the maximum, the LeastConnections router was
+//! degenerate, and the scaler couldn't observe saturation. With
+//! accurate counts, both unlock.
+//!
+//! ## What this is NOT
+//!
+//! - Not a heartbeat receiver. ShinyProxy listens for explicit
+//!   client pings; here, **any HTTP/WS request from the visitor
+//!   counts as a heartbeat** because we touch on every routed
+//!   request. Good enough for the MVP; explicit pings can be
+//!   added if the apps stop generating traffic during idle UI
+//!   work.
+//! - Not persistent. Restart wipes the tracker. The cookie's
+//!   session_id is still valid (HMAC verifies), and the next
+//!   request will re-register on the same replica if the
+//!   reconcile picked it up. Counter restarts from zero.
+
+use dashmap::DashMap;
+use ruscker_core::{ReplicaId, ReplicaRegistry};
+use std::sync::Arc;
+use std::time::{Duration, Instant};
+use tokio::sync::RwLock;
+use tokio::task::JoinHandle;
+use tracing::info;
+use uuid::Uuid;
+
+/// How often the sweeper checks for expired sessions. Tighter
+/// than `heartbeat_timeout` so freed seats become available
+/// promptly; coarse enough that the lock-write cost is trivial.
+pub const SWEEPER_INTERVAL: Duration = Duration::from_secs(5);
+
+#[derive(Debug, Clone)]
+struct SessionEntry {
+    spec_id: String,
+    replica_id: ReplicaId,
+    last_seen: Instant,
+}
+
+/// In-memory tracker. Shared across handlers via `Arc`. The
+/// internal map is `DashMap` so per-request `touch_or_register`
+/// only locks a single shard, never the whole structure.
+///
+/// The registry write-lock is taken **only** on register/evict
+/// (counter mutation). `touch` for an existing session goes
+/// through DashMap alone — read traffic on a warm session never
+/// blocks on the registry RwLock.
+#[derive(Debug)]
+pub struct SessionTracker {
+    sessions: DashMap<Uuid, SessionEntry>,
+}
+
+/// Outcome of a `touch_or_register` call. Useful for the proxy
+/// to know whether it just minted a new session (and therefore
+/// should set the sticky cookie on the response) or refreshed
+/// an existing one.
+#[derive(Debug, PartialEq, Eq)]
+pub enum TouchOutcome {
+    Registered,
+    Touched,
+}
+
+impl SessionTracker {
+    pub fn new() -> Self {
+        Self {
+            sessions: DashMap::new(),
+        }
+    }
+
+    /// Record activity for `session_id`. If unknown, register it
+    /// against `(spec_id, replica_id)` and increment the
+    /// replica's counter. If known, just refresh `last_seen`.
+    ///
+    /// Returns whether this was a fresh registration so the
+    /// caller can decide cookie-setting policy.
+    pub async fn touch_or_register(
+        &self,
+        registry: &RwLock<ReplicaRegistry>,
+        session_id: Uuid,
+        spec_id: &str,
+        replica_id: &ReplicaId,
+    ) -> TouchOutcome {
+        // Fast path: the session already exists. Update
+        // last_seen without touching the registry lock at all.
+        if let Some(mut entry) = self.sessions.get_mut(&session_id) {
+            entry.last_seen = Instant::now();
+            return TouchOutcome::Touched;
+        }
+        // Cold path: register. Insert under the entry API to
+        // serialize against a concurrent twin caller (the
+        // DashMap shard mutex covers us).
+        let was_new = match self.sessions.entry(session_id) {
+            dashmap::Entry::Occupied(mut occ) => {
+                occ.get_mut().last_seen = Instant::now();
+                false
+            }
+            dashmap::Entry::Vacant(vac) => {
+                vac.insert(SessionEntry {
+                    spec_id: spec_id.to_string(),
+                    replica_id: replica_id.clone(),
+                    last_seen: Instant::now(),
+                });
+                true
+            }
+        };
+        if was_new {
+            registry.write().await.inc_sessions(replica_id);
+            TouchOutcome::Registered
+        } else {
+            TouchOutcome::Touched
+        }
+    }
+
+    /// One sweeper pass. Walks the map, evicts entries older
+    /// than `timeout`, and decrements the replica counter for
+    /// each. Returns the number of sessions evicted (for
+    /// metrics / logging).
+    ///
+    /// `timeout < 0` semantics live one level up — the caller
+    /// (loop) decides whether to call this at all. Here we
+    /// require an unsigned timeout.
+    pub async fn sweep(
+        &self,
+        registry: &RwLock<ReplicaRegistry>,
+        timeout: Duration,
+    ) -> usize {
+        let now = Instant::now();
+        // Collect victims first so we don't hold DashMap shard
+        // guards across the registry await.
+        let mut victims: Vec<(Uuid, ReplicaId)> = Vec::new();
+        for kv in self.sessions.iter() {
+            if now.duration_since(kv.value().last_seen) > timeout {
+                victims.push((*kv.key(), kv.value().replica_id.clone()));
+            }
+        }
+        if victims.is_empty() {
+            return 0;
+        }
+        let n = victims.len();
+        {
+            let mut reg = registry.write().await;
+            for (sid, rid) in &victims {
+                reg.dec_sessions(rid);
+                self.sessions.remove(sid);
+            }
+        }
+        n
+    }
+
+    /// Number of tracked sessions. For introspection / tests.
+    pub fn len(&self) -> usize {
+        self.sessions.len()
+    }
+
+    pub fn is_empty(&self) -> bool {
+        self.sessions.is_empty()
+    }
+}
+
+impl Default for SessionTracker {
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
+/// Spawn the sweeper as a detached tokio task. Returns a handle
+/// that callers can drop on shutdown — the loop only does
+/// idempotent work, no graceful-stop protocol needed.
+///
+/// `heartbeat_timeout_ms < 0` (the `-1` ShinyProxy idiom for
+/// "never expire") makes this a no-op task that ticks but
+/// evicts nothing. Useful so the wiring stays uniform.
+pub fn spawn(
+    tracker: Arc<SessionTracker>,
+    registry: Arc<RwLock<ReplicaRegistry>>,
+    heartbeat_timeout_ms: i64,
+) -> JoinHandle<()> {
+    tokio::spawn(async move {
+        if heartbeat_timeout_ms < 0 {
+            info!("session sweeper started in never-expire mode (heartbeat-timeout=-1)");
+            // We still hold the task open so the JoinHandle stays
+            // valid for callers; this branch deliberately spins
+            // forever doing nothing.
+            loop {
+                tokio::time::sleep(Duration::from_secs(60)).await;
+            }
+        }
+        let timeout = Duration::from_millis(heartbeat_timeout_ms as u64);
+        info!(?timeout, interval = ?SWEEPER_INTERVAL, "session sweeper started");
+        let mut ticker = tokio::time::interval(SWEEPER_INTERVAL);
+        ticker.set_missed_tick_behavior(tokio::time::MissedTickBehavior::Skip);
+        loop {
+            ticker.tick().await;
+            let evicted = tracker.sweep(&registry, timeout).await;
+            if evicted > 0 {
+                info!(evicted, "session sweeper evicted idle sessions");
+            }
+            // Quiet on no-op — would spam logs every 5s.
+        }
+    })
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use ruscker_core::{Replica, ReplicaId, ReplicaState};
+    use std::net::SocketAddr;
+
+    fn fake_replica(spec: &str) -> Replica {
+        Replica {
+            id: ReplicaId(Uuid::new_v4()),
+            spec_id: spec.to_string(),
+            container_id: "x".into(),
+            upstream: "127.0.0.1:1".parse::<SocketAddr>().unwrap(),
+            state: ReplicaState::Ready,
+            started_at: chrono::Utc::now(),
+            sessions_active: 0,
+            sessions_max: 5,
+        }
+    }
+
+    #[tokio::test]
+    async fn first_touch_registers_and_increments() {
+        let reg = Arc::new(RwLock::new(ReplicaRegistry::new()));
+        let r = fake_replica("alpha");
+        let rid = r.id.clone();
+        reg.write().await.add(r);
+        let tracker = SessionTracker::new();
+
+        let sid = Uuid::new_v4();
+        let outcome = tracker
+            .touch_or_register(&reg, sid, "alpha", &rid)
+            .await;
+        assert_eq!(outcome, TouchOutcome::Registered);
+        assert_eq!(reg.read().await.replicas_of("alpha")[0].sessions_active, 1);
+    }
+
+    #[tokio::test]
+    async fn second_touch_only_refreshes() {
+        let reg = Arc::new(RwLock::new(ReplicaRegistry::new()));
+        let r = fake_replica("alpha");
+        let rid = r.id.clone();
+        reg.write().await.add(r);
+        let tracker = SessionTracker::new();
+
+        let sid = Uuid::new_v4();
+        let _ = tracker.touch_or_register(&reg, sid, "alpha", &rid).await;
+        let outcome = tracker.touch_or_register(&reg, sid, "alpha", &rid).await;
+        assert_eq!(outcome, TouchOutcome::Touched);
+        assert_eq!(reg.read().await.replicas_of("alpha")[0].sessions_active, 1);
+        assert_eq!(tracker.len(), 1);
+    }
+
+    #[tokio::test]
+    async fn sweep_evicts_idle_sessions_and_decrements() {
+        let reg = Arc::new(RwLock::new(ReplicaRegistry::new()));
+        let r = fake_replica("alpha");
+        let rid = r.id.clone();
+        reg.write().await.add(r);
+        let tracker = SessionTracker::new();
+
+        let sid = Uuid::new_v4();
+        tracker.touch_or_register(&reg, sid, "alpha", &rid).await;
+        assert_eq!(reg.read().await.replicas_of("alpha")[0].sessions_active, 1);
+
+        // Force the entry's last_seen back in time so it expires
+        // under a small timeout.
+        if let Some(mut e) = tracker.sessions.get_mut(&sid) {
+            e.last_seen = Instant::now() - Duration::from_secs(60);
+        }
+
+        let evicted = tracker.sweep(&reg, Duration::from_secs(10)).await;
+        assert_eq!(evicted, 1);
+        assert_eq!(reg.read().await.replicas_of("alpha")[0].sessions_active, 0);
+        assert!(tracker.is_empty());
+    }
+
+    #[tokio::test]
+    async fn sweep_keeps_fresh_sessions() {
+        let reg = Arc::new(RwLock::new(ReplicaRegistry::new()));
+        let r = fake_replica("alpha");
+        let rid = r.id.clone();
+        reg.write().await.add(r);
+        let tracker = SessionTracker::new();
+
+        let sid = Uuid::new_v4();
+        tracker.touch_or_register(&reg, sid, "alpha", &rid).await;
+        // last_seen is now, sweep with 10s timeout — nothing
+        // should evict.
+        let evicted = tracker.sweep(&reg, Duration::from_secs(10)).await;
+        assert_eq!(evicted, 0);
+        assert_eq!(tracker.len(), 1);
+        assert_eq!(reg.read().await.replicas_of("alpha")[0].sessions_active, 1);
+    }
+}

--- a/crates/ruscker-admin/tests/landing_render.rs
+++ b/crates/ruscker-admin/tests/landing_render.rs
@@ -32,6 +32,7 @@ fn app_state() -> AppState {
         replicas: std::sync::Arc::new(tokio::sync::RwLock::new(Default::default())),
         cookie_key: ruscker_proxy::sticky::CookieKey::random(),
         spawn_locks: std::sync::Arc::new(dashmap::DashMap::new()),
+        sessions: std::sync::Arc::new(ruscker_admin::sessions::SessionTracker::new()),
     }
 }
 

--- a/crates/ruscker-core/src/lib.rs
+++ b/crates/ruscker-core/src/lib.rs
@@ -161,4 +161,82 @@ impl ReplicaRegistry {
     pub fn total(&self) -> usize {
         self.by_spec.values().map(Vec::len).sum()
     }
+
+    /// Increment the active-session counter on a replica. Called
+    /// by the session tracker when a new visitor lands. Silently
+    /// no-ops if the replica is gone (race with stop/remove).
+    pub fn inc_sessions(&mut self, replica_id: &ReplicaId) {
+        if let Some(r) = self.find_mut(replica_id) {
+            r.sessions_active = r.sessions_active.saturating_add(1);
+        }
+    }
+
+    /// Decrement the active-session counter on a replica. Used
+    /// by the sweeper on idle-expiry. Saturating-subtraction so
+    /// a stray double-dec can't underflow.
+    pub fn dec_sessions(&mut self, replica_id: &ReplicaId) {
+        if let Some(r) = self.find_mut(replica_id) {
+            r.sessions_active = r.sessions_active.saturating_sub(1);
+        }
+    }
+
+    fn find_mut(&mut self, replica_id: &ReplicaId) -> Option<&mut Replica> {
+        for replicas in self.by_spec.values_mut() {
+            if let Some(r) = replicas.iter_mut().find(|r| r.id == *replica_id) {
+                return Some(r);
+            }
+        }
+        None
+    }
+}
+
+#[cfg(test)]
+mod registry_tests {
+    use super::*;
+    use crate::replica::ReplicaState;
+    use std::net::SocketAddr;
+
+    fn fake_replica(spec: &str) -> Replica {
+        Replica {
+            id: ReplicaId(uuid::Uuid::new_v4()),
+            spec_id: spec.to_string(),
+            container_id: "x".into(),
+            upstream: "127.0.0.1:1".parse::<SocketAddr>().unwrap(),
+            state: ReplicaState::Ready,
+            started_at: chrono::Utc::now(),
+            sessions_active: 0,
+            sessions_max: 5,
+        }
+    }
+
+    #[test]
+    fn inc_and_dec_round_trip() {
+        let mut reg = ReplicaRegistry::new();
+        let r = fake_replica("x");
+        let id = r.id.clone();
+        reg.add(r);
+        reg.inc_sessions(&id);
+        reg.inc_sessions(&id);
+        assert_eq!(reg.replicas_of("x")[0].sessions_active, 2);
+        reg.dec_sessions(&id);
+        assert_eq!(reg.replicas_of("x")[0].sessions_active, 1);
+    }
+
+    #[test]
+    fn dec_saturates_at_zero() {
+        let mut reg = ReplicaRegistry::new();
+        let r = fake_replica("x");
+        let id = r.id.clone();
+        reg.add(r);
+        reg.dec_sessions(&id); // already zero, must not underflow
+        reg.dec_sessions(&id);
+        assert_eq!(reg.replicas_of("x")[0].sessions_active, 0);
+    }
+
+    #[test]
+    fn inc_on_unknown_id_is_noop() {
+        let mut reg = ReplicaRegistry::new();
+        let unknown = ReplicaId(uuid::Uuid::new_v4());
+        reg.inc_sessions(&unknown); // must not panic
+    }
 }


### PR DESCRIPTION
## Summary

`Replica::sessions_active` was always zero — nothing populated it. That meant `available_seats()` always returned the maximum, the LeastConnections router was degenerate, and the auto-scaler couldn't observe saturation. This PR wires up real per-visitor session tracking so all three become meaningful.

### What's new
- **`sessions::SessionTracker`** — DashMap of `session_id → (spec, replica, last_seen)`. Per-request cost = a single DashMap shard lock; the registry write-lock fires only on actual lifecycle events (register / evict).
- **`sessions::spawn` sweeper** — periodic 5s task that evicts sessions older than `proxy.heartbeat_timeout` ms and decrements the replica counter. `-1` ⇒ never-expire no-op loop.
- **Proxy integration** — `resolve_replica` now returns `(Replica, session_id, cookie_used)` so the cookie and the tracker share the same session id.
- **`ReplicaRegistry::{inc,dec}_sessions`** in ruscker-core — saturating, underflow-safe.

### Why this matters
- Saturation-based scale-up is now possible (next slice will add it to `scaler::tick`).
- Idle scale-down is now meaningful.
- The future dashboard's "active sessions" column has a real source.

### Tests
- [x] 3 new in core: inc/dec round-trip, saturation, unknown id is no-op
- [x] 4 new in admin::sessions: register, touch, sweep evicts, sweep keeps fresh
- [x] Workspace: 94+ tests green
- [x] Real-Docker smoke: cookie minted on first request to `/app/nginxweb/`, second request reuses; sweeper evicted=1 at T+5s with `heartbeat-timeout: 2000`

🤖 Generated with [Claude Code](https://claude.com/claude-code)