### PR TITLE
Wire DB-backed credential store to image pulls

### DIFF
--- a/crates/ruscker-admin/src/db/credentials.rs
+++ b/crates/ruscker-admin/src/db/credentials.rs
@@ -109,6 +109,50 @@ pub async fn list_all(pool: &SqlitePool) -> Result<Vec<CredentialMeta>> {
         .collect())
 }
 
+/// Resolve a named credential to backend-neutral
+/// [`RegistryCredentials`] for use at image-pull time: fetch
+/// registry + username, decrypt the password. Returns `None`
+/// when the name doesn't exist.
+///
+/// This is the one place where a stored secret is turned back
+/// into a usable credential outside the admin's own
+/// encrypt/decrypt path; it's called from the spawn path, never
+/// from a UI handler.
+pub async fn resolve(
+    pool: &SqlitePool,
+    key: &MasterKey,
+    name: &str,
+) -> Result<Option<ruscker_core::RegistryCredentials>> {
+    let row: Option<(String, String, Vec<u8>, Vec<u8>)> = sqlx::query_as(
+        "SELECT registry, username, password_enc, nonce FROM credentials WHERE name = ?",
+    )
+    .bind(name)
+    .fetch_optional(pool)
+    .await
+    .with_context(|| format!("resolve credential {name}"))?;
+    match row {
+        None => Ok(None),
+        Some((registry, username, enc, nonce)) => {
+            let pt = key.decrypt(&enc, &nonce)?;
+            let password = String::from_utf8(pt.to_vec())
+                .context("decrypted password is not valid UTF-8")?;
+            // An empty `registry` means Docker Hub — keep
+            // `server_address` None in that case so bollard
+            // doesn't get an empty serveraddress.
+            let server_address = if registry.trim().is_empty() {
+                None
+            } else {
+                Some(registry)
+            };
+            Ok(Some(ruscker_core::RegistryCredentials {
+                username,
+                password,
+                server_address,
+            }))
+        }
+    }
+}
+
 /// Decrypt the password for a single credential. Used by the
 /// runtime when pulling an image; **not** exposed in the UI.
 /// Returns `None` if the name doesn't exist.
@@ -212,5 +256,34 @@ mod tests {
         upsert(&pool, &key, "dh", "docker.io", "milkway", "x", None).await.unwrap();
         assert!(delete_one(&pool, "dh", None).await.unwrap());
         assert!(fetch_password(&pool, &key, "dh").await.unwrap().is_none());
+    }
+
+    #[tokio::test]
+    async fn resolve_returns_full_credential() {
+        let pool = open_memory().await.unwrap();
+        let key = fixed_key();
+        upsert(&pool, &key, "priv", "registry.example.com", "bot", "hunter2", None)
+            .await
+            .unwrap();
+        let c = resolve(&pool, &key, "priv").await.unwrap().expect("resolved");
+        assert_eq!(c.username, "bot");
+        assert_eq!(c.password, "hunter2");
+        assert_eq!(c.server_address.as_deref(), Some("registry.example.com"));
+    }
+
+    #[tokio::test]
+    async fn resolve_empty_registry_means_docker_hub() {
+        let pool = open_memory().await.unwrap();
+        let key = fixed_key();
+        upsert(&pool, &key, "hub", "", "bot", "pw", None).await.unwrap();
+        let c = resolve(&pool, &key, "hub").await.unwrap().unwrap();
+        assert!(c.server_address.is_none(), "empty registry -> Docker Hub default");
+    }
+
+    #[tokio::test]
+    async fn resolve_unknown_name_is_none() {
+        let pool = open_memory().await.unwrap();
+        let key = fixed_key();
+        assert!(resolve(&pool, &key, "nope").await.unwrap().is_none());
     }
 }

--- a/crates/ruscker-admin/src/routes/admin/spec_form.rs
+++ b/crates/ruscker-admin/src/routes/admin/spec_form.rs
@@ -166,6 +166,7 @@ impl SpecForm {
             docker_registry_username: None,
             docker_registry_password: None,
             docker_registry_domain: None,
+            docker_registry_credential: None,
             container_cpu_limit: None,
             container_cpu_request: None,
             container_memory_limit: None,

--- a/crates/ruscker-admin/src/routes/proxy.rs
+++ b/crates/ruscker-admin/src/routes/proxy.rs
@@ -384,7 +384,7 @@ async fn pick_or_spawn(state: &AppState, spec: &Spec) -> anyhow::Result<Replica>
         .and_then(|a| a.port)
         .or_else(|| infer_inner_port(spec));
 
-    let creds = creds_from_spec(spec);
+    let creds = resolve_creds(state, spec).await;
     let limits = limits_from_spec(spec);
     tracing::info!(
         spec = %spec.id,
@@ -462,6 +462,59 @@ pub(crate) fn creds_from_spec(spec: &Spec) -> Option<ruscker_core::RegistryCrede
         }),
         _ => None,
     }
