### PR TITLE
Phase 5: configurable max request body size (#5)

### DIFF
--- a/crates/ruscker-admin/src/routes/admin/spec_form.rs
+++ b/crates/ruscker-admin/src/routes/admin/spec_form.rs
@@ -184,6 +184,7 @@ impl SpecForm {
             container_cpu_request: None,
             container_memory_limit: None,
             container_memory_request: None,
+            max_body_size: None,
             template_properties: TemplateProperties(tp_map),
             kind_override,
             api: None,

--- a/crates/ruscker-admin/src/routes/proxy.rs
+++ b/crates/ruscker-admin/src/routes/proxy.rs
@@ -236,6 +236,36 @@ async fn forward(
         }
     }
 
+    // 2c. Max body size. Applies to both route families (`/app/` and
+    //     `/api/`). The effective limit is the spec's override or the
+    //     global `proxy.max-body-size`. We reject early on a declared
+    //     `Content-Length` over the cap (no backend work); the body is
+    //     *also* wrapped in `Limited` at the forward step (below) so a
+    //     chunked or under-declared body can't slip past the cap.
+    let max_body = spec.effective_max_body_bytes(state.config.proxy.max_body_bytes());
+    if let Some(limit) = max_body {
+        if let Some(len) = req
+            .headers()
+            .get(header::CONTENT_LENGTH)
+            .and_then(|v| v.to_str().ok())
+            .and_then(|s| s.parse::<i64>().ok())
+        {
+            if len > limit {
+                tracing::debug!(spec = %spec.id, content_length = len, limit, "body too large");
+                return with_cors(
+                    (
+                        StatusCode::PAYLOAD_TOO_LARGE,
+                        format!("request body exceeds {limit} bytes\n"),
+                    )
+                        .into_response(),
+                    cors_on,
+                );
+            }
+        }
+    }
+    // Byte cap to hand to the forward step; `None` ⇒ unlimited.
+    let body_cap = max_body.map(|l| usize::try_from(l).unwrap_or(usize::MAX));
+
     // 3. Backend required to proxy.
     if state.backend.is_none() {
         return with_cors(
@@ -295,7 +325,7 @@ async fn forward(
         upstream = %replica.upstream, path = %upstream_path,
         "forwarding"
     );
-    let resp = match do_forward(&replica, upstream_path, req).await {
+    let resp = match do_forward(&replica, upstream_path, req, body_cap).await {
         Ok(r) => r,
         Err(err) => {
             tracing::error!(
@@ -699,6 +729,7 @@ async fn do_forward(
     replica: &Replica,
     upstream_path: String,
     mut req: Request,
+    max_body: Option<usize>,
 ) -> anyhow::Result<Response> {
     let query = req.uri().query().map(|q| format!("?{q}")).unwrap_or_default();
     let new_uri: Uri = format!("http://{}{}{}", replica.upstream, upstream_path, query)
@@ -707,6 +738,17 @@ async fn do_forward(
     *req.uri_mut() = new_uri;
 
     strip_hop_headers(req.headers_mut());
+
+    // Hard cap on the streamed request body. The `Content-Length`
+    // fast-path in `forward` already rejected declared-oversize
+    // uploads with a clean 413; this catches a chunked / under-
+    // declared body that tries to slip past — it surfaces as a
+    // forward error (502) once the limit trips mid-stream.
+    if let Some(limit) = max_body {
+        let (parts, body) = req.into_parts();
+        let limited = http_body_util::Limited::new(body, limit);
+        req = Request::from_parts(parts, Body::new(limited));
+    }
 
     let client = http_client().clone();
     let upstream_resp = client.request(req).await?;

--- a/crates/ruscker-admin/tests/max_body_size.rs
+++ b/crates/ruscker-admin/tests/max_body_size.rs
@@ -1,0 +1,104 @@
+//! Integration tests for `max-body-size` enforcement on proxied
+//! routes.
+//!
+//! Uses `Router::oneshot` with no backend wired. A request under the
+//! cap passes the gate and falls through to `503 no backend`; one
+//! over the declared `Content-Length` is rejected with `413` before
+//! any backend work. The fast path keys off the `Content-Length`
+//! header, so these tests set it explicitly and don't need a real
+//! body of that size.
+
+use axum::body::Body;
+use axum::http::header::CONTENT_LENGTH;
+use axum::http::{Request, StatusCode};
+use ruscker_admin::{router, AppState};
+use ruscker_config::Config;
+use std::sync::Arc;
+use tower::ServiceExt;
+
+/// `tight` overrides the global with a 1 KiB cap and enables CORS;
+/// `global` inherits the 1 MiB `proxy.max-body-size`.
+const YAML: &str = r#"
+proxy:
+  max-body-size: 1m
+  specs:
+    - id: tight
+      display-name: Tight API
+      container-image: org/api:1
+      type: api
+      max-body-size: "1k"
+      api:
+        cors: true
+    - id: global
+      display-name: Global App
+      container-image: org/app:1
+"#;
+
+fn state() -> AppState {
+    std::env::set_var("DOCKER_REGISTRY_PASSWORD", "test");
+    let config = Config::from_yaml(YAML).expect("parse config");
+    let locales = ruscker_admin::i18n::Locales::load().expect("load locales");
+    AppState {
+        config: Arc::new(config),
+        locales: Arc::new(locales),
+        admin_auth: Default::default(),
+        login_limiter: Arc::new(ruscker_admin::auth::LoginRateLimiter::default_policy()),
+        api_limiter: Arc::new(ruscker_admin::ratelimit::ApiRateLimiter::new()),
+        db: None,
+        images_dir: None,
+        master_key: Default::default(),
+        backend: None,
+        replicas: Arc::new(tokio::sync::RwLock::new(Default::default())),
+        cookie_key: ruscker_proxy::sticky::CookieKey::random(),
+        spawn_locks: Arc::new(dashmap::DashMap::new()),
+        sessions: Arc::new(ruscker_admin::sessions::SessionTracker::new()),
+        metrics: ruscker_admin::metrics_cache::MetricsCache::new(),
+        draining: Arc::new(std::sync::atomic::AtomicBool::new(false)),
+    }
+}
+
+/// POST to `uri` declaring `content_length` bytes of body.
+async fn post_with_len(uri: &str, content_length: u64) -> axum::http::Response<Body> {
+    let app = router(state());
+    let req = Request::builder()
+        .method("POST")
+        .uri(uri)
+        .header(CONTENT_LENGTH, content_length)
+        .body(Body::empty())
+        .unwrap();
+    app.oneshot(req).await.unwrap()
+}
+
+#[tokio::test]
+async fn spec_override_rejects_over_its_cap() {
+    // `tight` caps at 1 KiB; 2000 bytes is over.
+    let resp = post_with_len("/api/tight", 2000).await;
+    assert_eq!(resp.status(), StatusCode::PAYLOAD_TOO_LARGE);
+    // CORS headers ride on the 413 for an api+cors spec.
+    assert_eq!(
+        resp.headers()
+            .get("access-control-allow-origin")
+            .map(|v| v.to_str().unwrap()),
+        Some("*")
+    );
+}
+
+#[tokio::test]
+async fn under_cap_passes_gate() {
+    // 500 bytes is under `tight`'s 1 KiB cap, so it passes the body
+    // gate and falls through to the no-backend 503.
+    let resp = post_with_len("/api/tight", 500).await;
+    assert_eq!(resp.status(), StatusCode::SERVICE_UNAVAILABLE);
+}
+
+#[tokio::test]
+async fn global_default_applies_to_spec_without_override() {
+    // `global` has no override, so the 1 MiB `proxy.max-body-size`
+    // applies. 2 MiB is over.
+    let resp = post_with_len("/app/global", 2 * 1024 * 1024).await;
+    assert_eq!(resp.status(), StatusCode::PAYLOAD_TOO_LARGE);
+
+    // Just under 1 MiB passes the gate (then 503: no backend).
+    let resp = post_with_len("/app/global", 1000).await;
+    assert_eq!(resp.status(), StatusCode::SERVICE_UNAVAILABLE);
+}

--- a/crates/ruscker-cli/src/main.rs
+++ b/crates/ruscker-cli/src/main.rs
@@ -476,6 +476,12 @@ fn format_warning(w: &Warning) -> String {
                  (expected `N/unit`, e.g. `100/min`) — no limit will be applied"
             )
         }
+        Warning::InvalidMaxBodySize { location, value } => {
+            format!(
+                "{location} has an invalid max-body-size `{value}` \
+                 (expected a size like `10m`, `1g`, or plain bytes) — no limit will be applied"
+            )
+        }
     }
 }
 

--- a/crates/ruscker-config/src/schema.rs
+++ b/crates/ruscker-config/src/schema.rs
@@ -138,6 +138,16 @@ pub struct Proxy {
     #[serde(rename = "shutdown-grace-ms")]
     pub shutdown_grace_ms: u64,
 
+    /// Maximum request body accepted on proxied routes (`/app/*`,
+    /// `/api/*`), as a Docker-style size string (`"10m"`, `"1g"`,
+    /// or plain bytes). A request whose `Content-Length` exceeds
+    /// this — or whose streamed body grows past it — gets
+    /// `413 Payload Too Large`. `None` (the default) means no limit.
+    /// A per-spec `max-body-size` overrides this for that spec.
+    /// Ruscker extension — not present in ShinyProxy YAML.
+    #[serde(rename = "max-body-size")]
+    pub max_body_size: Option<String>,
+
     /// Directory to write per-container logs to.
     #[serde(rename = "container-log-path")]
     pub container_log_path: Option<PathBuf>,
@@ -178,6 +188,7 @@ impl Default for Proxy {
             heartbeat_timeout: 3_600_000,
             container_wait_time: 60_000,
             shutdown_grace_ms: 30_000,
+            max_body_size: None,
             container_log_path: None,
             port: 8080,
             bind_address: "0.0.0.0".to_string(),
@@ -185,6 +196,15 @@ impl Default for Proxy {
             specs: Vec::new(),
             landing_customization: LandingCustomization::default(),
         }
+    }
+}
+
+impl Proxy {
+    /// Global default max request-body size in bytes, parsed from
+    /// `proxy.max-body-size`. `None` (unset or malformed) means no
+    /// global default; the validator flags a malformed value.
+    pub fn max_body_bytes(&self) -> Option<i64> {
+        self.max_body_size.as_deref().and_then(parse_memory_string)
     }
 }
 
@@ -344,6 +364,13 @@ pub struct Spec {
     /// elsewhere.
     #[serde(rename = "container-memory-request")]
     pub container_memory_request: Option<String>,
+
+    /// Per-spec override of [`Proxy::max_body_size`]. Same Docker-
+    /// style size format (`"10m"`, plain bytes, …). Takes precedence
+    /// over the global default for this spec's proxied requests.
+    /// Resolved via [`Spec::effective_max_body_bytes`].
+    #[serde(rename = "max-body-size")]
+    pub max_body_size: Option<String>,
 
     /// Free-form properties consumed by the landing page template.
     /// Common keys: `logo`, `icon`, `type`, `updated`, `state`, `link`.
@@ -541,6 +568,19 @@ impl Spec {
             .as_deref()
             .and_then(parse_memory_string)
     }
+
+    /// Effective max request-body size in bytes for this spec's
+    /// proxied requests: the spec's own `max-body-size` if set,
+    /// otherwise the `global` default (already parsed from
+    /// `proxy.max-body-size`). A malformed spec value falls back to
+    /// the global — the validator flags the typo separately.
+    /// `None` means no limit.
+    pub fn effective_max_body_bytes(&self, global: Option<i64>) -> Option<i64> {
+        self.max_body_size
+            .as_deref()
+            .and_then(parse_memory_string)
+            .or(global)
+    }
 }
 
 /// Parse Docker-style memory strings: `"512"` (bytes), `"512m"`,
@@ -622,6 +662,63 @@ mod parse_memory_tests {
     #[test]
     fn whitespace_tolerated() {
         assert_eq!(parse_memory_string("  512m  "), Some(512 * 1024 * 1024));
+    }
+}
+
+#[cfg(test)]
+mod max_body_size_tests {
+    use super::*;
+
+    fn spec_with_max(max: Option<&str>) -> Spec {
+        let mut s: Spec =
+            serde_yaml_ng::from_str("id: x\ncontainer-image: a:1\n").expect("parse");
+        s.max_body_size = max.map(|m| m.to_string());
+        s
+    }
+
+    #[test]
+    fn spec_override_wins_over_global() {
+        let s = spec_with_max(Some("10m"));
+        assert_eq!(
+            s.effective_max_body_bytes(Some(1024)),
+            Some(10 * 1024 * 1024)
+        );
+    }
+
+    #[test]
+    fn falls_back_to_global_when_spec_unset() {
+        let s = spec_with_max(None);
+        assert_eq!(s.effective_max_body_bytes(Some(2048)), Some(2048));
+    }
+
+    #[test]
+    fn none_when_neither_set() {
+        let s = spec_with_max(None);
+        assert_eq!(s.effective_max_body_bytes(None), None);
+    }
+
+    #[test]
+    fn malformed_spec_value_falls_back_to_global() {
+        // A typo in the spec value isn't a hard error — it falls
+        // back to the global default (and is flagged by validate).
+        let s = spec_with_max(Some("500frogs"));
+        assert_eq!(s.effective_max_body_bytes(Some(4096)), Some(4096));
+    }
+
+    #[test]
+    fn proxy_global_parses() {
+        let cfg: Config =
+            serde_yaml_ng::from_str("proxy:\n  max-body-size: 1g\n").expect("parse");
+        assert_eq!(cfg.proxy.max_body_bytes(), Some(1024 * 1024 * 1024));
+    }
+
+    #[test]
+    fn proxy_global_malformed_is_none() {
+        let cfg: Config =
+            serde_yaml_ng::from_str("proxy:\n  max-body-size: huge\n").expect("parse");
+        assert_eq!(cfg.proxy.max_body_bytes(), None);
+        // ...but the field round-trips so the validator can flag it.
+        assert_eq!(cfg.proxy.max_body_size.as_deref(), Some("huge"));
     }
 }
 
@@ -850,6 +947,7 @@ proxy:
             container_cpu_request: None,
             container_memory_limit: None,
             container_memory_request: None,
+            max_body_size: None,
             template_properties: TemplateProperties::default(),
             kind_override: None,
             api: None,
@@ -886,6 +984,7 @@ proxy:
             container_cpu_request: None,
             container_memory_limit: None,
             container_memory_request: None,
+            max_body_size: None,
             template_properties: TemplateProperties::default(),
             kind_override: None,
             api: None,
@@ -922,6 +1021,7 @@ proxy:
             container_cpu_request: None,
             container_memory_limit: None,
             container_memory_request: None,
+            max_body_size: None,
             template_properties: TemplateProperties::default(),
             kind_override: Some(SpecKindOverride::Api),
             api: None,

--- a/crates/ruscker-config/src/validate.rs
+++ b/crates/ruscker-config/src/validate.rs
@@ -90,6 +90,15 @@ pub enum Warning {
         spec_id: String,
         value: String,
     },
+    /// A `max-body-size` value (global `proxy.max-body-size` or a
+    /// per-spec override) doesn't parse as a Docker-style size
+    /// (`"10m"`, `"1g"`, plain bytes). The proxy falls back to "no
+    /// limit there", so the intended cap isn't enforced. `location`
+    /// is `"proxy"` for the global, or the spec id.
+    InvalidMaxBodySize {
+        location: String,
+        value: String,
+    },
 }
 
 const KNOWN_TYPES: &[&str] = &["app", "package", "talk", "report", "api"];
@@ -283,6 +292,15 @@ pub fn run(config: &Config) -> ValidationReport {
         }
     }
 
+    // Global max-body-size: set but unparseable means the intended
+    // cap silently does nothing.
+    if config.proxy.max_body_size.is_some() && config.proxy.max_body_bytes().is_none() {
+        warnings.push(Warning::InvalidMaxBodySize {
+            location: "proxy".to_string(),
+            value: config.proxy.max_body_size.clone().unwrap_or_default(),
+        });
+    }
+
     let stats = collect_stats(config);
 
     ValidationReport { warnings, stats }
@@ -364,6 +382,18 @@ fn check_spec(spec: &Spec, warnings: &mut Vec<Warning>) {
                     value: raw.clone(),
                 });
             }
+        }
+    }
+
+    // Per-spec max-body-size override that's set but unparseable —
+    // same hazard: the cap silently does nothing. Parsing with a
+    // `None` global isolates the spec's own value.
+    if let Some(raw) = &spec.max_body_size {
+        if spec.effective_max_body_bytes(None).is_none() {
+            warnings.push(Warning::InvalidMaxBodySize {
+                location: spec.id.clone(),
+                value: raw.clone(),
+            });
         }
     }
 }
