### PR TITLE
Phase 5: graceful shutdown with session drain

### DIFF
--- a/crates/ruscker-admin/src/lib.rs
+++ b/crates/ruscker-admin/src/lib.rs
@@ -100,6 +100,13 @@ pub struct AppState {
     /// [`metrics_cache::REFRESH_INTERVAL`]; the dashboard reads
     /// straight from here without ever waiting on Docker.
     pub metrics: metrics_cache::MetricsCache,
+
+    /// Set to `true` when a graceful shutdown begins (SIGTERM /
+    /// Ctrl-C). While set, `/readyz` reports `draining` (503) so
+    /// load balancers stop routing new traffic before the listener
+    /// closes. Shared (Arc) so the signal handler and every request
+    /// handler observe the same flag.
+    pub draining: Arc<std::sync::atomic::AtomicBool>,
 }
 
 /// HTTP server hosting the landing and (later) the admin panel.
@@ -139,6 +146,7 @@ impl AdminServer {
             spawn_locks: std::sync::Arc::new(dashmap::DashMap::new()),
             sessions: std::sync::Arc::new(sessions::SessionTracker::new()),
             metrics: metrics_cache::MetricsCache::new(),
+            draining: Arc::new(std::sync::atomic::AtomicBool::new(false)),
         };
         Ok(Self {
             addr,
@@ -269,10 +277,92 @@ impl AdminServer {
             .with_context(|| format!("bind {}", self.addr))?;
         info!(addr = %self.addr, images_dir = ?self.images_dir, "ruscker-admin listening");
         axum::serve(listener, app)
+            .with_graceful_shutdown(shutdown_signal(self.state.clone()))
             .await
             .context("axum serve")?;
+        info!("shutdown complete");
         Ok(())
     }
+}
+
+/// Resolves when the process receives a termination signal, then
+/// runs the graceful-drain sequence. Returning from this future is
+/// what tells `axum::serve` to stop accepting new connections and
+/// finish the in-flight ones.
+///
+/// Sequence on signal:
+/// 1. Flip [`AppState::draining`] so `/readyz` starts replying
+///    `503 draining` — load balancers deregister this instance.
+/// 2. Arm a hard-deadline watchdog that force-exits the process if
+///    draining overruns. Long-lived WebSocket sessions (Shiny,
+///    Streamlit) never close on their own, so without this the
+///    in-flight wait would hang forever.
+/// 3. Wait for active sessions to drain, polling
+///    [`sessions::SessionTracker::len`], up to
+///    `proxy.shutdown-grace-ms`. Exits the wait early the moment
+///    the last session ends.
+async fn shutdown_signal(state: AppState) {
+    use std::sync::atomic::Ordering;
+    use tokio::time::{sleep, Duration, Instant};
+
+    // SIGINT (Ctrl-C) on every platform; SIGTERM too on Unix
+    // (what `systemctl stop` / `docker stop` / k8s send).
+    let ctrl_c = async {
+        let _ = tokio::signal::ctrl_c().await;
+    };
+    #[cfg(unix)]
+    let terminate = async {
+        match tokio::signal::unix::signal(tokio::signal::unix::SignalKind::terminate()) {
+            Ok(mut s) => {
+                s.recv().await;
+            }
+            // If we can't install the handler, never resolve this
+            // arm — Ctrl-C still works.
+            Err(_) => std::future::pending::<()>().await,
+        }
+    };
+    #[cfg(not(unix))]
+    let terminate = std::future::pending::<()>();
+
+    tokio::select! {
+        _ = ctrl_c => {}
+        _ = terminate => {}
+    }
+
+    let grace = Duration::from_millis(state.config.proxy.shutdown_grace_ms);
+    let active = state.sessions.len();
+    info!(
+        grace_ms = state.config.proxy.shutdown_grace_ms,
+        active_sessions = active,
+        "shutdown signal received; draining"
+    );
+    state.draining.store(true, Ordering::SeqCst);
+
+    // Watchdog: guarantee the process exits even if in-flight
+    // connections (notably long-lived WebSockets) never close. The
+    // extra slack covers the time axum spends finishing in-flight
+    // HTTP requests after this future resolves.
+    let watchdog = grace + Duration::from_secs(5);
+    tokio::spawn(async move {
+        sleep(watchdog).await;
+        tracing::warn!(
+            deadline_ms = watchdog.as_millis() as u64,
+            "graceful-shutdown deadline exceeded; forcing exit"
+        );
+        std::process::exit(0);
+    });
+
+    // Drain loop: wait for sessions to wind down, but never longer
+    // than the grace window. Idle instances (no sessions) fall
+    // through immediately.
+    let deadline = Instant::now() + grace;
+    while !state.sessions.is_empty() && Instant::now() < deadline {
+        sleep(Duration::from_millis(250)).await;
+    }
+    info!(
+        remaining_sessions = state.sessions.len(),
+        "drain window elapsed; closing listener"
+    );
 }
 
 /// Compose the axum router. Pulled out so tests can hit it via

--- a/crates/ruscker-admin/src/routes/health.rs
+++ b/crates/ruscker-admin/src/routes/health.rs
@@ -58,6 +58,18 @@ async fn healthz() -> Response {
 /// `200` with `{"status":"ready", ...}` when all checks pass, or
 /// `503` with `{"status":"not_ready", ...}` when any fails.
 async fn readyz(State(state): State<AppState>) -> Response {
+    // Shutting down: report `not ready` immediately so the load
+    // balancer deregisters this instance before the listener
+    // closes. Skip the dependency probes — we're going away
+    // regardless of their state.
+    if state.draining.load(std::sync::atomic::Ordering::SeqCst) {
+        return (
+            StatusCode::SERVICE_UNAVAILABLE,
+            Json(json!({ "status": "draining" })),
+        )
+            .into_response();
+    }
+
     let mut checks = serde_json::Map::new();
     let mut ready = true;
 

--- a/crates/ruscker-admin/src/routes/proxy.rs
+++ b/crates/ruscker-admin/src/routes/proxy.rs
@@ -709,6 +709,7 @@ mod tests {
             spawn_locks: StdArc::new(dashmap::DashMap::new()),
             sessions: StdArc::new(crate::sessions::SessionTracker::new()),
             metrics: crate::metrics_cache::MetricsCache::new(),
+            draining: StdArc::new(std::sync::atomic::AtomicBool::new(false)),
         }
     }
 

--- a/crates/ruscker-admin/src/scaler.rs
+++ b/crates/ruscker-admin/src/scaler.rs
@@ -522,6 +522,7 @@ mod tests {
             spawn_locks: Arc::new(dashmap::DashMap::new()),
             sessions: Arc::new(crate::sessions::SessionTracker::new()),
             metrics: crate::metrics_cache::MetricsCache::new(),
+            draining: Arc::new(std::sync::atomic::AtomicBool::new(false)),
         }
     }
 

--- a/crates/ruscker-admin/tests/health_probes.rs
+++ b/crates/ruscker-admin/tests/health_probes.rs
@@ -37,6 +37,7 @@ fn base_state() -> AppState {
         spawn_locks: Arc::new(dashmap::DashMap::new()),
         sessions: Arc::new(ruscker_admin::sessions::SessionTracker::new()),
         metrics: ruscker_admin::metrics_cache::MetricsCache::new(),
+        draining: Arc::new(std::sync::atomic::AtomicBool::new(false)),
     }
 }
 
