### PR TITLE
Phase 5: /healthz + /readyz probes for orchestrators

### DIFF
--- a/crates/ruscker-admin/src/lib.rs
+++ b/crates/ruscker-admin/src/lib.rs
@@ -298,7 +298,13 @@ pub fn router_with_images(state: AppState, _images_dir: Option<&Path>) -> Router
         .merge(routes::admin::routes())
         .layer(axum::middleware::from_fn(security_headers));
 
+    // Health probes (`/healthz`, `/readyz`) sit outside the
+    // `security_headers` layer: they return JSON for orchestrators,
+    // not HTML for browsers, so CSP / X-Frame-Options are
+    // irrelevant. Like the proxy routes, they're merged at the
+    // outer level.
     own.merge(routes::proxy::routes())
+        .merge(routes::health::routes())
         .layer(CookieManagerLayer::new())
         .with_state(state)
 }

--- a/crates/ruscker-admin/src/routes/health.rs
+++ b/crates/ruscker-admin/src/routes/health.rs
@@ -1,0 +1,106 @@
+//! Liveness and readiness probes for orchestrators and load
+//! balancers (`/healthz`, `/readyz`).
+//!
+//! These follow the de-facto Kubernetes convention:
+//!
+//! - **`/healthz` (liveness)** — "is the process up and serving?".
+//!   Always returns `200`. It does *not* touch the DB or Docker:
+//!   a liveness probe that fails on a dependency outage would make
+//!   the orchestrator kill-and-restart Ruscker, which never fixes
+//!   a down database and only sheds the landing page too. Liveness
+//!   means "the event loop is responsive"; readiness means "my
+//!   dependencies are reachable".
+//!
+//! - **`/readyz` (readiness)** — "should traffic be routed to me?".
+//!   Probes the dependencies Ruscker was actually configured with
+//!   (the SQLite pool when `--db` is set, the container backend
+//!   when `--docker` is set) and returns `503` if any is
+//!   unreachable. A dependency that wasn't configured is simply
+//!   absent from the report — readiness reflects the running mode,
+//!   not an idealized full deployment.
+//!
+//! Both are unauthenticated: probes run before any operator logs
+//! in, and the responses carry no sensitive data. Dependency
+//! errors are logged at `warn` but reported to the caller only as
+//! a terse `"unreachable"` label, so internal details (socket
+//! paths, SQL text) never leak through the probe.
+
+use axum::{
+    extract::State,
+    http::StatusCode,
+    response::{IntoResponse, Response},
+    routing::get,
+    Json, Router,
+};
+use serde_json::json;
+use tracing::warn;
+
+use crate::AppState;
+
+pub fn routes() -> Router<AppState> {
+    Router::new()
+        .route("/healthz", get(healthz))
+        .route("/readyz", get(readyz))
+}
+
+/// Liveness: the process is up and the async runtime is servicing
+/// requests. Intentionally dependency-free — see the module docs.
+async fn healthz() -> Response {
+    Json(json!({
+        "status": "ok",
+        "service": "ruscker",
+        "version": env!("CARGO_PKG_VERSION"),
+    }))
+    .into_response()
+}
+
+/// Readiness: every configured dependency is reachable. Returns
+/// `200` with `{"status":"ready", ...}` when all checks pass, or
+/// `503` with `{"status":"not_ready", ...}` when any fails.
+async fn readyz(State(state): State<AppState>) -> Response {
+    let mut checks = serde_json::Map::new();
+    let mut ready = true;
+
+    // SQLite: a trivial round-trip confirms the pool can hand out a
+    // live connection (catches a deleted/locked DB file or an
+    // exhausted pool).
+    if let Some(pool) = &state.db {
+        match sqlx::query("SELECT 1").fetch_one(pool).await {
+            Ok(_) => {
+                checks.insert("db".into(), json!("ok"));
+            }
+            Err(err) => {
+                ready = false;
+                warn!(error = %err, "readyz: database check failed");
+                checks.insert("db".into(), json!("unreachable"));
+            }
+        }
+    }
+
+    // Container backend: `list()` is the cheapest "can I reach the
+    // Docker daemon?" call on the trait — it's the same one the
+    // startup reconcile uses.
+    if let Some(backend) = &state.backend {
+        match backend.list().await {
+            Ok(_) => {
+                checks.insert("docker".into(), json!("ok"));
+            }
+            Err(err) => {
+                ready = false;
+                warn!(error = %err, "readyz: container backend check failed");
+                checks.insert("docker".into(), json!("unreachable"));
+            }
+        }
+    }
+
+    let status = if ready {
+        StatusCode::OK
+    } else {
+        StatusCode::SERVICE_UNAVAILABLE
+    };
+    let body = json!({
+        "status": if ready { "ready" } else { "not_ready" },
+        "checks": checks,
+    });
+    (status, Json(body)).into_response()
+}

--- a/crates/ruscker-admin/src/routes/mod.rs
+++ b/crates/ruscker-admin/src/routes/mod.rs
@@ -2,6 +2,7 @@
 
 pub mod admin;
 pub mod assets;
+pub mod health;
 pub mod landing;
 pub mod prefs;
 pub mod proxy;

