### PR TITLE
Landing editor: logo picker from the media library (part of #54)

### DIFF
--- a/crates/ruscker-admin/assets/i18n/en/landing.ftl
+++ b/crates/ruscker-admin/assets/i18n/en/landing.ftl
@@ -107,6 +107,7 @@ spec-form-desc = Description
 spec-form-visual = Visual
 spec-form-logo = Card logo
 spec-form-logo-help = URL or /assets/img/foo.png path. See docs/IMAGES.md.
+spec-form-logo-pick-help = Or pick an image already uploaded to the media library.
 spec-form-access = Access
 spec-form-state = State
 spec-form-state-active = Active

--- a/crates/ruscker-admin/assets/i18n/es/landing.ftl
+++ b/crates/ruscker-admin/assets/i18n/es/landing.ftl
@@ -107,6 +107,7 @@ spec-form-desc = Descripción
 spec-form-visual = Visual
 spec-form-logo = Logo del card
 spec-form-logo-help = URL o ruta /assets/img/foo.png. Ver docs/IMAGES.md.
+spec-form-logo-pick-help = O elige una imagen ya subida en la biblioteca de medios.
 spec-form-access = Acceso
 spec-form-state = Estado
 spec-form-state-active = Activo

--- a/crates/ruscker-admin/assets/i18n/fr/landing.ftl
+++ b/crates/ruscker-admin/assets/i18n/fr/landing.ftl
@@ -107,6 +107,7 @@ spec-form-desc = Description
 spec-form-visual = Visuel
 spec-form-logo = Logo de la carte
 spec-form-logo-help = URL ou chemin /assets/img/foo.png. Voir docs/IMAGES.md.
+spec-form-logo-pick-help = Ou choisissez une image déjà importée dans la médiathèque.
 spec-form-access = Accès
 spec-form-state = État
 spec-form-state-active = Actif

--- a/crates/ruscker-admin/assets/i18n/pt/landing.ftl
+++ b/crates/ruscker-admin/assets/i18n/pt/landing.ftl
@@ -111,6 +111,7 @@ spec-form-desc = Descrição
 spec-form-visual = Visual
 spec-form-logo = Logo do card
 spec-form-logo-help = URL ou caminho /assets/img/foo.png. Veja docs/IMAGES.md.
+spec-form-logo-pick-help = Ou escolha uma imagem já enviada na biblioteca de mídia.
 spec-form-access = Acesso
 spec-form-state = Estado
 spec-form-state-active = Ativo

--- a/crates/ruscker-admin/src/routes/admin/spec_form.rs
+++ b/crates/ruscker-admin/src/routes/admin/spec_form.rs
@@ -262,6 +262,9 @@ struct SpecFormPage<'a> {
     form: SpecForm,
     /// Pre-validation errors (Fluent keys) shown above the form.
     errors: Vec<&'static str>,
+    /// Filenames in the media library, for the logo picker. Empty
+    /// when no DB is wired or the listing fails.
+    logo_images: Vec<String>,
 }
 
 impl<'a> SpecFormPage<'a> {
@@ -291,6 +294,18 @@ impl<'a> SpecFormPage<'a> {
 
 // ── Handlers ─────────────────────────────────────────────────────
 
+/// Media-library filenames for the logo picker. Empty when no DB is
+/// wired or the query fails — the picker degrades to the text field.
+async fn logo_filenames(state: &AppState) -> Vec<String> {
+    match state.db.as_ref() {
+        Some(pool) => db::images::list_all(pool)
+            .await
+            .map(|imgs| imgs.into_iter().map(|i| i.filename).collect())
+            .unwrap_or_default(),
+        None => Vec::new(),
+    }
+}
+
 async fn new_form(
     _: AdminSession,
     State(state): State<AppState>,
@@ -312,6 +327,7 @@ async fn new_form(
             ..Default::default()
         },
         errors: Vec::new(),
+        logo_images: logo_filenames(&state).await,
     };
     super::render(&page)
 }
@@ -343,6 +359,7 @@ async fn edit_form(
         mode: FormMode::Edit,
         form: SpecForm::from_spec(&spec),
         errors: Vec::new(),
+        logo_images: logo_filenames(&state).await,
     };
     super::render(&page)
 }
