### PR TITLE
Phase 4: per-replica stop / restart actions

### DIFF
--- a/crates/ruscker-admin/assets/i18n/en/landing.ftl
+++ b/crates/ruscker-admin/assets/i18n/en/landing.ftl
@@ -246,3 +246,9 @@ admin-logs-back = Back to dashboard
 admin-logs-replica = Replica
 admin-logs-empty = No log output for this replica yet.
 admin-logs-tail-note = Showing the last lines (newest at the bottom).
+
+# Dashboard replica actions
+admin-dashboard-action-stop = Stop
+admin-dashboard-action-restart = Restart
+admin-dashboard-confirm-stop = Stop this replica? The auto-scaler may recreate it if the configured minimum requires it.
+admin-dashboard-confirm-restart = Restart this replica? Any active session will be lost.

--- a/crates/ruscker-admin/assets/i18n/es/landing.ftl
+++ b/crates/ruscker-admin/assets/i18n/es/landing.ftl
@@ -246,3 +246,9 @@ admin-logs-back = Volver al panel
 admin-logs-replica = Réplica
 admin-logs-empty = Aún no hay salida de log para esta réplica.
 admin-logs-tail-note = Mostrando las últimas líneas (más recientes al final).
+
+# Dashboard replica actions
+admin-dashboard-action-stop = Detener
+admin-dashboard-action-restart = Reiniciar
+admin-dashboard-confirm-stop = ¿Detener esta réplica? El auto-scaler puede recrearla si el mínimo configurado lo exige.
+admin-dashboard-confirm-restart = ¿Reiniciar esta réplica? Se perderá la sesión activa.

--- a/crates/ruscker-admin/assets/i18n/fr/landing.ftl
+++ b/crates/ruscker-admin/assets/i18n/fr/landing.ftl
@@ -246,3 +246,9 @@ admin-logs-back = Retour au tableau de bord
 admin-logs-replica = Réplique
 admin-logs-empty = Pas encore de sortie de log pour cette réplique.
 admin-logs-tail-note = Affichage des dernières lignes (les plus récentes en bas).
+
+# Dashboard replica actions
+admin-dashboard-action-stop = Arrêter
+admin-dashboard-action-restart = Redémarrer
+admin-dashboard-confirm-stop = Arrêter cette réplique ? L auto-scaler peut la recréer si le minimum configuré l exige.
+admin-dashboard-confirm-restart = Redémarrer cette réplique ? La session active sera perdue.

--- a/crates/ruscker-admin/assets/i18n/pt/landing.ftl
+++ b/crates/ruscker-admin/assets/i18n/pt/landing.ftl
@@ -250,3 +250,9 @@ admin-logs-back = Voltar ao painel
 admin-logs-replica = Réplica
 admin-logs-empty = Sem saída de log para esta réplica ainda.
 admin-logs-tail-note = Mostrando as últimas linhas (mais recentes ao final).
+
+# Dashboard replica actions
+admin-dashboard-action-stop = Parar
+admin-dashboard-action-restart = Reiniciar
+admin-dashboard-confirm-stop = Parar esta réplica? O auto-scaler pode recriá-la se o mínimo configurado exigir.
+admin-dashboard-confirm-restart = Reiniciar esta réplica? A sessão ativa será perdida.

--- a/crates/ruscker-admin/src/routes/admin/dashboard.rs
+++ b/crates/ruscker-admin/src/routes/admin/dashboard.rs
@@ -24,9 +24,9 @@ use axum::{
     http::StatusCode,
     response::{
         sse::{Event, KeepAlive, Sse},
-        IntoResponse, Response,
+        IntoResponse, Redirect, Response,
     },
-    routing::get,
+    routing::{get, post},
     Router,
 };
 use chrono::Utc;
@@ -45,6 +45,11 @@ pub fn routes() -> Router<AppState> {
         .route("/admin/dashboard", get(index))
         .route("/admin/dashboard/events", get(events))
         .route("/admin/dashboard/logs/{replica_id}", get(logs))
+        .route("/admin/dashboard/replicas/{replica_id}/stop", post(stop_replica))
+        .route(
+            "/admin/dashboard/replicas/{replica_id}/restart",
+            post(restart_replica),
+        )
 }
 
 /// How many trailing log lines the logs page requests. Enough
@@ -464,6 +469,108 @@ async fn logs(
         lines,
     };
     super::render(&page)
