### PR TITLE
Add interactive-app e2e harness (Shiny-readiness validation)

### DIFF
--- a/examples/e2e-interactive-app/Dockerfile
+++ b/examples/e2e-interactive-app/Dockerfile
@@ -1,0 +1,5 @@
+FROM python:3.12-slim
+RUN pip install --no-cache-dir aiohttp
+COPY app.py /app.py
+EXPOSE 8080
+CMD ["python", "/app.py"]

--- a/examples/e2e-interactive-app/README.md
+++ b/examples/e2e-interactive-app/README.md
@@ -1,0 +1,52 @@
+# Interactive-app e2e harness
+
+A minimal containerized app that stands in for Shiny / Streamlit
+/ Dash when validating Ruscker's interactive-app support — HTML
+URL rewriting, the JS runtime shim, and WebSocket proxying —
+without pulling a heavyweight R/Python framework image.
+
+## What's here
+
+- **`app.py`** — an [aiohttp](https://docs.aiohttp.org) server
+  that deliberately exercises every URL flavor an interactive
+  app uses behind a reverse proxy:
+  - serves HTML referencing **absolute-root** static assets
+    (`/static/app.js`, `/static/app.css`)
+  - the page's JS does a `fetch('/api/ping')` (absolute path)
+  - and opens a `WebSocket` to an absolute path (`/ws`)
+- **`Dockerfile`** — `python:3.12-slim` + aiohttp.
+- **`wsapp.yml`** — a Ruscker config mounting the app as a
+  `type: streamlit` (InteractiveApp) spec on inner port 8080.
+- **`wsclient.py`** — a dependency-free stdlib WebSocket client
+  (socket + handshake + one masked frame) used to drive the WS
+  echo through the proxy. No `websockets`/`websocat` needed.
+
+## Running
+
+```bash
+cargo build --bin ruscker
+./scripts/e2e-interactive.sh
+```
+
+The script builds the image, starts `ruscker serve --docker`
+against `wsapp.yml`, and asserts four things end-to-end:
+
+1. **HTML transform** — `<base href>` + JS shim + absolute-attr
+   rewriting present in the served page.
+2. **Asset round-trip** — a rewritten `/app/wsapp/static/app.js`
+   routes back through the proxy and serves the file.
+3. **JSON endpoint** — `/app/wsapp/api/ping` returns.
+4. **WebSocket proxy** — bidirectional echo works against a
+   genuine upstream WebSocket server.
+
+Exit code 0 = all four passed.
+
+## What it does NOT cover
+
+The JS shim's **runtime** behavior (monkey-patching
+`WebSocket` / `fetch` / `XMLHttpRequest` inside a browser) is
+not exercised — that needs a headless browser. This harness
+proves the server-side mechanisms and the WS proxy path; the
+shim is covered by unit tests in `ruscker-admin`'s
+`routes::rewrite` module and by visual inspection of the
+injected script.

--- a/examples/e2e-interactive-app/app.py
+++ b/examples/e2e-interactive-app/app.py
@@ -1,0 +1,61 @@
+# Minimal interactive app to e2e-test Ruscker's URL rewriting +
+# WebSocket proxying. Pure aiohttp: HTTP + WS in one process.
+import asyncio
+from aiohttp import web, WSMsgType
+
+INDEX = """<!doctype html>
+<html>
+<head>
+  <title>wsapp</title>
+  <link rel="stylesheet" href="/static/app.css">
+  <script src="/static/app.js"></script>
+</head>
+<body>
+  <h1>wsapp</h1>
+  <div id="out">init</div>
+</body>
+</html>"""
+
+APP_JS = """// served from /static/app.js
+console.log("app.js loaded");
+fetch('/api/ping').then(r => r.json()).then(j => {
+  document.getElementById('out').textContent = 'fetch:' + j.pong;
+});
+var ws = new WebSocket((location.protocol === 'https:' ? 'wss://' : 'ws://') + location.host + '/ws');
+ws.onopen = function(){ ws.send('hello'); };
+ws.onmessage = function(e){ document.getElementById('out').textContent += ' ws:' + e.data; };
+"""
+
+async def index(request):
+    return web.Response(text=INDEX, content_type='text/html')
+
+async def app_js(request):
+    return web.Response(text=APP_JS, content_type='application/javascript')
+
+async def app_css(request):
+    return web.Response(text="body{font-family:sans-serif}", content_type='text/css')
+
+async def ping(request):
+    return web.json_response({"pong": "ok"})
+
+async def ws_handler(request):
+    ws = web.WebSocketResponse()
+    await ws.prepare(request)
+    async for msg in ws:
+        if msg.type == WSMsgType.TEXT:
+            await ws.send_str("echo:" + msg.data)
+            if msg.data == "close":
+                await ws.close()
+    return ws
+
+app = web.Application()
+app.add_routes([
+    web.get('/', index),
+    web.get('/static/app.js', app_js),
+    web.get('/static/app.css', app_css),
+    web.get('/api/ping', ping),
+    web.get('/ws', ws_handler),
+])
+
+if __name__ == '__main__':
+    web.run_app(app, host='0.0.0.0', port=8080)

