### PR TITLE
Phase 5: multi-stage Dockerfile + .dockerignore (#5)

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,28 @@
+# Keep the build context small and the image reproducible.
+# The biggest offender is target/ (multi-GB of build artifacts).
+target/
+**/target/
+
+# Version control + CI metadata
+.git/
+.github/
+
+# Local Claude Code memory/instructions (never shipped)
+CLAUDE.md
+**/CLAUDE.md
+.claude/
+
+# Editor / OS cruft
+.vscode/
+.idea/
+.DS_Store
+
+# Local databases, logs, scratch
+*.db
+*.db-*
+*.sqlite
+*.log
+/tmp/
+
+# Docs and mockups aren't needed to build the binary
+docs/

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,56 @@
+# syntax=docker/dockerfile:1
+#
+# Multi-stage build for the `ruscker` binary.
+#
+#   docker build -t ruscker:latest .
+#   docker run --rm -p 8080:8080 \
+#     -v "$PWD/application.yml:/etc/ruscker/application.yml:ro" \
+#     ruscker:latest serve --config /etc/ruscker/application.yml --bind 0.0.0.0:8080
+#
+# To let Ruscker orchestrate containers (the --docker backend), also
+# mount the Docker socket:  -v /var/run/docker.sock:/var/run/docker.sock
+#
+# Health probes for orchestrators: GET /healthz (liveness) and
+# /readyz (readiness) — see docs/ROADMAP.md / CLAUDE.md.
+
+# ----------------------------------------------------------------------
+# Builder — compiles the release binary. The full (non-slim) rust
+# image ships curl + a C toolchain, which build.rs needs: it downloads
+# the standalone Tailwind CLI via curl and compiles the admin
+# stylesheet, and sqlx bundles SQLite (needs cc). The pinned tag
+# matches rust-toolchain.toml so the image's toolchain is used
+# directly (no extra rustup download).
+# ----------------------------------------------------------------------
+FROM rust:1.95-bookworm AS builder
+
+WORKDIR /build
+COPY . .
+
+# Build only the `ruscker` binary in release mode.
+RUN cargo build --release --bin ruscker \
+ && /build/target/release/ruscker --help >/dev/null
+
+# ----------------------------------------------------------------------
+# Runtime — a slim Debian with just the binary and the CA bundle.
+# debian-slim (glibc) matches the builder's dynamic linkage; sqlite is
+# statically bundled, so the only runtime dependency is
+# ca-certificates (TLS when pulling app images from registries).
+# ----------------------------------------------------------------------
+FROM debian:bookworm-slim AS runtime
+
+RUN apt-get update \
+ && apt-get install -y --no-install-recommends ca-certificates \
+ && rm -rf /var/lib/apt/lists/*
+
+# Run as an unprivileged user. Note: using the --docker backend
+# requires access to the Docker socket, which usually means adding
+# this user to the host's docker group (or running with that gid).
+RUN useradd --system --no-create-home --uid 10001 ruscker
+
+COPY --from=builder /build/target/release/ruscker /usr/local/bin/ruscker
+
+USER ruscker
+EXPOSE 8080
+
+ENTRYPOINT ["ruscker"]
+CMD ["--help"]


### PR DESCRIPTION
Part of Phase 5 distribution track (#5). First artifact: a container image for Ruscker — attractive for Kubernetes / modern-ops users and for trying it out fast (`docker run`).

## What

- **Multi-stage `Dockerfile`**:
  - **Builder** `rust:1.95-bookworm` (pinned to match `rust-toolchain.toml`; the non-slim image ships `curl` + a C toolchain, which `build.rs` needs to download the standalone Tailwind CLI and which `sqlx` needs to bundle SQLite). Builds `--release --bin ruscker`.
  - **Runtime** `debian:bookworm-slim` with just the binary + `ca-certificates` (the only runtime dep — TLS to registries; SQLite is statically bundled). Runs as an unprivileged user (uid 10001), `EXPOSE 8080`, `ENTRYPOINT ["ruscker"]`.
- **`.dockerignore`** keeps the build context small (excludes `target/`, `.git`, `docs/`, local `CLAUDE.md`/`.claude`, scratch DBs).
- Header comments document the config mount, the `/var/run/docker.sock` mount for the `--docker` backend, and the `/healthz` + `/readyz` probes.

## Usage

```sh
docker build -t ruscker:latest .
docker run --rm -p 8080:8080 \
  -v "$PWD/application.yml:/etc/ruscker/application.yml:ro" \
  ruscker:latest serve --config /etc/ruscker/application.yml --bind 0.0.0.0:8080
```

## Smoke (local, arm64)

Image **119 MB**. `docker run ... serve` then:
- `GET /healthz` → `200` (`{"status":"ok",...}`)
- `GET /readyz` → `200` (ready, no deps)
- `GET /` (landing) → `200`
- `GET /assets/styles.css` → `200 text/css` — **Tailwind compiled inside the container** (validates the `build.rs` curl-download path under Docker)
- container runs as **non-root** (uid 10001), no errors in logs ✓

## Notes / scope

- Arch-agnostic (`build.rs` resolves the Tailwind asset per arch; no arch-specific code). **Multi-arch buildx** (`linux/amd64,linux/arm64`) is deferred to the **release workflow** slice — building amd64 under QEMU here is too slow to smoke meaningfully, and it belongs in CI anyway.
- Next distribution slice: **cargo-deb + systemd unit** (the most ShinyProxy-familiar install), smoked by building/inspecting the `.deb` inside a Debian container.

🤖 Generated with [Claude Code](https://claude.com/claude-code)