@@ -90,6 +91,19 @@ async fn readyz_is_ready_with_no_dependencies() {
     let (status, body) = get(base_state(), "/readyz").await;
     assert_eq!(status, StatusCode::OK);
     assert!(body.contains("\"status\":\"ready\""), "body: {body}");
+}
+
+#[tokio::test]
+async fn readyz_503_when_draining() {
+    // Once the draining flag is set, readiness must fail fast and
+    // skip the dependency probes — even with healthy deps.
+    let state = base_state();
+    state
+        .draining
+        .store(true, std::sync::atomic::Ordering::SeqCst);
+    let (status, body) = get(state, "/readyz").await;
+    assert_eq!(status, StatusCode::SERVICE_UNAVAILABLE);
+    assert!(body.contains("\"status\":\"draining\""), "body: {body}");
 }
 
 #[tokio::test]

--- a/crates/ruscker-admin/tests/landing_render.rs
+++ b/crates/ruscker-admin/tests/landing_render.rs
@@ -35,6 +35,7 @@ fn app_state() -> AppState {
         spawn_locks: std::sync::Arc::new(dashmap::DashMap::new()),
         sessions: std::sync::Arc::new(ruscker_admin::sessions::SessionTracker::new()),
         metrics: ruscker_admin::metrics_cache::MetricsCache::new(),
+        draining: std::sync::Arc::new(std::sync::atomic::AtomicBool::new(false)),
     }
 }
 

