### PR TITLE
Landing: custom card cover via template-properties.cover (#11)

### DIFF
--- a/crates/ruscker-admin/src/view_model.rs
+++ b/crates/ruscker-admin/src/view_model.rs
@@ -199,6 +199,15 @@ pub struct CardCtx<'a> {
     /// in the UI — operators choose their own taxonomy.
     pub tema: Option<&'a str>,
     pub logo: Option<&'a str>,
+    /// Optional CSS background for the card cover, read verbatim
+    /// from `template-properties.cover` (a solid color or a
+    /// `linear-/radial-gradient(...)`). When `None`, the card
+    /// falls back to the per-kind tint class. Interpolated raw
+    /// into a `style="background: …"` — the browser fail-softs on
+    /// invalid CSS, and the value round-trips through YAML/export
+    /// untouched. (Not server-validated, same policy as
+    /// `landing_customization.header_bg`.)
+    pub cover: Option<&'a str>,
     pub updated_raw: Option<&'a str>,
     /// "DD/MM" — short form used in the meta row.
     pub updated_short: Option<String>,
@@ -222,6 +231,9 @@ impl<'a> CardCtx<'a> {
         let active = tp.is_active();
         let tema = tp.get_str("tema");
         let logo = tp.get_str("logo");
+        // Empty string ⇒ treat as unset so the kind-tint fallback
+        // kicks in rather than rendering `background: ;`.
+        let cover = tp.get_str("cover").filter(|s| !s.trim().is_empty());
         let updated_raw = tp.get_str("updated");
         let updated_date = updated_raw.and_then(parse_dmy);
         let updated_short = updated_date.map(|d| d.format("%d/%m").to_string());
@@ -239,6 +251,7 @@ impl<'a> CardCtx<'a> {
             active,
             tema,
             logo,
+            cover,
             updated_raw,
             updated_short,
             status,
@@ -378,6 +391,36 @@ mod tests {
         );
         // missing → Unknown
         assert_eq!(compute_status(None, today), StatusKind::Unknown);
+    }
+
+    fn spec_with_tp(yaml_tp: &str) -> ruscker_config::Spec {
+        let yaml = format!(
+            "id: x\ndisplay-name: X\ncontainer-image: a:1\ntemplate-properties:\n{yaml_tp}"
+        );
+        serde_yaml_ng::from_str(&yaml).expect("parse spec")
+    }
+
+    #[test]
+    fn card_cover_read_from_template_properties() {
+        let spec = spec_with_tp("  cover: \"linear-gradient(135deg, #0f6e56, #5dcaa5)\"\n");
+        let card = CardCtx::from_spec(&spec);
+        assert_eq!(card.cover, Some("linear-gradient(135deg, #0f6e56, #5dcaa5)"));
+    }
+
+    #[test]
+    fn card_cover_absent_falls_back_to_tint() {
+        let spec = spec_with_tp("  tema: Saúde\n");
+        let card = CardCtx::from_spec(&spec);
+        assert_eq!(card.cover, None);
+    }
+
+    #[test]
+    fn card_cover_empty_string_is_none() {
+        // Empty cover must not render `background: ;` — it should
+        // fall through to the kind tint.
+        let spec = spec_with_tp("  cover: \"  \"\n");
+        let card = CardCtx::from_spec(&spec);
+        assert_eq!(card.cover, None);
     }
 }
 

--- a/crates/ruscker-admin/templates/landing.html
+++ b/crates/ruscker-admin/templates/landing.html
@@ -128,7 +128,12 @@
          x-transition.opacity>
 
         <div class="rcover">
-          <div class="rcover-bg tint-{{ card.display_type.key() }}"></div>
+          {% match card.cover %}
+            {% when Some with (cover) %}
+              <div class="rcover-bg" style="background: {{ cover }};"></div>
+            {% when None %}
+              <div class="rcover-bg tint-{{ card.display_type.key() }}"></div>
+          {% endmatch %}
           {% match card.logo %}{% when Some with (logo) %}
             <img src="{{ logo }}"
                  alt=""


### PR DESCRIPTION
Operators can override a card's per-kind tint with a custom CSS background (solid or gradient) per spec, no image needed:

```yaml
template-properties:
  cover: "linear-gradient(135deg, #0f6e56 0%, #5dcaa5 100%)"
```

## Changes
- `CardCtx.cover: Option<&str>` from `template-properties.cover` (empty/whitespace → None).
- `landing.html` renders `style="background: {{ cover }}"` when set, else the `tint-{kind}` class. Logo still layers on top.

## Policy
No server-side CSS validation (browser fail-softs), same as `header_bg`. Round-trips through YAML/export/import. No schema change.

## Scope
Render plumbing only — works today via YAML or the import modal (#40). The point-and-click gradient-builder UI (shared with landing header editor #10) is a tracked follow-up.

## Tests + smoke
- [x] 3 new `view_model` tests (read / absent→None / empty→None)
- [x] Workspace 192 green
- [x] Smoke: `cover:` spec → `style="background: linear-gradient(…)"`; plain spec → `tint-app`

Partially addresses #11 (render done; UI editor pending).

🤖 Generated with [Claude Code](https://claude.com/claude-code)