### PR TITLE
Phase 4 slice 3: SSE live dashboard updates

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -227,6 +227,28 @@ dependencies = [
 ]
 
 [[package]]
+name = "async-stream"
+version = "0.3.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0b5a71a6f37880a80d1d7f19efd781e4b5de42c88f0722cc13bcb6cc2cfe8476"
+dependencies = [
+ "async-stream-impl",
+ "futures-core",
+ "pin-project-lite",
+]
+
+[[package]]
+name = "async-stream-impl"
+version = "0.3.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c7c24de15d275a1ecfd47a380fb4d5ec9bfe0933f309ed5e705b775596a3574d"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
+]
+
+[[package]]
 name = "async-trait"
 version = "0.1.89"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2521,6 +2543,7 @@ dependencies = [
  "aes-gcm",
  "anyhow",
  "askama",
+ "async-stream",
  "async-trait",
  "axum",
  "axum-extra",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -38,6 +38,7 @@ hyper-util = { version = "0.1", features = ["client", "client-legacy", "http1", 
 http-body-util = "0.1"
 tokio-tungstenite = "0.29"
 futures-util = "0.3"
+async-stream = "0.3.6"
 
 # Serialization
 serde = { version = "1.0.228", features = ["derive"] }

--- a/crates/ruscker-admin/Cargo.toml
+++ b/crates/ruscker-admin/Cargo.toml
@@ -22,6 +22,7 @@ hyper = { workspace = true }
 hyper-util = { workspace = true }
 http-body-util = { workspace = true }
 futures-util = { workspace = true }
+async-stream = { workspace = true }
 
 # Async
 tokio = { workspace = true }

--- a/crates/ruscker-admin/src/routes/admin/dashboard.rs
+++ b/crates/ruscker-admin/src/routes/admin/dashboard.rs
@@ -21,12 +21,18 @@
 use askama::Template;
 use axum::{
     extract::State,
-    response::Response,
+    response::{
+        sse::{Event, KeepAlive, Sse},
+        Response,
+    },
     routing::get,
     Router,
 };
 use chrono::Utc;
+use futures_util::stream::Stream;
 use ruscker_core::{Replica, ReplicaState};
+use std::convert::Infallible;
+use std::time::Duration;
 
 use crate::auth::AdminSession;
 use crate::i18n::{Locale, Locales};
@@ -34,20 +40,51 @@ use crate::theme::Theme;
 use crate::AppState;
 
 pub fn routes() -> Router<AppState> {
-    Router::new().route("/admin/dashboard", get(index))
+    Router::new()
+        .route("/admin/dashboard", get(index))
+        .route("/admin/dashboard/events", get(events))
 }
 
-/// One row of the replicas table — flattened for the template.
+/// How often the SSE stream emits a snapshot. Same cadence as
+/// the metrics cache refresh — emitting more often would show
+/// stale CPU/memory values, less often would feel laggy on
+/// container state changes.
+const SSE_INTERVAL: Duration = Duration::from_secs(5);
+
+/// How often to send a comment-only keep-alive when no real
+/// event has fired. Stays under the typical 30-60s reverse-
+/// proxy idle timeout. Doesn't trigger the JS `onmessage`
+/// handler.
+const SSE_KEEPALIVE_INTERVAL: Duration = Duration::from_secs(15);
+
+/// One row of the replicas table — flattened for the template
+/// and also serialized as JSON over the SSE stream so the
+/// client-side patcher can update in place.
+///
 /// We project `Replica` plus the operator-facing `display_name`
 /// resolved from the spec config (replicas only carry `spec_id`).
+/// The `replica_id` round-trips as a stringified UUID so the JS
+/// can target the right `<tr data-replica-id="…">`.
+#[derive(serde::Serialize, Clone)]
 struct ReplicaRow {
+    replica_id: String,
     spec_id: String,
     /// `display-name` from the spec config, or the spec_id if
     /// the spec was renamed/deleted out from under the registry.
     display_name: String,
-    state: ReplicaState,
+    /// Lowercase state string ("ready", "starting", …).
+    /// Kept stable across versions — the JS uses it to pick
+    /// the dot CSS class and (via the i18n keys baked into the
+    /// initial render) the state label.
+    state: &'static str,
+    /// CSS class for the dot — pre-resolved so the JS doesn't
+    /// have to mirror our match.
+    state_dot: &'static str,
+    /// i18n-translated label — server-translated so the JS
+    /// doesn't need its own locale bundle.
+    state_label: String,
     /// Pre-formatted "2h 14m" string. Built once at render time
-    /// so the template stays declarative.
+    /// so the template (and the JS) stays declarative.
     uptime: String,
     sessions_active: u32,
     sessions_max: u32,
@@ -63,6 +100,22 @@ struct ReplicaRow {
     memory_display: Option<String>,
 }
 
+/// What both the HTML render and the SSE stream consume.
+/// Building this once and serializing twice keeps the two
+/// surfaces in lockstep — fix a counting bug here, both
+/// endpoints get the fix.
+#[derive(serde::Serialize, Clone)]
+struct DashboardSnapshot {
+    backend_connected: bool,
+    total_containers: usize,
+    total_sessions: u32,
+    spec_count: usize,
+    tracker_sessions: usize,
+    total_memory_bytes: u64,
+    total_memory_display: String,
+    rows: Vec<ReplicaRow>,
+}
+
 #[derive(Template)]
 #[template(path = "admin/dashboard.html")]
 struct DashboardPage<'a> {
@@ -71,52 +124,55 @@ struct DashboardPage<'a> {
     locales: &'a Locales,
     locales_all: &'static [Locale],
     nav_section: &'static str,
-    /// `None` when ruscker was started without `--docker`. The
-    /// template renders a friendly "wire up Docker" banner
-    /// instead of a 0-everything dashboard, which would look
-    /// like a real production state.
+    /// Inline copy of `DashboardSnapshot` fields. Could be a
+    /// nested `snapshot:` field but askama doesn't auto-flatten
+    /// and rewriting all `{{ foo }}` to `{{ snapshot.foo }}`
+    /// buys no clarity.
     backend_connected: bool,
     total_containers: usize,
     total_sessions: u32,
     spec_count: usize,
     tracker_sessions: usize,
-    /// Sum of `memory_bytes` across all replicas with cached
-    /// metrics. `0` when no replicas have been observed yet
-    /// (refresher hasn't ticked, or backend isn't connected).
     total_memory_bytes: u64,
-    /// "412 MB" / "1.2 GB" pre-formatted for the top metric card.
     total_memory_display: String,
     rows: Vec<ReplicaRow>,
+    /// JSON of the same snapshot, embedded in a `<script
+    /// type="application/json">` tag so the SSE-driven JS
+    /// patcher has a starting state without an immediate
+    /// extra HTTP round-trip.
+    snapshot_json: String,
 }
 
 impl<'a> DashboardPage<'a> {
     fn t(&self, key: &str) -> String {
         self.locales.t(self.locale, key, None)
     }
+}
 
-    /// Per-state label key. Kept in Rust (not the template) so a
-    /// new `ReplicaState` variant produces a compiler error
-    /// instead of a missing translation at render time.
-    fn state_label(&self, s: &ReplicaState) -> String {
-        let key = match s {
-            ReplicaState::Ready => "admin-dashboard-state-ready",
-            ReplicaState::Starting => "admin-dashboard-state-starting",
-            ReplicaState::Draining => "admin-dashboard-state-draining",
-            ReplicaState::Stopped => "admin-dashboard-state-stopped",
-            ReplicaState::Failed => "admin-dashboard-state-failed",
-        };
-        self.t(key)
+/// Map a `ReplicaState` enum to the (lowercase id, CSS class)
+/// pair used throughout the dashboard. Centralized so the SSE
+/// JSON and the server-side HTML render stay consistent.
+fn state_codes(s: ReplicaState) -> (&'static str, &'static str) {
+    match s {
+        ReplicaState::Ready => ("ready", "dot-on"),
+        ReplicaState::Starting => ("starting", "dot-pulse"),
+        ReplicaState::Draining => ("draining", "dot-warm"),
+        ReplicaState::Stopped => ("stopped", "dot-off"),
+        ReplicaState::Failed => ("failed", "dot-off"),
     }
+}
 
-    /// CSS class for the status dot. Matches the mockup's
-    /// `.dot-on / .dot-pulse / .dot-warm / .dot-off` palette.
-    fn state_dot(&self, s: &ReplicaState) -> &'static str {
-        match s {
-            ReplicaState::Ready => "dot-on",
-            ReplicaState::Starting => "dot-pulse",
-            ReplicaState::Draining => "dot-warm",
-            ReplicaState::Stopped | ReplicaState::Failed => "dot-off",
-        }
+/// i18n key for each replica state. Kept in Rust (not the
+/// template) so a new `ReplicaState` variant produces a
+/// compiler error instead of a missing translation at render
+/// time.
+fn state_label_key(s: ReplicaState) -> &'static str {
+    match s {
+        ReplicaState::Ready => "admin-dashboard-state-ready",
+        ReplicaState::Starting => "admin-dashboard-state-starting",
+        ReplicaState::Draining => "admin-dashboard-state-draining",
+        ReplicaState::Stopped => "admin-dashboard-state-stopped",
+        ReplicaState::Failed => "admin-dashboard-state-failed",
     }
 }
 
@@ -126,6 +182,35 @@ async fn index(
     loc: Locale,
     theme: Theme,
 ) -> Response {
+    let snap = build_snapshot(&state, loc).await;
+    let snapshot_json = serde_json::to_string(&snap).unwrap_or_else(|_| "{}".to_string());
+    let page = DashboardPage {
+        locale: loc,
+        theme,
+        locales: &state.locales,
+        locales_all: &Locale::ALL,
+        nav_section: "dashboard",
+        backend_connected: snap.backend_connected,
+        total_containers: snap.total_containers,
+        total_sessions: snap.total_sessions,
+        spec_count: snap.spec_count,
+        tracker_sessions: snap.tracker_sessions,
+        total_memory_bytes: snap.total_memory_bytes,
+        total_memory_display: snap.total_memory_display.clone(),
+        rows: snap.rows.clone(),
+        snapshot_json,
+    };
+    super::render(&page)
+}
+
+/// Build the dashboard data snapshot. Pure(ish) function used
+/// by both the initial HTML render and the SSE event stream
+/// so they can't drift.
+///
+/// `locale` is needed to translate the per-state labels server-
+/// side; the JS subscriber then just stamps the strings into
+/// the DOM without owning a locale bundle of its own.
+async fn build_snapshot(state: &AppState, locale: Locale) -> DashboardSnapshot {
     let backend_connected = state.backend.is_some();
 
     // Snapshot the registry once. Cloning `Replica` is cheap
@@ -151,11 +236,6 @@ async fn index(
         .len();
     let tracker_sessions = state.sessions.len();
 
-    // Build display rows. `display_name` falls back to spec_id
-    // when the operator deleted / renamed a spec out from under
-    // a still-running replica. Each row also looks up its
-    // cached metrics; rows without cached metrics show "n/a"
-    // until the next refresher tick.
     let mut total_memory_bytes: u64 = 0;
     let rows: Vec<ReplicaRow> = snap
         .into_iter()
@@ -176,10 +256,15 @@ async fn index(
             if let Some(c) = cached.as_ref() {
                 total_memory_bytes = total_memory_bytes.saturating_add(c.metrics.memory_bytes);
             }
+            let (state_code, state_dot) = state_codes(r.state);
+            let state_label = state.locales.t(locale, state_label_key(r.state), None);
             ReplicaRow {
+                replica_id: r.id.0.to_string(),
                 spec_id: r.spec_id,
                 display_name,
-                state: r.state,
+                state: state_code,
+                state_dot,
+                state_label,
                 uptime,
                 sessions_active: r.sessions_active,
                 sessions_max: r.sessions_max,
@@ -192,19 +277,10 @@ async fn index(
     let total_memory_display = if total_memory_bytes > 0 {
         format_bytes(total_memory_bytes)
     } else {
-        // i18n-friendly default: render an em-dash and let the
-        // operator infer "no data yet" from context. The full
-        // explanation lives below as the metrics-pending hint
-        // when rows exist but none have cached metrics.
         "—".to_string()
     };
 
-    let page = DashboardPage {
-        locale: loc,
-        theme,
-        locales: &state.locales,
-        locales_all: &Locale::ALL,
-        nav_section: "dashboard",
+    DashboardSnapshot {
         backend_connected,
         total_containers,
         total_sessions,
@@ -213,8 +289,7 @@ async fn index(
         total_memory_bytes,
         total_memory_display,
         rows,
-    };
-    super::render(&page)
+    }
 }
 
 /// Render a byte count as a short human string with binary
@@ -238,6 +313,45 @@ fn format_bytes(bytes: u64) -> String {
     } else {
         format!("{:.1} GB", bytes as f64 / GIB as f64)
     }
+}
+
+/// Server-Sent Events stream of dashboard snapshots. The
+/// client connects with `EventSource('/admin/dashboard/events')`
+/// and receives a JSON-encoded [`DashboardSnapshot`] every
+/// [`SSE_INTERVAL`], plus a comment keep-alive every
+/// [`SSE_KEEPALIVE_INTERVAL`] to defeat proxy idle timeouts.
+///
+/// Each emission is independent; reconnecting after a network
+/// blip just resumes the cadence — there's no event-id /
+/// last-event-id handshake to manage, and replaying a snapshot
+/// is idempotent on the client side anyway.
+async fn events(
+    _: AdminSession,
+    State(state): State<AppState>,
+    loc: Locale,
+) -> Sse<impl Stream<Item = Result<Event, Infallible>>> {
+    use async_stream::stream;
+    let stream = stream! {
+        // Emit the first snapshot immediately so the client
+        // patches on connect instead of waiting one full
+        // interval. Avoids a visible "stale" gap right after
+        // page load.
+        let first = build_snapshot(&state, loc).await;
+        let body = serde_json::to_string(&first).unwrap_or_else(|_| "{}".to_string());
+        yield Ok::<_, Infallible>(Event::default().data(body));
+
+        let mut ticker = tokio::time::interval(SSE_INTERVAL);
+        ticker.set_missed_tick_behavior(tokio::time::MissedTickBehavior::Skip);
+        // Burn the immediate first tick — we already emitted.
+        ticker.tick().await;
+        loop {
+            ticker.tick().await;
+            let snap = build_snapshot(&state, loc).await;
+            let body = serde_json::to_string(&snap).unwrap_or_else(|_| "{}".to_string());
+            yield Ok::<_, Infallible>(Event::default().data(body));
+        }
+    };
+    Sse::new(stream).keep_alive(KeepAlive::new().interval(SSE_KEEPALIVE_INTERVAL))
 }
 
 /// Format a chrono `Duration` as a short uptime: "45s", "12m",
@@ -312,10 +426,23 @@ mod tests {
     }
 
     fn fake_row(spec: &str, name: &str, st: ReplicaState, active: u32, max: u32) -> ReplicaRow {
+        let (state_code, state_dot) = state_codes(st);
         ReplicaRow {
+            replica_id: uuid::Uuid::new_v4().to_string(),
             spec_id: spec.into(),
             display_name: name.into(),
-            state: st,
+            state: state_code,
+            state_dot,
+            // Hard-coded pt labels — keeps the test independent
+            // of the live locale bundle for these specific keys.
+            state_label: match st {
+                ReplicaState::Ready => "pronto",
+                ReplicaState::Starting => "iniciando",
+                ReplicaState::Draining => "drenando",
+                ReplicaState::Stopped => "parado",
+                ReplicaState::Failed => "falhou",
+            }
+            .into(),
             uptime: "2h 14m".into(),
             sessions_active: active,
             sessions_max: max,
@@ -345,6 +472,7 @@ mod tests {
             total_memory_bytes: 0,
             total_memory_display: "—".to_string(),
             rows,
+            snapshot_json: "{}".to_string(),
         };
         page.render().expect("render dashboard")
     }

--- a/crates/ruscker-admin/templates/admin/dashboard.html
+++ b/crates/ruscker-admin/templates/admin/dashboard.html
@@ -102,77 +102,181 @@
   </div>
 {% endif %}
 
-<div class="dash-metric-grid">
+<div class="dash-metric-grid" id="dash-metrics">
   <div class="dash-metric">
     <div class="dash-metric-label"><i class="ti ti-box"></i>{{ self.t("admin-dashboard-metric-containers") }}</div>
-    <div class="dash-metric-value">{{ total_containers }}</div>
+    <div class="dash-metric-value" data-metric="containers">{{ total_containers }}</div>
   </div>
   <div class="dash-metric">
     <div class="dash-metric-label"><i class="ti ti-users"></i>{{ self.t("admin-dashboard-metric-sessions") }}</div>
-    <div class="dash-metric-value">{{ total_sessions }}</div>
+    <div class="dash-metric-value" data-metric="sessions">{{ total_sessions }}</div>
   </div>
   <div class="dash-metric">
     <div class="dash-metric-label"><i class="ti ti-apps"></i>{{ self.t("admin-dashboard-metric-specs") }}</div>
-    <div class="dash-metric-value">{{ spec_count }}</div>
+    <div class="dash-metric-value" data-metric="specs">{{ spec_count }}</div>
   </div>
   <div class="dash-metric">
     <div class="dash-metric-label"><i class="ti ti-activity"></i>{{ self.t("admin-dashboard-metric-tracker") }}</div>
-    <div class="dash-metric-value">{{ tracker_sessions }}</div>
+    <div class="dash-metric-value" data-metric="tracker">{{ tracker_sessions }}</div>
   </div>
   <div class="dash-metric">
     <div class="dash-metric-label"><i class="ti ti-database"></i>{{ self.t("admin-dashboard-metric-memory") }}</div>
-    <div class="dash-metric-value">{{ total_memory_display }}</div>
+    <div class="dash-metric-value" data-metric="memory">{{ total_memory_display }}</div>
   </div>
 </div>
 
 <h2 class="text-sm font-medium mb-2">{{ self.t("admin-dashboard-replicas-heading") }}</h2>
 
-{% if rows.is_empty() %}
-  <div class="dash-empty">{{ self.t("admin-dashboard-no-replicas") }}</div>
-{% else %}
-  <div style="border: 0.5px solid var(--color-border-tertiary, rgba(120,120,120,0.2)); border-radius: 10px; overflow: hidden;">
-    <table class="dash-table">
-      <thead>
-        <tr>
-          <th style="width: 24px;"></th>
-          <th>{{ self.t("admin-dashboard-col-spec") }}</th>
-          <th>{{ self.t("admin-dashboard-col-state") }}</th>
-          <th>{{ self.t("admin-dashboard-col-uptime") }}</th>
-          <th>{{ self.t("admin-dashboard-col-sessions") }}</th>
-          <th>{{ self.t("admin-dashboard-col-cpu") }}</th>
-          <th>{{ self.t("admin-dashboard-col-memory") }}</th>
-          <th>{{ self.t("admin-dashboard-col-container") }}</th>
+<div id="dash-rows-empty" class="dash-empty"{% if !rows.is_empty() %} style="display:none"{% endif %}>{{ self.t("admin-dashboard-no-replicas") }}</div>
+<div id="dash-rows-wrap" style="border: 0.5px solid var(--color-border-tertiary, rgba(120,120,120,0.2)); border-radius: 10px; overflow: hidden;{% if rows.is_empty() %} display:none;{% endif %}">
+  <table class="dash-table">
+    <thead>
+      <tr>
+        <th style="width: 24px;"></th>
+        <th>{{ self.t("admin-dashboard-col-spec") }}</th>
+        <th>{{ self.t("admin-dashboard-col-state") }}</th>
+        <th>{{ self.t("admin-dashboard-col-uptime") }}</th>
+        <th>{{ self.t("admin-dashboard-col-sessions") }}</th>
+        <th>{{ self.t("admin-dashboard-col-cpu") }}</th>
+        <th>{{ self.t("admin-dashboard-col-memory") }}</th>
+        <th>{{ self.t("admin-dashboard-col-container") }}</th>
+      </tr>
+    </thead>
+    <tbody id="dash-rows" data-pending-label="{{ self.t("admin-dashboard-metrics-pending") }}">
+      {% for row in rows %}
+        <tr data-replica-id="{{ row.replica_id }}">
+          <td><span class="dash-dot {{ row.state_dot }}"></span></td>
+          <td>
+            <div style="font-weight: 500;">{{ row.display_name }}</div>
+            <div class="dash-mono">{{ row.spec_id }}</div>
+          </td>
+          <td>{{ row.state_label }}</td>
+          <td class="dash-mono">{{ row.uptime }}</td>
+          <td>{{ row.sessions_active }}<span style="color: var(--text-muted)">/{{ row.sessions_max }}</span></td>
+          <td>
+            {% match row.cpu_display %}
+              {% when Some with (s) %}{{ s }}
+              {% when None %}<span style="color: var(--text-faint)" title="{{ self.t("admin-dashboard-metrics-pending") }}">—</span>
+            {% endmatch %}
+          </td>
+          <td>
+            {% match row.memory_display %}
+              {% when Some with (s) %}{{ s }}
+              {% when None %}<span style="color: var(--text-faint)" title="{{ self.t("admin-dashboard-metrics-pending") }}">—</span>
+            {% endmatch %}
+          </td>
+          <td class="dash-mono">{{ row.container_short }}</td>
         </tr>
-      </thead>
-      <tbody>
-        {% for row in rows %}
-          <tr>
-            <td><span class="dash-dot {{ self.state_dot(row.state) }}"></span></td>
-            <td>
-              <div style="font-weight: 500;">{{ row.display_name }}</div>
-              <div class="dash-mono">{{ row.spec_id }}</div>
-            </td>
-            <td>{{ self.state_label(row.state) }}</td>
-            <td class="dash-mono">{{ row.uptime }}</td>
-            <td>{{ row.sessions_active }}<span style="color: var(--text-muted)">/{{ row.sessions_max }}</span></td>
-            <td>
-              {% match row.cpu_display %}
-                {% when Some with (s) %}{{ s }}
-                {% when None %}<span style="color: var(--text-faint)" title="{{ self.t("admin-dashboard-metrics-pending") }}">—</span>
-              {% endmatch %}
-            </td>
-            <td>
-              {% match row.memory_display %}
-                {% when Some with (s) %}{{ s }}
-                {% when None %}<span style="color: var(--text-faint)" title="{{ self.t("admin-dashboard-metrics-pending") }}">—</span>
-              {% endmatch %}
-            </td>
-            <td class="dash-mono">{{ row.container_short }}</td>
-          </tr>
-        {% endfor %}
-      </tbody>
-    </table>
-  </div>
-{% endif %}
+      {% endfor %}
+    </tbody>
+  </table>
+</div>
+
+{# Tiny SSE patcher. No framework — just EventSource +
+   targeted DOM updates. Initial state already came in the
+   server-rendered HTML; this only handles refreshes. #}
+<script id="dash-initial-snapshot" type="application/json">{{ snapshot_json|safe }}</script>
+<script>
+(function () {
+  var pendingLabel = document.getElementById('dash-rows')
+    && document.getElementById('dash-rows').dataset.pendingLabel
+    || 'awaiting first reading';
+
+  function escapeHtml(s) {
+    return String(s).replace(/[&<>"']/g, function (c) {
+      return { '&':'&amp;','<':'&lt;','>':'&gt;','"':'&quot;',"'":'&#39;' }[c];
+    });
+  }
+
+  function metric(name, value) {
+    var el = document.querySelector('[data-metric="' + name + '"]');
+    if (el && el.textContent !== String(value)) el.textContent = value;
+  }
+
+  function rowHtml(row) {
+    var cpu = row.cpu_display !== null && row.cpu_display !== undefined
+      ? escapeHtml(row.cpu_display)
+      : '<span style="color: var(--text-faint)" title="' + escapeHtml(pendingLabel) + '">—</span>';
+    var mem = row.memory_display !== null && row.memory_display !== undefined
+      ? escapeHtml(row.memory_display)
+      : '<span style="color: var(--text-faint)" title="' + escapeHtml(pendingLabel) + '">—</span>';
+    return ''
+      + '<td><span class="dash-dot ' + escapeHtml(row.state_dot) + '"></span></td>'
+      + '<td>'
+        + '<div style="font-weight: 500;">' + escapeHtml(row.display_name) + '</div>'
+        + '<div class="dash-mono">' + escapeHtml(row.spec_id) + '</div>'
+      + '</td>'
+      + '<td>' + escapeHtml(row.state_label) + '</td>'
+      + '<td class="dash-mono">' + escapeHtml(row.uptime) + '</td>'
+      + '<td>' + row.sessions_active + '<span style="color: var(--text-muted)">/' + row.sessions_max + '</span></td>'
+      + '<td>' + cpu + '</td>'
+      + '<td>' + mem + '</td>'
+      + '<td class="dash-mono">' + escapeHtml(row.container_short) + '</td>';
+  }
+
+  function apply(snap) {
+    metric('containers', snap.total_containers);
+    metric('sessions', snap.total_sessions);
+    metric('specs', snap.spec_count);
+    metric('tracker', snap.tracker_sessions);
+    metric('memory', snap.total_memory_display);
+
+    var tbody = document.getElementById('dash-rows');
+    var wrap = document.getElementById('dash-rows-wrap');
+    var empty = document.getElementById('dash-rows-empty');
+    if (!tbody || !wrap || !empty) return;
+
+    if (!snap.rows || snap.rows.length === 0) {
+      wrap.style.display = 'none';
+      empty.style.display = '';
+      tbody.innerHTML = '';
+      return;
+    }
+    wrap.style.display = '';
+    empty.style.display = 'none';
+
+    // Build new rows keyed by replica_id. Reuse existing <tr>
+    // when the id matches so the browser preserves any focus /
+    // selection inside (defensive — we don't have any inputs
+    // here yet, but cheap).
+    var existing = {};
+    Array.prototype.forEach.call(tbody.children, function (tr) {
+      var id = tr.dataset.replicaId;
+      if (id) existing[id] = tr;
+    });
+
+    var frag = document.createDocumentFragment();
+    snap.rows.forEach(function (row) {
+      var tr = existing[row.replica_id];
+      if (!tr) {
+        tr = document.createElement('tr');
+        tr.dataset.replicaId = row.replica_id;
+      }
+      tr.innerHTML = rowHtml(row);
+      frag.appendChild(tr);
+    });
+    tbody.replaceChildren(frag);
+  }
+
+  // The initial render already populated the DOM, but parsing
+  // the embedded snapshot keeps the JS path covered even if
+  // the SSE connection is slow to open or proxied through
+  // something that buffers.
+  try {
+    var initial = JSON.parse(
+      document.getElementById('dash-initial-snapshot').textContent
+    );
+    if (initial && initial.rows !== undefined) apply(initial);
+  } catch (_) { /* initial snapshot embedding is best-effort */ }
+
+  if (!window.EventSource) return;
+  var es = new EventSource('/admin/dashboard/events');
+  es.onmessage = function (e) {
+    try { apply(JSON.parse(e.data)); } catch (_) { /* ignore */ }
+  };
+  // No retry handling needed — EventSource auto-reconnects
+  // on network errors. We just let it.
+})();
+</script>
 
 {% endblock %}


### PR DESCRIPTION
## Summary

Closes the dashboard arc started in #24. Static render + metrics cache from slices 1 & 2 are now pushed to the client without manual refresh, via Server-Sent Events and a ~120-line vanilla-JS patcher embedded in the template. No framework, no build step.

## New endpoint
`GET /admin/dashboard/events` — same auth, returns `text/event-stream`. Emits a JSON snapshot immediately on connect (client patches without waiting one full interval), then every 5 s. Keep-alive comments every 15 s defeat reverse-proxy timeouts without firing `onmessage`.

## Shared snapshot builder
`build_snapshot(&state, locale) -> DashboardSnapshot` — single source of truth used by both HTML render and SSE. State labels and CSS dot classes pre-resolved on the server so the JS doesn't need a locale bundle.

## Initial state embedding
First render embeds the snapshot as `<script id="dash-initial-snapshot" type="application/json">` so the JS can apply it before EventSource opens.

## JS patcher
- `metric(name, value)` only touches DOM when text actually changed
- `apply(snap)` updates 5 cards then replaces tbody rows, reusing `<tr data-replica-id>` across renders
- `escapeHtml` on every interpolated string (server controls shape but the rule is uniform)
- Browsers without `EventSource` see the initial render and never patch — falls back gracefully

## Tests
- [x] Updated `fake_row` for new `replica_id` / `state_dot` / `state_label` fields
- [x] 7 dashboard unit tests + 150 workspace tests green

## Real-Docker smoke

`curl /admin/dashboard/events` for 16 s → **4 events**:

```
"total_containers":1  "total_memory_display":"—"
"total_containers":1  "total_memory_display":"8 MB"
"total_containers":1  "total_memory_display":"8 MB"
"total_containers":1  "total_memory_display":"8 MB"
```

The `"—" → "8 MB"` transition between events 1 and 2 proves the metrics cache populates and the SSE stream delivers the update to the client in real time.

Initial HTML render contains: `dash-initial-snapshot`, `data-metric`, `data-replica-id`, `new EventSource`.

## Phase 4 dashboard arc — complete
- ✓ slice 1: static render (PR #24)
- ✓ slice 2: per-replica CPU + memory (PR #25)
- ✓ slice 3: SSE live updates (this PR)

🤖 Generated with [Claude Code](https://claude.com/claude-code)