### PR TITLE
Phase 4: live follow-mode logs (SSE)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2763,6 +2763,7 @@ version = "0.1.0"
 dependencies = [
  "async-trait",
  "chrono",
+ "futures-util",
  "ruscker-config",
  "serde",
  "thiserror",
@@ -2774,6 +2775,7 @@ name = "ruscker-docker"
 version = "0.1.0"
 dependencies = [
  "anyhow",
+ "async-stream",
  "async-trait",
  "bollard",
  "chrono",

--- a/crates/ruscker-admin/assets/i18n/en/landing.ftl
+++ b/crates/ruscker-admin/assets/i18n/en/landing.ftl
@@ -252,3 +252,5 @@ admin-dashboard-action-stop = Stop
 admin-dashboard-action-restart = Restart
 admin-dashboard-confirm-stop = Stop this replica? The auto-scaler may recreate it if the configured minimum requires it.
 admin-dashboard-confirm-restart = Restart this replica? Any active session will be lost.
+admin-logs-follow = Live
+admin-logs-follow-stop = Stop

--- a/crates/ruscker-admin/assets/i18n/es/landing.ftl
+++ b/crates/ruscker-admin/assets/i18n/es/landing.ftl
@@ -252,3 +252,5 @@ admin-dashboard-action-stop = Detener
 admin-dashboard-action-restart = Reiniciar
 admin-dashboard-confirm-stop = ¿Detener esta réplica? El auto-scaler puede recrearla si el mínimo configurado lo exige.
 admin-dashboard-confirm-restart = ¿Reiniciar esta réplica? Se perderá la sesión activa.
+admin-logs-follow = En vivo
+admin-logs-follow-stop = Detener

--- a/crates/ruscker-admin/assets/i18n/fr/landing.ftl
+++ b/crates/ruscker-admin/assets/i18n/fr/landing.ftl
@@ -252,3 +252,5 @@ admin-dashboard-action-stop = Arrêter
 admin-dashboard-action-restart = Redémarrer
 admin-dashboard-confirm-stop = Arrêter cette réplique ? L auto-scaler peut la recréer si le minimum configuré l exige.
 admin-dashboard-confirm-restart = Redémarrer cette réplique ? La session active sera perdue.
+admin-logs-follow = En direct
+admin-logs-follow-stop = Arrêter

--- a/crates/ruscker-admin/assets/i18n/pt/landing.ftl
+++ b/crates/ruscker-admin/assets/i18n/pt/landing.ftl
@@ -256,3 +256,5 @@ admin-dashboard-action-stop = Parar
 admin-dashboard-action-restart = Reiniciar
 admin-dashboard-confirm-stop = Parar esta réplica? O auto-scaler pode recriá-la se o mínimo configurado exigir.
 admin-dashboard-confirm-restart = Reiniciar esta réplica? A sessão ativa será perdida.
+admin-logs-follow = Ao vivo
+admin-logs-follow-stop = Parar

--- a/crates/ruscker-admin/src/routes/admin/dashboard.rs
+++ b/crates/ruscker-admin/src/routes/admin/dashboard.rs
@@ -45,6 +45,7 @@ pub fn routes() -> Router<AppState> {
         .route("/admin/dashboard", get(index))
         .route("/admin/dashboard/events", get(events))
         .route("/admin/dashboard/logs/{replica_id}", get(logs))
+        .route("/admin/dashboard/logs/{replica_id}/stream", get(logs_stream))
         .route("/admin/dashboard/replicas/{replica_id}/stop", post(stop_replica))
         .route(
             "/admin/dashboard/replicas/{replica_id}/restart",
@@ -471,6 +472,43 @@ async fn logs(
     super::render(&page)
 }
 
+/// SSE stream of live log lines for a replica. The logs page's
+/// "Live" toggle opens an `EventSource` against this; each new
+/// line from the container becomes one SSE `data:` event. The
+/// stream ends when the container stops (bollard's follow
+/// stream completes), which the browser sees as the source
+/// closing.
+///
+/// Seeded with the last 100 lines so turning Live on shows
+/// recent context, not just lines that arrive after connect.
+async fn logs_stream(
+    _: AdminSession,
+    State(state): State<AppState>,
+    Path(replica_id): Path<String>,
+) -> Response {
+    let rid = match parse_replica_id(&replica_id) {
+        Ok(r) => r,
+        Err(resp) => return resp,
+    };
+    let Some(backend) = state.backend.clone() else {
+        return (StatusCode::SERVICE_UNAVAILABLE, "no backend").into_response();
+    };
+
+    let line_stream = match backend.logs_follow(&rid, 100).await {
+        Ok(s) => s,
+        Err(e) => {
+            tracing::warn!(replica = %replica_id, error = ?e, "logs_follow failed");
+            return (StatusCode::NOT_FOUND, format!("could not follow logs: {e}")).into_response();
+        }
+    };
+
+    use futures_util::StreamExt;
+    let event_stream = line_stream.map(|line| Ok::<_, Infallible>(Event::default().data(line)));
+    Sse::new(event_stream)
+        .keep_alive(KeepAlive::new().interval(SSE_KEEPALIVE_INTERVAL))
+        .into_response()
+}
+
 /// Resolve a `{replica_id}` path param to a `ReplicaId`,
 /// 400ing on a malformed UUID. Shared by the action handlers.
 fn parse_replica_id(s: &str) -> Result<ReplicaId, Response> {
@@ -723,15 +761,26 @@ mod tests {
         assert!(html.contains("11111111-2222-3333-4444-555555555555"));
         assert!(html.contains("starting nginx"));
         assert!(html.contains("worker process 1 started"));
-        // Tail note present, empty hint absent.
         assert!(html.contains("últimas linhas"));
-        assert!(!html.contains("Sem saída de log"));
+        // The empty hint div is always in the DOM now (the
+        // follow-mode JS toggles it), but with lines present it
+        // must be hidden with `display:none`.
+        assert!(
+            html.contains(r#"id="logs-empty" class="logs-empty" style="display:none""#),
+            "empty hint should be present-but-hidden when lines exist"
+        );
+        // The <pre> is visible (no inline display:none on it).
+        assert!(html.contains(r#"id="logs-pre">"#));
     }
 
     #[test]
     fn logs_page_renders_empty_hint() {
         let html = render_logs(vec![]);
+        // With no lines the empty hint is visible (no display:none).
+        assert!(html.contains(r#"id="logs-empty" class="logs-empty">"#));
         assert!(html.contains("Sem saída de log"));
+        // ...and the <pre> + note are hidden.
+        assert!(html.contains(r#"id="logs-pre" style="display:none""#));
     }
 
     #[test]

--- a/crates/ruscker-admin/templates/admin/logs.html
+++ b/crates/ruscker-admin/templates/admin/logs.html
@@ -43,25 +43,80 @@
     </p>
     <p class="logs-mono mt-1">{{ self.t("admin-logs-replica") }}: {{ replica_id }}</p>
   </div>
-  <a href="/admin/dashboard" class="admin-nav-link">
-    <i class="ti ti-arrow-left" aria-hidden="true"></i>
-    <span>{{ self.t("admin-logs-back") }}</span>
-  </a>
+  <div style="display:flex; gap:8px; align-items:center;">
+    <button type="button" id="logs-follow-btn" class="admin-nav-link"
+            data-follow-label="{{ self.t("admin-logs-follow") }}"
+            data-stop-label="{{ self.t("admin-logs-follow-stop") }}"
+            data-replica-id="{{ replica_id }}">
+      <i class="ti ti-player-play" aria-hidden="true"></i>
+      <span id="logs-follow-text">{{ self.t("admin-logs-follow") }}</span>
+    </button>
+    <a href="/admin/dashboard" class="admin-nav-link">
+      <i class="ti ti-arrow-left" aria-hidden="true"></i>
+      <span>{{ self.t("admin-logs-back") }}</span>
+    </a>
+  </div>
 </div>
 
-{% if lines.is_empty() %}
-  <div class="logs-empty">{{ self.t("admin-logs-empty") }}</div>
-{% else %}
-  <p class="text-xs text-[color:var(--text-faint)] mb-2">{{ self.t("admin-logs-tail-note") }}</p>
-  <pre class="logs-pre" id="logs-pre">{% for line in lines %}{{ line }}
+<div id="logs-empty" class="logs-empty"{% if !lines.is_empty() %} style="display:none"{% endif %}>{{ self.t("admin-logs-empty") }}</div>
+<p id="logs-note" class="text-xs text-[color:var(--text-faint)] mb-2"{% if lines.is_empty() %} style="display:none"{% endif %}>{{ self.t("admin-logs-tail-note") }}</p>
+<pre class="logs-pre" id="logs-pre"{% if lines.is_empty() %} style="display:none"{% endif %}>{% for line in lines %}{{ line }}
 {% endfor %}</pre>
-  <script>
-    // Scroll to the newest line on load.
-    (function () {
-      var pre = document.getElementById('logs-pre');
-      if (pre) pre.scrollTop = pre.scrollHeight;
-    })();
-  </script>
-{% endif %}
+
+<script>
+(function () {
+  var pre = document.getElementById('logs-pre');
+  var empty = document.getElementById('logs-empty');
+  var note = document.getElementById('logs-note');
+  var btn = document.getElementById('logs-follow-btn');
+  var btnText = document.getElementById('logs-follow-text');
+  var btnIcon = btn ? btn.querySelector('i') : null;
+
+  // Scroll to newest on load.
+  if (pre) pre.scrollTop = pre.scrollHeight;
+
+  var es = null;
+  var followLabel = btn ? btn.dataset.followLabel : 'Live';
+  var stopLabel = btn ? btn.dataset.stopLabel : 'Stop';
+  var replicaId = btn ? btn.dataset.replicaId : '';
+
+  function appendLine(text) {
+    if (!pre) return;
+    // Reveal the pre / hide the empty hint on first line.
+    if (empty) empty.style.display = 'none';
+    if (note) note.style.display = '';
+    pre.style.display = '';
+    var atBottom = pre.scrollHeight - pre.scrollTop - pre.clientHeight < 40;
+    pre.textContent += text + '\n';
+    if (atBottom) pre.scrollTop = pre.scrollHeight;
+  }
+
+  function startFollow() {
+    if (!window.EventSource || es) return;
+    es = new EventSource('/admin/dashboard/logs/' + encodeURIComponent(replicaId) + '/stream');
+    es.onmessage = function (e) { appendLine(e.data); };
+    es.onerror = function () {
+      // The stream closed (container stopped, or network).
+      // Leave the button in "following" state so the browser's
+      // own auto-reconnect can resume; the user can also click
+      // to stop.
+    };
+    if (btnText) btnText.textContent = stopLabel;
+    if (btnIcon) { btnIcon.classList.remove('ti-player-play'); btnIcon.classList.add('ti-player-pause'); }
+  }
+
+  function stopFollow() {
+    if (es) { es.close(); es = null; }
+    if (btnText) btnText.textContent = followLabel;
+    if (btnIcon) { btnIcon.classList.remove('ti-player-pause'); btnIcon.classList.add('ti-player-play'); }
+  }
+
+  if (btn) {
+    btn.addEventListener('click', function () {
+      if (es) stopFollow(); else startFollow();
+    });
+  }
+})();
+</script>
 
 {% endblock %}

--- a/crates/ruscker-core/Cargo.toml
+++ b/crates/ruscker-core/Cargo.toml
@@ -13,6 +13,7 @@ description = "Core domain logic for Ruscker: session management, routing, lifec
 ruscker-config = { path = "../ruscker-config" }
 
 async-trait = { workspace = true }
+futures-util = { workspace = true }
 serde = { workspace = true }
 thiserror = { workspace = true }
 uuid = { workspace = true }

--- a/crates/ruscker-core/src/lib.rs
+++ b/crates/ruscker-core/src/lib.rs
@@ -30,8 +30,15 @@ pub use routing::{RoutingDecision, Router};
 pub use session::{Session, SessionId, SessionStore, StickySession};
 
 use async_trait::async_trait;
+use futures_util::Stream;
 use std::collections::HashMap;
+use std::pin::Pin;
 use thiserror::Error;
+
+/// A boxed, owned stream of log lines. Boxed (rather than an
+/// `impl Stream` associated type) so it can travel through the
+/// `dyn ContainerBackend` trait object the proxy/admin hold.
+pub type LogStream = Pin<Box<dyn Stream<Item = String> + Send>>;
 
 #[derive(Debug, Error)]
 pub enum CoreError {
@@ -240,6 +247,16 @@ pub trait ContainerBackend: Send + Sync {
     /// the caller.
     async fn logs(&self, _replica_id: &ReplicaId, _tail: usize) -> CoreResult<Vec<String>> {
         Ok(Vec::new())
+    }
+
+    /// Follow a replica's combined stdout+stderr as a live
+    /// stream of lines, seeded with the last `tail` lines. The
+    /// stream stays open until the container stops (then it
+    /// ends) or the consumer drops it. Used by the dashboard's
+    /// live-logs SSE endpoint. Default impl returns an empty
+    /// stream so non-streaming backends don't break callers.
+    async fn logs_follow(&self, _replica_id: &ReplicaId, _tail: usize) -> CoreResult<LogStream> {
+        Ok(Box::pin(futures_util::stream::empty()))
     }
 }
 

--- a/crates/ruscker-docker/Cargo.toml
+++ b/crates/ruscker-docker/Cargo.toml
@@ -20,6 +20,7 @@ tracing = { workspace = true }
 uuid = { workspace = true }
 serde_json = { workspace = true }
 futures-util = { workspace = true }
+async-stream = { workspace = true }
 
 [features]
 # Integration tests that hit a real Docker daemon. Enable with

--- a/crates/ruscker-docker/src/lib.rs
+++ b/crates/ruscker-docker/src/lib.rs
@@ -458,6 +458,44 @@ impl ContainerBackend for LocalDockerBackend {
         let container_id = self.container_id_for_replica(replica_id).await?;
         self.logs_for_container(&container_id, tail).await
     }
+
+    async fn logs_follow(
+        &self,
+        replica_id: &ReplicaId,
+        tail: usize,
+    ) -> CoreResult<ruscker_core::LogStream> {
+        let container_id = self.container_id_for_replica(replica_id).await?;
+        // Clone the bollard handle (cheap — Arc inside) so the
+        // returned stream owns everything it needs and is
+        // `'static`. The `follow: true` stream stays open until
+        // the container exits.
+        let docker = self.docker.clone();
+        let opts = LogsOptionsBuilder::default()
+            .stdout(true)
+            .stderr(true)
+            .follow(true)
+            .tail(&tail.min(5_000).to_string())
+            .build();
+        let stream = async_stream::stream! {
+            let mut inner = docker.logs(&container_id, Some(opts));
+            while let Some(item) = inner.next().await {
+                match item {
+                    Ok(chunk) => {
+                        let text = chunk.to_string();
+                        for line in text.split_inclusive('\n') {
+                            yield line.trim_end_matches(['\r', '\n']).to_string();
+                        }
+                    }
+                    // A read error ends the follow — the
+                    // container likely went away. The SSE layer
+                    // turns stream-end into a closed event source,
+                    // which the browser may auto-reconnect.
+                    Err(_) => break,
+                }
+            }
+        };
+        Ok(Box::pin(stream))
+    }
 }
 
 impl LocalDockerBackend {

--- a/examples/e2e-interactive-app/Dockerfile
+++ b/examples/e2e-interactive-app/Dockerfile
@@ -1,4 +1,8 @@
 FROM python:3.12-slim
+# Unbuffered stdout so log lines reach `docker logs` (and thus
+# Ruscker's live-logs follow stream) immediately instead of
+# sitting in Python's block buffer.
+ENV PYTHONUNBUFFERED=1
 RUN pip install --no-cache-dir aiohttp
 COPY app.py /app.py
 EXPOSE 8080

--- a/examples/e2e-interactive-app/app.py
+++ b/examples/e2e-interactive-app/app.py
@@ -48,6 +48,23 @@ async def ws_handler(request):
                 await ws.close()
     return ws
 
+async def heartbeat():
+    # Emit a flushed line every 2s so the live-logs follow path
+    # has a steady stream to forward. stdout is unbuffered via
+    # PYTHONUNBUFFERED in the Dockerfile, so each line reaches
+    # `docker logs` immediately.
+    n = 0
+    while True:
+        print(f"heartbeat {n}", flush=True)
+        n += 1
+        await asyncio.sleep(2)
+
+async def on_startup(app):
+    app["hb"] = asyncio.create_task(heartbeat())
+
+async def on_cleanup(app):
+    app["hb"].cancel()
+
 app = web.Application()
 app.add_routes([
     web.get('/', index),
@@ -56,6 +73,8 @@ app.add_routes([
     web.get('/api/ping', ping),
     web.get('/ws', ws_handler),
 ])
+app.on_startup.append(on_startup)
+app.on_cleanup.append(on_cleanup)
 
 if __name__ == '__main__':
     web.run_app(app, host='0.0.0.0', port=8080)


### PR DESCRIPTION
## Summary

Extends the one-shot logs viewer (#29) with a live "follow" mode — a toggle on the logs page streams new container log lines as they arrive via SSE.

## Backend
- `ContainerBackend::logs_follow(replica_id, tail) -> LogStream` (boxed `Stream<Item=String>`, type alias in core). Default: empty stream.
- `LocalDockerBackend::logs_follow` via bollard `logs(follow:true)`; bollard handle cloned into an `async_stream::stream!` generator so the stream is `'static`. Read error ends the follow.

## Admin
- `GET /admin/dashboard/logs/{id}/stream` — admin-gated SSE, each line → `Event::data`, keep-alive 15s, seeded with last 100 lines.
- Logs page Live/Stop toggle (vanilla JS): opens/closes EventSource, appends to `<pre>`, auto-scrolls only when already at bottom.
- 2 new i18n keys × 4 locales.

## e2e fixture upgrade
`examples/e2e-interactive-app` now emits a flushed `heartbeat N` line every 2s (`PYTHONUNBUFFERED=1`) — a faithful follow-logs target.

## Tests
- [x] Updated `logs_page_*` render tests for always-present-but-hidden empty hint/pre
- [x] Workspace: 166 tests green

## Real-Docker smoke
Followed the stream for 8s:
```
data: events captured: 9
data: heartbeat 0
data: heartbeat 1
...
data: heartbeat 5
```
Incrementing `heartbeat N` over time proves genuine live streaming, not a snapshot.

🤖 Generated with [Claude Code](https://claude.com/claude-code)