### PR TITLE
Admin: card-cover gradient editor in the spec form (#11)

### DIFF
--- a/crates/ruscker-admin/assets/i18n/en/landing.ftl
+++ b/crates/ruscker-admin/assets/i18n/en/landing.ftl
@@ -273,3 +273,8 @@ admin-grad-linear = Linear
 admin-grad-radial = Radial
 admin-grad-add-stop = Add stop
 admin-grad-remove-stop = Remove stop
+
+# Spec form — card cover
+spec-form-cover = Card cover
+spec-form-cover-auto = Auto (type tint)
+spec-form-cover-auto-help = Uses the card type default tint. Pick Solid or Gradient to customize.

--- a/crates/ruscker-admin/assets/i18n/es/landing.ftl
+++ b/crates/ruscker-admin/assets/i18n/es/landing.ftl
@@ -273,3 +273,8 @@ admin-grad-linear = Lineal
 admin-grad-radial = Radial
 admin-grad-add-stop = Agregar color
 admin-grad-remove-stop = Quitar color
+
+# Spec form — card cover
+spec-form-cover = Cover de la tarjeta
+spec-form-cover-auto = Auto (color del tipo)
+spec-form-cover-auto-help = Usa el tono por defecto del tipo. Elija Sólido o Degradado para personalizar.

--- a/crates/ruscker-admin/assets/i18n/fr/landing.ftl
+++ b/crates/ruscker-admin/assets/i18n/fr/landing.ftl
@@ -273,3 +273,8 @@ admin-grad-linear = Linéaire
 admin-grad-radial = Radial
 admin-grad-add-stop = Ajouter une couleur
 admin-grad-remove-stop = Retirer la couleur
+
+# Spec form — card cover
+spec-form-cover = Couverture de la carte
+spec-form-cover-auto = Auto (teinte du type)
+spec-form-cover-auto-help = Utilise la teinte par défaut du type. Choisissez Uni ou Dégradé pour personnaliser.

--- a/crates/ruscker-admin/assets/i18n/pt/landing.ftl
+++ b/crates/ruscker-admin/assets/i18n/pt/landing.ftl
@@ -277,3 +277,8 @@ admin-grad-linear = Linear
 admin-grad-radial = Radial
 admin-grad-add-stop = Adicionar cor
 admin-grad-remove-stop = Remover cor
+
+# Spec form — card cover
+spec-form-cover = Cover do card
+spec-form-cover-auto = Auto (cor do tipo)
+spec-form-cover-auto-help = Usa o tom padrão do tipo do card. Escolha Sólida ou Gradiente para personalizar.

--- a/crates/ruscker-admin/src/routes/admin/spec_form.rs
+++ b/crates/ruscker-admin/src/routes/admin/spec_form.rs
@@ -63,6 +63,12 @@ pub struct SpecForm {
     pub access: String,
     pub tema: String,
     pub logo: String,
+    /// Card-cover CSS background (`template-properties.cover`):
+    /// a solid color or a gradient string. Empty ⇒ fall back to
+    /// the per-kind tint. Not validated server-side (browser
+    /// fail-softs), same policy as `landing_customization.header_bg`.
+    #[serde(default)]
+    pub cover: String,
     /// Updated date in DD/MM/YYYY. Empty ⇒ stamp with today.
     pub updated: String,
     /// External link target (for type=link/package).
@@ -93,6 +99,7 @@ impl SpecForm {
                 .unwrap_or_else(|| "lock".into()),
             tema: tp.get_str("tema").map(str::to_string).unwrap_or_default(),
             logo: tp.get_str("logo").map(str::to_string).unwrap_or_default(),
+            cover: tp.get_str("cover").map(str::to_string).unwrap_or_default(),
             updated: tp.get_str("updated").map(str::to_string).unwrap_or_default(),
             link: tp.get_str("link").map(str::to_string).unwrap_or_default(),
             seats_per_container: spec
@@ -139,6 +146,12 @@ impl SpecForm {
             tp_map.insert(
                 "logo".into(),
                 YamlValue::String(self.logo.trim().to_string()),
+            );
+        }
+        if !self.cover.trim().is_empty() {
+            tp_map.insert(
+                "cover".into(),
+                YamlValue::String(self.cover.trim().to_string()),
             );
         }
         if !self.link.trim().is_empty() {

--- a/crates/ruscker-admin/templates/admin/_layout.html
+++ b/crates/ruscker-admin/templates/admin/_layout.html
@@ -72,6 +72,51 @@
 </nav>
 {% endblock %}
 
+<style>
+  /* Shared gradient-builder widget styles (landing header + spec cover). */
+  .grad-modes { display: inline-flex; gap: 2px; margin-bottom: 8px;
+    border: 0.5px solid var(--border, rgba(120,120,120,0.25)); border-radius: 8px; padding: 2px; }
+  .grad-mode { font-size: 12px; padding: 4px 12px; border: none; background: transparent;
+    color: var(--text-muted); cursor: pointer; border-radius: 6px; }
+  .grad-mode.is-active { background: var(--surface-soft, rgba(120,120,120,0.15)); color: var(--text-primary); }
+  .grad-builder { display: flex; flex-direction: column; gap: 8px; }
+  .grad-row { display: flex; align-items: center; gap: 10px; }
+  .grad-angle { display: flex; align-items: center; gap: 6px; font-size: 12px;
+    color: var(--text-muted); flex: 1; }
+  .grad-angle input[type=range] { flex: 1; }
+  .grad-stop { display: flex; align-items: center; gap: 6px; }
+  .grad-pos { width: 56px; font-size: 12px; padding: 4px 6px;
+    border: 0.5px solid var(--border, rgba(120,120,120,0.25)); border-radius: 6px; }
+  .grad-pos-unit { font-size: 11px; color: var(--text-faint); }
+  .grad-add { font-size: 12px; align-self: flex-start; }
+  .grad-output { font-size: 11px; opacity: 0.75; }
+</style>
+<script>
+// Shared gradient helpers — used by the landing header editor
+// and the spec-form card cover. Defined here (before the page's
+// own Alpine factory scripts) so every admin page has them.
+window.ruscker = window.ruscker || {};
+// Build a CSS background from builder state.
+// g = { type:'linear'|'radial', angle:0-360, stops:[{color,pos}] }
+window.ruscker.gradientCss = (g) => {
+  const stops = (g.stops || [])
+    .filter((s) => s && s.color)
+    .map((s) => (s.pos === '' || s.pos == null) ? s.color : `${s.color} ${s.pos}%`)
+    .join(', ');
+  if (!stops) return '';
+  if (g.type === 'radial') return `radial-gradient(circle, ${stops})`;
+  return `linear-gradient(${g.angle | 0}deg, ${stops})`;
+};
+window.ruscker.gradientDefault = () => ({
+  type: 'linear', angle: 135,
+  stops: [ { color: '#0f6e56', pos: 0 }, { color: '#5dcaa5', pos: 100 } ],
+});
+// Editing mode for an existing value: gradient string → 'gradient'.
+window.ruscker.bgMode = (value) =>
+  (typeof value === 'string' && /^(linear|radial)-gradient\(/.test(value.trim()))
+    ? 'gradient' : 'solid';
+</script>
+
 <main class="flex-1 px-6 py-6 max-w-7xl mx-auto w-full">
   {% block content %}{% endblock %}
 </main>

--- a/crates/ruscker-admin/templates/admin/landing.html
+++ b/crates/ruscker-admin/templates/admin/landing.html
@@ -4,25 +4,6 @@
 
 {% block content %}
 
-<style>
-  .grad-modes { display: inline-flex; gap: 2px; margin-bottom: 8px;
-    border: 0.5px solid var(--border, rgba(120,120,120,0.25)); border-radius: 8px; padding: 2px; }
-  .grad-mode { font-size: 12px; padding: 4px 12px; border: none; background: transparent;
-    color: var(--text-muted); cursor: pointer; border-radius: 6px; }
-  .grad-mode.is-active { background: var(--surface-soft, rgba(120,120,120,0.15)); color: var(--text-primary); }
-  .grad-builder { display: flex; flex-direction: column; gap: 8px; }
-  .grad-row { display: flex; align-items: center; gap: 10px; }
-  .grad-angle { display: flex; align-items: center; gap: 6px; font-size: 12px;
-    color: var(--text-muted); flex: 1; }
-  .grad-angle input[type=range] { flex: 1; }
-  .grad-stop { display: flex; align-items: center; gap: 6px; }
-  .grad-pos { width: 56px; font-size: 12px; padding: 4px 6px;
-    border: 0.5px solid var(--border, rgba(120,120,120,0.25)); border-radius: 6px; }
-  .grad-pos-unit { font-size: 11px; color: var(--text-faint); }
-  .grad-add { font-size: 12px; align-self: flex-start; }
-  .grad-output { font-size: 11px; opacity: 0.75; }
-</style>
-
 <div x-data="ruscker.landingForm({{ form_initial_json() }})" x-cloak>
 
   {# ── Header ───────────────────────────────────────────────── #}
@@ -237,36 +218,10 @@
 
 <script src="/assets/js/alpine.min.js" defer></script>
 <script>
+// Gradient helpers (gradientCss / gradientDefault / bgMode) are
+// defined in admin/_layout.html so they're shared with the
+// spec-form cover editor.
 window.ruscker = window.ruscker || {};
-
-// ── Shared gradient helpers (reused by the spec-form cover too) ──
-
-// Build a CSS background string from builder state.
-// g = { type: 'linear'|'radial', angle: 0-360, stops: [{color, pos}] }
-// `pos` is an optional 0-100 percentage; omitted when null/''.
-window.ruscker.gradientCss = (g) => {
-  const stops = (g.stops || [])
-    .filter((s) => s && s.color)
-    .map((s) => (s.pos === '' || s.pos == null) ? s.color : `${s.color} ${s.pos}%`)
-    .join(', ');
-  if (!stops) return '';
-  if (g.type === 'radial') return `radial-gradient(circle, ${stops})`;
-  return `linear-gradient(${g.angle | 0}deg, ${stops})`;
-};
-
-// Fresh default builder state — two stops, a pleasant diagonal.
-window.ruscker.gradientDefault = () => ({
-  type: 'linear',
-  angle: 135,
-  stops: [ { color: '#0f6e56', pos: 0 }, { color: '#5dcaa5', pos: 100 } ],
-});
-
-// Decide the initial editing mode for an existing value:
-// a gradient string → 'gradient', anything else → 'solid'.
-window.ruscker.bgMode = (value) =>
-  (typeof value === 'string' && /^(linear|radial)-gradient\(/.test(value.trim()))
-    ? 'gradient' : 'solid';
-
 window.ruscker.landingForm = (initial) => ({
   form: initial,
   // Header-background editing mode + gradient builder sub-state.

--- a/crates/ruscker-admin/templates/admin/spec_form.html
+++ b/crates/ruscker-admin/templates/admin/spec_form.html
@@ -104,6 +104,67 @@
         <div class="spec-form-help">{{ self.t("spec-form-logo-help") }}</div>
       </div>
 
+      {# ── Card cover (#11) — Auto tint / Solid / Gradient ───── #}
+      <div class="spec-form-field">
+        <label class="spec-form-label">{{ self.t("spec-form-cover") }}</label>
+        <div class="grad-modes" role="tablist">
+          <button type="button" class="grad-mode" :class="coverMode === 'auto' ? 'is-active' : ''"
+                  @click="setCoverMode('auto')">{{ self.t("spec-form-cover-auto") }}</button>
+          <button type="button" class="grad-mode" :class="coverMode === 'solid' ? 'is-active' : ''"
+                  @click="setCoverMode('solid')">{{ self.t("admin-grad-solid") }}</button>
+          <button type="button" class="grad-mode" :class="coverMode === 'gradient' ? 'is-active' : ''"
+                  @click="setCoverMode('gradient')">{{ self.t("admin-grad-gradient") }}</button>
+        </div>
+
+        {# AUTO: nothing to configure — the kind tint is used. The
+           submitted `cover` is empty (the disabled input below). #}
+        <div class="spec-form-help" x-show="coverMode === 'auto'">{{ self.t("spec-form-cover-auto-help") }}</div>
+
+        {# SOLID #}
+        <div class="color-input" x-show="coverMode === 'solid'" x-cloak>
+          <input type="color" x-model="form.cover" :value="form.cover || '#0f6e56'">
+          <input type="text" name="cover" x-model="form.cover"
+                 :disabled="coverMode !== 'solid'"
+                 placeholder="#0f6e56"
+                 class="spec-form-input spec-form-input--mono">
+        </div>
+
+        {# GRADIENT — same builder component as the landing header. #}
+        <div class="grad-builder" x-show="coverMode === 'gradient'" x-cloak>
+          <div class="grad-row">
+            <select class="theme-select" x-model="grad.type" @change="applyCoverGrad()">
+              <option value="linear">{{ self.t("admin-grad-linear") }}</option>
+              <option value="radial">{{ self.t("admin-grad-radial") }}</option>
+            </select>
+            <label class="grad-angle" x-show="grad.type === 'linear'">
+              <span x-text="grad.angle + '°'"></span>
+              <input type="range" min="0" max="360" step="5"
+                     x-model.number="grad.angle" @input="applyCoverGrad()">
+            </label>
+          </div>
+          <template x-for="(stop, i) in grad.stops" :key="i">
+            <div class="grad-stop">
+              <input type="color" x-model="stop.color" @input="applyCoverGrad()">
+              <input type="number" min="0" max="100" class="grad-pos"
+                     x-model.number="stop.pos" @input="applyCoverGrad()">
+              <span class="grad-pos-unit">%</span>
+              <button type="button" class="admin-nav-link" @click="removeStop(i)"
+                      x-show="grad.stops.length > 2"
+                      title="{{ self.t("admin-grad-remove-stop") }}">
+                <i class="ti ti-x" aria-hidden="true"></i>
+              </button>
+            </div>
+          </template>
+          <button type="button" class="admin-nav-link grad-add" @click="addStop()"
+                  x-show="grad.stops.length < 4">
+            <i class="ti ti-plus" aria-hidden="true"></i> {{ self.t("admin-grad-add-stop") }}
+          </button>
+          <input type="text" name="cover" x-model="form.cover" readonly
+                 :disabled="coverMode !== 'gradient'"
+                 class="spec-form-input spec-form-input--mono grad-output">
+        </div>
+      </div>
+
       <div class="grid grid-cols-3 gap-3">
         <div class="spec-form-field">
           <label for="f-access" class="spec-form-label">{{ self.t("spec-form-access") }}</label>
@@ -204,7 +265,9 @@
 
       <div class="rcard" style="margin:0">
         <div class="rcover">
-          <div class="rcover-bg" :class="'tint-' + form.display_type"></div>
+          <div class="rcover-bg"
+               :class="form.cover ? '' : 'tint-' + form.display_type"
+               :style="form.cover ? `background:${form.cover};` : ''"></div>
           <template x-if="form.logo">
             <img :src="form.logo" alt="" class="rcover-img">
           </template>
@@ -257,6 +320,35 @@
 window.ruscker = window.ruscker || {};
 window.ruscker.specForm = (initial) => ({
   form: initial,
+  // Card-cover editing mode: 'auto' (kind tint, empty cover),
+  // 'solid' (color), 'gradient' (builder). Seeded from any
+  // existing `cover` value.
+  coverMode: !((initial.cover || '').trim())
+    ? 'auto'
+    : window.ruscker.bgMode(initial.cover),
+  grad: window.ruscker.gradientDefault(),
+  applyCoverGrad() {
+    this.form.cover = window.ruscker.gradientCss(this.grad);
+  },
+  addStop() {
+    if (this.grad.stops.length < 4) {
+      this.grad.stops.push({ color: '#1d9e75', pos: 50 });
+      this.applyCoverGrad();
+    }
+  },
+  removeStop(i) {
+    if (this.grad.stops.length > 2) {
+      this.grad.stops.splice(i, 1);
+      this.applyCoverGrad();
+    }
+  },
+  setCoverMode(mode) {
+    this.coverMode = mode;
+    if (mode === 'auto') this.form.cover = '';
+    else if (mode === 'gradient') this.applyCoverGrad();
+    // 'solid' keeps whatever's in form.cover (or the picker
+    // default once the operator touches it).
+  },
   needsContainer() {
     return ['app', 'api', 'talk', 'report'].includes(this.form.display_type);
   },


### PR DESCRIPTION
## Summary
- Spec form's **Visual** section gains a card-cover editor with an **Auto / Solid / Gradient** toggle, reusing the gradient-builder widget from the landing header (#43).
- Pairs with the cover *render* plumbing already merged in #42 — this PR is the *editor* half.
- `SpecForm` gains `cover: String`; `from_spec` reads `template-properties.cover`, `into_spec` writes it back when non-empty. Only the active mode's input submits (`:disabled` on the others).
- Gradient helpers (`gradientCss` / `gradientDefault` / `bgMode`) + `.grad-*` CSS extracted to `admin/_layout.html` so the landing editor and spec-form cover share one copy (removed the duplicate from `landing.html`).
- 3 new i18n keys × 4 locales; parity passes.

## Test plan
- [x] `cargo test` workspace — 192 green
- [x] `./scripts/i18n-check.sh` parity
- [x] Real smoke: `POST /admin/specs cover=linear-gradient(…)` → DB `config_json` carries the cover string
- [x] `GET /admin/specs/{id}/edit` prefills the cover value + seeds `coverMode`
- [x] Shared helpers + grad CSS served on the spec-form page via the layout
- [ ] **Browser pass** for Alpine toggle/builder reactivity — not headlessly testable (same caveat as #43)

Closes #11.

🤖 Generated with [Claude Code](https://claude.com/claude-code)