--- a/examples/e2e-interactive-app/wsapp.yml
+++ b/examples/e2e-interactive-app/wsapp.yml
@@ -1,0 +1,15 @@
+proxy:
+  title: WS App e2e
+  port: 8082
+  bind-address: 127.0.0.1
+  authentication: none
+  heartbeat-timeout: 60000
+  specs:
+    - id: wsapp
+      display-name: WS Test App
+      type: streamlit
+      container-image: ruscker-wsapp:test
+      min-replicas: 1
+      max-replicas: 1
+      api:
+        port: 8080

--- a/examples/e2e-interactive-app/wsclient.py
+++ b/examples/e2e-interactive-app/wsclient.py
@@ -1,0 +1,55 @@
+# Minimal stdlib WebSocket client: connect through a path,
+# send one text frame, read one echo frame. No deps.
+import socket, base64, os, sys, struct
+
+def ws_echo(host, port, path, payload):
+    key = base64.b64encode(os.urandom(16)).decode()
+    req = (
+        f"GET {path} HTTP/1.1\r\n"
+        f"Host: {host}:{port}\r\n"
+        "Upgrade: websocket\r\n"
+        "Connection: Upgrade\r\n"
+        f"Sec-WebSocket-Key: {key}\r\n"
+        "Sec-WebSocket-Version: 13\r\n"
+        "\r\n"
+    )
+    s = socket.create_connection((host, port), timeout=10)
+    s.sendall(req.encode())
+    # Read handshake response headers
+    buf = b""
+    while b"\r\n\r\n" not in buf:
+        chunk = s.recv(4096)
+        if not chunk:
+            raise RuntimeError("connection closed during handshake")
+        buf += chunk
+    head = buf.split(b"\r\n\r\n", 1)[0].decode(errors="replace")
+    status = head.splitlines()[0]
+    if "101" not in status:
+        print("HANDSHAKE FAILED:", status)
+        print(head)
+        return None
+    # Send a masked text frame (client frames MUST be masked)
+    data = payload.encode()
+    mask = os.urandom(4)
+    masked = bytes(b ^ mask[i % 4] for i, b in enumerate(data))
+    frame = bytes([0x81, 0x80 | len(data)]) + mask + masked  # FIN+text, masked, <126 len
+    s.sendall(frame)
+    # Read one server frame (server->client is unmasked)
+    hdr = s.recv(2)
+    if len(hdr) < 2:
+        raise RuntimeError("short frame header")
+    ln = hdr[1] & 0x7F
+    if ln == 126:
+        ln = struct.unpack(">H", s.recv(2))[0]
+    elif ln == 127:
+        ln = struct.unpack(">Q", s.recv(8))[0]
+    body = b""
+    while len(body) < ln:
+        body += s.recv(ln - len(body))
+    s.close()
+    return body.decode(errors="replace")
+
+if __name__ == "__main__":
+    host, port, path, payload = sys.argv[1], int(sys.argv[2]), sys.argv[3], sys.argv[4]
+    result = ws_echo(host, port, path, payload)
+    print("RECV:", result)

