### PR TITLE
Phase 5: Debian package (cargo-deb) + systemd unit (#5)

### DIFF
--- a/crates/ruscker-cli/Cargo.toml
+++ b/crates/ruscker-cli/Cargo.toml
@@ -10,6 +10,39 @@ description = "Ruscker command-line interface"
 name = "ruscker"
 path = "src/main.rs"
 
+# --- Debian/Ubuntu packaging (cargo-deb) -----------------------------
+# Build with: cargo deb -p ruscker-cli
+# Paths are relative to this manifest dir, hence the ../../ to reach the
+# repo-root `packaging/` directory.
+[package.metadata.deb]
+name = "ruscker"
+maintainer = "Ruscker contributors <ruscker@strategicprojects.github.io>"
+copyright = "2025-2026, Ruscker contributors. Licensed under Apache-2.0."
+section = "web"
+priority = "optional"
+# $auto pulls the binary's shared-lib deps (libc, …); ca-certificates
+# is needed for TLS when pulling private images from registries.
+depends = "$auto, ca-certificates"
+extended-description = """\
+Ruscker is a lightweight Rust alternative to ShinyProxy and Shiny Server \
+Free. It hosts and load-balances containerized interactive web apps \
+(R/Shiny, Streamlit, Dash, Voila) and stateless HTTP APIs behind a single \
+proxy with a custom landing page and an admin panel. Ships as a single \
+binary with no JVM."""
+assets = [
+    ["target/release/ruscker", "usr/bin/", "755"],
+    ["../../packaging/application.example.yml", "etc/ruscker/application.yml", "644"],
+    ["../../packaging/ruscker.env.example", "etc/ruscker/ruscker.env", "640"],
+    ["../../packaging/README.Debian", "usr/share/doc/ruscker/README.Debian", "644"],
+]
+conf-files = ["/etc/ruscker/application.yml", "/etc/ruscker/ruscker.env"]
+maintainer-scripts = "../../packaging/debian/"
+
+[package.metadata.deb.systemd-units]
+unit-scripts = "../../packaging/systemd"
+enable = true
+start = true
+
 [dependencies]
 ruscker-config = { path = "../ruscker-config" }
 ruscker-core = { path = "../ruscker-core" }

--- a/packaging/README.Debian
+++ b/packaging/README.Debian
@@ -1,0 +1,53 @@
+Ruscker for Debian/Ubuntu
+=========================
+
+Installed layout
+----------------
+  /usr/bin/ruscker                 the binary
+  /etc/ruscker/application.yml     your config (conffile)
+  /etc/ruscker/ruscker.env         secrets & env, root:ruscker 0640 (conffile)
+  /lib/systemd/system/ruscker.service   the service unit
+  /var/lib/ruscker/                writable state (SQLite db, etc.)
+
+The package creates a `ruscker` system user and enables + starts the
+service on install. By default it serves the public landing page,
+the admin panel, and the proxy on 0.0.0.0:8080.
+
+  systemctl status ruscker
+  curl http://localhost:8080/healthz
+
+First steps
+-----------
+1. Edit /etc/ruscker/application.yml to add your apps/APIs.
+2. Put secrets in /etc/ruscker/ruscker.env (admin token, master key,
+   registry password). Generate values with `openssl rand -hex 32`.
+3. `sudo systemctl restart ruscker`
+
+Validate a config before restarting:
+
+  ruscker validate /etc/ruscker/application.yml
+  ruscker validate --strict-compat /etc/ruscker/application.yml   # migrating from ShinyProxy
+
+Enabling the container backend (--docker)
+-----------------------------------------
+To let Ruscker spawn app containers, it must talk to the Docker daemon:
+
+1. Add `--docker` (and usually `--db /var/lib/ruscker/ruscker.db`) to
+   ExecStart. Use a drop-in so package upgrades don't clobber it:
+
+     sudo systemctl edit ruscker
+     # then add:
+     [Service]
+     ExecStart=
+     ExecStart=/usr/bin/ruscker serve --config /etc/ruscker/application.yml \
+       --bind 0.0.0.0:8080 --docker --db /var/lib/ruscker/ruscker.db
+
+2. Give the `ruscker` user access to the Docker socket by uncommenting
+   `SupplementaryGroups=docker` in the same drop-in. NOTE: membership in
+   the docker group is effectively root on the host — the same trade-off
+   ShinyProxy carries.
+
+3. `sudo systemctl daemon-reload && sudo systemctl restart ruscker`
+
+Health probes for load balancers / orchestrators: GET /healthz
+(liveness) and /readyz (readiness).

--- a/packaging/README.Debian
+++ b/packaging/README.Debian
@@ -16,6 +16,17 @@ the admin panel, and the proxy on 0.0.0.0:8080.
   systemctl status ruscker
   curl http://localhost:8080/healthz
 
+Admin token
+-----------
+On first install the package generates a strong, unique admin token
+and prints it ONCE in the install output (there is no default
+password). It is stored in /etc/ruscker/ruscker.env as
+RUSCKER_ADMIN_TOKEN. Log in at /admin/login with it. To see it again
+or rotate it:
+
+  sudo grep RUSCKER_ADMIN_TOKEN /etc/ruscker/ruscker.env
+  # to rotate: edit the value, then  sudo systemctl restart ruscker
+
 First steps
 -----------
 1. Edit /etc/ruscker/application.yml to add your apps/APIs.

--- a/packaging/application.example.yml
+++ b/packaging/application.example.yml
@@ -1,0 +1,36 @@
+# Ruscker configuration — installed at /etc/ruscker/application.yml.
+#
+# This is a minimal, working starting point. Edit it for your apps,
+# then `systemctl restart ruscker`. Full schema reference:
+# https://github.com/StrategicProjects/ruscker/blob/main/docs/YAML_SCHEMA.md
+#
+# NEVER put secrets here. Use ${ENV_VAR} interpolation and set the
+# variables in /etc/ruscker/ruscker.env (read by the systemd unit).
+
+proxy:
+  title: Ruscker
+  # The admin panel is gated by RUSCKER_ADMIN_TOKEN (set it in
+  # /etc/ruscker/ruscker.env). With no token, admin routes return 503
+  # and only the public landing + proxy are served.
+  authentication: none
+
+  specs:
+    # A simple external-link card so the landing page isn't empty out
+    # of the box. Replace with your own apps / APIs.
+    - id: welcome
+      display-name: "Welcome to Ruscker"
+      description: "Edit /etc/ruscker/application.yml to add your apps."
+      template-properties:
+        type: package
+        state: active
+        link: https://github.com/StrategicProjects/ruscker
+
+    # Example containerized app (commented). Requires the --docker
+    # backend — add `--docker` to ExecStart in the systemd unit and
+    # give the `ruscker` user Docker access (see README.Debian).
+    #
+    # - id: my_shiny
+    #   display-name: "My Shiny App"
+    #   container-image: org/my-shiny-app:latest
+    #   type: shiny
+    #   seats-per-container: 10

--- a/packaging/debian/postinst
+++ b/packaging/debian/postinst
@@ -22,9 +22,36 @@ case "$1" in
         chmod 750 /var/lib/ruscker
 
         # The secrets file must not be world-readable.
-        if [ -f /etc/ruscker/ruscker.env ]; then
-            chown root:ruscker /etc/ruscker/ruscker.env || true
-            chmod 640 /etc/ruscker/ruscker.env || true
+        ENVF=/etc/ruscker/ruscker.env
+        if [ -f "$ENVF" ]; then
+            chown root:ruscker "$ENVF" || true
+            chmod 640 "$ENVF" || true
+        fi
+
+        # On FIRST install only ("$2" empty), if no admin token is set
+        # yet, generate a strong random one so the admin panel works out
+        # of the box — WITHOUT shipping a guessable default credential.
+        # We never regenerate on upgrades, and never overwrite a token
+        # the operator already set. Uses /dev/urandom + od (coreutils),
+        # so there's no openssl dependency.
+        if [ -z "${2:-}" ] && [ -f "$ENVF" ] && ! grep -qE '^RUSCKER_ADMIN_TOKEN=.' "$ENVF"; then
+            TOKEN=$(head -c 32 /dev/urandom | od -An -tx1 | tr -d ' \n')
+            if grep -qE '^#*RUSCKER_ADMIN_TOKEN=' "$ENVF"; then
+                sed -i "s|^#*RUSCKER_ADMIN_TOKEN=.*|RUSCKER_ADMIN_TOKEN=${TOKEN}|" "$ENVF"
+            else
+                printf '\nRUSCKER_ADMIN_TOKEN=%s\n' "$TOKEN" >> "$ENVF"
+            fi
+            chown root:ruscker "$ENVF" || true
+            chmod 640 "$ENVF" || true
+            echo ""
+            echo "  +------------------------------------------------------------------+"
+            echo "  | Ruscker admin token (generated now, shown ONCE):                 |"
+            echo "  |   $TOKEN"
+            echo "  | Stored in $ENVF (root:ruscker 0640).         |"
+            echo "  | Log in at  /admin/login  with this token.                        |"
+            echo "  | Rotate it by editing that file, then: systemctl restart ruscker  |"
+            echo "  +------------------------------------------------------------------+"
+            echo ""
         fi
         ;;
 esac

--- a/packaging/debian/postinst
+++ b/packaging/debian/postinst
@@ -1,0 +1,34 @@
+#!/bin/sh
+# postinst — create the service account and lock down the secrets file.
+# cargo-deb injects the systemd enable/start logic at the marker below.
+set -e
+
+case "$1" in
+    configure)
+        # System group + user the unit runs as. No login, no home dir
+        # of its own beyond the state directory.
+        if ! getent group ruscker >/dev/null; then
+            addgroup --system ruscker
+        fi
+        # Create the state directory before adduser so it doesn't warn
+        # about the home dir (/var/lib/ruscker) not existing yet.
+        mkdir -p /var/lib/ruscker
+        if ! getent passwd ruscker >/dev/null; then
+            adduser --system --ingroup ruscker --no-create-home \
+                --home /var/lib/ruscker --shell /usr/sbin/nologin \
+                --gecos "Ruscker service" ruscker
+        fi
+        chown ruscker:ruscker /var/lib/ruscker
+        chmod 750 /var/lib/ruscker
+
+        # The secrets file must not be world-readable.
+        if [ -f /etc/ruscker/ruscker.env ]; then
+            chown root:ruscker /etc/ruscker/ruscker.env || true
+            chmod 640 /etc/ruscker/ruscker.env || true
+        fi
+        ;;
+esac
+
+#DEBHELPER#
+
+exit 0

