### PR TITLE
Phase 4: per-replica logs viewer

### DIFF
--- a/crates/ruscker-admin/assets/i18n/en/landing.ftl
+++ b/crates/ruscker-admin/assets/i18n/en/landing.ftl
@@ -239,3 +239,10 @@ footer-theme = Theme
 theme-light = Light
 theme-dark = Dark
 theme-auto = Auto
+
+# Admin logs viewer
+admin-logs-title = Container logs
+admin-logs-back = Back to dashboard
+admin-logs-replica = Replica
+admin-logs-empty = No log output for this replica yet.
+admin-logs-tail-note = Showing the last lines (newest at the bottom).

--- a/crates/ruscker-admin/assets/i18n/es/landing.ftl
+++ b/crates/ruscker-admin/assets/i18n/es/landing.ftl
@@ -239,3 +239,10 @@ footer-theme = Tema
 theme-light = Claro
 theme-dark = Oscuro
 theme-auto = Automático
+
+# Admin logs viewer
+admin-logs-title = Logs del contenedor
+admin-logs-back = Volver al panel
+admin-logs-replica = Réplica
+admin-logs-empty = Aún no hay salida de log para esta réplica.
+admin-logs-tail-note = Mostrando las últimas líneas (más recientes al final).

--- a/crates/ruscker-admin/assets/i18n/fr/landing.ftl
+++ b/crates/ruscker-admin/assets/i18n/fr/landing.ftl
@@ -239,3 +239,10 @@ footer-theme = Thème
 theme-light = Clair
 theme-dark = Sombre
 theme-auto = Automatique
+
+# Admin logs viewer
+admin-logs-title = Logs du conteneur
+admin-logs-back = Retour au tableau de bord
+admin-logs-replica = Réplique
+admin-logs-empty = Pas encore de sortie de log pour cette réplique.
+admin-logs-tail-note = Affichage des dernières lignes (les plus récentes en bas).

--- a/crates/ruscker-admin/assets/i18n/pt/landing.ftl
+++ b/crates/ruscker-admin/assets/i18n/pt/landing.ftl
@@ -243,3 +243,10 @@ footer-theme = Tema
 theme-light = Claro
 theme-dark = Escuro
 theme-auto = Automático
+
+# Admin logs viewer
+admin-logs-title = Logs do container
+admin-logs-back = Voltar ao painel
+admin-logs-replica = Réplica
+admin-logs-empty = Sem saída de log para esta réplica ainda.
+admin-logs-tail-note = Mostrando as últimas linhas (mais recentes ao final).

--- a/crates/ruscker-admin/src/routes/admin/dashboard.rs
+++ b/crates/ruscker-admin/src/routes/admin/dashboard.rs
@@ -20,17 +20,18 @@
 
 use askama::Template;
 use axum::{
-    extract::State,
+    extract::{Path, State},
+    http::StatusCode,
     response::{
         sse::{Event, KeepAlive, Sse},
-        Response,
+        IntoResponse, Response,
     },
     routing::get,
     Router,
 };
 use chrono::Utc;
 use futures_util::stream::Stream;
-use ruscker_core::{Replica, ReplicaState};
+use ruscker_core::{Replica, ReplicaId, ReplicaState};
 use std::convert::Infallible;
 use std::time::Duration;
 
@@ -43,7 +44,13 @@ pub fn routes() -> Router<AppState> {
     Router::new()
         .route("/admin/dashboard", get(index))
         .route("/admin/dashboard/events", get(events))
+        .route("/admin/dashboard/logs/{replica_id}", get(logs))
 }
+
+/// How many trailing log lines the logs page requests. Enough
+/// to see a crash traceback without flooding the page; the
+/// backend caps harder at its own `MAX_TAIL`.
+const LOGS_TAIL: usize = 500;
 
 /// How often the SSE stream emits a snapshot. Same cadence as
 /// the metrics cache refresh — emitting more often would show
