### PR TITLE
Landing editor: SEO + social meta tags (part of #54)

### DIFF
--- a/crates/ruscker-admin/assets/i18n/en/landing.ftl
+++ b/crates/ruscker-admin/assets/i18n/en/landing.ftl
@@ -190,8 +190,17 @@ admin-landing-intro-fr = French
 admin-landing-preview = Portal preview
 admin-landing-preview-help = Approximate look of the header and intro. Cards and filters appear as on the real landing.
 admin-landing-preview-empty = (no intro text)
+admin-landing-seo = SEO & sharing
+admin-landing-seo-title = Page title (SEO)
+admin-landing-seo-title-placeholder = Default: portal title
+admin-landing-seo-title-help = Sets the browser tab title and og:title. Empty uses the portal's default title.
+admin-landing-seo-description = Description (meta description)
+admin-landing-seo-description-placeholder = Short summary for search engines and social cards
+admin-landing-seo-description-help = Used in the meta description and og:description. Empty falls back to the intro text.
+admin-landing-og-image = Share image (og:image)
+admin-landing-og-image-help = URL or path (e.g. /assets/img/og.png) shown when the page is shared on social media.
 admin-landing-future-title = Coming soon
-admin-landing-future-help = Logo editor, section reordering, custom HTML blocks, SEO/analytics and meta tags. For now those fields follow the YAML.
+admin-landing-future-help = Logo editor, section reordering, custom HTML blocks and analytics. For now those fields follow the YAML.
 
 # Admin audit log
 admin-audit-title = Audit log

--- a/crates/ruscker-admin/assets/i18n/es/landing.ftl
+++ b/crates/ruscker-admin/assets/i18n/es/landing.ftl
@@ -190,8 +190,17 @@ admin-landing-intro-fr = Francés
 admin-landing-preview = Vista previa
 admin-landing-preview-help = Aproximación visual del encabezado y la introducción. Cards y filtros como en la landing real.
 admin-landing-preview-empty = (sin texto de introducción)
+admin-landing-seo = SEO y compartir
+admin-landing-seo-title = Título de la página (SEO)
+admin-landing-seo-title-placeholder = Predeterminado: título del portal
+admin-landing-seo-title-help = Define el título de la pestaña y el og:title. Vacío usa el título por defecto del portal.
+admin-landing-seo-description = Descripción (meta description)
+admin-landing-seo-description-placeholder = Resumen para buscadores y redes sociales
+admin-landing-seo-description-help = Se usa en la meta description y el og:description. Vacío usa el texto de introducción.
+admin-landing-og-image = Imagen para compartir (og:image)
+admin-landing-og-image-help = URL o ruta (p. ej. /assets/img/og.png) que se muestra al compartir en redes sociales.
 admin-landing-future-title = Próximamente
-admin-landing-future-help = Editor de logos, reordenación de secciones, bloques HTML custom, SEO/analytics y meta tags. Por ahora siguen el YAML.
+admin-landing-future-help = Editor de logos, reordenación de secciones, bloques HTML custom y analytics. Por ahora siguen el YAML.
 
 # Admin audit log
 admin-audit-title = Auditoría

--- a/crates/ruscker-admin/assets/i18n/fr/landing.ftl
+++ b/crates/ruscker-admin/assets/i18n/fr/landing.ftl
@@ -190,8 +190,17 @@ admin-landing-intro-fr = Français
 admin-landing-preview = Aperçu du portail
 admin-landing-preview-help = Approximation visuelle de l'en-tête et de l'intro. Les cartes et filtres ressemblent au portail réel.
 admin-landing-preview-empty = (pas de texte d'introduction)
+admin-landing-seo = SEO et partage
+admin-landing-seo-title = Titre de la page (SEO)
+admin-landing-seo-title-placeholder = Par défaut : titre du portail
+admin-landing-seo-title-help = Définit le titre de l'onglet et og:title. Vide utilise le titre par défaut du portail.
+admin-landing-seo-description = Description (meta description)
+admin-landing-seo-description-placeholder = Résumé pour les moteurs de recherche et les réseaux sociaux
+admin-landing-seo-description-help = Utilisé dans la meta description et og:description. Vide reprend le texte d'introduction.
+admin-landing-og-image = Image de partage (og:image)
+admin-landing-og-image-help = URL ou chemin (ex. /assets/img/og.png) affiché lors du partage sur les réseaux sociaux.
 admin-landing-future-title = Bientôt
-admin-landing-future-help = Éditeur de logos, réorganisation des sections, blocs HTML personnalisés, SEO/analytics et meta tags. Pour l'instant ces champs suivent le YAML.
+admin-landing-future-help = Éditeur de logos, réorganisation des sections, blocs HTML personnalisés et analytics. Pour l'instant ces champs suivent le YAML.
 
 # Admin audit log
 admin-audit-title = Journal d'audit

--- a/crates/ruscker-admin/assets/i18n/pt/landing.ftl
+++ b/crates/ruscker-admin/assets/i18n/pt/landing.ftl
@@ -194,8 +194,17 @@ admin-landing-intro-fr = Francês
 admin-landing-preview = Prévia do portal
 admin-landing-preview-help = Aproximação visual do cabeçalho e texto. Cards e filtros ficam como na landing real.
 admin-landing-preview-empty = (sem texto introdutório)
+admin-landing-seo = SEO e compartilhamento
+admin-landing-seo-title = Título da página (SEO)
+admin-landing-seo-title-placeholder = Padrão: título do portal
+admin-landing-seo-title-help = Define o título da aba e o og:title. Vazio usa o título padrão do portal.
+admin-landing-seo-description = Descrição (meta description)
+admin-landing-seo-description-placeholder = Resumo do portal para buscadores e redes sociais
+admin-landing-seo-description-help = Usada na meta description e no og:description. Vazio usa o texto de introdução.
+admin-landing-og-image = Imagem de compartilhamento (og:image)
+admin-landing-og-image-help = URL ou caminho (ex.: /assets/img/og.png) mostrado ao compartilhar em redes sociais.
 admin-landing-future-title = Em breve
-admin-landing-future-help = Editor de logos, reordenação de seções, blocos HTML customizados, SEO/analytics e meta tags. Por enquanto, esses campos seguem o YAML.
+admin-landing-future-help = Editor de logos, reordenação de seções, blocos HTML customizados e analytics. Por enquanto, esses campos seguem o YAML.
 
 # Admin audit log
 admin-audit-title = Auditoria

--- a/crates/ruscker-admin/migrations/0003_landing_seo.sql
+++ b/crates/ruscker-admin/migrations/0003_landing_seo.sql
@@ -1,0 +1,7 @@
+-- SEO / social-share meta tags for the public landing.
+-- Added to the landing_customization singleton (id = 1). All optional;
+-- NULL means "fall back" (title -> proxy.title, description -> intro,
+-- image -> omitted).
+ALTER TABLE landing_customization ADD COLUMN seo_title       TEXT;
+ALTER TABLE landing_customization ADD COLUMN seo_description TEXT;
+ALTER TABLE landing_customization ADD COLUMN og_image        TEXT;

--- a/crates/ruscker-admin/src/db/export.rs
+++ b/crates/ruscker-admin/src/db/export.rs
@@ -9,7 +9,7 @@
 //! `unchanged = total_specs` and `updated = 0`.
 
 use anyhow::{Context, Result};
-use ruscker_config::{Config, LandingCustomization, Logging, Proxy, Server, Spec};
+use ruscker_config::{Config, Logging, Proxy, Server, Spec};
 use sqlx::SqlitePool;
 
 /// Rebuild a full [`Config`] from everything currently in the
@@ -30,25 +30,10 @@ pub async fn reconstruct_config(pool: &SqlitePool) -> Result<Config> {
         specs.push(s);
     }
 
-    // 2. Landing customization singleton.
-    let lc_row: Option<(Option<String>, Option<String>, Option<String>, String)> =
-        sqlx::query_as(
-            "SELECT header_bg, header_fg, intro, intro_locales_json
-               FROM landing_customization WHERE id = 1",
-        )
-        .fetch_optional(pool)
-        .await
-        .context("load landing_customization")?;
-    let landing_customization = match lc_row {
-        Some((bg, fg, intro, locales_json)) => LandingCustomization {
-            header_bg: bg,
-            header_fg: fg,
-            intro,
-            intro_locales: serde_json::from_str(&locales_json)
-                .context("parse intro_locales_json")?,
-        },
-        None => LandingCustomization::default(),
-    };
+    // 2. Landing customization singleton — reuse the repository
+    //    loader so every field (incl. SEO) round-trips without
+    //    duplicating the column list here.
+    let landing_customization = super::landing::fetch(pool).await?;
 
     // 3. config_meta sections — start with default structs and let
     //    serde_json overlay whatever the import persisted. Falling

--- a/crates/ruscker-admin/src/db/landing.rs
+++ b/crates/ruscker-admin/src/db/landing.rs
@@ -15,17 +15,26 @@ use sqlx::SqlitePool;
 /// yet (which shouldn't normally happen — migration 0001 inserts
 /// it — but defensive code keeps tests with a fresh DB happy).
 pub async fn fetch(pool: &SqlitePool) -> Result<LandingCustomization> {
-    let row: Option<(Option<String>, Option<String>, Option<String>, String)> =
-        sqlx::query_as(
-            "SELECT header_bg, header_fg, intro, intro_locales_json
-               FROM landing_customization WHERE id = 1",
-        )
-        .fetch_optional(pool)
-        .await
-        .context("load landing_customization")?;
+    type Row = (
+        Option<String>, // header_bg
+        Option<String>, // header_fg
+        Option<String>, // intro
+        String,         // intro_locales_json
+        Option<String>, // seo_title
+        Option<String>, // seo_description
+        Option<String>, // og_image
+    );
+    let row: Option<Row> = sqlx::query_as(
+        "SELECT header_bg, header_fg, intro, intro_locales_json,
+                seo_title, seo_description, og_image
+           FROM landing_customization WHERE id = 1",
+    )
+    .fetch_optional(pool)
+    .await
+    .context("load landing_customization")?;
     match row {
         None => Ok(LandingCustomization::default()),
-        Some((bg, fg, intro, locales_json)) => {
+        Some((bg, fg, intro, locales_json, seo_title, seo_description, og_image)) => {
             let intro_locales =
                 serde_json::from_str(&locales_json).context("parse intro_locales_json")?;
             Ok(LandingCustomization {
@@ -33,6 +42,9 @@ pub async fn fetch(pool: &SqlitePool) -> Result<LandingCustomization> {
                 header_fg: fg,
                 intro,
                 intro_locales,
+                seo_title,
+                seo_description,
+                og_image,
             })
         }
     }
@@ -56,13 +68,17 @@ pub async fn update(
     sqlx::query(
         "UPDATE landing_customization
             SET header_bg = ?, header_fg = ?, intro = ?,
-                intro_locales_json = ?, updated_at = ?
+                intro_locales_json = ?, seo_title = ?, seo_description = ?,
+                og_image = ?, updated_at = ?
           WHERE id = 1",
     )
     .bind(none_if_empty(&lc.header_bg))
     .bind(none_if_empty(&lc.header_fg))
     .bind(none_if_empty(&lc.intro))
     .bind(&intro_locales_json)
+    .bind(none_if_empty(&lc.seo_title))
+    .bind(none_if_empty(&lc.seo_description))
+    .bind(none_if_empty(&lc.og_image))
     .bind(now)
     .execute(&mut *tx)
     .await
@@ -128,6 +144,23 @@ mod tests {
                 .await
                 .unwrap();
         assert_eq!(n, 1);
+    }
+
+    #[tokio::test]
+    async fn seo_fields_roundtrip() {
+        let pool = open_memory().await.unwrap();
+        let mut lc = LandingCustomization::default();
+        lc.seo_title = Some("Portal SEPE".into());
+        lc.seo_description = Some("Monitoramento estratégico do estado".into());
+        lc.og_image = Some("/assets/img/og.png".into());
+        update(&pool, &lc, Some("admin")).await.unwrap();
+        let got = fetch(&pool).await.unwrap();
+        assert_eq!(got.seo_title.as_deref(), Some("Portal SEPE"));
+        assert_eq!(
+            got.seo_description.as_deref(),
+            Some("Monitoramento estratégico do estado")
+        );
+        assert_eq!(got.og_image.as_deref(), Some("/assets/img/og.png"));
     }
 
     #[tokio::test]

--- a/crates/ruscker-admin/src/routes/admin/landing.rs
+++ b/crates/ruscker-admin/src/routes/admin/landing.rs
@@ -75,6 +75,9 @@ pub struct LandingForm {
     pub intro_en: String,
     pub intro_es: String,
     pub intro_fr: String,
+    pub seo_title: String,
+    pub seo_description: String,
+    pub og_image: String,
 }
 
 impl LandingForm {
@@ -88,6 +91,9 @@ impl LandingForm {
             intro_en: g("en"),
             intro_es: g("es"),
             intro_fr: g("fr"),
+            seo_title: lc.seo_title.clone().unwrap_or_default(),
+            seo_description: lc.seo_description.clone().unwrap_or_default(),
+            og_image: lc.og_image.clone().unwrap_or_default(),
         }
     }
 
@@ -109,6 +115,9 @@ impl LandingForm {
             header_fg: empty_to_none(self.header_fg),
             intro: empty_to_none(self.intro),
             intro_locales,
+            seo_title: empty_to_none(self.seo_title),
+            seo_description: empty_to_none(self.seo_description),
+            og_image: empty_to_none(self.og_image),
         }
     }
 }

--- a/crates/ruscker-admin/src/routes/landing.rs
+++ b/crates/ruscker-admin/src/routes/landing.rs
@@ -45,6 +45,15 @@ struct LandingPage<'a> {
     /// the operator set a custom background color. Empty string ⇒
     /// no override.
     header_style: String,
+    /// Effective page title — `landing-customization.seo-title` when
+    /// set, otherwise the localized `landing-title`. Drives both the
+    /// `<title>` tag and `og:title`.
+    page_title: String,
+    /// `<meta name="description">` / `og:description` — `seo-description`
+    /// when set, otherwise the resolved intro. Empty ⇒ tags omitted.
+    seo_description: String,
+    /// `og:image` URL, or empty ⇒ tag omitted.
+    og_image: String,
 }
 
 impl<'a> LandingPage<'a> {
@@ -105,6 +114,19 @@ async fn index(State(state): State<AppState>, loc: Locale, theme: Theme) -> Resp
         .or_else(|| lc.intro.clone())
         .unwrap_or_default();
 
+    // SEO: explicit overrides win; otherwise sensible fallbacks
+    // (title → localized `landing-title`, description → intro).
+    let not_blank = |s: &Option<String>| {
+        s.as_deref()
+            .map(str::trim)
+            .filter(|t| !t.is_empty())
+            .map(str::to_string)
+    };
+    let page_title =
+        not_blank(&lc.seo_title).unwrap_or_else(|| state.locales.t(loc, "landing-title", None));
+    let seo_description = not_blank(&lc.seo_description).unwrap_or_else(|| intro.clone());
+    let og_image = not_blank(&lc.og_image).unwrap_or_default();
+
     let page = LandingPage {
         locale: loc,
         theme,
@@ -116,6 +138,9 @@ async fn index(State(state): State<AppState>, loc: Locale, theme: Theme) -> Resp
         counts,
         intro,
         header_style,
+        page_title,
+        seo_description,
+        og_image,
     };
     render(&page)
 }

--- a/crates/ruscker-admin/templates/_layout.html
+++ b/crates/ruscker-admin/templates/_layout.html
@@ -6,6 +6,7 @@
 <meta name="theme-color" content="#0f6e56">
 <meta name="application-name" content="Ruscker">
 <title>{% block title %}{{ self.t("landing-title") }}{% endblock %}</title>
+{% block head_extra %}{% endblock %}
 
 <link rel="icon" type="image/svg+xml" href="/favicon.svg">
 <link rel="mask-icon" href="/assets/brand/mark.svg" color="#0f6e56">

--- a/crates/ruscker-admin/templates/admin/landing.html
+++ b/crates/ruscker-admin/templates/admin/landing.html
@@ -172,6 +172,29 @@
         </div>
       </div>
 
+      <div class="spec-form-section-title">{{ self.t("admin-landing-seo") }}</div>
+      <div class="spec-form-field">
+        <label class="spec-form-label">{{ self.t("admin-landing-seo-title") }}</label>
+        <input type="text" name="seo_title" x-model="form.seo_title"
+               placeholder="{{ self.t("admin-landing-seo-title-placeholder") }}"
+               class="spec-form-input" value="{{ form.seo_title }}">
+        <div class="spec-form-help">{{ self.t("admin-landing-seo-title-help") }}</div>
+      </div>
+      <div class="spec-form-field">
+        <label class="spec-form-label">{{ self.t("admin-landing-seo-description") }}</label>
+        <textarea name="seo_description" rows="2" x-model="form.seo_description"
+                  placeholder="{{ self.t("admin-landing-seo-description-placeholder") }}"
+                  class="spec-form-input">{{ form.seo_description }}</textarea>
+        <div class="spec-form-help">{{ self.t("admin-landing-seo-description-help") }}</div>
+      </div>
+      <div class="spec-form-field">
+        <label class="spec-form-label">{{ self.t("admin-landing-og-image") }}</label>
+        <input type="text" name="og_image" x-model="form.og_image"
+               placeholder="/assets/img/og.png"
+               class="spec-form-input" value="{{ form.og_image }}">
+        <div class="spec-form-help">{{ self.t("admin-landing-og-image-help") }}</div>
+      </div>
+
       <div class="info-box">
         <i class="ti ti-info-circle" aria-hidden="true"></i>
         <div>

--- a/crates/ruscker-admin/templates/landing.html
+++ b/crates/ruscker-admin/templates/landing.html
@@ -1,5 +1,16 @@
 {% extends "_layout.html" %}
 
+{% block title %}{{ page_title }}{% endblock %}
+
+{% block head_extra %}
+{% if !seo_description.is_empty() %}<meta name="description" content="{{ seo_description }}">{% endif %}
+<meta property="og:type" content="website">
+<meta property="og:title" content="{{ page_title }}">
+{% if !seo_description.is_empty() %}<meta property="og:description" content="{{ seo_description }}">{% endif %}
+{% if !og_image.is_empty() %}<meta property="og:image" content="{{ og_image }}">{% endif %}
+<meta name="twitter:card" content="{% if !og_image.is_empty() %}summary_large_image{% else %}summary{% endif %}">
+{% endblock %}
+
 {% block content %}
 
 <header class="border-b border-[color:var(--border)]"

--- a/crates/ruscker-config/src/schema.rs
+++ b/crates/ruscker-config/src/schema.rs
@@ -246,6 +246,21 @@ pub struct LandingCustomization {
     /// ```
     #[serde(default, rename = "intro-locales")]
     pub intro_locales: std::collections::HashMap<String, String>,
+
+    /// SEO / social-share meta tags for the public landing `<head>`.
+    /// Optional page-title override; falls back to `proxy.title`.
+    #[serde(default, rename = "seo-title")]
+    pub seo_title: Option<String>,
+
+    /// `<meta name="description">` and `og:description`. When empty,
+    /// the rendered head falls back to the resolved intro text.
+    #[serde(default, rename = "seo-description")]
+    pub seo_description: Option<String>,
+
+    /// `og:image` / social-share image — a path (`/assets/img/og.png`)
+    /// or an absolute URL. Omitted from the head when unset.
+    #[serde(default, rename = "og-image")]
+    pub og_image: Option<String>,
 }
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
@@ -925,6 +940,22 @@ proxy:
         assert_eq!(config.proxy.title, "Test");
         assert_eq!(config.proxy.specs.len(), 1);
         assert_eq!(config.proxy.specs[0].id, "hello");
+    }
+
+    #[test]
+    fn parses_landing_seo_fields() {
+        let yaml = r#"
+proxy:
+  landing-customization:
+    seo-title: My Portal
+    seo-description: A short summary
+    og-image: /assets/img/og.png
+"#;
+        let config: Config = serde_yaml_ng::from_str(yaml).unwrap();
+        let lc = &config.proxy.landing_customization;
+        assert_eq!(lc.seo_title.as_deref(), Some("My Portal"));
+        assert_eq!(lc.seo_description.as_deref(), Some("A short summary"));
+        assert_eq!(lc.og_image.as_deref(), Some("/assets/img/og.png"));
     }
 
     #[test]


### PR DESCRIPTION
First slice of #54 — moves the **SEO / meta tags** out of YAML-only into the admin landing editor.

## What
- **`LandingCustomization`** (ruscker-config) gains `seo-title`, `seo-description`, `og-image` (all optional).
- **Migration `0003`** adds 3 nullable columns to the `landing_customization` singleton; `db::landing` loads/saves them, and `db::export` now reuses `db::landing::fetch` (DRY) so every field round-trips through import/export.
- **Public landing `<head>`** — a `head_extra` block emits `<meta name="description">` + `og:type/title/description/image` + `twitter:card`. `seo-title` also overrides the `<title>`. Fallbacks: title → localized `landing-title`, description → resolved intro, image → omitted.
- **Admin editor** — a new "SEO & sharing" section (3 inputs) wired through `LandingForm`.
- **i18n** — 9 new keys × 4 locales; `admin-landing-future-help` updated to drop "SEO/meta tags" (now shipped), leaving logo editor / section reordering / custom HTML / analytics for the rest of #54.

## Tests / smoke
- Unit: config parse of the YAML keys; DB round-trip of the 3 fields. `cargo test -p ruscker-admin -p ruscker-config` green; `scripts/i18n-check.sh` parity OK.
- **Config path**: serving a config with the SEO fields emits all the tags and overrides the `<title>`.
- **DB/editor path**: `/admin/landing` renders the inputs (i18n labels resolve, not raw keys); submitting the form makes the public landing reflect the new title / description / og:title.

## Scope
- Single-value fields (not per-locale) for now — per-locale SEO can follow the `intro-locales` pattern later.
- Analytics deferred (CSP-aware) — tracked in #54 along with logo editor, section reordering, custom HTML blocks.

Part of #54.

🤖 Generated with [Claude Code](https://claude.com/claude-code)