+}
+
+/// Resolve a `{replica_id}` path param to a `ReplicaId`,
+/// 400ing on a malformed UUID. Shared by the action handlers.
+fn parse_replica_id(s: &str) -> Result<ReplicaId, Response> {
+    uuid::Uuid::parse_str(s)
+        .map(ReplicaId)
+        .map_err(|_| (StatusCode::BAD_REQUEST, "invalid replica id").into_response())
+}
+
+/// POST `/admin/dashboard/replicas/{id}/stop` — stop a replica
+/// and drop it from the registry. The auto-scaler will respawn
+/// it to `min-replicas` on its next tick if the spec demands a
+/// baseline, so for a `min-replicas: 1` spec this reads as
+/// "recycle this container".
+///
+/// Safe against CSRF by the admin cookie being SameSite=Strict.
+/// Redirects back to the dashboard so the browser lands on a
+/// fresh render.
+async fn stop_replica(
+    _: AdminSession,
+    State(state): State<AppState>,
+    Path(replica_id): Path<String>,
+) -> Response {
+    let rid = match parse_replica_id(&replica_id) {
+        Ok(r) => r,
+        Err(resp) => return resp,
+    };
+    let Some(backend) = state.backend.as_ref() else {
+        return (StatusCode::SERVICE_UNAVAILABLE, "no backend").into_response();
+    };
+
+    if let Err(e) = backend.stop(&rid).await {
+        tracing::warn!(replica = %replica_id, error = ?e, "stop replica failed");
+        // Fall through to remove it from the registry anyway —
+        // a stop that errored usually means the container is
+        // already gone, and we don't want a phantom row.
+    }
+    state.replicas.write().await.remove(&rid);
+    tracing::info!(replica = %replica_id, "replica stopped via dashboard");
+    Redirect::to("/admin/dashboard").into_response()
+}
+
+/// POST `/admin/dashboard/replicas/{id}/restart` — stop the
+/// replica, then immediately spawn a fresh one for the same
+/// spec. Unlike plain stop (which leans on the scaler to
+/// respawn ~one tick later), restart brings capacity back
+/// right away.
+async fn restart_replica(
+    _: AdminSession,
+    State(state): State<AppState>,
+    Path(replica_id): Path<String>,
+) -> Response {
+    let rid = match parse_replica_id(&replica_id) {
+        Ok(r) => r,
+        Err(resp) => return resp,
+    };
+    let Some(backend) = state.backend.as_ref() else {
+        return (StatusCode::SERVICE_UNAVAILABLE, "no backend").into_response();
+    };
+
+    // Resolve the spec before stopping so a restart of a
+    // since-deleted spec fails cleanly without first killing
+    // the running container.
+    let spec_id = {
+        let reg = state.replicas.read().await;
+        let found = reg.all().find(|r| r.id == rid).map(|r| r.spec_id.clone());
+        found
+    };
+    let Some(spec_id) = spec_id else {
+        return (StatusCode::NOT_FOUND, "replica not found").into_response();
+    };
+    let spec = state
+        .config
+        .proxy
+        .specs
+        .iter()
+        .find(|s| s.id == spec_id)
+        .cloned();
+    let Some(spec) = spec else {
+        return (
+            StatusCode::CONFLICT,
+            format!("spec `{spec_id}` no longer in config; cannot restart"),
+        )
+            .into_response();
+    };
+
+    if let Err(e) = backend.stop(&rid).await {
+        tracing::warn!(replica = %replica_id, error = ?e, "restart: stop phase failed");
+    }
+    state.replicas.write().await.remove(&rid);
+
+    if let Err(e) = crate::scaler::spawn_replica(&state, &spec).await {
+        tracing::error!(spec = %spec.id, error = ?e, "restart: spawn phase failed");
+        return (
+            StatusCode::BAD_GATEWAY,
+            format!("stopped old replica but failed to spawn a new one: {e}"),
+        )
+            .into_response();
+    }
+    tracing::info!(replica = %replica_id, spec = %spec.id, "replica restarted via dashboard");
+    Redirect::to("/admin/dashboard").into_response()
 }
 
 /// Format a chrono `Duration` as a short uptime: "45s", "12m",

--- a/crates/ruscker-admin/src/scaler.rs
+++ b/crates/ruscker-admin/src/scaler.rs
@@ -306,6 +306,22 @@ async fn stop_one(
     Ok(())
 }
 