@@ -482,6 +512,63 @@ proxy:
                 .iter()
                 .any(|w| matches!(w, Warning::InvalidRateLimit { .. })),
             "valid rate-limit should not warn, got {:?}",
+            report.warnings
+        );
+    }
+
+    #[test]
+    fn flags_malformed_global_max_body_size() {
+        let yaml = "proxy:\n  max-body-size: huge\n  specs: []\n";
+        let report = Config::from_yaml(yaml).expect("parse").validate();
+        assert!(
+            report.warnings.iter().any(|w| matches!(
+                w,
+                Warning::InvalidMaxBodySize { location, value }
+                    if location == "proxy" && value == "huge"
+            )),
+            "expected proxy InvalidMaxBodySize, got {:?}",
+            report.warnings
+        );
+    }
+
+    #[test]
+    fn flags_malformed_spec_max_body_size() {
+        let yaml = r#"
+proxy:
+  specs:
+    - id: api1
+      container-image: org/api:1
+      max-body-size: "500frogs"
+"#;
+        let report = Config::from_yaml(yaml).expect("parse").validate();
+        assert!(
+            report.warnings.iter().any(|w| matches!(
+                w,
+                Warning::InvalidMaxBodySize { location, value }
+                    if location == "api1" && value == "500frogs"
+            )),
+            "expected spec InvalidMaxBodySize, got {:?}",
+            report.warnings
+        );
+    }
+
+    #[test]
+    fn accepts_valid_max_body_sizes() {
+        let yaml = r#"
+proxy:
+  max-body-size: 50m
+  specs:
+    - id: api1
+      container-image: org/api:1
+      max-body-size: "10m"
+"#;
+        let report = Config::from_yaml(yaml).expect("parse").validate();
+        assert!(
+            !report
+                .warnings
+                .iter()
+                .any(|w| matches!(w, Warning::InvalidMaxBodySize { .. })),
+            "valid sizes should not warn, got {:?}",
             report.warnings
         );
     }

