### PR TITLE
Phase 5: language + theme picker in the admin panel (#5)

### DIFF
--- a/crates/ruscker-admin/templates/admin/_layout.html
+++ b/crates/ruscker-admin/templates/admin/_layout.html
@@ -121,5 +121,36 @@ window.ruscker.bgMode = (value) =>
   {% block content %}{% endblock %}
 </main>
 
+{# Preference footer — same language + theme options as the public
+   portal. Posts to the shared /__set/* endpoints, which set the
+   cookie and redirect back here (Referer), so the admin re-renders
+   in the chosen locale/theme. #}
+<footer class="mt-auto border-t border-[color:var(--border)] py-4 px-6 text-xs text-[color:var(--text-muted)] flex flex-wrap items-center gap-6">
+  <div class="flex items-center gap-2">
+    <span>{{ self.t("footer-language") }}:</span>
+    <form method="post" action="/__set/locale" class="contents">
+      {% for loc in locales_all %}
+        <button type="submit" name="locale" value="{{ loc.code() }}"
+                class="px-2 py-0.5 rounded {% if *loc == locale %}bg-[color:var(--text)] text-[color:var(--bg)] font-medium{% else %}hover:bg-[color:var(--border)]{% endif %}"
+                aria-current="{% if *loc == locale %}true{% else %}false{% endif %}">
+          {{ loc.native_name() }}
+        </button>
+      {% endfor %}
+    </form>
+  </div>
+
+  <div class="flex items-center gap-2">
+    <span>{{ self.t("footer-theme") }}:</span>
+    <form method="post" action="/__set/theme" class="contents">
+      <button type="submit" name="theme" value="light"
+              class="px-2 py-0.5 rounded {% if theme.is_light() %}bg-[color:var(--text)] text-[color:var(--bg)] font-medium{% else %}hover:bg-[color:var(--border)]{% endif %}">{{ self.t("theme-light") }}</button>
+      <button type="submit" name="theme" value="dark"
+              class="px-2 py-0.5 rounded {% if theme.is_dark() %}bg-[color:var(--text)] text-[color:var(--bg)] font-medium{% else %}hover:bg-[color:var(--border)]{% endif %}">{{ self.t("theme-dark") }}</button>
+      <button type="submit" name="theme" value="auto"
+              class="px-2 py-0.5 rounded {% if theme.is_auto() %}bg-[color:var(--text)] text-[color:var(--bg)] font-medium{% else %}hover:bg-[color:var(--border)]{% endif %}">{{ self.t("theme-auto") }}</button>
+    </form>
+  </div>
+</footer>
+
 </body>
 </html>


### PR DESCRIPTION
The public landing has a locale/theme picker in its footer, but the **authenticated admin pages had no language switcher** (reported in production at SEPE). This adds the same picker — same 4 locales (pt-BR / en-US / es-ES / fr-FR) + light/dark/auto theme — to the admin layout footer.

## What

- A footer in `templates/admin/_layout.html` mirroring the landing footer: a `/__set/locale` form (one button per `locales_all`, current one highlighted) and a `/__set/theme` form.

## Why it's template-only

Every admin template struct already carries `locales_all`, `locale`, `theme` and `t()` (the Phase 4 dashboard already localizes via the shared Fluent bundles). The picker posts to the existing `/__set/{locale,theme}` endpoints, which set the cookie and redirect back via `Referer` — so the admin page re-renders in the chosen locale. The login page already had its own picker; this covers the rest of the admin.

## Smoke

- `cargo build -p ruscker-admin` — Askama's compile-time check confirms every admin template extending the layout exposes the referenced fields.
- Ran `serve` with a token, logged in, `GET /admin/dashboard` → picker present with all four languages (English / Español / Français / Português) + theme picker.
- `POST /__set/locale locale=en-US` then re-fetched the dashboard → nav labels flipped from Portuguese (Painel/Aplicativos) to English (Dashboard/Apps). End-to-end switch confirmed.
- `cargo test -p ruscker-admin`: 133 + integration suites green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)