--- a/crates/ruscker-admin/tests/health_probes.rs
+++ b/crates/ruscker-admin/tests/health_probes.rs
@@ -1,0 +1,108 @@
+//! Integration tests for the `/healthz` and `/readyz` probes.
+//!
+//! Uses an in-process `Router::oneshot` — no socket bound. Covers:
+//! liveness always 200; readiness 200 when no deps are configured;
+//! readiness 503 when a configured backend is unreachable.
+
+use async_trait::async_trait;
+use axum::body::Body;
+use axum::http::{Request, StatusCode};
+use ruscker_admin::{router, AppState};
+use ruscker_config::Config;
+use ruscker_core::{ContainerBackend, CoreError, CoreResult, Replica, ReplicaId, ReplicaMetrics};
+use std::sync::Arc;
+use tower::ServiceExt;
+
+const MINIMAL_YAML: &str = r#"
+proxy:
+  title: Test
+  specs: []
+"#;
+
+fn base_state() -> AppState {
+    std::env::set_var("DOCKER_REGISTRY_PASSWORD", "test");
+    let config = Config::from_yaml(MINIMAL_YAML).expect("parse config");
+    let locales = ruscker_admin::i18n::Locales::load().expect("load locales");
+    AppState {
+        config: Arc::new(config),
+        locales: Arc::new(locales),
+        admin_auth: Default::default(),
+        login_limiter: Arc::new(ruscker_admin::auth::LoginRateLimiter::default_policy()),
+        db: None,
+        images_dir: None,
+        master_key: Default::default(),
+        backend: None,
+        replicas: Arc::new(tokio::sync::RwLock::new(Default::default())),
+        cookie_key: ruscker_proxy::sticky::CookieKey::random(),
+        spawn_locks: Arc::new(dashmap::DashMap::new()),
+        sessions: Arc::new(ruscker_admin::sessions::SessionTracker::new()),
+        metrics: ruscker_admin::metrics_cache::MetricsCache::new(),
+    }
+}
+
+async fn get(state: AppState, uri: &str) -> (StatusCode, String) {
+    let app = router(state);
+    let req = Request::builder()
+        .method("GET")
+        .uri(uri)
+        .body(Body::empty())
+        .unwrap();
+    let resp = app.oneshot(req).await.unwrap();
+    let status = resp.status();
+    let body = axum::body::to_bytes(resp.into_body(), 64 * 1024)
+        .await
+        .unwrap();
+    (status, String::from_utf8(body.to_vec()).unwrap())
+}
+
+/// A backend whose every `list()` call fails — stands in for an
+/// unreachable Docker daemon so `/readyz` can be driven to 503.
+struct UnreachableBackend;
+
+#[async_trait]
+impl ContainerBackend for UnreachableBackend {
+    async fn spawn(&self, _spec_id: &str, _image: &str) -> CoreResult<Replica> {
+        Err(CoreError::Backend("down".into()))
+    }
+    async fn stop(&self, _replica_id: &ReplicaId) -> CoreResult<()> {
+        Err(CoreError::Backend("down".into()))
+    }
+    async fn list(&self) -> CoreResult<Vec<Replica>> {
+        Err(CoreError::Backend("daemon unreachable".into()))
+    }
+    async fn metrics(&self, _replica_id: &ReplicaId) -> CoreResult<ReplicaMetrics> {
+        Err(CoreError::Backend("down".into()))
+    }
+}
+
+#[tokio::test]
+async fn healthz_is_always_ok() {
+    let (status, body) = get(base_state(), "/healthz").await;
+    assert_eq!(status, StatusCode::OK);
+    assert!(body.contains("\"status\":\"ok\""), "body: {body}");
+    assert!(body.contains("\"service\":\"ruscker\""), "body: {body}");
+}
+
+#[tokio::test]
+async fn readyz_is_ready_with_no_dependencies() {
+    // Landing-only mode (no --db, no --docker): nothing to probe,
+    // so readiness is trivially satisfied.
+    let (status, body) = get(base_state(), "/readyz").await;
+    assert_eq!(status, StatusCode::OK);
+    assert!(body.contains("\"status\":\"ready\""), "body: {body}");
+}
+
+#[tokio::test]
+async fn readyz_503_when_backend_unreachable() {
+    let mut state = base_state();
+    state.backend = Some(Arc::new(UnreachableBackend));
+    let (status, body) = get(state, "/readyz").await;
+    assert_eq!(status, StatusCode::SERVICE_UNAVAILABLE);
+    assert!(body.contains("\"status\":\"not_ready\""), "body: {body}");
+    assert!(body.contains("\"docker\":\"unreachable\""), "body: {body}");
+    // The internal error string must not leak through the probe.
+    assert!(
+        !body.contains("daemon unreachable"),
+        "body leaked error: {body}"
+    );
+}


### PR DESCRIPTION
First **runtime-polish** slice of #5 (Phase 5 — production polish).

## Summary
- **`GET /healthz`** (liveness) — always `200`, dependency-free. A liveness probe that failed on a DB/Docker outage would just get Ruscker killed-and-restarted (never fixes the dep, sheds the landing too), so it only asserts "the runtime is responsive".
- **`GET /readyz`** (readiness) — probes the deps Ruscker was started with: `SELECT 1` on the SQLite pool when `--db` is set, `backend.list()` when `--docker` is set. `200`/`ready` when all pass, `503`/`not_ready` when any fails. Unconfigured deps are omitted from the report.
- Both unauthenticated and outside the `security_headers` layer (JSON for machines, not HTML). Dependency errors log at `warn` but surface only as a terse `"unreachable"` label — no socket paths / SQL text leak.

## Test plan
- [x] `cargo test` — 3 new integration tests + full suite green
- [x] Real smoke (`serve --db`, no `--docker`): `/healthz` → `200 {…"status":"ok","version":"0.1.0"}`; `/readyz` → `200 {"checks":{"db":"ok"},"status":"ready"}`; both reachable with no auth
- [x] `readyz` 503 path covered by a mock backend whose `list()` fails (asserts no internal error string leaks)

Advances #5 runtime-polish checklist (`/healthz`, `/readyz`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)