@@ -144,6 +151,30 @@ struct DashboardPage<'a> {
 }
 
 impl<'a> DashboardPage<'a> {
+    fn t(&self, key: &str) -> String {
+        self.locales.t(self.locale, key, None)
+    }
+}
+
+#[derive(Template)]
+#[template(path = "admin/logs.html")]
+struct LogsPage<'a> {
+    locale: Locale,
+    theme: Theme,
+    locales: &'a Locales,
+    locales_all: &'static [Locale],
+    nav_section: &'static str,
+    /// Display name resolved from the spec config (or spec_id
+    /// fallback) for the page heading.
+    display_name: String,
+    spec_id: String,
+    replica_id: String,
+    /// The log lines, oldest-first. Empty vec renders an
+    /// "no output" hint.
+    lines: Vec<String>,
+}
+
+impl<'a> LogsPage<'a> {
     fn t(&self, key: &str) -> String {
         self.locales.t(self.locale, key, None)
     }
@@ -354,6 +385,87 @@ async fn events(
     Sse::new(stream).keep_alive(KeepAlive::new().interval(SSE_KEEPALIVE_INTERVAL))
 }
 
+/// Per-replica logs page. Fetches the last [`LOGS_TAIL`] lines
+/// of combined stdout+stderr via the backend and renders them
+/// in a `<pre>`. One-shot — no live follow yet (that's a
+/// future slice that would reuse the SSE machinery).
+///
+/// `replica_id` is the stringified UUID from the dashboard
+/// row's `data-replica-id`. A malformed id → 400; a valid id
+/// that no longer maps to a container → the backend returns an
+/// error which we surface as 404.
+async fn logs(
+    _: AdminSession,
+    State(state): State<AppState>,
+    loc: Locale,
+    theme: Theme,
+    Path(replica_id): Path<String>,
+) -> Response {
+    let Ok(uuid) = uuid::Uuid::parse_str(&replica_id) else {
+        return (StatusCode::BAD_REQUEST, "invalid replica id").into_response();
+    };
+    let rid = ReplicaId(uuid);
+
+    let Some(backend) = state.backend.as_ref() else {
+        return (
+            StatusCode::SERVICE_UNAVAILABLE,
+            "no container backend — start with --docker",
+        )
+            .into_response();
+    };
+
+    // Resolve display_name + spec_id from the registry snapshot
+    // so the page heading is friendly even though logs come
+    // straight from the backend.
+    let (display_name, spec_id) = {
+        let reg = state.replicas.read().await;
+        let found = reg.all().find(|r| r.id == rid).map(|r| r.spec_id.clone());
+        match found {
+            Some(sid) => {
+                let dn = state
+                    .config
+                    .proxy
+                    .specs
+                    .iter()
+                    .find(|s| s.id == sid)
+                    .and_then(|s| s.display_name.clone())
+                    .unwrap_or_else(|| sid.clone());
+                (dn, sid)
+            }
+            // Replica not in registry — still try to fetch logs
+            // (it may have just been dropped from the registry
+            // but the container lingers). Heading falls back to
+            // the raw id.
+            None => (replica_id.clone(), String::new()),
+        }
+    };
+
+    let lines = match backend.logs(&rid, LOGS_TAIL).await {
+        Ok(l) => l,
+        Err(e) => {
+            tracing::warn!(replica = %replica_id, error = ?e, "fetch logs failed");
+            return (
+                StatusCode::NOT_FOUND,
+                format!("could not fetch logs for replica {replica_id}: {e}"),
+            )
+                .into_response();
+        }
+    };
+
+    let page = LogsPage {
+        locale: loc,
+        theme,
+        locales: &state.locales,
+        locales_all: &Locale::ALL,
+        nav_section: "dashboard",
+        display_name,
+        spec_id,
+        replica_id,
+        lines,
+    };
+    super::render(&page)
+}
+
 /// Format a chrono `Duration` as a short uptime: "45s", "12m",
 /// "2h 14m", "3d 7h". One-line because that's how the table
 /// renders it; longer formats land in the per-replica detail
@@ -475,6 +587,63 @@ mod tests {
             snapshot_json: "{}".to_string(),
         };
         page.render().expect("render dashboard")
+    }
+
+    fn render_logs(lines: Vec<String>) -> String {
+        let locales = load_locales();
+        let page = LogsPage {
+            locale: Locale::Pt,
+            theme: Theme::Auto,
+            locales: &locales,
+            locales_all: &Locale::ALL,
+            nav_section: "dashboard",
+            display_name: "Aurora Prime".into(),
+            spec_id: "auroraprime".into(),
+            replica_id: "11111111-2222-3333-4444-555555555555".into(),
+            lines,
+        };
+        page.render().expect("render logs")
+    }
+
+    #[test]
+    fn logs_page_renders_each_line() {
+        let html = render_logs(vec![
+            "2026-05-24 starting nginx".into(),
+            "worker process 1 started".into(),
+        ]);
+        assert!(html.contains("Aurora Prime"));
+        assert!(html.contains("auroraprime"));
+        assert!(html.contains("11111111-2222-3333-4444-555555555555"));
+        assert!(html.contains("starting nginx"));
+        assert!(html.contains("worker process 1 started"));
+        // Tail note present, empty hint absent.
+        assert!(html.contains("últimas linhas"));
+        assert!(!html.contains("Sem saída de log"));
+    }
+
+    #[test]
+    fn logs_page_renders_empty_hint() {
+        let html = render_logs(vec![]);
+        assert!(html.contains("Sem saída de log"));
+    }
+
+    #[test]
+    fn logs_page_escapes_html_in_log_lines() {
+        // A log line containing HTML must not break out of the
+        // <pre>. Askama auto-escapes by default. We don't assert
+        // the exact entity form (askama may emit `&lt;` or
+        // `&#60;`) — only that the raw injectable form is gone
+        // and the `<` got encoded to *some* entity.
+        let html = render_logs(vec!["<script>alert(1)</script>".into()]);
+        assert!(
+            !html.contains("<script>alert(1)</script>"),
+            "raw script tag must not survive: {html}"
+        );
+        // The literal payload's `<` must be entity-encoded.
+        assert!(
+            html.contains("&lt;script&gt;") || html.contains("&#60;script&#62;"),
+            "escaped form not found in: {html}"
+        );
     }
 
     #[test]

