### PR TITLE
Admin: import ShinyProxy/Ruscker YAML via modal (#8)

### DIFF
--- a/crates/ruscker-admin/assets/i18n/en/landing.ftl
+++ b/crates/ruscker-admin/assets/i18n/en/landing.ftl
@@ -254,3 +254,14 @@ admin-dashboard-confirm-stop = Stop this replica? The auto-scaler may recreate i
 admin-dashboard-confirm-restart = Restart this replica? Any active session will be lost.
 admin-logs-follow = Live
 admin-logs-follow-stop = Stop
+
+# Admin YAML import
+admin-import-button = Import YAML
+admin-import-title = Import YAML configuration
+admin-import-help = Pick a ShinyProxy or Ruscker application.yml. Import is idempotent and never deletes existing specs.
+admin-import-file = .yml / .yaml file
+admin-import-submit = Import
+admin-import-cancel = Cancel
+admin-import-ok = Import complete: { $created } created, { $updated } updated, { $unchanged } unchanged.
+admin-import-ok-warnings = { $warnings } validation warning(s) — review embedded credentials and empty names.
+admin-import-err = Import failed: { $msg }

--- a/crates/ruscker-admin/assets/i18n/es/landing.ftl
+++ b/crates/ruscker-admin/assets/i18n/es/landing.ftl
@@ -254,3 +254,14 @@ admin-dashboard-confirm-stop = ¿Detener esta réplica? El auto-scaler puede rec
 admin-dashboard-confirm-restart = ¿Reiniciar esta réplica? Se perderá la sesión activa.
 admin-logs-follow = En vivo
 admin-logs-follow-stop = Detener
+
+# Admin YAML import
+admin-import-button = Importar YAML
+admin-import-title = Importar configuración YAML
+admin-import-help = Elija un application.yml de ShinyProxy o Ruscker. El import es idempotente y no elimina specs existentes.
+admin-import-file = Archivo .yml / .yaml
+admin-import-submit = Importar
+admin-import-cancel = Cancelar
+admin-import-ok = Import completo: { $created } creados, { $updated } actualizados, { $unchanged } sin cambios.
+admin-import-ok-warnings = { $warnings } advertencia(s) de validación — revise credenciales embebidas y nombres vacíos.
+admin-import-err = Error en el import: { $msg }

--- a/crates/ruscker-admin/assets/i18n/fr/landing.ftl
+++ b/crates/ruscker-admin/assets/i18n/fr/landing.ftl
@@ -254,3 +254,14 @@ admin-dashboard-confirm-stop = Arrêter cette réplique ? L auto-scaler peut la 
 admin-dashboard-confirm-restart = Redémarrer cette réplique ? La session active sera perdue.
 admin-logs-follow = En direct
 admin-logs-follow-stop = Arrêter
+
+# Admin YAML import
+admin-import-button = Importer YAML
+admin-import-title = Importer une configuration YAML
+admin-import-help = Choisissez un application.yml ShinyProxy ou Ruscker. L import est idempotent et ne supprime jamais les specs existants.
+admin-import-file = Fichier .yml / .yaml
+admin-import-submit = Importer
+admin-import-cancel = Annuler
+admin-import-ok = Import terminé : { $created } créés, { $updated } mis à jour, { $unchanged } inchangés.
+admin-import-ok-warnings = { $warnings } avertissement(s) de validation — vérifiez les identifiants intégrés et les noms vides.
+admin-import-err = Échec de l import : { $msg }

--- a/crates/ruscker-admin/assets/i18n/pt/landing.ftl
+++ b/crates/ruscker-admin/assets/i18n/pt/landing.ftl
@@ -258,3 +258,14 @@ admin-dashboard-confirm-stop = Parar esta réplica? O auto-scaler pode recriá-l
 admin-dashboard-confirm-restart = Reiniciar esta réplica? A sessão ativa será perdida.
 admin-logs-follow = Ao vivo
 admin-logs-follow-stop = Parar
+
+# Admin YAML import
+admin-import-button = Importar YAML
+admin-import-title = Importar configuração YAML
+admin-import-help = Cole ou selecione um application.yml do ShinyProxy ou Ruscker. O import é idempotente e não remove specs existentes.
+admin-import-file = Arquivo .yml / .yaml
+admin-import-submit = Importar
+admin-import-cancel = Cancelar
+admin-import-ok = Import concluído: { $created } criados, { $updated } atualizados, { $unchanged } inalterados.
+admin-import-ok-warnings = { $warnings } aviso(s) de validação — revise as credenciais embutidas e nomes vazios.
+admin-import-err = Falha no import: { $msg }

--- a/crates/ruscker-admin/src/routes/admin/specs.rs
+++ b/crates/ruscker-admin/src/routes/admin/specs.rs
@@ -6,13 +6,14 @@
 
 use askama::Template;
 use axum::{
-    extract::State,
+    extract::{DefaultBodyLimit, Multipart, Query, State},
     http::StatusCode,
-    response::{IntoResponse, Response},
-    routing::get,
+    response::{IntoResponse, Redirect, Response},
+    routing::{get, post},
     Router,
 };
 use chrono::{DateTime, Utc};
+use serde::Deserialize;
 use sqlx::FromRow;
 
 use crate::auth::AdminSession;
@@ -20,8 +21,16 @@ use crate::i18n::{Locale, Locales};
 use crate::theme::Theme;
 use crate::AppState;
 
+/// Body cap for the YAML import upload. ShinyProxy configs are
+/// tiny (<100 KB typically); 2 MB is generous and stops a huge
+/// paste from buffering unbounded.
+const IMPORT_BODY_LIMIT: usize = 2 * 1024 * 1024;
+
 pub fn routes() -> Router<AppState> {
-    Router::new().route("/admin/specs", get(index))
+    Router::new()
+        .route("/admin/specs", get(index))
+        .route("/admin/specs/import", post(import))
+        .layer(DefaultBodyLimit::max(IMPORT_BODY_LIMIT))
 }
 
 /// One row out of the `specs` table, picked for the list view.
@@ -37,6 +46,35 @@ pub struct SpecRow {
     pub version: i64,
 }
 
+/// Post-import flash, carried back via query params on the
+/// redirect (stateless — no session flash store needed).
+#[derive(Debug, Deserialize, Default)]
+pub struct SpecsQuery {
+    /// "ok" or "err" — present only right after an import.
+    #[serde(default)]
+    pub import: Option<String>,
+    #[serde(default)]
+    pub created: Option<usize>,
+    #[serde(default)]
+    pub updated: Option<usize>,
+    #[serde(default)]
+    pub unchanged: Option<usize>,
+    #[serde(default)]
+    pub warnings: Option<usize>,
+    /// Error message (URL-encoded) when `import=err`.
+    #[serde(default)]
+    pub msg: Option<String>,
+}
+
+/// A pre-rendered flash banner: tone (`ok`/`warn`/`err`) drives
+/// the CSS class, `text` is the already-localized message. Built
+/// in `index` from the import query params so the template stays
+/// arg-free.
+struct Flash {
+    tone: &'static str,
+    text: String,
+}
+
 #[derive(Template)]
 #[template(path = "admin/specs.html")]
 struct SpecsPage<'a> {
@@ -46,6 +84,7 @@ struct SpecsPage<'a> {
     locales_all: &'static [Locale],
     nav_section: &'static str,
     specs: Vec<SpecRow>,
+    flash: Option<Flash>,
 }
 
 impl<'a> SpecsPage<'a> {
@@ -54,11 +93,46 @@ impl<'a> SpecsPage<'a> {
     }
 }
 
