### PR TITLE
Landing editor: analytics snippet + scoped CSP (part of #54)

### DIFF
--- a/crates/ruscker-admin/assets/i18n/en/landing.ftl
+++ b/crates/ruscker-admin/assets/i18n/en/landing.ftl
@@ -200,8 +200,13 @@ admin-landing-seo-description-placeholder = Short summary for search engines and
 admin-landing-seo-description-help = Used in the meta description and og:description. Empty falls back to the intro text.
 admin-landing-og-image = Share image (og:image)
 admin-landing-og-image-help = URL or path (e.g. /assets/img/og.png) shown when the page is shared on social media.
+admin-landing-analytics = Analytics
+admin-landing-analytics-html = Analytics snippet
+admin-landing-analytics-html-help = HTML injected into the landing <head> (e.g. a Plausible/Matomo/GA <script> tag). Rendered unescaped — only use trusted sources.
+admin-landing-analytics-origins = Allowed origins (CSP)
+admin-landing-analytics-origins-help = Space-separated domains (e.g. https://plausible.io) allowed in the landing CSP so the script can load and report.
 admin-landing-future-title = Coming soon
-admin-landing-future-help = Logo editor, section reordering, custom HTML blocks and analytics. For now those fields follow the YAML.
+admin-landing-future-help = Section reordering and custom HTML blocks. For now those fields follow the YAML.
 
 # Admin audit log
 admin-audit-title = Audit log

--- a/crates/ruscker-admin/assets/i18n/es/landing.ftl
+++ b/crates/ruscker-admin/assets/i18n/es/landing.ftl
@@ -200,8 +200,13 @@ admin-landing-seo-description-placeholder = Resumen para buscadores y redes soci
 admin-landing-seo-description-help = Se usa en la meta description y el og:description. Vacío usa el texto de introducción.
 admin-landing-og-image = Imagen para compartir (og:image)
 admin-landing-og-image-help = URL o ruta (p. ej. /assets/img/og.png) que se muestra al compartir en redes sociales.
+admin-landing-analytics = Analytics
+admin-landing-analytics-html = Snippet de analytics
+admin-landing-analytics-html-help = HTML inyectado en el <head> de la landing (p. ej. una etiqueta <script> de Plausible/Matomo/GA). Se renderiza sin escapar — usa solo fuentes de confianza.
+admin-landing-analytics-origins = Orígenes permitidos (CSP)
+admin-landing-analytics-origins-help = Dominios separados por espacios (p. ej. https://plausible.io) permitidos en la CSP de la landing para que el script cargue y reporte.
 admin-landing-future-title = Próximamente
-admin-landing-future-help = Editor de logos, reordenación de secciones, bloques HTML custom y analytics. Por ahora siguen el YAML.
+admin-landing-future-help = Reordenación de secciones y bloques HTML custom. Por ahora siguen el YAML.
 
 # Admin audit log
 admin-audit-title = Auditoría

--- a/crates/ruscker-admin/assets/i18n/fr/landing.ftl
+++ b/crates/ruscker-admin/assets/i18n/fr/landing.ftl
@@ -200,8 +200,13 @@ admin-landing-seo-description-placeholder = Résumé pour les moteurs de recherc
 admin-landing-seo-description-help = Utilisé dans la meta description et og:description. Vide reprend le texte d'introduction.
 admin-landing-og-image = Image de partage (og:image)
 admin-landing-og-image-help = URL ou chemin (ex. /assets/img/og.png) affiché lors du partage sur les réseaux sociaux.
+admin-landing-analytics = Analytics
+admin-landing-analytics-html = Snippet analytics
+admin-landing-analytics-html-help = HTML injecté dans le <head> de la landing (ex. une balise <script> Plausible/Matomo/GA). Rendu sans échappement — n'utilisez que des sources de confiance.
+admin-landing-analytics-origins = Origines autorisées (CSP)
+admin-landing-analytics-origins-help = Domaines séparés par des espaces (ex. https://plausible.io) autorisés dans la CSP de la landing pour que le script se charge et envoie ses données.
 admin-landing-future-title = Bientôt
-admin-landing-future-help = Éditeur de logos, réorganisation des sections, blocs HTML personnalisés et analytics. Pour l'instant ces champs suivent le YAML.
+admin-landing-future-help = Réorganisation des sections et blocs HTML personnalisés. Pour l'instant ces champs suivent le YAML.
 
 # Admin audit log
 admin-audit-title = Journal d'audit

--- a/crates/ruscker-admin/assets/i18n/pt/landing.ftl
+++ b/crates/ruscker-admin/assets/i18n/pt/landing.ftl
@@ -204,8 +204,13 @@ admin-landing-seo-description-placeholder = Resumo do portal para buscadores e r
 admin-landing-seo-description-help = Usada na meta description e no og:description. Vazio usa o texto de introdução.
 admin-landing-og-image = Imagem de compartilhamento (og:image)
 admin-landing-og-image-help = URL ou caminho (ex.: /assets/img/og.png) mostrado ao compartilhar em redes sociais.
+admin-landing-analytics = Analytics
+admin-landing-analytics-html = Snippet de analytics
+admin-landing-analytics-html-help = HTML inserido no <head> da landing (ex.: tag <script> do Plausible/Matomo/GA). Renderizado sem escape — use só fontes confiáveis.
+admin-landing-analytics-origins = Origens permitidas (CSP)
+admin-landing-analytics-origins-help = Domínios separados por espaço (ex.: https://plausible.io) liberados na CSP da landing para o script carregar e reportar.
 admin-landing-future-title = Em breve
-admin-landing-future-help = Editor de logos, reordenação de seções, blocos HTML customizados e analytics. Por enquanto, esses campos seguem o YAML.
+admin-landing-future-help = Reordenação de seções e blocos HTML customizados. Por enquanto, esses campos seguem o YAML.
 
 # Admin audit log
 admin-audit-title = Auditoria

--- a/crates/ruscker-admin/migrations/0004_landing_analytics.sql
+++ b/crates/ruscker-admin/migrations/0004_landing_analytics.sql
@@ -1,0 +1,4 @@
+-- Analytics snippet + the CSP origins it needs, on the
+-- landing_customization singleton (id = 1). Both optional/NULL.
+ALTER TABLE landing_customization ADD COLUMN analytics_html    TEXT;
+ALTER TABLE landing_customization ADD COLUMN analytics_origins TEXT;

--- a/crates/ruscker-admin/src/db/landing.rs
+++ b/crates/ruscker-admin/src/db/landing.rs
@@ -23,10 +23,13 @@ pub async fn fetch(pool: &SqlitePool) -> Result<LandingCustomization> {
         Option<String>, // seo_title
         Option<String>, // seo_description
         Option<String>, // og_image
+        Option<String>, // analytics_html
+        Option<String>, // analytics_origins
     );
     let row: Option<Row> = sqlx::query_as(
         "SELECT header_bg, header_fg, intro, intro_locales_json,
-                seo_title, seo_description, og_image
+                seo_title, seo_description, og_image,
+                analytics_html, analytics_origins
            FROM landing_customization WHERE id = 1",
     )
     .fetch_optional(pool)
@@ -34,7 +37,17 @@ pub async fn fetch(pool: &SqlitePool) -> Result<LandingCustomization> {
     .context("load landing_customization")?;
     match row {
         None => Ok(LandingCustomization::default()),
-        Some((bg, fg, intro, locales_json, seo_title, seo_description, og_image)) => {
+        Some((
+            bg,
+            fg,
+            intro,
+            locales_json,
+            seo_title,
+            seo_description,
+            og_image,
+            analytics_html,
+            analytics_origins,
+        )) => {
             let intro_locales =
                 serde_json::from_str(&locales_json).context("parse intro_locales_json")?;
             Ok(LandingCustomization {
@@ -45,6 +58,8 @@ pub async fn fetch(pool: &SqlitePool) -> Result<LandingCustomization> {
                 seo_title,
                 seo_description,
                 og_image,
+                analytics_html,
+                analytics_origins,
             })
         }
     }
@@ -69,7 +84,8 @@ pub async fn update(
         "UPDATE landing_customization
             SET header_bg = ?, header_fg = ?, intro = ?,
                 intro_locales_json = ?, seo_title = ?, seo_description = ?,
-                og_image = ?, updated_at = ?
+                og_image = ?, analytics_html = ?, analytics_origins = ?,
+                updated_at = ?
           WHERE id = 1",
     )
     .bind(none_if_empty(&lc.header_bg))
@@ -79,6 +95,8 @@ pub async fn update(
     .bind(none_if_empty(&lc.seo_title))
     .bind(none_if_empty(&lc.seo_description))
     .bind(none_if_empty(&lc.og_image))
+    .bind(none_if_empty(&lc.analytics_html))
+    .bind(none_if_empty(&lc.analytics_origins))
     .bind(now)
     .execute(&mut *tx)
     .await
@@ -161,6 +179,20 @@ mod tests {
             Some("Monitoramento estratégico do estado")
         );
         assert_eq!(got.og_image.as_deref(), Some("/assets/img/og.png"));
+    }
+
+    #[tokio::test]
+    async fn analytics_fields_roundtrip() {
+        let pool = open_memory().await.unwrap();
+        let snippet = "<script src=\"https://plausible.io/js/script.js\"></script>";
+        let origins = "https://plausible.io";
+        let mut lc = LandingCustomization::default();
+        lc.analytics_html = Some(snippet.into());
+        lc.analytics_origins = Some(origins.into());
+        update(&pool, &lc, Some("admin")).await.unwrap();
+        let got = fetch(&pool).await.unwrap();
+        assert_eq!(got.analytics_html.as_deref(), Some(snippet));
+        assert_eq!(got.analytics_origins.as_deref(), Some(origins));
     }
 
     #[tokio::test]

--- a/crates/ruscker-admin/src/lib.rs
+++ b/crates/ruscker-admin/src/lib.rs
@@ -445,23 +445,71 @@ async fn security_headers(
         ("x-content-type-options", "nosniff"),
         ("x-frame-options", "DENY"),
         ("referrer-policy", "same-origin"),
-        (
-            "content-security-policy",
-            "default-src 'self'; \
-             script-src 'self' 'unsafe-inline'; \
-             style-src 'self' 'unsafe-inline'; \
-             img-src 'self' data:; \
-             font-src 'self'; \
-             connect-src 'self'; \
-             frame-ancestors 'none'; \
-             base-uri 'self'; \
-             form-action 'self'",
-        ),
     ];
     for (name, value) in defaults {
         if let Ok(hn) = HeaderName::from_bytes(name.as_bytes()) {
             h.entry(hn).or_insert(HeaderValue::from_static(value));
         }
     }
+    // CSP as a default too — but the landing route may set its own
+    // (widened for an operator's analytics origins), so `or_insert`
+    // must leave a handler-set value intact.
+    if let Ok(v) = HeaderValue::from_str(&content_security_policy("")) {
+        h.entry(axum::http::header::CONTENT_SECURITY_POLICY)
+            .or_insert(v);
+    }
     resp
+}
+
+/// Build the Content-Security-Policy for Ruscker's own pages.
+///
+/// `extra_origins` (space-separated, may be empty) is appended to the
+/// directives that fetch third-party resources (`script-src`,
+/// `img-src`, `connect-src`). The landing uses this to allow an
+/// operator-configured analytics provider without loosening the
+/// policy for every other page. `'unsafe-inline'` on script/style is
+/// still required by the inline landing/dashboard scripts (a
+/// nonce-based CSP is a tracked follow-up).
+pub(crate) fn content_security_policy(extra_origins: &str) -> String {
+    let e = extra_origins.trim();
+    let extra = if e.is_empty() {
+        String::new()
+    } else {
+        format!(" {e}")
+    };
+    format!(
+        "default-src 'self'; \
+         script-src 'self' 'unsafe-inline'{extra}; \
+         style-src 'self' 'unsafe-inline'; \
+         img-src 'self' data:{extra}; \
+         font-src 'self'; \
+         connect-src 'self'{extra}; \
+         frame-ancestors 'none'; \
+         base-uri 'self'; \
+         form-action 'self'"
+    )
+}
+
+#[cfg(test)]
+mod csp_tests {
+    use super::content_security_policy;
+
+    #[test]
+    fn base_policy_is_self_only() {
+        let csp = content_security_policy("");
+        assert!(csp.contains("script-src 'self' 'unsafe-inline';"));
+        assert!(csp.contains("connect-src 'self';"));
+        assert!(!csp.contains("plausible"));
+    }
+
+    #[test]
+    fn extra_origins_widen_script_img_connect() {
+        let csp = content_security_policy("https://plausible.io");
+        assert!(csp.contains("script-src 'self' 'unsafe-inline' https://plausible.io;"));
+        assert!(csp.contains("img-src 'self' data: https://plausible.io;"));
+        assert!(csp.contains("connect-src 'self' https://plausible.io;"));
+        // Directives that must NOT be widened.
+        assert!(csp.contains("style-src 'self' 'unsafe-inline';"));
+        assert!(csp.contains("frame-ancestors 'none';"));
+    }
 }

--- a/crates/ruscker-admin/src/routes/admin/landing.rs
+++ b/crates/ruscker-admin/src/routes/admin/landing.rs
@@ -78,6 +78,8 @@ pub struct LandingForm {
     pub seo_title: String,
     pub seo_description: String,
     pub og_image: String,
+    pub analytics_html: String,
+    pub analytics_origins: String,
 }
 
 impl LandingForm {
@@ -94,6 +96,8 @@ impl LandingForm {
             seo_title: lc.seo_title.clone().unwrap_or_default(),
             seo_description: lc.seo_description.clone().unwrap_or_default(),
             og_image: lc.og_image.clone().unwrap_or_default(),
+            analytics_html: lc.analytics_html.clone().unwrap_or_default(),
+            analytics_origins: lc.analytics_origins.clone().unwrap_or_default(),
         }
     }
 
@@ -118,6 +122,8 @@ impl LandingForm {
             seo_title: empty_to_none(self.seo_title),
             seo_description: empty_to_none(self.seo_description),
             og_image: empty_to_none(self.og_image),
+            analytics_html: empty_to_none(self.analytics_html),
+            analytics_origins: empty_to_none(self.analytics_origins),
         }
     }
 }

--- a/crates/ruscker-admin/src/routes/landing.rs
+++ b/crates/ruscker-admin/src/routes/landing.rs
@@ -7,7 +7,7 @@
 use askama::Template;
 use axum::{
     extract::State,
-    http::StatusCode,
+    http::{header, HeaderValue, StatusCode},
     response::{Html, IntoResponse, Response},
     routing::get,
     Router,
@@ -54,6 +54,9 @@ struct LandingPage<'a> {
     seo_description: String,
     /// `og:image` URL, or empty ⇒ tag omitted.
     og_image: String,
+    /// Operator analytics snippet, injected verbatim into `<head>`
+    /// (rendered with `|safe`). Empty ⇒ nothing injected.
+    analytics_html: String,
 }
 
 impl<'a> LandingPage<'a> {
@@ -126,6 +129,8 @@ async fn index(State(state): State<AppState>, loc: Locale, theme: Theme) -> Resp
         not_blank(&lc.seo_title).unwrap_or_else(|| state.locales.t(loc, "landing-title", None));
     let seo_description = not_blank(&lc.seo_description).unwrap_or_else(|| intro.clone());
     let og_image = not_blank(&lc.og_image).unwrap_or_default();
+    let analytics_html = not_blank(&lc.analytics_html).unwrap_or_default();
+    let analytics_origins = not_blank(&lc.analytics_origins).unwrap_or_default();
 
     let page = LandingPage {
         locale: loc,
@@ -141,8 +146,19 @@ async fn index(State(state): State<AppState>, loc: Locale, theme: Theme) -> Resp
         page_title,
         seo_description,
         og_image,
+        analytics_html,
     };
-    render(&page)
+    let mut resp = render(&page);
+    // Widen *this page's* CSP so the analytics script can load/report.
+    // `security_headers` uses `or_insert`, so this handler-set value
+    // wins. Only applied when the operator listed origins.
+    if !analytics_origins.is_empty() {
+        if let Ok(v) = HeaderValue::from_str(&crate::content_security_policy(&analytics_origins)) {
+            resp.headers_mut()
+                .insert(header::CONTENT_SECURITY_POLICY, v);
+        }
+    }
+    resp
 }
 
 /// Centralized `askama::Template` → axum `Response`. Replaces the

--- a/crates/ruscker-admin/templates/admin/landing.html
+++ b/crates/ruscker-admin/templates/admin/landing.html
@@ -195,6 +195,22 @@
         <div class="spec-form-help">{{ self.t("admin-landing-og-image-help") }}</div>
       </div>
 
+      <div class="spec-form-section-title">{{ self.t("admin-landing-analytics") }}</div>
+      <div class="spec-form-field">
+        <label class="spec-form-label">{{ self.t("admin-landing-analytics-html") }}</label>
+        <textarea name="analytics_html" rows="3" x-model="form.analytics_html"
+                  placeholder="&lt;script defer data-domain=&quot;...&quot; src=&quot;https://plausible.io/js/script.js&quot;&gt;&lt;/script&gt;"
+                  class="spec-form-input spec-form-input--mono">{{ form.analytics_html }}</textarea>
+        <div class="spec-form-help">{{ self.t("admin-landing-analytics-html-help") }}</div>
+      </div>
+      <div class="spec-form-field">
+        <label class="spec-form-label">{{ self.t("admin-landing-analytics-origins") }}</label>
+        <input type="text" name="analytics_origins" x-model="form.analytics_origins"
+               placeholder="https://plausible.io"
+               class="spec-form-input spec-form-input--mono" value="{{ form.analytics_origins }}">
+        <div class="spec-form-help">{{ self.t("admin-landing-analytics-origins-help") }}</div>
+      </div>
+
       <div class="info-box">
         <i class="ti ti-info-circle" aria-hidden="true"></i>
         <div>

--- a/crates/ruscker-admin/templates/landing.html
+++ b/crates/ruscker-admin/templates/landing.html
@@ -9,6 +9,8 @@
 {% if !seo_description.is_empty() %}<meta property="og:description" content="{{ seo_description }}">{% endif %}
 {% if !og_image.is_empty() %}<meta property="og:image" content="{{ og_image }}">{% endif %}
 <meta name="twitter:card" content="{% if !og_image.is_empty() %}summary_large_image{% else %}summary{% endif %}">
+{# Operator analytics snippet — rendered verbatim (admin-trusted). #}
+{% if !analytics_html.is_empty() %}{{ analytics_html|safe }}{% endif %}
 {% endblock %}
 
 {% block content %}

--- a/crates/ruscker-config/src/schema.rs
+++ b/crates/ruscker-config/src/schema.rs
@@ -261,6 +261,22 @@ pub struct LandingCustomization {
     /// or an absolute URL. Omitted from the head when unset.
     #[serde(default, rename = "og-image")]
     pub og_image: Option<String>,
+
+    /// Raw analytics snippet (e.g. a Plausible / Matomo / GA
+    /// `<script>` tag) injected verbatim into the public landing
+    /// `<head>`. Operator-authored and **admin-trusted** — rendered
+    /// unescaped, so only set it from a trusted source. External
+    /// scripts also need their origin listed in
+    /// [`Self::analytics_origins`] (the landing CSP blocks others).
+    #[serde(default, rename = "analytics-html")]
+    pub analytics_html: Option<String>,
+
+    /// Space-separated origins (e.g. `https://plausible.io`) added to
+    /// the landing's CSP `script-src` / `connect-src` / `img-src` so
+    /// the analytics script can load and report. Only widens the
+    /// public landing's policy, not the admin's.
+    #[serde(default, rename = "analytics-origins")]
+    pub analytics_origins: Option<String>,
 }
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]


### PR DESCRIPTION
Third slice of #54 — configure a web-analytics provider (Plausible / Matomo / GA…) from the admin instead of YAML, with the landing CSP widened **just enough** to let it load.

## What
- **`LandingCustomization`** gains `analytics-html` (raw snippet) + `analytics-origins` (space-separated CSP origins). Migration `0004` adds 2 nullable columns; `db::landing` loads/saves them.
- **`lib.rs`**: extracted `content_security_policy(extra_origins)`, shared by the `security_headers` default and the landing. The CSP is now applied via `or_insert`, so a handler can set its own.
- **Landing route**: injects the snippet verbatim into `<head>` (Askama `|safe` — admin-trusted input) and, when origins are set, attaches a CSP **to that response only** allowing them in `script-src`/`img-src`/`connect-src`. Every other page keeps the base self-only CSP.
- **Admin editor**: an "Analytics" section (snippet textarea + origins input) with a "rendered unescaped — trusted sources only" hint.
- **i18n**: 5 keys × 4 locales; `admin-landing-future-help` trimmed to the remaining #54 items (section reordering + custom HTML blocks) — logo editor (#56), SEO (#55) and analytics are now shipped.

## Tests / smoke
- Unit: DB round-trip; `content_security_policy` (base is self-only; extra origins widen **only** script/img/connect, not style/frame-ancestors). `cargo test -p ruscker-admin -p ruscker-config` (137 + 43) green; i18n parity OK.
- Smoke: serving an analytics config → the landing emits the `<script>` in `<head>` **and** a CSP header with the origin in `script-src`; `/admin/login` keeps the base CSP (the widening is landing-scoped, not global).

## Security note
`analytics-html` is rendered unescaped on the public landing — it's **admin-gated** input (the editor is behind admin auth), the intentional escape hatch for analytics tags. The CSP only allows the operator-listed origins.

## #54 status
Remaining after this: **section reordering** + **custom HTML blocks** — both need a landing *section model* (a larger foundation slice).

Part of #54.

🤖 Generated with [Claude Code](https://claude.com/claude-code)