### PR TITLE
Security audit slice 1: open-redirect fix + response headers

### DIFF
--- a/crates/ruscker-admin/src/lib.rs
+++ b/crates/ruscker-admin/src/lib.rs
@@ -280,12 +280,62 @@ pub fn router(state: AppState) -> Router {
 /// `images_dir` argument is now ignored because state carries the
 /// fallback directory itself (set via [`AdminServer::with_images_dir`]).
 pub fn router_with_images(state: AppState, _images_dir: Option<&Path>) -> Router {
-    Router::new()
+    // Ruscker's own surfaces (landing, admin, prefs, assets) get
+    // security response headers. The proxy routes do NOT — those
+    // forward upstream app responses verbatim, and injecting our
+    // X-Frame-Options / CSP into a Shiny page would interfere
+    // with how the app expects to be served. Apps own their own
+    // security headers.
+    let own = Router::new()
         .merge(routes::landing::routes())
         .merge(routes::assets::routes())
         .merge(routes::prefs::routes())
         .merge(routes::admin::routes())
-        .merge(routes::proxy::routes())
+        .layer(axum::middleware::from_fn(security_headers));
+
+    own.merge(routes::proxy::routes())
         .layer(CookieManagerLayer::new())
         .with_state(state)
+}
+
+/// Baseline security response headers for Ruscker's own pages.
+///
+/// - `X-Content-Type-Options: nosniff` — stop MIME sniffing
+///   (defends against polyglot uploads being interpreted as
+///   active content).
+/// - `X-Frame-Options: DENY` — the portal/admin is not meant to
+///   be embedded; blocks clickjacking.
+/// - `Referrer-Policy: same-origin` — don't leak admin URLs to
+///   third parties.
+/// - `Content-Security-Policy` — restricts resource origins to
+///   self. `'unsafe-inline'` is currently required because the
+///   landing + dashboard use inline `<script>`/`<style>`; a
+///   nonce-based CSP that drops `unsafe-inline` is a tracked
+///   follow-up. Even with it, this still blocks loading scripts
+///   / frames / objects from other origins.
+async fn security_headers(
+    req: axum::extract::Request,
+    next: axum::middleware::Next,
+) -> axum::response::Response {
+    use axum::http::HeaderValue;
+    let mut resp = next.run(req).await;
+    let h = resp.headers_mut();
+    h.insert("x-content-type-options", HeaderValue::from_static("nosniff"));
+    h.insert("x-frame-options", HeaderValue::from_static("DENY"));
+    h.insert("referrer-policy", HeaderValue::from_static("same-origin"));
+    h.insert(
+        "content-security-policy",
+        HeaderValue::from_static(
+            "default-src 'self'; \
+             script-src 'self' 'unsafe-inline'; \
+             style-src 'self' 'unsafe-inline'; \
+             img-src 'self' data:; \
+             font-src 'self'; \
+             connect-src 'self'; \
+             frame-ancestors 'none'; \
+             base-uri 'self'; \
+             form-action 'self'",
+        ),
+    );
+    resp
 }

--- a/crates/ruscker-admin/src/routes/admin.rs
+++ b/crates/ruscker-admin/src/routes/admin.rs
@@ -139,15 +139,18 @@ async fn login_submit(
     c.set_max_age(Duration::hours(24));
     cookies.add(c);
 
-    // Redirect to the page the operator was trying to reach. The
-    // login form preserves the destination in a `?next=` param —
-    // not implemented yet, so default to /admin/dashboard.
-    let target = headers
-        .get(REFERER)
-        .and_then(|v| v.to_str().ok())
-        .filter(|r| r.contains("/admin/") && !r.contains("/admin/login"))
-        .unwrap_or("/admin/dashboard");
-    Redirect::to(target).into_response()
+    // Redirect to the page the operator was trying to reach,
+    // reduced to a same-origin path (no open redirect). Only
+    // honor admin paths; anything else (or the login page
+    // itself) falls back to the dashboard.
+    let referer = headers.get(REFERER).and_then(|v| v.to_str().ok());
+    let path = super::same_origin_path(referer, "/admin/dashboard");
+    let target = if path.starts_with("/admin/") && !path.starts_with("/admin/login") {
+        path
+    } else {
+        "/admin/dashboard".to_string()
+    };
+    Redirect::to(&target).into_response()
 }
 
 async fn logout(_: MaybeAdminSession, cookies: Cookies) -> Redirect {

--- a/crates/ruscker-admin/src/routes/mod.rs
+++ b/crates/ruscker-admin/src/routes/mod.rs
@@ -6,3 +6,82 @@ pub mod landing;
 pub mod prefs;
 pub mod proxy;
 pub mod rewrite;
+
+/// Reduce a `Referer` header to a safe **same-origin path** for
+/// a post-action redirect, falling back to `fallback` when the
+/// referer is absent or can't be trusted.
+///
+/// Browsers send `Referer` as an absolute URL
+/// (`https://host:port/path?query`). We keep only the path +
+/// query and discard the scheme + host entirely, so the redirect
+/// always lands on Ruscker's own origin — a referer of
+/// `https://evil.com/x` becomes `/x` here, not an open redirect.
+///
+/// Guards against protocol-relative (`//evil.com`) and backslash
+/// (`/\evil.com`) tricks that some browsers/proxies normalize
+/// into a cross-origin navigation.
+pub(crate) fn same_origin_path(referer: Option<&str>, fallback: &'static str) -> String {
+    let Some(referer) = referer else {
+        return fallback.to_string();
+    };
+    // Drop `scheme://authority`, keep everything from the first
+    // `/` of the path onward. A referer with no scheme is treated
+    // as already path-like.
+    let after_authority = match referer.split_once("://") {
+        Some((_scheme, rest)) => match rest.find('/') {
+            Some(i) => &rest[i..], // "/path?query"
+            None => return fallback.to_string(),
+        },
+        None => referer,
+    };
+    // Must be a single-slash absolute path on our origin.
+    let bytes = after_authority.as_bytes();
+    let looks_cross_origin = !after_authority.starts_with('/')
+        || after_authority.starts_with("//")
+        || (bytes.len() >= 2 && bytes[0] == b'/' && bytes[1] == b'\\');
+    if looks_cross_origin {
+        return fallback.to_string();
+    }
+    after_authority.to_string()
+}
+
+#[cfg(test)]
+mod same_origin_tests {
+    use super::same_origin_path;
+
+    #[test]
+    fn keeps_path_from_absolute_referer() {
+        assert_eq!(
+            same_origin_path(Some("http://127.0.0.1:8082/admin/specs"), "/"),
+            "/admin/specs"
+        );
+        assert_eq!(
+            same_origin_path(Some("https://portal.gov.br/app/x?q=1"), "/"),
+            "/app/x?q=1"
+        );
+    }
+
+    #[test]
+    fn strips_cross_origin_host() {
+        // The classic open-redirect payload: we keep only the
+        // path, so the user stays on our origin.
+        assert_eq!(same_origin_path(Some("https://evil.com/phish"), "/"), "/phish");
+    }
+
+    #[test]
+    fn rejects_protocol_relative_and_backslash() {
+        assert_eq!(same_origin_path(Some("//evil.com"), "/admin"), "/admin");
+        assert_eq!(same_origin_path(Some("/\\evil.com"), "/admin"), "/admin");
+    }
+
+    #[test]
+    fn falls_back_when_absent_or_pathless() {
+        assert_eq!(same_origin_path(None, "/home"), "/home");
+        assert_eq!(same_origin_path(Some("https://host-no-path"), "/home"), "/home");
+    }
+
+    #[test]
+    fn accepts_already_relative_referer() {
+        assert_eq!(same_origin_path(Some("/dashboard"), "/"), "/dashboard");
+    }
+}

--- a/crates/ruscker-admin/src/routes/prefs.rs
+++ b/crates/ruscker-admin/src/routes/prefs.rs
@@ -75,9 +75,8 @@ fn persistent_cookie(name: &'static str, value: String) -> Cookie<'static> {
 }
 
 fn redirect_back(headers: &HeaderMap) -> Redirect {
-    let target = headers
-        .get(REFERER)
-        .and_then(|v| v.to_str().ok())
-        .unwrap_or("/");
-    Redirect::to(target)
+    // Same-origin only: an attacker-controlled `Referer` must not
+    // turn this 303 into an open redirect off our origin.
+    let referer = headers.get(REFERER).and_then(|v| v.to_str().ok());
+    Redirect::to(&super::same_origin_path(referer, "/"))
 }

--- a/crates/ruscker-admin/tests/landing_render.rs
+++ b/crates/ruscker-admin/tests/landing_render.rs
@@ -131,3 +131,43 @@ async fn assets_styles_css_served_with_cache_headers() {
     assert!(cache.contains("must-revalidate"));
     assert!(!cache.contains("immutable"));
 }
+
+#[tokio::test]
+async fn landing_carries_security_headers() {
+    let app = router(app_state());
+    let response = app
+        .oneshot(Request::builder().uri("/").body(Body::empty()).unwrap())
+        .await
+        .unwrap();
+    let h = response.headers();
+    assert_eq!(h.get("x-content-type-options").unwrap(), "nosniff");
+    assert_eq!(h.get("x-frame-options").unwrap(), "DENY");
+    assert_eq!(h.get("referrer-policy").unwrap(), "same-origin");
+    let csp = h.get("content-security-policy").unwrap().to_str().unwrap();
+    assert!(csp.contains("default-src 'self'"));
+    assert!(csp.contains("frame-ancestors 'none'"));
+}
+
+#[tokio::test]
+async fn set_locale_redirect_is_same_origin_only() {
+    // An attacker-controlled Referer pointing off-origin must not
+    // become an open redirect — we keep only the path.
+    let app = router(app_state());
+    let response = app
+        .oneshot(
+            Request::builder()
+                .method("POST")
+                .uri("/__set/locale")
+                .header(header::REFERER, "https://evil.example.com/phish")
+                .header(header::CONTENT_TYPE, "application/x-www-form-urlencoded")
+                .body(Body::from("locale=en"))
+                .unwrap(),
+        )
+        .await
+        .unwrap();
+    assert_eq!(response.status(), StatusCode::SEE_OTHER);
+    let location = response.headers().get(header::LOCATION).unwrap().to_str().unwrap();
+    // Path preserved, host dropped → stays on our origin.
+    assert_eq!(location, "/phish");
+    assert!(!location.contains("evil.example.com"));
+}


### PR DESCRIPTION
First hardening pass from the Phase 5 security audit (#14). Closes two actionable findings.

## Open redirect (audit §5)
`prefs::redirect_back` + login post-success followed `Referer` verbatim → off-origin redirect possible. New `routes::same_origin_path` keeps only path+query, discards scheme+host, guards protocol-relative/backslash. Both call sites use it.

## Security headers (audit §7)
Own surfaces (landing/admin/prefs/assets) now carry via middleware:
- `X-Content-Type-Options: nosniff`
- `X-Frame-Options: DENY`
- `Referrer-Policy: same-origin`
- `Content-Security-Policy` (self + frame-ancestors none + base-uri/form-action self)

Proxy routes (`/app/*`, `/api/*`) deliberately NOT wrapped — apps own their headers.

CSP uses `'unsafe-inline'` for now (inline scripts/styles in landing+dashboard); nonce-based CSP is a follow-up.

## Tests
- [x] 5 `same_origin_path` unit tests
- [x] 2 integration tests (headers present; evil-Referer → same-origin path)
- [x] Workspace: 180 green (was 173)

## Real-Docker smoke
- landing `/` → all 4 headers
- proxy `/app/nginxweb/` → `x-frame-options` count 0 (correct)
- `POST /__set/locale` `Referer: https://evil.com/phish` → `Location: .../phish` (host dropped)

## Remaining audit items (follow-ups)
Blocking-for-prod: login rate limiting, `Secure` cookie under TLS. Plus SVG sanitization, nonce CSP, `docs/SECURITY.md` threat model.

🤖 Generated with [Claude Code](https://claude.com/claude-code)