### PR TITLE
Phase 5: structured (JSON) logging via --log-format

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3639,6 +3639,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "tracing-serde"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "704b1aeb7be0d0a84fc9828cae51dab5970fee5088f83d1dd7ee6f6246fc6ff1"
+dependencies = [
+ "serde",
+ "tracing-core",
+]
+
+[[package]]
 name = "tracing-subscriber"
 version = "0.3.23"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3648,12 +3658,15 @@ dependencies = [
  "nu-ansi-term",
  "once_cell",
  "regex-automata",
+ "serde",
+ "serde_json",
  "sharded-slab",
  "smallvec",
  "thread_local",
  "tracing",
  "tracing-core",
  "tracing-log",
+ "tracing-serde",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -52,7 +52,7 @@ anyhow = "1.0.102"
 
 # Logging / tracing
 tracing = "0.1.44"
-tracing-subscriber = { version = "0.3.23", features = ["env-filter", "fmt"] }
+tracing-subscriber = { version = "0.3.23", features = ["env-filter", "fmt", "json"] }
 
 # CLI
 clap = { version = "4.6", features = ["derive", "env"] }

--- a/crates/ruscker-cli/src/main.rs
+++ b/crates/ruscker-cli/src/main.rs
@@ -16,9 +16,21 @@
 //! - `ruscker export <path>` — export DB back to YAML
 
 use anyhow::{Context, Result};
-use clap::{Parser, Subcommand};
+use clap::{Parser, Subcommand, ValueEnum};
 use ruscker_config::{Config, SpecKind, ValidationReport, Warning};
 use std::path::PathBuf;
+
+/// How log lines are rendered.
+#[derive(Clone, Copy, Debug, Default, PartialEq, Eq, ValueEnum)]
+enum LogFormat {
+    /// Human-readable single-line output (default) — for terminals
+    /// and `journalctl`.
+    #[default]
+    Text,
+    /// One JSON object per line — for log shippers (Loki, Fluent
+    /// Bit, the ELK stack) that parse structured fields.
+    Json,
+}
 
 #[derive(Parser, Debug)]
 #[command(
@@ -31,6 +43,11 @@ struct Cli {
     /// Increase output verbosity (`-v`, `-vv`, `-vvv`)
     #[arg(short, long, action = clap::ArgAction::Count, global = true)]
     verbose: u8,
+
+    /// Log output format. `text` for humans, `json` for log
+    /// aggregators. Also settable via `RUSCKER_LOG_FORMAT`.
+    #[arg(long, value_enum, default_value_t = LogFormat::Text, env = "RUSCKER_LOG_FORMAT", global = true)]
+    log_format: LogFormat,
 
     #[command(subcommand)]
     command: Command,
@@ -130,7 +147,7 @@ enum Command {
 
 fn main() -> Result<()> {
     let cli = Cli::parse();
-    init_tracing(cli.verbose);
+    init_tracing(cli.verbose, cli.log_format);
 
     match cli.command {
         Command::Validate { path, json, strict } => cmd_validate(&path, json, strict),
@@ -257,18 +274,31 @@ fn cmd_serve(
     })
 }
 
-fn init_tracing(verbosity: u8) {
+fn init_tracing(verbosity: u8, format: LogFormat) {
     let level = match verbosity {
         0 => "warn",
         1 => "info",
         2 => "debug",
         _ => "trace",
     };
+    // `RUST_LOG` always wins when set (operators expect it); the
+    // verbosity flag only sets the default filter.
     let env = std::env::var("RUST_LOG").unwrap_or_else(|_| format!("ruscker={level}"));
-    tracing_subscriber::fmt()
-        .with_env_filter(env)
-        .with_target(false)
-        .init();
+    let builder = tracing_subscriber::fmt().with_env_filter(env);
+    match format {
+        // `.json()` and the default formatter return different
+        // builder types, so each arm must call `.init()` itself.
+        LogFormat::Text => builder.with_target(false).init(),
+        LogFormat::Json => builder
+            // Keep the module target in structured logs — it's a
+            // cheap, high-value field for filtering in a shipper.
+            .json()
+            // Lift the event's fields to the top level instead of
+            // nesting them under `"fields"`, so queries like
+            // `addr="…"` work without a path prefix.
+            .flatten_event(true)
+            .init(),
+    }
 }
 
 fn cmd_validate(path: &PathBuf, json: bool, strict: bool) -> Result<()> {
@@ -421,5 +451,30 @@ fn truncate(s: &str, n: usize) -> String {
         s.to_string()
     } else {
         format!("{}…", &s[..n.saturating_sub(1)])
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn log_format_defaults_to_text() {
+        let cli = Cli::try_parse_from(["ruscker", "validate", "app.yml"]).unwrap();
+        assert_eq!(cli.log_format, LogFormat::Text);
+    }
+
+    #[test]
+    fn log_format_accepts_json() {
+        let cli =
+            Cli::try_parse_from(["ruscker", "--log-format", "json", "validate", "app.yml"]).unwrap();
+        assert_eq!(cli.log_format, LogFormat::Json);
+    }
+
+    #[test]
+    fn log_format_rejects_unknown_value() {
+        assert!(
+            Cli::try_parse_from(["ruscker", "--log-format", "xml", "validate", "app.yml"]).is_err()
+        );
     }
 }


### PR DESCRIPTION
Third **runtime-polish** slice of #5. Adds a `--log-format text|json` global flag (also `RUSCKER_LOG_FORMAT`) so production can emit machine-parseable logs for shippers (Loki, Fluent Bit, ELK); dev keeps the human-readable default.

## Changes
- New `LogFormat` clap `ValueEnum` (default `Text`), global on the top-level CLI → applies to every subcommand. `RUST_LOG` still wins for filtering; `--verbose` only sets the default filter (unchanged).
- `init_tracing` branches: `Text` = current single-line formatter; `Json` = `fmt().json().flatten_event(true)` (event fields lifted to top level so `addr="…"` queries work without a `fields.` prefix). Enabled the `json` feature on the workspace `tracing-subscriber` pin.

## Test plan
- [x] 3 CLI parse tests (default `text`; `--log-format json` → `Json`; unknown rejected); full workspace suite green; clippy clean
- [x] Real smoke (`serve -v --log-format json`): `listening` line is valid JSON with flattened fields (validated via `python -m json.tool`); default → ANSI single-line; `--help` documents the flag

Advances #5 runtime-polish checklist (structured logging).

🤖 Generated with [Claude Code](https://claude.com/claude-code)