--- a/crates/ruscker-admin/templates/admin/dashboard.html
+++ b/crates/ruscker-admin/templates/admin/dashboard.html
@@ -140,9 +140,10 @@
         <th>{{ self.t("admin-dashboard-col-cpu") }}</th>
         <th>{{ self.t("admin-dashboard-col-memory") }}</th>
         <th>{{ self.t("admin-dashboard-col-container") }}</th>
+        <th style="width: 32px;"></th>
       </tr>
     </thead>
-    <tbody id="dash-rows" data-pending-label="{{ self.t("admin-dashboard-metrics-pending") }}">
+    <tbody id="dash-rows" data-pending-label="{{ self.t("admin-dashboard-metrics-pending") }}" data-logs-title="{{ self.t("admin-logs-title") }}">
       {% for row in rows %}
         <tr data-replica-id="{{ row.replica_id }}">
           <td><span class="dash-dot {{ row.state_dot }}"></span></td>
@@ -166,6 +167,10 @@
             {% endmatch %}
           </td>
           <td class="dash-mono">{{ row.container_short }}</td>
+          <td>
+            <a href="/admin/dashboard/logs/{{ row.replica_id }}" title="{{ self.t("admin-logs-title") }}"
+               style="color: var(--text-muted)"><i class="ti ti-file-text"></i></a>
+          </td>
         </tr>
       {% endfor %}
     </tbody>