--- a/docs/YAML_SCHEMA.md
+++ b/docs/YAML_SCHEMA.md
@@ -49,6 +49,7 @@ ignored by Ruscker.
 | `heartbeat-timeout` | ms | `3600000` | Session expiry; `-1` = never |
 | `container-wait-time` | ms | `60000` | Max wait for container Ready |
 | `shutdown-grace-ms` | ms | `30000` | Drain window on SIGTERM/Ctrl-C before forced exit; `/readyz` reports `draining` during it. Ruscker extension |
+| `max-body-size` | size | none | Global cap on proxied request bodies (`"10m"`, `"1g"`, bytes); over → `413`. Per-spec `max-body-size` overrides. Ruscker extension |
 | `container-log-path` | path | none | Directory for per-container logs |
 | `port` | u16 | `8080` | HTTP listener port |
 | `bind-address` | string | `"0.0.0.0"` | Listener interface |
@@ -174,6 +175,33 @@ every response for that API spec, and answer `OPTIONS` preflight
 requests itself (`204`) without touching the container. Headers an
 upstream app already set are never overwritten — an API that does
 its own CORS wins. CORS applies only to the `/api/` route family.
+
+### `max-body-size` — cap proxied request bodies
+
+Limits how large a request body the proxy will forward, for both
+`/app/` and `/api/` routes. Set it globally on `proxy.max-body-size`
+and/or override it per spec:
+
+```yaml
+proxy:
+  max-body-size: 10m          # global default
+  specs:
+    - id: upload_api
+      container-image: org/api:1
+      type: api
+      max-body-size: 100m     # this spec accepts larger uploads
+```
+
+Format is the Docker-style size string used elsewhere (`"512"` bytes,
+`"10m"`, `"1g"`; binary units). The effective limit is the spec's own
+value if set, otherwise the global default; unset everywhere means **no
+limit** (the default, preserving prior behaviour).
+
+A request whose `Content-Length` exceeds the limit is rejected with
+`413 Payload Too Large` before any container is touched. A chunked or
+under-declared body that grows past the cap mid-stream is also stopped
+(it surfaces as a `502`). A malformed size string is ignored (no limit
+applied) and flagged by `ruscker validate`.
 
 ### Load-balancing fields (any containerized spec)
 


