### PR TITLE
Security audit slice 2: login rate limiting + Secure cookies

### DIFF
--- a/crates/ruscker-admin/src/auth.rs
+++ b/crates/ruscker-admin/src/auth.rs
@@ -80,6 +80,95 @@ fn ct_eq(a: &[u8], b: &[u8]) -> bool {
     diff == 0
 }
 
+/// Global sliding-window rate limiter for login attempts.
+///
+/// Brute-forcing the admin token is the threat. This bounds how
+/// many failed attempts the server will entertain in a window,
+/// regardless of source — deliberately **global** (not per-IP)
+/// because Ruscker runs behind a reverse proxy where the peer
+/// IP is always the proxy, and a per-IP key would trust a
+/// spoofable `X-Forwarded-For`. A global cap can't be evaded by
+/// rotating source addresses.
+///
+/// Trade-off: a flood of bad attempts can lock out the
+/// legitimate operator for up to `window`. Acceptable for a
+/// single-operator install and documented in SECURITY.md; the
+/// window is short (60s) so lockout self-heals quickly.
+///
+/// Successful logins clear the window so an operator who
+/// fat-fingered a few times isn't blocked once they get it right.
+#[derive(Debug)]
+pub struct LoginRateLimiter {
+    failures: std::sync::Mutex<std::collections::VecDeque<std::time::Instant>>,
+    max: usize,
+    window: std::time::Duration,
+}
+
+impl LoginRateLimiter {
+    pub fn new(max: usize, window: std::time::Duration) -> Self {
+        Self {
+            failures: std::sync::Mutex::new(std::collections::VecDeque::new()),
+            max,
+            window,
+        }
+    }
+
+    /// Default policy: 10 failed attempts per 60s. Generous for
+    /// human retries, far below anything that threatens a
+    /// high-entropy token.
+    pub fn default_policy() -> Self {
+        Self::new(10, std::time::Duration::from_secs(60))
+    }
+
+    /// Returns `true` if a login attempt is allowed right now
+    /// (i.e. the failure window isn't saturated). Prunes expired
+    /// failures as a side effect.
+    pub fn allow(&self) -> bool {
+        let now = std::time::Instant::now();
+        let mut q = self.failures.lock().unwrap();
+        while q.front().is_some_and(|t| now.duration_since(*t) > self.window) {
+            q.pop_front();
+        }
+        q.len() < self.max
+    }
+
+    pub fn record_failure(&self) {
+        let mut q = self.failures.lock().unwrap();
+        q.push_back(std::time::Instant::now());
+    }
+
+    pub fn record_success(&self) {
+        self.failures.lock().unwrap().clear();
+    }
+}
+
+impl Default for LoginRateLimiter {
+    fn default() -> Self {
+        Self::default_policy()
+    }
+}
+
+/// Whether the original client request reached us over HTTPS.
+/// Ruscker terminates TLS at a reverse proxy, which signals the
+/// original scheme via `X-Forwarded-Proto`. Used to decide
+/// whether to set the `Secure` flag on cookies — we can't just
+/// always set it because the dev server runs plain HTTP and the
+/// browser would then drop the cookie.
+pub fn request_is_https(headers: &axum::http::HeaderMap) -> bool {
+    headers
+        .get("x-forwarded-proto")
+        .and_then(|v| v.to_str().ok())
+        // XFP can be a comma list ("https, http") when chained;
+        // the leftmost is the original client scheme.
+        .map(|s| {
+            s.split(',')
+                .next()
+                .map(|p| p.trim().eq_ignore_ascii_case("https"))
+                .unwrap_or(false)
+        })
+        .unwrap_or(false)
+}
+
 /// Marker extracted by admin routes to assert that the request is
 /// authenticated. Absence of a valid session redirects to the
 /// login form (303 See Other so re-POST isn't suggested by
@@ -136,5 +225,71 @@ impl FromRequestParts<crate::AppState> for MaybeAdminSession {
             Ok(_) => Ok(MaybeAdminSession(true)),
             Err(_) => Ok(MaybeAdminSession(false)),
         }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use axum::http::HeaderMap;