+/// Spawn one replica for `spec` using the configured backend.
+/// Public entry point for callers outside the scaler loop
+/// (e.g. the dashboard's "restart" action). Resolves the
+/// backend off `state`; errors if none is wired.
+///
+/// Same coalescer semantics as the internal scale-up path —
+/// concurrent spawns for the same spec serialize on the
+/// per-spec mutex.
+pub(crate) async fn spawn_replica(state: &AppState, spec: &Spec) -> anyhow::Result<()> {
+    let backend = state
+        .backend
+        .clone()
+        .ok_or_else(|| anyhow::anyhow!("no container backend wired"))?;
+    spawn_one(state, spec, backend.as_ref()).await
+}
+
 /// Spawn one additional replica for `spec`. Used by every
 /// scale-up branch (to-min and on-saturation). Goes through the
 /// per-spec mutex so a concurrent on-demand spawn coalesces

--- a/crates/ruscker-admin/templates/admin/dashboard.html
+++ b/crates/ruscker-admin/templates/admin/dashboard.html
@@ -86,6 +86,22 @@
     border: 0.5px dashed var(--color-border-tertiary, rgba(120,120,120,0.2));
     border-radius: 10px;
   }
+  .dash-action {
+    display: inline-flex;
+    align-items: center;
+    justify-content: center;
+    width: 24px;
+    height: 24px;
+    border: none;
+    background: transparent;
+    color: var(--text-muted);
+    cursor: pointer;
+    border-radius: 6px;
+    font-size: 14px;
+    vertical-align: middle;
+  }
+  .dash-action:hover { background: var(--color-background-secondary, rgba(120,120,120,0.12)); }
+  .dash-action--danger:hover { color: #ef4444; }
 </style>
 
 <div class="flex items-end justify-between mb-5">
@@ -140,10 +156,16 @@
         <th>{{ self.t("admin-dashboard-col-cpu") }}</th>
         <th>{{ self.t("admin-dashboard-col-memory") }}</th>
         <th>{{ self.t("admin-dashboard-col-container") }}</th>
-        <th style="width: 32px;"></th>
+        <th style="width: 84px;"></th>
       </tr>
     </thead>
-    <tbody id="dash-rows" data-pending-label="{{ self.t("admin-dashboard-metrics-pending") }}" data-logs-title="{{ self.t("admin-logs-title") }}">
+    <tbody id="dash-rows"
+           data-pending-label="{{ self.t("admin-dashboard-metrics-pending") }}"
+           data-logs-title="{{ self.t("admin-logs-title") }}"
+           data-stop-label="{{ self.t("admin-dashboard-action-stop") }}"
+           data-restart-label="{{ self.t("admin-dashboard-action-restart") }}"
+           data-confirm-stop="{{ self.t("admin-dashboard-confirm-stop") }}"
+           data-confirm-restart="{{ self.t("admin-dashboard-confirm-restart") }}">
       {% for row in rows %}
         <tr data-replica-id="{{ row.replica_id }}">
           <td><span class="dash-dot {{ row.state_dot }}"></span></td>
@@ -167,9 +189,17 @@
             {% endmatch %}
           </td>
           <td class="dash-mono">{{ row.container_short }}</td>
-          <td>
+          <td style="white-space: nowrap;">
             <a href="/admin/dashboard/logs/{{ row.replica_id }}" title="{{ self.t("admin-logs-title") }}"
-               style="color: var(--text-muted)"><i class="ti ti-file-text"></i></a>
+               class="dash-action" style="color: var(--text-muted)"><i class="ti ti-file-text"></i></a>
+            <form method="post" action="/admin/dashboard/replicas/{{ row.replica_id }}/restart"
+                  style="display:inline" onsubmit="return confirm('{{ self.t("admin-dashboard-confirm-restart") }}')">
+              <button type="submit" class="dash-action" title="{{ self.t("admin-dashboard-action-restart") }}"><i class="ti ti-refresh"></i></button>
+            </form>
+            <form method="post" action="/admin/dashboard/replicas/{{ row.replica_id }}/stop"
+                  style="display:inline" onsubmit="return confirm('{{ self.t("admin-dashboard-confirm-stop") }}')">
+              <button type="submit" class="dash-action dash-action--danger" title="{{ self.t("admin-dashboard-action-stop") }}"><i class="ti ti-player-stop"></i></button>
+            </form>
           </td>
         </tr>
       {% endfor %}
@@ -184,8 +214,13 @@
 <script>
 (function () {
   var tbodyEl = document.getElementById('dash-rows');
-  var pendingLabel = (tbodyEl && tbodyEl.dataset.pendingLabel) || 'awaiting first reading';
-  var logsTitle = (tbodyEl && tbodyEl.dataset.logsTitle) || 'Logs';
+  var ds = (tbodyEl && tbodyEl.dataset) || {};
+  var pendingLabel = ds.pendingLabel || 'awaiting first reading';
+  var logsTitle = ds.logsTitle || 'Logs';
+  var stopLabel = ds.stopLabel || 'Stop';
+  var restartLabel = ds.restartLabel || 'Restart';
+  var confirmStop = ds.confirmStop || 'Stop this replica?';
+  var confirmRestart = ds.confirmRestart || 'Restart this replica?';
 
   function escapeHtml(s) {
     return String(s).replace(/[&<>"']/g, function (c) {
@@ -217,9 +252,19 @@
       + '<td>' + cpu + '</td>'
       + '<td>' + mem + '</td>'
       + '<td class="dash-mono">' + escapeHtml(row.container_short) + '</td>'
-      + '<td><a href="/admin/dashboard/logs/' + encodeURIComponent(row.replica_id)
-        + '" title="' + escapeHtml(logsTitle)
-        + '" style="color: var(--text-muted)"><i class="ti ti-file-text"></i></a></td>';
+      + '<td style="white-space: nowrap;">'
+        + '<a href="/admin/dashboard/logs/' + encodeURIComponent(row.replica_id)
+          + '" title="' + escapeHtml(logsTitle)
+          + '" class="dash-action" style="color: var(--text-muted)"><i class="ti ti-file-text"></i></a>'
+        + '<form method="post" action="/admin/dashboard/replicas/' + encodeURIComponent(row.replica_id)
+          + '/restart" style="display:inline" onsubmit="return confirm(' + JSON.stringify(confirmRestart) + ')">'
+          + '<button type="submit" class="dash-action" title="' + escapeHtml(restartLabel) + '"><i class="ti ti-refresh"></i></button>'
+        + '</form>'
+        + '<form method="post" action="/admin/dashboard/replicas/' + encodeURIComponent(row.replica_id)
+          + '/stop" style="display:inline" onsubmit="return confirm(' + JSON.stringify(confirmStop) + ')">'
+          + '<button type="submit" class="dash-action dash-action--danger" title="' + escapeHtml(stopLabel) + '"><i class="ti ti-player-stop"></i></button>'
+        + '</form>'
+      + '</td>';
   }
 
   function apply(snap) {


### PR DESCRIPTION
## Summary

Completes the monitor → inspect → act loop. Each dashboard row now has stop + restart buttons next to its logs link.

## Routes (POST, admin-gated)
- `POST .../replicas/{id}/stop` — stop + drop from registry. Auto-scaler respawns to min on next tick (so min≥1 → "recycle").
- `POST .../replicas/{id}/restart` — stop, then immediately spawn fresh. Resolves spec BEFORE stopping so a since-deleted spec fails cleanly (409) without killing the running container.

Both 303 → `/admin/dashboard`. Bad id → 400, unknown replica → 404, no backend → 503.

## CSRF
Admin cookie is `SameSite=Strict` + `HttpOnly` — cross-site forms can't ride the session. No separate token at this scope.

## Spawn reuse
Exposed `scaler::spawn_replica` (`pub(crate)`) wrapping `spawn_one`, so restart goes through the same coalescer-mutex path — no duplicate-spawn race, correct creds/limits/seat enrichment.

## UI
- Logs / restart / stop icon buttons, added to BOTH server render AND SSE patcher `rowHtml`.
- `confirm()` dialogs (session-loss warning), text from i18n via `data-*` attrs.
- 4 new i18n keys × 4 locales.

## Tests
- [x] 166 tests still green
- [x] Real-Docker smoke (handlers are thin; e2e smoke > mock-heavy unit)

## Real-Docker smoke
- **restart**: `ruscker-nginxweb-3dda2f82` → `-d3772e5d` (new container, count stays 1), 303, log line
- **stop**: 303, container removed immediately, scaler respawns within ~10s
- **bad id**: 400

🤖 Generated with [Claude Code](https://claude.com/claude-code)