@@ -373,7 +390,7 @@ async fn create(
     }
 
     if !errors.is_empty() {
-        return render_form_with_errors(&state, loc, theme, FormMode::New, form, errors);
+        return render_form_with_errors(&state, loc, theme, FormMode::New, form, errors).await;
     }
 
     let id = form.id.trim().to_string();
@@ -413,7 +430,7 @@ async fn update(
 
     let errors = form.validate(FormMode::Edit);
     if !errors.is_empty() {
-        return render_form_with_errors(&state, loc, theme, FormMode::Edit, form, errors);
+        return render_form_with_errors(&state, loc, theme, FormMode::Edit, form, errors).await;
     }
 
     let spec = match form.into_spec() {
@@ -450,7 +467,7 @@ async fn delete(
     }
 }
 
-fn render_form_with_errors(
+async fn render_form_with_errors(
     state: &AppState,
     loc: Locale,
     theme: Theme,
@@ -467,6 +484,7 @@ fn render_form_with_errors(
         mode,
         form,
         errors,
+        logo_images: logo_filenames(&state).await,
     };
     let body = match page.render() {
         Ok(s) => s,

--- a/crates/ruscker-admin/templates/admin/spec_form.html
+++ b/crates/ruscker-admin/templates/admin/spec_form.html
@@ -102,6 +102,24 @@
                placeholder="/assets/img/myapp.png"
                class="spec-form-input spec-form-input--mono">
         <div class="spec-form-help">{{ self.t("spec-form-logo-help") }}</div>
+
+        {# Logo picker — choose from the media library (#54). Clicking a
+           thumbnail sets form.logo; the text field still accepts manual
+           paths / external URLs. Hidden when the library is empty. #}
+        {% if !logo_images.is_empty() %}
+        <div class="flex flex-wrap gap-2 mt-2" x-cloak>
+          {% for name in logo_images %}
+          <button type="button" title="{{ name }}"
+                  @click="form.logo = '/assets/img/{{ name }}'"
+                  class="w-12 h-12 rounded-md overflow-hidden border-2 transition-colors"
+                  :class="form.logo === '/assets/img/{{ name }}' ? 'border-[#0f6e56]' : 'border-transparent hover:border-[color:var(--border)]'">
+            <img src="/assets/img/{{ name }}" alt="{{ name }}" loading="lazy"
+                 class="w-full h-full object-cover">
+          </button>
+          {% endfor %}
+        </div>
+        <div class="spec-form-help">{{ self.t("spec-form-logo-pick-help") }}</div>
+        {% endif %}
       </div>
 
       {# ── Card cover (#11) — Auto tint / Solid / Gradient ───── #}


### PR DESCRIPTION
Second slice of #54 — assign a card logo by **clicking an image in the media library**, instead of typing the `/assets/img/...` path by hand.

## What
- **spec_form route**: a `logo_filenames(state)` helper lists the media library (`db::images::list_all` → filenames; empty when no DB), threaded into `SpecFormPage` at all three render sites (new / edit / error re-render). `render_form_with_errors` becomes `async` to query.
- **spec_form.html**: a thumbnail gallery under the logo field. Clicking a thumbnail sets `form.logo` (Alpine) and highlights the current pick; the text field still accepts manual paths / external URLs. Hidden when the library is empty.
- **i18n**: `spec-form-logo-pick-help` × 4 locales.

## Smoke
- `cargo test -p ruscker-admin` (134) green; `scripts/i18n-check.sh` parity OK.
- End-to-end: uploaded a PNG to `/admin/media` (→ WebP), then `/admin/specs/new` renders the thumbnail with `src="/assets/img/<file>"`, the i18n label resolves, and the `@click` sets `form.logo` to that path.

## Scope / notes
- Picks from **already-uploaded** images; uploading a new one is still done at `/admin/media` (inline upload-from-form deferred).
- Remaining #54 items: section reordering, custom HTML blocks (both need a section model), analytics.

Part of #54.

🤖 Generated with [Claude Code](https://claude.com/claude-code)