+    use std::time::Duration;
+
+    #[test]
+    fn ct_eq_basics() {
+        assert!(ct_eq(b"abc", b"abc"));
+        assert!(!ct_eq(b"abc", b"abd"));
+        assert!(!ct_eq(b"abc", b"ab")); // length mismatch
+    }
+
+    #[test]
+    fn rate_limiter_allows_until_saturated() {
+        let rl = LoginRateLimiter::new(3, Duration::from_secs(60));
+        assert!(rl.allow());
+        rl.record_failure();
+        rl.record_failure();
+        assert!(rl.allow(), "2 < 3 still allowed");
+        rl.record_failure();
+        assert!(!rl.allow(), "3 failures saturate the window");
+    }
+
+    #[test]
+    fn rate_limiter_success_clears_window() {
+        let rl = LoginRateLimiter::new(2, Duration::from_secs(60));
+        rl.record_failure();
+        rl.record_failure();
+        assert!(!rl.allow());
+        rl.record_success();
+        assert!(rl.allow(), "success clears the failure window");
+    }
+
+    #[test]
+    fn rate_limiter_prunes_expired_failures() {
+        // Zero-length window → every failure is immediately
+        // expired, so allow() always trims back to empty.
+        let rl = LoginRateLimiter::new(1, Duration::from_secs(0));
+        rl.record_failure();
+        rl.record_failure();
+        std::thread::sleep(Duration::from_millis(2));
+        assert!(rl.allow(), "expired failures pruned");
+    }
+
+    #[test]
+    fn request_is_https_reads_x_forwarded_proto() {
+        let mut h = HeaderMap::new();
+        assert!(!request_is_https(&h), "no header → not https");
+        h.insert("x-forwarded-proto", "http".parse().unwrap());
+        assert!(!request_is_https(&h));
+        h.insert("x-forwarded-proto", "https".parse().unwrap());
+        assert!(request_is_https(&h));
+    }
+
+    #[test]
+    fn request_is_https_handles_chained_proto_list() {
+        let mut h = HeaderMap::new();
+        // Chained proxies: leftmost is the original client scheme.
+        h.insert("x-forwarded-proto", "https, http".parse().unwrap());
+        assert!(request_is_https(&h));
+        h.insert("x-forwarded-proto", "HTTPS".parse().unwrap());
+        assert!(request_is_https(&h), "case-insensitive");
     }
 }