### PR DESCRIPTION
Part of Phase 5 (production polish, #5). Closes out the runtime-polish trio (rate-limit → CORS → **max-body**). Caps how large a request body the proxy will forward, on both `/app/` and `/api/` routes.

## What

- **Global default**: `proxy.max-body-size: 10m`.
- **Per-spec override**: `max-body-size` on any spec; takes precedence over the global for that spec.
- Docker-style size strings (`"512"` bytes, `"10m"`, `"1g"`; binary units). Unset everywhere ⇒ **no limit** (default, preserves prior behaviour).
- Over the cap ⇒ `413 Payload Too Large`, returned **before any container work** (CORS headers ride along for `api` + `cors:true` specs).

## How

- **`ruscker-config`**: fields on `Proxy` + `Spec`; helpers `Proxy::max_body_bytes()` and `Spec::effective_max_body_bytes(global)` (reuse the existing Docker-size parser). Malformed value ⇒ ignored + `Warning::InvalidMaxBodySize` (location `"proxy"` for the global, else the spec id), surfaced by `ruscker validate`.
- **`ruscker-admin`**: forward path does a fast-path `Content-Length` check → `413`. The forwarded body is **also** wrapped in `http_body_util::Limited`, so a chunked / under-declared body that grows past the cap is stopped mid-stream (surfaces as a `502`). The fast path covers the common honest case cleanly; the wrap is the safety net against a lying/omitted `Content-Length`.

## Tests

- `ruscker-config`: `effective_max_body_bytes` (override/global/none/malformed-fallback), `max_body_bytes`, and `InvalidMaxBodySize` for both global and per-spec.
- `ruscker-admin`: `max_body_size` integration tests — `413` over a spec cap (with CORS), under-cap passes the gate, global default applies to a spec without its own override.
- **Live smoke** against `ruscker serve` (no `--docker`) with real curl bodies: `413` over cap (+CORS), `503` under cap, global (`1m`) vs per-spec (`1k`) override; `validate` flags both malformed locations. ✓

## Notes

- Applies to both route families on purpose — body-size abuse isn't API-specific.
- This completes the runtime-polish items in the Phase 5 plan; next up is the **distribution** track (cargo-deb + systemd, musl tarball, multi-arch Docker image, release workflow).

🤖 Generated with [Claude Code](https://claude.com/claude-code)