### PR TITLE
Landing editor: repoint info box to the Blocks editor (closes #54)

### DIFF
--- a/crates/ruscker-admin/assets/i18n/en/landing.ftl
+++ b/crates/ruscker-admin/assets/i18n/en/landing.ftl
@@ -233,8 +233,8 @@ admin-landing-analytics-html = Analytics snippet
 admin-landing-analytics-html-help = HTML injected into the landing <head> (e.g. a Plausible/Matomo/GA <script> tag). Rendered unescaped — only use trusted sources.
 admin-landing-analytics-origins = Allowed origins (CSP)
 admin-landing-analytics-origins-help = Space-separated domains (e.g. https://plausible.io) allowed in the landing CSP so the script can load and report.
-admin-landing-future-title = Coming soon
-admin-landing-future-help = Section reordering and custom HTML blocks. For now those fields follow the YAML.
+admin-landing-future-title = HTML blocks
+admin-landing-future-help = Manage custom HTML blocks (banners, notices) in the Blocks section of the menu.
 
 # Admin audit log
 admin-audit-title = Audit log

--- a/crates/ruscker-admin/assets/i18n/es/landing.ftl
+++ b/crates/ruscker-admin/assets/i18n/es/landing.ftl
@@ -233,8 +233,8 @@ admin-landing-analytics-html = Snippet de analytics
 admin-landing-analytics-html-help = HTML inyectado en el <head> de la landing (p. ej. una etiqueta <script> de Plausible/Matomo/GA). Se renderiza sin escapar — usa solo fuentes de confianza.
 admin-landing-analytics-origins = Orígenes permitidos (CSP)
 admin-landing-analytics-origins-help = Dominios separados por espacios (p. ej. https://plausible.io) permitidos en la CSP de la landing para que el script cargue y reporte.
-admin-landing-future-title = Próximamente
-admin-landing-future-help = Reordenación de secciones y bloques HTML custom. Por ahora siguen el YAML.
+admin-landing-future-title = Bloques HTML
+admin-landing-future-help = Gestiona bloques HTML personalizados (banners, avisos) en la sección Bloques del menú.
 
 # Admin audit log
 admin-audit-title = Auditoría

--- a/crates/ruscker-admin/assets/i18n/fr/landing.ftl
+++ b/crates/ruscker-admin/assets/i18n/fr/landing.ftl
@@ -233,8 +233,8 @@ admin-landing-analytics-html = Snippet analytics
 admin-landing-analytics-html-help = HTML injecté dans le <head> de la landing (ex. une balise <script> Plausible/Matomo/GA). Rendu sans échappement — n'utilisez que des sources de confiance.
 admin-landing-analytics-origins = Origines autorisées (CSP)
 admin-landing-analytics-origins-help = Domaines séparés par des espaces (ex. https://plausible.io) autorisés dans la CSP de la landing pour que le script se charge et envoie ses données.
-admin-landing-future-title = Bientôt
-admin-landing-future-help = Réorganisation des sections et blocs HTML personnalisés. Pour l'instant ces champs suivent le YAML.
+admin-landing-future-title = Blocs HTML
+admin-landing-future-help = Gérez les blocs HTML personnalisés (bannières, avis) dans la section Blocs du menu.
 
 # Admin audit log
 admin-audit-title = Journal d'audit

--- a/crates/ruscker-admin/assets/i18n/pt/landing.ftl
+++ b/crates/ruscker-admin/assets/i18n/pt/landing.ftl
@@ -237,8 +237,8 @@ admin-landing-analytics-html = Snippet de analytics
 admin-landing-analytics-html-help = HTML inserido no <head> da landing (ex.: tag <script> do Plausible/Matomo/GA). Renderizado sem escape — use só fontes confiáveis.
 admin-landing-analytics-origins = Origens permitidas (CSP)
 admin-landing-analytics-origins-help = Domínios separados por espaço (ex.: https://plausible.io) liberados na CSP da landing para o script carregar e reportar.
-admin-landing-future-title = Em breve
-admin-landing-future-help = Reordenação de seções e blocos HTML customizados. Por enquanto, esses campos seguem o YAML.
+admin-landing-future-title = Blocos HTML
+admin-landing-future-help = Gerencie blocos HTML customizados (banners, avisos) na seção Blocos do menu.
 
 # Admin audit log
 admin-audit-title = Auditoria


### PR DESCRIPTION
Wrap-up for #54. The landing editor's "coming soon" box still listed SEO / analytics / custom HTML — all shipped (#55–#58). Repoint it to the new **Blocks** section instead of advertising delivered features as future work. i18n-only (4 locales).

Closes #54.

🤖 Generated with [Claude Code](https://claude.com/claude-code)