+/// Build the localized import flash from the redirect query
+/// params. `None` when there was no import this request.
+fn build_flash(locales: &Locales, loc: Locale, q: &SpecsQuery) -> Option<Flash> {
+    use fluent_bundle::FluentArgs;
+    match q.import.as_deref() {
+        Some("ok") => {
+            let mut args = FluentArgs::new();
+            args.set("created", q.created.unwrap_or(0) as i64);
+            args.set("updated", q.updated.unwrap_or(0) as i64);
+            args.set("unchanged", q.unchanged.unwrap_or(0) as i64);
+            let mut text = locales.t(loc, "admin-import-ok", Some(&args));
+            let warnings = q.warnings.unwrap_or(0);
+            if warnings > 0 {
+                let mut wargs = FluentArgs::new();
+                wargs.set("warnings", warnings as i64);
+                text.push(' ');
+                text.push_str(&locales.t(loc, "admin-import-ok-warnings", Some(&wargs)));
+                return Some(Flash { tone: "warn", text });
+            }
+            Some(Flash { tone: "ok", text })
+        }
+        Some("err") => {
+            let mut args = FluentArgs::new();
+            let msg = q.msg.clone().unwrap_or_default().replace('+', " ");
+            args.set("msg", msg);
+            Some(Flash {
+                tone: "err",
+                text: locales.t(loc, "admin-import-err", Some(&args)),
+            })
+        }
+        _ => None,
+    }
+}
+
 async fn index(
     _: AdminSession,
     State(state): State<AppState>,
     loc: Locale,
     theme: Theme,
+    Query(flash): Query<SpecsQuery>,
 ) -> Response {
     let Some(pool) = state.db.as_ref() else {
         return (
@@ -83,6 +157,7 @@ async fn index(
         }
     };
 
+    let flash = build_flash(&state.locales, loc, &flash);
     let page = SpecsPage {
         locale: loc,
         theme,
@@ -90,6 +165,93 @@ async fn index(
         locales_all: &Locale::ALL,
         nav_section: "specs",
         specs,
+        flash,
     };
     super::render(&page)
+}
+
+/// `POST /admin/specs/import` — multipart upload of a ShinyProxy
+/// / Ruscker `application.yml`. Parses, runs the same warning
+/// scan as `ruscker validate`, then `import_all` (idempotent +
+/// non-destructive: specs in the DB but absent from the YAML are
+/// kept). Redirects back to the list with a flash summary.
+///
+/// No separate dry-run/preview step yet (issue #8 wants one) —
+/// import is idempotent and never deletes, so re-importing is
+/// safe; a preview is a follow-up.
+async fn import(
+    _: AdminSession,
+    State(state): State<AppState>,
+    mut multipart: Multipart,
+) -> Response {
+    let Some(pool) = state.db.as_ref() else {
+        return (StatusCode::SERVICE_UNAVAILABLE, "no db").into_response();
+    };
+
+    // Pull the YAML out of the `file` field.
+    let mut raw: Option<String> = None;
+    loop {
+        match multipart.next_field().await {
+            Ok(Some(field)) => {
+                if field.name() != Some("file") {
+                    continue;
+                }
+                match field.bytes().await {
+                    Ok(b) if !b.is_empty() => {
+                        raw = Some(String::from_utf8_lossy(&b).into_owned());
+                    }
+                    Ok(_) => {} // empty file input
+                    Err(e) => return redirect_err(&format!("read upload: {e}")),
+                }
+            }
+            Ok(None) => break,
+            Err(e) => return redirect_err(&format!("multipart parse: {e}")),
+        }
+    }
+    let Some(raw) = raw else {
+        return redirect_err("no file selected");
+    };
+
+    // Parse (env-interpolation + raw-text credential scan happen
+    // inside from_yaml; parse failure → error flash).
+    let config = match ruscker_config::Config::from_yaml(&raw) {
+        Ok(c) => c,
+        Err(e) => return redirect_err(&format!("YAML parse failed: {e}")),
+    };
+    // Validation warnings (embedded creds, empty names, dup ids…)
+    // — surfaced as a count; non-fatal, import still proceeds.
+    let report = ruscker_config::validate::run(&config);
+    let warning_count = report.warnings.len() + config.raw_warnings.len();
+
+    match crate::db::specs::import_all(pool, &config).await {
+        Ok(r) => {
+            tracing::info!(
+                created = r.created, updated = r.updated, unchanged = r.unchanged,
+                warnings = warning_count, "YAML import via admin"
+            );
+            Redirect::to(&format!(
+                "/admin/specs?import=ok&created={}&updated={}&unchanged={}&warnings={}",
+                r.created, r.updated, r.unchanged, warning_count
+            ))
+            .into_response()
+        }
+        Err(e) => {
+            tracing::error!(error = ?e, "import_all failed");
+            redirect_err(&format!("import failed: {e}"))
+        }
+    }
+}
+
+fn redirect_err(msg: &str) -> Response {
+    // Keep the message short + URL-safe enough for a query param.
+    let encoded: String = msg
+        .chars()
+        .map(|c| match c {
+            ' ' => '+',
+            '&' | '#' | '?' | '=' => '_',
+            c => c,
+        })
+        .take(200)
+        .collect();
+    Redirect::to(&format!("/admin/specs?import=err&msg={encoded}")).into_response()
 }

--- a/crates/ruscker-admin/templates/admin/specs.html
+++ b/crates/ruscker-admin/templates/admin/specs.html
@@ -11,12 +11,65 @@
   </div>
   <div class="flex items-center gap-2">
     <span class="text-xs text-[color:var(--text-faint)]">{{ specs.len() }}</span>
+    <button type="button" class="admin-nav-link" style="padding:6px 10px;font-size:12px"
+            title="{{ self.t("admin-import-title") }}"
+            onclick="document.getElementById('import-modal').showModal()">
+      <i class="ti ti-file-upload" aria-hidden="true"></i>
+      {{ self.t("admin-import-button") }}
+    </button>
     <a href="/admin/specs/new" class="admin-login-btn" style="padding:6px 10px;font-size:12px">
       <i class="ti ti-plus" aria-hidden="true"></i>
       {{ self.t("admin-specs-add") }}
     </a>
   </div>
 </div>
+
+{% match flash %}
+  {% when Some with (f) %}
+    <div class="import-flash import-flash--{{ f.tone }}" role="status">{{ f.text }}</div>
+  {% when None %}
+{% endmatch %}
+
+<dialog id="import-modal" class="import-dialog">
+  <form method="post" action="/admin/specs/import" enctype="multipart/form-data" class="import-form">
+    <h2 class="text-base font-medium mb-1">{{ self.t("admin-import-title") }}</h2>
+    <p class="text-xs text-[color:var(--text-muted)] mb-3">{{ self.t("admin-import-help") }}</p>
+    <label class="block text-xs mb-1">{{ self.t("admin-import-file") }}</label>
+    <input type="file" name="file" accept=".yml,.yaml" required class="import-file" />
+    <div class="flex justify-end gap-2 mt-4">
+      <button type="button" class="admin-nav-link" style="font-size:12px"
+              onclick="document.getElementById('import-modal').close()">
+        {{ self.t("admin-import-cancel") }}
+      </button>
+      <button type="submit" class="admin-login-btn" style="padding:6px 12px;font-size:12px">
+        <i class="ti ti-file-upload" aria-hidden="true"></i>
+        {{ self.t("admin-import-submit") }}
+      </button>
+    </div>
+  </form>
+</dialog>
+
+<style>
+  .import-flash {
+    margin-bottom: 16px; padding: 10px 14px; border-radius: 8px; font-size: 13px;
+    border: 0.5px solid var(--color-border-tertiary, rgba(120,120,120,0.2));
+  }
+  .import-flash--ok   { background: color-mix(in srgb, #10b981 12%, transparent); }
+  .import-flash--warn { background: color-mix(in srgb, #f59e0b 14%, transparent); }
+  .import-flash--err  { background: color-mix(in srgb, #ef4444 14%, transparent); }
+  .import-dialog {
+    border: 0.5px solid var(--color-border-tertiary, rgba(120,120,120,0.25));
+    border-radius: 12px; padding: 0; max-width: 460px; width: 92%;
+    background: var(--surface, #fff); color: var(--text-primary);
+  }
+  .import-dialog::backdrop { background: rgba(0,0,0,0.35); }
+  .import-form { padding: 20px; }
+  .import-file {
+    width: 100%; font-size: 12px; padding: 8px;
+    border: 0.5px dashed var(--color-border-tertiary, rgba(120,120,120,0.3));
+    border-radius: 8px;
+  }
+</style>
 
 {% if specs.is_empty() %}
   <div class="card-surface rounded-lg p-12 text-center text-sm text-[color:var(--text-muted)]">


### PR DESCRIPTION
Operators migrating from ShinyProxy no longer need a terminal for initial onboarding — the admin ingests `application.yml` directly. Closes #8 (sans the optional preview step).

## What's new
- **`POST /admin/specs/import`** — multipart upload (2 MB cap). Parses via `Config::from_yaml`, runs `validate::run`, then reuses `db::specs::import_all` (same path as CLI `ruscker import`). Redirects with a flash.
- **Import button + `<dialog>` modal** on `/admin/specs` (`.yml`/`.yaml` picker). No new JS deps.
- **Flash banner** ok/warn/err, localized in the handler (`build_flash`) so the template stays arg-free. `warn` when import succeeded with validation warnings.
- 9 i18n keys × 4 locales.

## Design
- Reuses `import_all` verbatim → admin & CLI can't drift.
- **No dry-run preview yet** (issue asks for one). `import_all` is idempotent + non-destructive, so direct import is safe to re-run; preview is a tracked follow-up.

## Tests + smoke
- [x] Workspace: 189 green
- [x] Smoke: import `examples/application.yml` → `created=31`; re-import → `unchanged=31` (idempotent); flash "31 inalterados … 1 aviso" (`warn`); malformed YAML → `err` banner.

🤖 Generated with [Claude Code](https://claude.com/claude-code)