--- a/crates/ruscker-config/src/schema.rs
+++ b/crates/ruscker-config/src/schema.rs
@@ -128,6 +128,16 @@ pub struct Proxy {
     #[serde(rename = "container-wait-time")]
     pub container_wait_time: u64,
 
+    /// How long to wait for active sessions to drain on graceful
+    /// shutdown (SIGTERM / Ctrl-C) before forcing exit, in
+    /// milliseconds. During the drain window `/readyz` reports
+    /// `draining` so load balancers stop routing new traffic; the
+    /// process exits early once the last session ends. `0` exits
+    /// as soon as in-flight HTTP requests finish. Ruscker
+    /// extension — not present in ShinyProxy YAML.
+    #[serde(rename = "shutdown-grace-ms")]
+    pub shutdown_grace_ms: u64,
+
     /// Directory to write per-container logs to.
     #[serde(rename = "container-log-path")]
     pub container_log_path: Option<PathBuf>,
@@ -167,6 +177,7 @@ impl Default for Proxy {
             heartbeat_rate: 10_000,
             heartbeat_timeout: 3_600_000,
             container_wait_time: 60_000,
+            shutdown_grace_ms: 30_000,
             container_log_path: None,
             port: 8080,
             bind_address: "0.0.0.0".to_string(),

--- a/crates/ruscker-config/tests/shinyproxy_compat.rs
+++ b/crates/ruscker-config/tests/shinyproxy_compat.rs
@@ -30,6 +30,9 @@ fn parses_full_sepe_config() {
     assert!(config.proxy.hide_navbar);
     assert_eq!(config.proxy.heartbeat_rate, 10_000);
     assert_eq!(config.proxy.heartbeat_timeout, 3_600_000);
+    // `shutdown-grace-ms` is a Ruscker extension absent from the
+    // SEPE config — it must fall back to the 30s default.
+    assert_eq!(config.proxy.shutdown_grace_ms, 30_000);
     assert_eq!(config.proxy.port, 8080);
     assert_eq!(config.proxy.bind_address, "127.0.0.1");
 }

--- a/docs/YAML_SCHEMA.md
+++ b/docs/YAML_SCHEMA.md
@@ -48,6 +48,7 @@ ignored by Ruscker.
 | `heartbeat-rate` | ms | `10000` | Client heartbeat interval |
 | `heartbeat-timeout` | ms | `3600000` | Session expiry; `-1` = never |
 | `container-wait-time` | ms | `60000` | Max wait for container Ready |
+| `shutdown-grace-ms` | ms | `30000` | Drain window on SIGTERM/Ctrl-C before forced exit; `/readyz` reports `draining` during it. Ruscker extension |
 | `container-log-path` | path | none | Directory for per-container logs |
 | `port` | u16 | `8080` | HTTP listener port |
 | `bind-address` | string | `"0.0.0.0"` | Listener interface |


### PR DESCRIPTION
Second **runtime-polish** slice of #5. On SIGTERM (systemctl/docker/k8s) or Ctrl-C, Ruscker drains instead of dropping connections on a hard kill. Pairs with the `/healthz` `/readyz` probes from #45.

## Sequence
1. Flip `AppState.draining` → `/readyz` reports `503 {"status":"draining"}` so LBs deregister before the listener closes.
2. Arm a hard-deadline watchdog (`grace + 5s`) that force-exits — long-lived WebSocket sessions never close on their own, so the in-flight wait would otherwise hang forever.
3. Wait for sessions to drain (poll `SessionTracker::len()`) up to `proxy.shutdown-grace-ms`; exit early when the last session ends.
4. `axum::serve().with_graceful_shutdown(...)` stops accepting + finishes in-flight HTTP.

## New config
- `proxy.shutdown-grace-ms` (default `30000`). `0` = exit as soon as in-flight HTTP finishes. Ruscker extension; documented in `docs/YAML_SCHEMA.md`.

## Test plan
- [x] 4 health-probe tests (incl. `/readyz` → `draining` 503 with healthy deps)
- [x] config default-fallback assertion; full workspace suite green; clippy clean
- [x] Real SIGTERM smoke: `/readyz` 200 → `kill -TERM` → exit 0, logs `draining` → `drain window elapsed` → `shutdown complete`

Advances #5 runtime-polish checklist (graceful shutdown).

🤖 Generated with [Claude Code](https://claude.com/claude-code)