+}
+
+/// Resolve the registry credentials a spec should pull with,
+/// consulting (in priority order):
+///
+/// 1. **DB credential store** — if the spec sets
+///    `docker-registry-credential: "name"` and the admin DB +
+///    master key are available, look the name up and decrypt.
+///    Keeps secrets entirely out of YAML.
+/// 2. **Inline fields** — the env-interpolated
+///    `docker-registry-{username,password,domain}` on the spec.
+///
+/// Async (unlike `creds_from_spec`) because the DB lookup +
+/// decrypt is I/O. Both spawn paths call this.
+pub(crate) async fn resolve_creds(
+    state: &AppState,
+    spec: &Spec,
+) -> Option<ruscker_core::RegistryCredentials> {
+    if let Some(name) = spec
+        .docker_registry_credential
+        .as_deref()
+        .filter(|s| !s.is_empty())
+    {
+        match (state.db.as_ref(), state.master_key.is_configured()) {
+            (Some(pool), true) => {
+                match crate::db::credentials::resolve(pool, &state.master_key, name).await {
+                    Ok(Some(c)) => return Some(c),
+                    Ok(None) => {
+                        tracing::warn!(
+                            credential = name, spec = %spec.id,
+                            "spec references a credential not in the store; \
+                             falling back to inline fields"
+                        );
+                    }
+                    Err(e) => {
+                        tracing::error!(
+                            credential = name, spec = %spec.id, error = ?e,
+                            "failed to resolve stored credential; \
+                             falling back to inline fields"
+                        );
+                    }
+                }
+            }
+            _ => {
+                tracing::warn!(
+                    credential = name, spec = %spec.id,
+                    "spec references a stored credential but DB / master key \
+                     is unavailable; falling back to inline fields"
+                );
+            }
+        }
+    }
+    creds_from_spec(spec)
 }
 
 fn pick_index(n: usize) -> usize {

--- a/crates/ruscker-admin/src/scaler.rs
+++ b/crates/ruscker-admin/src/scaler.rs
@@ -353,7 +353,7 @@ async fn spawn_one(
         .and_then(|a| a.port)
         .or_else(|| infer_inner_port(spec));
 
-    let creds = crate::routes::proxy::creds_from_spec(spec);
+    let creds = crate::routes::proxy::resolve_creds(state, spec).await;
     let limits = crate::routes::proxy::limits_from_spec(spec);
     let mut req = ruscker_core::SpawnRequest::new(&spec.id, image).with_limits(limits);
     if let Some(port) = inner_port {

--- a/crates/ruscker-config/src/schema.rs
+++ b/crates/ruscker-config/src/schema.rs
@@ -296,6 +296,16 @@ pub struct Spec {
     #[serde(rename = "docker-registry-domain")]
     pub docker_registry_domain: Option<String>,
 
+    /// Ruscker extension: name of a credential stored in the
+    /// admin's encrypted credential store. When set, the runtime
+    /// resolves username/password/registry from the DB (decrypted
+    /// with the master key) at pull time, taking precedence over
+    /// the inline `docker-registry-*` fields above. Lets operators
+    /// keep secrets out of YAML entirely — reference a named
+    /// credential instead.
+    #[serde(rename = "docker-registry-credential")]
+    pub docker_registry_credential: Option<String>,
+
     // -- Container resource limits (ShinyProxy-compatible) --
     /// CPU hard limit, expressed as a fraction of a single core.
     /// `0.5` = half a core, `2.0` = two cores. Maps to Docker's
@@ -690,6 +700,7 @@ proxy:
             docker_registry_username: None,
             docker_registry_password: None,
             docker_registry_domain: None,
+            docker_registry_credential: None,
             container_cpu_limit: None,
             container_cpu_request: None,
             container_memory_limit: None,
@@ -725,6 +736,7 @@ proxy:
             docker_registry_username: None,
             docker_registry_password: None,
             docker_registry_domain: None,
+            docker_registry_credential: None,
             container_cpu_limit: None,
             container_cpu_request: None,
             container_memory_limit: None,
@@ -760,6 +772,7 @@ proxy:
             docker_registry_username: None,
             docker_registry_password: None,
             docker_registry_domain: None,
+            docker_registry_credential: None,
             container_cpu_limit: None,
             container_cpu_request: None,
             container_memory_limit: None,


### PR DESCRIPTION
## Summary

Phase 2 built an AES-256-GCM encrypted credentials table + admin UI, but nothing consumed it at runtime — the spawn path only read inline `docker-registry-*` fields. This closes the loop: a spec references a stored credential by name, resolved + decrypted at pull time.

## Schema
New `docker-registry-credential: "name"` field. When set, takes precedence over inline fields — secrets stay out of YAML.

## Resolution
- `db::credentials::resolve(pool, key, name) -> Option<RegistryCredentials>` — fetch registry+username, decrypt password, empty-registry→Docker Hub.
- `routes::proxy::resolve_creds(state, spec)` (async) — priority: DB store → inline fallback. Missing cred / no DB / no key → warn + fall back, never fails the spawn.
- Both spawn paths now `resolve_creds(...).await`.

## Tests
- [x] 3 new `resolve` tests (full / empty-registry / unknown-name)
- [x] Workspace: 169 tests green (was 166)

## Real-Docker smoke
- spec with `docker-registry-credential: my-registry`, `min-replicas: 0`
- stored `my-registry` (registry.example.com / botuser / s3cret) via admin API
- removed `busybox:1.36`, hit `/app/busy/` → on-demand spawn
- log: `pulling image with_creds=true registry=Some("registry.example.com")`

The encrypted store now drives real authenticated pulls — no longer dead code.

🤖 Generated with [Claude Code](https://claude.com/claude-code)