--- a/packaging/debian/postrm
+++ b/packaging/debian/postrm
@@ -1,0 +1,14 @@
+#!/bin/sh
+# postrm — cargo-deb injects the systemd cleanup at the marker below. On
+# purge we also drop the state directory. The `ruscker` system user is
+# intentionally left behind (Debian policy discourages removing system
+# users), and config files are conf-files that dpkg removes on purge.
+set -e
+
+#DEBHELPER#
+
+if [ "$1" = "purge" ]; then
+    rm -rf /var/lib/ruscker
+fi
+
+exit 0

--- a/packaging/debian/prerm
+++ b/packaging/debian/prerm
@@ -1,0 +1,7 @@
+#!/bin/sh
+# prerm — cargo-deb injects the systemd stop/disable logic at the marker.
+set -e
+
+#DEBHELPER#
+
+exit 0

--- a/packaging/ruscker.env.example
+++ b/packaging/ruscker.env.example
@@ -1,0 +1,28 @@
+# Ruscker secrets & environment — installed at /etc/ruscker/ruscker.env
+# and read by the systemd unit (EnvironmentFile). Keep this file
+# readable only by root:ruscker (the postinst sets 0640).
+#
+# Uncomment and fill the values you need, then `systemctl restart ruscker`.
+
+# Admin panel token. Until this is set, /admin/* returns 503 and only
+# the public landing + proxy are served. Generate a strong value, e.g.:
+#   openssl rand -hex 32
+#RUSCKER_ADMIN_TOKEN=
+
+# Master key for the encrypted credentials store (AES-256-GCM).
+# Required only if you use the admin credentials store. Hex (64 chars)
+# or base64 (44 chars):  openssl rand -hex 32
+#RUSCKER_MASTER_KEY=
+
+# Key used to sign sticky-session cookies. Auto-generated per process
+# if unset — set it to keep sessions valid across restarts / replicas:
+#   openssl rand -hex 32
+#RUSCKER_COOKIE_KEY=
+
+# Credentials for pulling private container images, referenced from
+# application.yml as ${DOCKER_REGISTRY_PASSWORD}:
+#DOCKER_REGISTRY_PASSWORD=
+
+# Log verbosity / format (see `ruscker serve --help`).
+#RUST_LOG=info
+#RUSCKER_LOG_FORMAT=json