@@ -178,9 +183,9 @@
 <script id="dash-initial-snapshot" type="application/json">{{ snapshot_json|safe }}</script>
 <script>
 (function () {
-  var pendingLabel = document.getElementById('dash-rows')
-    && document.getElementById('dash-rows').dataset.pendingLabel
-    || 'awaiting first reading';
+  var tbodyEl = document.getElementById('dash-rows');
+  var pendingLabel = (tbodyEl && tbodyEl.dataset.pendingLabel) || 'awaiting first reading';
+  var logsTitle = (tbodyEl && tbodyEl.dataset.logsTitle) || 'Logs';
 
   function escapeHtml(s) {
     return String(s).replace(/[&<>"']/g, function (c) {
@@ -211,7 +216,10 @@
       + '<td>' + row.sessions_active + '<span style="color: var(--text-muted)">/' + row.sessions_max + '</span></td>'
       + '<td>' + cpu + '</td>'
       + '<td>' + mem + '</td>'
-      + '<td class="dash-mono">' + escapeHtml(row.container_short) + '</td>';
+      + '<td class="dash-mono">' + escapeHtml(row.container_short) + '</td>'
+      + '<td><a href="/admin/dashboard/logs/' + encodeURIComponent(row.replica_id)
+        + '" title="' + escapeHtml(logsTitle)
+        + '" style="color: var(--text-muted)"><i class="ti ti-file-text"></i></a></td>';
   }
 
   function apply(snap) {

--- a/crates/ruscker-admin/templates/admin/logs.html
+++ b/crates/ruscker-admin/templates/admin/logs.html
@@ -1,0 +1,67 @@
+{% extends "admin/_layout.html" %}
+
+{% block title %}{{ self.t("admin-logs-title") }} · Ruscker{% endblock %}
+
+{% block content %}
+
+<style>
+  .logs-pre {
+    background: var(--color-background-secondary, #1113);
+    border: 0.5px solid var(--color-border-tertiary, rgba(120,120,120,0.2));
+    border-radius: 10px;
+    padding: 14px 16px;
+    font-family: ui-monospace, SFMono-Regular, "SF Mono", Menlo, monospace;
+    font-size: 12px;
+    line-height: 1.5;
+    white-space: pre-wrap;
+    word-break: break-word;
+    max-height: 70vh;
+    overflow-y: auto;
+    margin: 0;
+  }
+  .logs-empty {
+    padding: 32px 16px;
+    text-align: center;
+    color: var(--text-muted);
+    font-size: 13px;
+    border: 0.5px dashed var(--color-border-tertiary, rgba(120,120,120,0.2));
+    border-radius: 10px;
+  }
+  .logs-mono {
+    font-family: ui-monospace, SFMono-Regular, "SF Mono", Menlo, monospace;
+    font-size: 11px;
+    color: var(--text-muted);
+  }
+</style>
+
+<div class="flex items-end justify-between mb-5">
+  <div>
+    <h1 class="text-xl font-medium tracking-tight">{{ self.t("admin-logs-title") }}</h1>
+    <p class="text-xs text-[color:var(--text-muted)] mt-1">
+      {{ display_name }}
+      {% if !spec_id.is_empty() %}<span class="logs-mono"> · {{ spec_id }}</span>{% endif %}
+    </p>
+    <p class="logs-mono mt-1">{{ self.t("admin-logs-replica") }}: {{ replica_id }}</p>
+  </div>
+  <a href="/admin/dashboard" class="admin-nav-link">
+    <i class="ti ti-arrow-left" aria-hidden="true"></i>
+    <span>{{ self.t("admin-logs-back") }}</span>
+  </a>
+</div>
+
+{% if lines.is_empty() %}
+  <div class="logs-empty">{{ self.t("admin-logs-empty") }}</div>
+{% else %}
+  <p class="text-xs text-[color:var(--text-faint)] mb-2">{{ self.t("admin-logs-tail-note") }}</p>
+  <pre class="logs-pre" id="logs-pre">{% for line in lines %}{{ line }}
+{% endfor %}</pre>
+  <script>
+    // Scroll to the newest line on load.
+    (function () {
+      var pre = document.getElementById('logs-pre');
+      if (pre) pre.scrollTop = pre.scrollHeight;
+    })();
+  </script>
+{% endif %}
+
+{% endblock %}

--- a/crates/ruscker-core/src/lib.rs
+++ b/crates/ruscker-core/src/lib.rs
@@ -231,6 +231,16 @@ pub trait ContainerBackend: Send + Sync {
 
     /// Per-replica metrics (CPU, memory, network I/O).
     async fn metrics(&self, replica_id: &ReplicaId) -> CoreResult<ReplicaMetrics>;
+
+    /// Fetch the last `tail` lines of a replica's combined
+    /// stdout+stderr. A one-shot snapshot (no follow) — the
+    /// dashboard logs page uses it for "why did this container
+    /// crash" debugging. Default impl returns an empty vec so
+    /// backends that don't support log retrieval don't break
+    /// the caller.
+    async fn logs(&self, _replica_id: &ReplicaId, _tail: usize) -> CoreResult<Vec<String>> {
+        Ok(Vec::new())
+    }
 }
 
 #[derive(Debug, Clone, serde::Serialize, serde::Deserialize)]

--- a/crates/ruscker-docker/src/lib.rs
+++ b/crates/ruscker-docker/src/lib.rs
@@ -19,8 +19,8 @@
 use async_trait::async_trait;
 use bollard::models::{ContainerCreateBody, HostConfig, PortBinding};
 use bollard::query_parameters::{
-    CreateContainerOptions, CreateImageOptions, ListContainersOptions, RemoveContainerOptions,
-    StartContainerOptions, StatsOptionsBuilder, StopContainerOptions,
+    CreateContainerOptions, CreateImageOptions, ListContainersOptions, LogsOptionsBuilder,
+    RemoveContainerOptions, StartContainerOptions, StatsOptionsBuilder, StopContainerOptions,
 };
 use bollard::Docker;
 use chrono::Utc;
@@ -453,6 +453,11 @@ impl ContainerBackend for LocalDockerBackend {
         let container_id = self.container_id_for_replica(replica_id).await?;
         self.metrics_for_container(&container_id).await
     }
+
+    async fn logs(&self, replica_id: &ReplicaId, tail: usize) -> CoreResult<Vec<String>> {
+        let container_id = self.container_id_for_replica(replica_id).await?;
+        self.logs_for_container(&container_id, tail).await
+    }
 }
 
 impl LocalDockerBackend {
@@ -557,6 +562,45 @@ impl LocalDockerBackend {
     /// bound across long-lived deployments.
     pub fn forget_metrics(&self, container_id: &str) {
         self.prev_stats.remove(container_id);
+    }
+
+    /// Fetch the last `tail` lines of a container's combined
+    /// stdout + stderr. One-shot (`follow: false`). Each
+    /// returned `String` is one log line with its trailing
+    /// newline trimmed; the stream framing bytes that Docker
+    /// prepends in multiplexed mode are stripped by bollard's
+    /// `LogOutput` decoding, so we just stringify each chunk.
+    ///
+    /// `tail` is capped defensively — an operator-supplied
+    /// huge number shouldn't let a chatty container balloon
+    /// the response.
+    pub async fn logs_for_container(
+        &self,
+        container_id: &str,
+        tail: usize,
+    ) -> CoreResult<Vec<String>> {
+        const MAX_TAIL: usize = 5_000;
+        let tail = tail.min(MAX_TAIL);
+        let opts = LogsOptionsBuilder::default()
+            .stdout(true)
+            .stderr(true)
+            .follow(false)
+            .tail(&tail.to_string())
+            .build();
+
+        let mut stream = self.docker.logs(container_id, Some(opts));
+        let mut lines: Vec<String> = Vec::new();
+        while let Some(item) = stream.next().await {
+            let chunk = item.map_err(|e| backend_err("logs", e))?;
+            // `LogOutput` Display gives the decoded text for the
+            // frame (stdout/stderr/console). A single frame can
+            // hold multiple newline-separated lines, so split.
+            let text = chunk.to_string();
+            for line in text.split_inclusive('\n') {
+                lines.push(line.trim_end_matches(['\r', '\n']).to_string());
+            }
+        }
+        Ok(lines)
     }
 }
 


### PR DESCRIPTION
## Summary

Adds `/admin/dashboard/logs/{replica_id}` — a one-shot view of the last 500 lines of a replica's combined stdout+stderr. First operator-facing debugging surface: "why did this container fail to start / crash".

## Backend
- `ContainerBackend::logs(replica_id, tail) -> Vec<String>` — new trait method, default returns empty.
- `LocalDockerBackend::logs_for_container` via bollard `logs` (`stdout+stderr`, `follow: false`, `tail: N`). Frames stringified + split on newlines, `\r\n` trimmed. `tail` capped at 5000.

## Page
- Admin-gated route, resolves display-name + spec_id from the registry for the heading (raw-id fallback if the replica already left the registry).
- `<pre>` with auto-scroll-to-bottom.
- Malformed id → 400; valid id, no container → 404.
- Logs-link icon (`ti-file-text`) on every dashboard row — added to both the server render AND the SSE JS `rowHtml` so live-added rows get it.
- 5 new i18n keys × 4 locales.

## Tests
- [x] 3 new render tests: each line rendered, empty hint, HTML-escaping of log content (XSS guard)
- [x] Workspace: 166 tests (was 163)

## Real-Docker smoke
- Dashboard row carries the logs link
- `GET` logs URL → 200, 6.5 KB
- Heading: "Nginx Web" / "nginxweb"
- `<pre>` shows real nginx output: `/docker-entrypoint.sh: /docker-entrypoint.d/ is not empty...`
- Bad replica id → 400

## Next (deferred)
Live follow-mode logs (reuse the SSE machinery). One-shot tail covers the common "show me the crash" case.

🤖 Generated with [Claude Code](https://claude.com/claude-code)