--- a/crates/ruscker-admin/src/lib.rs
+++ b/crates/ruscker-admin/src/lib.rs
@@ -43,6 +43,10 @@ pub struct AppState {
     pub config: Arc<Config>,
     pub locales: Arc<i18n::Locales>,
     pub admin_auth: auth::AdminAuth,
+    /// Global rate limiter for `/admin/login` — bounds brute
+    /// force against the admin token. Shared (Arc) so every
+    /// cloned `AppState` sees the same window.
+    pub login_limiter: Arc<auth::LoginRateLimiter>,
     /// Optional SQLite pool. `None` ⇒ admin CRUD routes 503
     /// because they have no source of truth to read or write.
     pub db: Option<SqlitePool>,
@@ -122,6 +126,7 @@ impl AdminServer {
             config: Arc::new(config),
             locales: Arc::new(locales),
             admin_auth: auth::AdminAuth::from_env(),
+            login_limiter: Arc::new(auth::LoginRateLimiter::default_policy()),
             db: None,
             images_dir: None,
             master_key: crypto::MasterKey::from_env().context("load master key")?,

--- a/crates/ruscker-admin/src/routes/admin.rs
+++ b/crates/ruscker-admin/src/routes/admin.rs
@@ -105,7 +105,22 @@ async fn login_submit(
             .into_response();
     }
 
+    // Rate limit: bound brute force against the token. Saturated
+    // window → 429 with Retry-After, before we even compare.
+    if !state.login_limiter.allow() {
+        let mut resp = (
+            StatusCode::TOO_MANY_REQUESTS,
+            "too many login attempts — try again shortly",
+        )
+            .into_response();
+        resp.headers_mut()
+            .insert(axum::http::header::RETRY_AFTER, "60".parse().unwrap());
+        return resp;
+    }
+
     if !state.admin_auth.matches(&form.token) {
+        // Count the failure toward the rate-limit window.
+        state.login_limiter.record_failure();
         // Re-render the form with the error banner. 401 status so
         // CLI clients / tests can distinguish.
         let page = LoginPage {
@@ -128,14 +143,20 @@ async fn login_submit(
         return resp;
     }
 
-    // Success — set the cookie. 24h lifetime; re-login required
-    // after that. Long enough that operators don't have to log in
-    // multiple times per day, short enough that a left-open tab on
-    // a shared device expires within a workday.
+    // Success — clear the failure window so a few fat-fingered
+    // attempts before getting it right don't linger.
+    state.login_limiter.record_success();
+
+    // Set the cookie. 24h lifetime; re-login required after that.
+    // `Secure` is set only when the original request came over
+    // HTTPS (signalled by the reverse proxy via X-Forwarded-Proto)
+    // — setting it unconditionally would make the browser drop the
+    // cookie on the plain-HTTP dev server.
     let mut c = Cookie::new(COOKIE_NAME, form.token);
     c.set_path("/");
     c.set_http_only(true);
     c.set_same_site(tower_cookies::cookie::SameSite::Strict);
+    c.set_secure(crate::auth::request_is_https(&headers));
     c.set_max_age(Duration::hours(24));
     cookies.add(c);
 

--- a/crates/ruscker-admin/src/routes/proxy.rs
+++ b/crates/ruscker-admin/src/routes/proxy.rs
@@ -138,6 +138,11 @@ async fn forward(
     upstream_path: String,
     req: Request,
 ) -> Response {
+    // Capture the request scheme before `req` is consumed by the
+    // forward — used to decide the `Secure` flag on the sticky
+    // cookie we may set at the end.
+    let is_https = crate::auth::request_is_https(req.headers());
+
     // 1. Find the spec.
     let Some(spec) = find_spec(&state.config, &spec_id) else {
         return (StatusCode::NOT_FOUND, format!("spec `{spec_id}` not found")).into_response();
@@ -251,7 +256,7 @@ async fn forward(
             spec_id: spec.id.clone(),
             replica_id: replica.id.clone(),
         };
-        set_sticky_cookie(&cookies, &state.cookie_key, &session);
+        set_sticky_cookie(&cookies, &state.cookie_key, &session, is_https);
     }
 
     resp
@@ -299,7 +304,12 @@ async fn resolve_replica(
 /// — keeps the session_id consistent with what we tracked in the
 /// `SessionTracker` rather than minting a fresh, untracked id
 /// inside the cookie helper.
-fn set_sticky_cookie(cookies: &Cookies, key: &CookieKey, session: &StickySession) {
+fn set_sticky_cookie(
+    cookies: &Cookies,
+    key: &CookieKey,
+    session: &StickySession,
+    is_https: bool,
+) {
     let value = match sticky::encode(key, session) {
         Ok(v) => v,
         Err(err) => {
@@ -311,6 +321,10 @@ fn set_sticky_cookie(cookies: &Cookies, key: &CookieKey, session: &StickySession
     c.set_path("/");
     c.set_http_only(true);
     c.set_same_site(tower_cookies::cookie::SameSite::Lax);
+    // `Secure` only under TLS (X-Forwarded-Proto: https) — the
+    // plain-HTTP dev server would otherwise see the browser drop
+    // the cookie.
+    c.set_secure(is_https);
     // 8h matches a typical workday — long enough that returning
     // visitors don't lose state mid-session, short enough that a
     // forgotten browser tab doesn't pin a container forever.
@@ -685,6 +699,7 @@ mod tests {
                 crate::i18n::Locales::load().expect("load locales"),
             ),
             admin_auth: Default::default(),
+            login_limiter: StdArc::new(crate::auth::LoginRateLimiter::default_policy()),
             db: None,
             images_dir: None,
             master_key: Default::default(),

--- a/crates/ruscker-admin/src/scaler.rs
+++ b/crates/ruscker-admin/src/scaler.rs
@@ -512,6 +512,7 @@ mod tests {
             config: Arc::new(cfg),
             locales: Arc::new(crate::i18n::Locales::load().expect("load locales")),
             admin_auth: Default::default(),
+            login_limiter: Arc::new(crate::auth::LoginRateLimiter::default_policy()),
             db: None,
             images_dir: None,
             master_key: Default::default(),

--- a/crates/ruscker-admin/tests/landing_render.rs
+++ b/crates/ruscker-admin/tests/landing_render.rs
@@ -25,6 +25,7 @@ fn app_state() -> AppState {
         config: Arc::new(config),
         locales: Arc::new(locales),
         admin_auth: Default::default(),
+        login_limiter: std::sync::Arc::new(ruscker_admin::auth::LoginRateLimiter::default_policy()),
         db: None,
         images_dir: None,
         master_key: Default::default(),


### PR DESCRIPTION
Clears the two remaining blocking-for-prod items from audit #14 (§1, §7).

## Login rate limiting (§1)
New `auth::LoginRateLimiter` — global sliding window (10 failures / 60s). Login checks `allow()` before token compare; saturated → `429` + `Retry-After: 60`. Failures recorded; success clears.

**Global, not per-IP**: behind a proxy the peer IP is the proxy, and per-IP would trust spoofable `X-Forwarded-For`. Global cap can't be evaded by rotating sources. Lockout trade-off documented, self-heals in 60s.

## Secure cookies under TLS (§7)
Admin + sticky cookies now set `Secure` when the request came over HTTPS — detected via `auth::request_is_https` (`X-Forwarded-Proto`, leftmost of a chained list, case-insensitive). Not set on plain HTTP so the dev server still works.

## Tests
- [x] 6 new `auth` unit tests (ct_eq, limiter allow/clear/prune, https detection)
- [x] Workspace: 186 green (was 180)

## Real-Docker smoke
- 10 bad logins → 11th = `429`
- plain HTTP → `Set-Cookie` without Secure
- `X-Forwarded-Proto: https` → `Set-Cookie` with Secure

## Audit status
Blocking-for-prod trio complete: CSP/headers (#36) + rate limit + Secure (this). Remaining: `docs/SECURITY.md` threat model + optional hardening (SVG sanitization, nonce CSP) — non-blocking.

🤖 Generated with [Claude Code](https://claude.com/claude-code)