--- a/packaging/ruscker.env.example
+++ b/packaging/ruscker.env.example
@@ -4,8 +4,10 @@
 #
 # Uncomment and fill the values you need, then `systemctl restart ruscker`.
 
-# Admin panel token. Until this is set, /admin/* returns 503 and only
-# the public landing + proxy are served. Generate a strong value, e.g.:
+# Admin panel token. On first .deb install a strong random value is
+# generated here automatically and printed once (no default password).
+# Until a token is set, /admin/* returns 503 and only the public
+# landing + proxy are served. To set/rotate manually:
 #   openssl rand -hex 32
 #RUSCKER_ADMIN_TOKEN=
 

--- a/packaging/systemd/ruscker.service
+++ b/packaging/systemd/ruscker.service
@@ -1,0 +1,48 @@
+[Unit]
+Description=Ruscker — container portal, load balancer & admin
+Documentation=https://github.com/StrategicProjects/ruscker
+# Ruscker orchestrates containers via the Docker daemon, so prefer to
+# start after it. Both are soft deps: Ruscker still serves the landing
+# page and admin without a backend.
+After=network-online.target docker.service
+Wants=network-online.target
+
+[Service]
+Type=exec
+User=ruscker
+Group=ruscker
+# Secrets live here, NOT in application.yml: RUSCKER_ADMIN_TOKEN,
+# RUSCKER_MASTER_KEY, RUSCKER_COOKIE_KEY, DOCKER_REGISTRY_PASSWORD, …
+# The leading `-` makes systemd tolerate the file being absent/empty.
+EnvironmentFile=-/etc/ruscker/ruscker.env
+# Default command: landing + admin + proxy. Add `--docker` to enable
+# the container backend (see /usr/share/doc/ruscker/README.Debian),
+# and `--db /var/lib/ruscker/ruscker.db` to persist the admin catalog.
+ExecStart=/usr/bin/ruscker serve --config /etc/ruscker/application.yml --bind 0.0.0.0:8080
+Restart=on-failure
+RestartSec=5s
+
+# Writable state (SQLite db, etc.) at /var/lib/ruscker.
+StateDirectory=ruscker
+WorkingDirectory=/var/lib/ruscker
+
+# --- Hardening -------------------------------------------------------
+# Ruscker needs very little of the host. If you enable the --docker
+# backend, the `ruscker` user also needs access to the Docker socket;
+# uncomment SupplementaryGroups below (note: docker group ≈ root).
+#SupplementaryGroups=docker
+NoNewPrivileges=true
+ProtectSystem=strict
+ProtectHome=true
+PrivateTmp=true
+ReadWritePaths=/var/lib/ruscker
+ProtectControlGroups=true
+ProtectKernelTunables=true
+ProtectKernelModules=true
+RestrictSUIDSGID=true
+RestrictNamespaces=true
+LockPersonality=true
+MemoryDenyWriteExecute=true
+
+[Install]
+WantedBy=multi-user.target


