### PR TITLE
Admin: rename Imagens tab to Media, move to /admin/media (#9)

### DIFF
--- a/crates/ruscker-admin/assets/i18n/en/landing.ftl
+++ b/crates/ruscker-admin/assets/i18n/en/landing.ftl
@@ -26,7 +26,7 @@ type-link-abbr = LNK
 # Admin shell
 admin-nav-dashboard = Dashboard
 admin-nav-apps = Apps
-admin-nav-images = Images
+admin-nav-images = Media
 admin-nav-credentials = Credentials
 admin-nav-landing = Portal
 admin-nav-audit = Audit log
@@ -134,7 +134,7 @@ spec-form-error-id-duplicate = An app with that ID already exists.
 spec-form-error-name-required = Display name is required.
 
 # Admin image library
-admin-images-title = Image library
+admin-images-title = Media library
 admin-images-subtitle = PNG, JPEG and WebP are converted to WebP. SVG passes through.
 admin-images-drop-here = Click to pick a file
 admin-images-formats = PNG · JPEG · WebP · SVG · up to 10 MB

--- a/crates/ruscker-admin/assets/i18n/es/landing.ftl
+++ b/crates/ruscker-admin/assets/i18n/es/landing.ftl
@@ -26,7 +26,7 @@ type-link-abbr = LNK
 # Admin shell
 admin-nav-dashboard = Panel
 admin-nav-apps = Aplicaciones
-admin-nav-images = Imágenes
+admin-nav-images = Multimedia
 admin-nav-credentials = Credenciales
 admin-nav-landing = Portal
 admin-nav-audit = Auditoría
@@ -134,7 +134,7 @@ spec-form-error-id-duplicate = Ya existe una aplicación con ese ID.
 spec-form-error-name-required = El nombre visible es obligatorio.
 
 # Admin image library
-admin-images-title = Biblioteca de imágenes
+admin-images-title = Biblioteca multimedia
 admin-images-subtitle = PNG, JPEG y WebP se convierten a WebP. SVG pasa directo.
 admin-images-drop-here = Haga clic para elegir un archivo
 admin-images-formats = PNG · JPEG · WebP · SVG · hasta 10 MB

--- a/crates/ruscker-admin/assets/i18n/fr/landing.ftl
+++ b/crates/ruscker-admin/assets/i18n/fr/landing.ftl
@@ -26,7 +26,7 @@ type-link-abbr = LNK
 # Admin shell
 admin-nav-dashboard = Tableau de bord
 admin-nav-apps = Applications
-admin-nav-images = Images
+admin-nav-images = Médias
 admin-nav-credentials = Identifiants
 admin-nav-landing = Portail
 admin-nav-audit = Journal
@@ -134,7 +134,7 @@ spec-form-error-id-duplicate = Une application avec cet ID existe déjà.
 spec-form-error-name-required = Le nom d'affichage est obligatoire.
 
 # Admin image library
-admin-images-title = Bibliothèque d'images
+admin-images-title = Bibliothèque de médias
 admin-images-subtitle = PNG, JPEG et WebP sont convertis en WebP. Le SVG passe tel quel.
 admin-images-drop-here = Cliquez pour choisir un fichier
 admin-images-formats = PNG · JPEG · WebP · SVG · jusqu'à 10 Mo

--- a/crates/ruscker-admin/assets/i18n/pt/landing.ftl
+++ b/crates/ruscker-admin/assets/i18n/pt/landing.ftl
@@ -30,7 +30,7 @@ type-link-abbr = LNK
 # Admin shell
 admin-nav-dashboard = Painel
 admin-nav-apps = Aplicações
-admin-nav-images = Imagens
+admin-nav-images = Mídia
 admin-nav-credentials = Credenciais
 admin-nav-landing = Portal
 admin-nav-audit = Auditoria
@@ -138,7 +138,7 @@ spec-form-error-id-duplicate = Já existe uma aplicação com esse ID.
 spec-form-error-name-required = Nome de exibição é obrigatório.
 
 # Admin image library
-admin-images-title = Biblioteca de imagens
+admin-images-title = Biblioteca de mídia
 admin-images-subtitle = PNG, JPEG e WebP são convertidos para WebP. SVG passa direto.
 admin-images-drop-here = Clique para escolher um arquivo
 admin-images-formats = PNG · JPEG · WebP · SVG · até 10 MB

--- a/crates/ruscker-admin/src/routes/admin/images.rs
+++ b/crates/ruscker-admin/src/routes/admin/images.rs
@@ -31,8 +31,18 @@ const UPLOAD_BODY_LIMIT: usize = 12 * 1024 * 1024;
 
 pub fn routes() -> Router<AppState> {
     Router::new()
-        .route("/admin/images", get(index).post(upload))
-        .route("/admin/images/{id}/delete", post(delete))
+        // The media library — card logos/covers. Mounted at
+        // `/admin/media` (the nav label is "Media") to avoid the
+        // "Docker images" confusion (#9). The DB table + Rust
+        // module stay `images` — that's internal and accurate.
+        .route("/admin/media", get(index).post(upload))
+        .route("/admin/media/{id}/delete", post(delete))
+        // 301 from the old path so any bookmarks / in-flight
+        // links keep working.
+        .route(
+            "/admin/images",
+            get(|| async { Redirect::permanent("/admin/media") }),
+        )
         .layer(DefaultBodyLimit::max(UPLOAD_BODY_LIMIT))
 }
 
@@ -187,7 +197,7 @@ async fn delete(
         return (StatusCode::SERVICE_UNAVAILABLE, "no db").into_response();
     };
     match db::images::delete_one(pool, &id, Some("admin")).await {
-        Ok(_) => Redirect::to("/admin/images").into_response(),
+        Ok(_) => Redirect::to("/admin/media").into_response(),
         Err(err) => {
             tracing::error!(error = ?err, id, "image delete failed");
             (StatusCode::INTERNAL_SERVER_ERROR, "delete failed").into_response()

--- a/crates/ruscker-admin/templates/admin/_layout.html
+++ b/crates/ruscker-admin/templates/admin/_layout.html
@@ -39,7 +39,7 @@
       <i class="ti ti-apps" aria-hidden="true"></i>
       <span>{{ self.t("admin-nav-apps") }}</span>
     </a>
-    <a href="/admin/images" class="admin-nav-link {% if nav_section == "images" %}is-active{% endif %}">
+    <a href="/admin/media" class="admin-nav-link {% if nav_section == "images" %}is-active{% endif %}">
       <i class="ti ti-photo" aria-hidden="true"></i>
       <span>{{ self.t("admin-nav-images") }}</span>
     </a>

--- a/crates/ruscker-admin/templates/admin/images.html
+++ b/crates/ruscker-admin/templates/admin/images.html
@@ -27,7 +27,7 @@
 {% when None %}{% endmatch %}
 
 {# ── Upload form ──────────────────────────────────────────── #}
-<form method="post" action="/admin/images" enctype="multipart/form-data"
+<form method="post" action="/admin/media" enctype="multipart/form-data"
       class="image-upload-zone">
   <input type="file" name="file" id="img-file" required
          accept="image/png,image/jpeg,image/webp,image/svg+xml">
@@ -66,7 +66,7 @@
             {% when None %}{% endmatch %}{% when None %}{% endmatch %}
           </div>
         </div>
-        <form method="post" action="/admin/images/{{ img.id }}/delete"
+        <form method="post" action="/admin/media/{{ img.id }}/delete"
               onsubmit="return confirm('{{ self.t("admin-images-delete-confirm") }}');">
           <button type="submit" class="image-tile-delete" title="{{ self.t("admin-images-delete") }}">
             <i class="ti ti-trash" aria-hidden="true"></i>


### PR DESCRIPTION
The "Imagens" nav tab is the card-cover media library, but Docker-fluent operators read it as "Docker images". Renamed per the issue.

## Changes
- **Label** "Mídia / Media / Multimedia / Médias" — nav tab + page title, 4 locales. Technical subtitle unchanged.
- **URL** `/admin/images` → `/admin/media`. Old path 308-redirects (`Redirect::permanent`, method-preserving) so bookmarks survive.
- Form actions + nav href updated.

## Kept internal (per the issue)
`db::images`, the `images` table, `crate::images`, and `nav_section: "images"` stay — accurate at the storage layer; only the label was the problem.

## Smoke
- i18n parity passes; 189 tests green.
- nav renders `Mídia` → `/admin/media`; `/admin/media` → 200 ("Biblioteca de mídia"); `/admin/images` → 308 → `/admin/media`.

Closes #9.

🤖 Generated with [Claude Code](https://claude.com/claude-code)