--- a/scripts/e2e-interactive.sh
+++ b/scripts/e2e-interactive.sh
@@ -1,0 +1,111 @@
+#!/usr/bin/env bash
+#
+# End-to-end validation of Ruscker's interactive-app support
+# against a REAL container that serves HTML, static assets, a
+# JSON endpoint, AND a WebSocket — the four things a Shiny /
+# Streamlit / Dash app exercises behind the proxy.
+#
+# What it proves:
+#   1. HTML transform — <base href> + JS shim + absolute-attr
+#      rewriting land in the served page (#21/#27/#28).
+#   2. Asset round-trip — a rewritten /app/{spec}/static/x path
+#      routes back through the proxy and serves the asset.
+#   3. JSON endpoint — a rewritten /app/{spec}/api/ping returns.
+#   4. WebSocket proxy — ws::pump bidirectional echo works with
+#      a genuine upstream WebSocket server (Phase 3).
+#
+# What it does NOT prove: the JS shim executing in a real
+# browser (runtime monkey-patching). That needs a headless
+# browser; out of scope for a shell harness.
+#
+# Requires: Docker daemon, a built `ruscker` binary, python3.
+# Usage:    ./scripts/e2e-interactive.sh
+# Exit 0 = all four checks passed.
+
+set -euo pipefail
+
+HERE="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+ROOT="$(cd "$HERE/.." && pwd)"
+APPDIR="$ROOT/examples/e2e-interactive-app"
+IMAGE="ruscker-wsapp:test"
+BIND="127.0.0.1:8082"
+BASEURL="http://$BIND"
+PIDFILE=""
+FAILED=0
+
+log()  { printf '\033[36m==>\033[0m %s\n' "$*"; }
+pass() { printf '  \033[32mPASS\033[0m %s\n' "$*"; }
+fail() { printf '  \033[31mFAIL\033[0m %s\n' "$*"; FAILED=1; }
+
+cleanup() {
+  [ -n "$PIDFILE" ] && kill -9 "$PIDFILE" 2>/dev/null || true
+  docker ps -a --filter "label=ruscker.replica_id" --format '{{.ID}}' \
+    | xargs -r docker rm -f >/dev/null 2>&1 || true
+}
+trap cleanup EXIT
+
+# ── locate the ruscker binary ──────────────────────────────
+RUSCKER="$ROOT/target/debug/ruscker"
+[ -x "$RUSCKER" ] || RUSCKER="$ROOT/target/release/ruscker"
+if [ ! -x "$RUSCKER" ]; then
+  echo "ruscker binary not found — run 'cargo build --bin ruscker' first" >&2
+  exit 2
+fi
+
+log "Building test image $IMAGE"
+docker build -q -t "$IMAGE" "$APPDIR" >/dev/null
+
+log "Starting ruscker (--docker) on $BIND"
+DOCKER_REGISTRY_PASSWORD=test \
+  "$RUSCKER" serve --config "$APPDIR/wsapp.yml" --bind "$BIND" --docker \
+  >/tmp/e2e-interactive.log 2>&1 &
+PIDFILE=$!
+
+# Wait for the landing page to answer.
+for _ in $(seq 1 10); do
+  curl -s -o /dev/null --max-time 1 "$BASEURL/" && break
+  sleep 1
+done
+# Wait for the scaler to bring the replica up and ready.
+for _ in $(seq 1 15); do
+  if docker ps --filter "label=ruscker.replica_id" --format '{{.Status}}' | grep -q Up; then
+    break
+  fi
+  sleep 1
+done
+sleep 3
+
+# ── 1. HTML transform ──────────────────────────────────────
+log "1. HTML transform"
+PAGE="$(curl -s "$BASEURL/app/wsapp/")"
+for needle in \
+  '<base href="/app/wsapp/">' \
+  'src="/app/wsapp/static/app.js"' \
+  'href="/app/wsapp/static/app.css"' \
+  'window.WebSocket' \
+  'XMLHttpRequest.prototype.open'; do
+  if grep -qF "$needle" <<<"$PAGE"; then pass "$needle"; else fail "$needle"; fi
+done
+
+# ── 2. asset round-trip ────────────────────────────────────
+log "2. Asset round-trip"
+CODE="$(curl -s -o /dev/null -w '%{http_code}' "$BASEURL/app/wsapp/static/app.js")"
+if [ "$CODE" = "200" ]; then pass "GET /app/wsapp/static/app.js -> 200"; else fail "app.js -> $CODE"; fi
+
+# ── 3. JSON endpoint ───────────────────────────────────────
+log "3. JSON endpoint"
+PING="$(curl -s "$BASEURL/app/wsapp/api/ping")"
+if grep -qF '"pong"' <<<"$PING"; then pass "api/ping -> $PING"; else fail "api/ping -> $PING"; fi
+
+# ── 4. WebSocket proxy ─────────────────────────────────────
+log "4. WebSocket proxy"
+WS="$(python3 "$APPDIR/wsclient.py" 127.0.0.1 8082 /app/wsapp/ws hello)"
+if grep -qF 'echo:hello' <<<"$WS"; then pass "ws echo -> $WS"; else fail "ws echo -> $WS"; fi
+
+echo
+if [ "$FAILED" -eq 0 ]; then
+  printf '\033[32mALL CHECKS PASSED\033[0m\n'
+else
+  printf '\033[31mSOME CHECKS FAILED\033[0m (see /tmp/e2e-interactive.log)\n'
+fi
+exit "$FAILED"


### PR DESCRIPTION
## Summary

Converts the manual smoke that validated the URL-rewriting arc (#21/#27/#28) + WebSocket proxy (Phase 3) into a committed, repeatable regression test.

## What it validates

A purpose-built aiohttp app (`examples/e2e-interactive-app/`) stands in for Shiny/Streamlit/Dash — small (165 MB), no framework noise — exercising every URL flavor an interactive app uses behind the proxy: absolute-root static assets, a JS `fetch`, and a `WebSocket`.

`scripts/e2e-interactive.sh` builds the image, starts `ruscker serve --docker`, and asserts:

1. **HTML transform** — `<base href>` + JS shim + absolute-attr rewriting present
2. **Asset round-trip** — rewritten `/app/wsapp/static/app.js` → 200 (paths actually resolve)
3. **JSON endpoint** — `/app/wsapp/api/ping` returns
4. **WebSocket proxy** — `ws::pump` echo against a **genuine upstream WS server**

→ `ALL CHECKS PASSED`, exit 0.

**#4 is the headline**: the WS proxy had only been spike-tested + smoked against nginx (no WS). This is the first real end-to-end validation of Phase 3's WebSocket path.

## Dependency-free WS client
`wsclient.py` — stdlib-only (raw socket + handshake + masked frame). Harness needs only python3.

## Not covered
The JS shim's runtime behavior in a real browser needs a headless browser (out of scope). Covered here: server-side mechanisms + WS proxy. Shim covered by `routes::rewrite` unit tests.

🤖 Generated with [Claude Code](https://claude.com/claude-code)