### PR DESCRIPTION
Part of Phase 5 distribution track (#5). Second artifact: a **.deb** for Debian/Ubuntu — the install that feels most like a ShinyProxy migration (`apt install` + `systemctl` on the Docker host, no JVM).

## What

- **`[package.metadata.deb]`** in `crates/ruscker-cli/Cargo.toml`: package `ruscker`, `$auto` + `ca-certificates` deps, assets for the binary + example config + env template + `README.Debian`. **`systemd-units`** enables + starts the service on install.
- **`packaging/systemd/ruscker.service`** — hardened unit: `Type=exec`, dedicated `ruscker` user, `EnvironmentFile` for secrets, `ProtectSystem=strict`, `StateDirectory=ruscker`, `NoNewPrivileges`, `PrivateTmp`, etc. Defaults to landing + admin + proxy on `0.0.0.0:8080`; `README.Debian` documents enabling `--docker` (+ docker group) via a `systemctl edit` drop-in so upgrades don't clobber it.
- **`packaging/application.example.yml`** + **`ruscker.env.example`** → `/etc/ruscker/` (conf-files). Secrets live in the env file, never the YAML.
- **`packaging/debian/{postinst,prerm,postrm}`** — create the `ruscker` system user + state dir, lock the secrets file to `root:ruscker 0640`; the `#DEBHELPER#` marker hosts cargo-deb's systemd logic; purge removes `/var/lib/ruscker`.

## Smoke (inside a `rust:1.95-bookworm` Debian container — Docker as the Linux env)

`cargo deb -p ruscker-cli` → `ruscker_0.1.0-1_<arch>.deb` (4 MB), then:
- `dpkg-deb -I`: `Depends: ca-certificates, libc6 (>= 2.34)`, section web.
- `dpkg-deb -c`: correct layout — `/usr/bin/ruscker`, `/etc/ruscker/{application.yml,ruscker.env}`, `/lib/systemd/system/ruscker.service`, doc + copyright.
- **`sh -n` on all three maintainer scripts → SYNTAX OK** (caught + fixed a `#DEBHELPER#`-in-a-comment bug that cargo-deb was substituting into the script body).
- **`dpkg -i` real install**: creates the `ruscker` user/group, places files, chowns `ruscker.env` → `root:ruscker 0640`, binary reports `ruscker 0.1.0`. ✓

## Notes

- The .deb built here is the container's arch; CI will build per-arch (amd64/arm64) in the **release workflow** slice.
- The `postinst` mkdir-before-adduser reorder is a cosmetic post-smoke tweak (silences an `adduser` home-dir warning); the install flow itself was validated by the `dpkg -i` run above.

🤖 Generated with [Claude Code](https://claude.com/claude-code)