### PR TITLE
Landing blocks: YAML import/export round-trip

### DIFF
--- a/crates/ruscker-admin/src/db/export.rs
+++ b/crates/ruscker-admin/src/db/export.rs
@@ -32,8 +32,14 @@ pub async fn reconstruct_config(pool: &SqlitePool) -> Result<Config> {
 
     // 2. Landing customization singleton — reuse the repository
     //    loader so every field (incl. SEO) round-trips without
-    //    duplicating the column list here.
-    let landing_customization = super::landing::fetch(pool).await?;
+    //    duplicating the column list here. Then attach the custom
+    //    HTML blocks (ordered by slot, position) so they round-trip too.
+    let mut landing_customization = super::landing::fetch(pool).await?;
+    landing_customization.blocks = super::landing_blocks::list_all(pool)
+        .await?
+        .iter()
+        .map(|b| b.to_config())
+        .collect();
 
     // 3. config_meta sections — start with default structs and let
     //    serde_json overlay whatever the import persisted. Falling
@@ -137,6 +143,42 @@ mod tests {
             cfg_out.proxy.landing_customization.intro_locales,
             cfg_in.proxy.landing_customization.intro_locales
         );
+    }
+
+    #[tokio::test]
+    async fn round_trip_preserves_landing_blocks() {
+        let pool = open_memory().await.unwrap();
+        let yaml = r#"
+proxy:
+  landing-customization:
+    blocks:
+      - { slot: top, title: Banner, html: "<div>hi</div>", csp-origins: "https://cdn.x", enabled: true }
+      - { slot: top, title: Second, html: "<p>2</p>" }
+      - { slot: bottom, title: Foot, html: "<footer>f</footer>", enabled: false }
+  specs: []
+"#;
+        let cfg_in = Config::from_yaml(yaml).unwrap();
+        assert_eq!(cfg_in.proxy.landing_customization.blocks.len(), 3);
+        // `enabled` defaults to true when the key is omitted.
+        assert!(cfg_in.proxy.landing_customization.blocks[1].enabled);
+
+        import_all(&pool, &cfg_in).await.unwrap();
+        let cfg_out = reconstruct_config(&pool).await.unwrap();
+        let out = &cfg_out.proxy.landing_customization.blocks;
+
+        assert_eq!(out.len(), 3);
+        // Per-slot order + content preserved (export groups by slot:
+        // bottom sorts before top).
+        let top: Vec<_> = out.iter().filter(|b| b.slot == "top").collect();
+        assert_eq!(
+            top.iter().map(|b| b.title.as_str()).collect::<Vec<_>>(),
+            ["Banner", "Second"]
+        );
+        assert_eq!(top[0].html, "<div>hi</div>");
+        assert_eq!(top[0].csp_origins, "https://cdn.x");
+        let bottom: Vec<_> = out.iter().filter(|b| b.slot == "bottom").collect();
+        assert_eq!(bottom.len(), 1);
+        assert!(!bottom[0].enabled);
     }
 
     #[tokio::test]

--- a/crates/ruscker-admin/src/db/landing.rs
+++ b/crates/ruscker-admin/src/db/landing.rs
@@ -60,6 +60,9 @@ pub async fn fetch(pool: &SqlitePool) -> Result<LandingCustomization> {
                 og_image,
                 analytics_html,
                 analytics_origins,
+                // Blocks live in their own table; callers that render
+                // or export them load via `landing_blocks`.
+                blocks: Vec::new(),
             })
         }
     }
@@ -75,11 +78,34 @@ pub async fn update(
     actor: Option<&str>,
 ) -> Result<()> {
     let now = Utc::now();
+    let mut tx = pool.begin().await.context("begin landing update tx")?;
+    update_in_tx(&mut tx, lc, now).await?;
+
+    sqlx::query(
+        "INSERT INTO audit_log (actor, action, target, diff_json, occurred_at)
+         VALUES (?, 'landing.update', 'landing:customization', NULL, ?)",
+    )
+    .bind(actor)
+    .bind(now)
+    .execute(&mut *tx)
+    .await
+    .context("audit landing.update")?;
+
+    tx.commit().await.context("commit landing update")?;
+    Ok(())
+}
+
+/// Write the singleton's columns inside an existing transaction
+/// (shared by [`update`] and the YAML import). Empty strings collapse
+/// to NULL so they vanish from the exported YAML rather than
+/// serializing as `""`.
+pub(crate) async fn update_in_tx(
+    tx: &mut sqlx::Transaction<'_, sqlx::Sqlite>,
+    lc: &LandingCustomization,
+    now: chrono::DateTime<Utc>,
+) -> Result<()> {
     let intro_locales_json =
         serde_json::to_string(&lc.intro_locales).context("serialize intro_locales")?;
-
-    let mut tx = pool.begin().await.context("begin landing update tx")?;
-
     sqlx::query(
         "UPDATE landing_customization
             SET header_bg = ?, header_fg = ?, intro = ?,
@@ -98,21 +124,9 @@ pub async fn update(
     .bind(none_if_empty(&lc.analytics_html))
     .bind(none_if_empty(&lc.analytics_origins))
     .bind(now)
-    .execute(&mut *tx)
+    .execute(&mut **tx)
     .await
     .context("update landing_customization")?;
-
-    sqlx::query(
-        "INSERT INTO audit_log (actor, action, target, diff_json, occurred_at)
-         VALUES (?, 'landing.update', 'landing:customization', NULL, ?)",
-    )
-    .bind(actor)
-    .bind(now)
-    .execute(&mut *tx)
-    .await
-    .context("audit landing.update")?;
-
-    tx.commit().await.context("commit landing update")?;
     Ok(())
 }
 

--- a/crates/ruscker-admin/src/db/landing_blocks.rs
+++ b/crates/ruscker-admin/src/db/landing_blocks.rs
@@ -216,6 +216,64 @@ pub async fn delete(pool: &SqlitePool, id: &str, actor: Option<&str>) -> Result<
     Ok(removed)
 }
 
+impl LandingBlock {
+    /// Map to the config-crate representation for YAML export.
+    pub fn to_config(&self) -> ruscker_config::LandingBlock {
+        ruscker_config::LandingBlock {
+            slot: self.slot.clone(),
+            title: self.title.clone(),
+            html: self.html.clone(),
+            csp_origins: self.csp_origins.clone(),
+            enabled: self.enabled,
+        }
+    }
+}
+
+/// Replace ALL blocks with `blocks` (used by the YAML import). Clears
+/// the table, then inserts each block with a per-slot `position` taken
+/// from its order of appearance. Runs inside the caller's transaction.
+pub(crate) async fn replace_all_in_tx(
+    tx: &mut sqlx::Transaction<'_, sqlx::Sqlite>,
+    blocks: &[ruscker_config::LandingBlock],
+    now: chrono::DateTime<Utc>,
+) -> Result<()> {
+    sqlx::query("DELETE FROM landing_blocks")
+        .execute(&mut **tx)
+        .await
+        .context("clear landing_blocks")?;
+
+    let mut next: std::collections::HashMap<String, i64> = std::collections::HashMap::new();
+    for b in blocks {
+        // Guard the slot so a hand-edited YAML can't create an
+        // unrenderable block.
+        let slot = if SLOTS.contains(&b.slot.as_str()) {
+            b.slot.as_str()
+        } else {
+            "top"
+        };
+        let pos = next.entry(slot.to_owned()).or_insert(0);
+        sqlx::query(
+            "INSERT INTO landing_blocks
+               (id, slot, position, enabled, title, html, csp_origins, created_at, updated_at)
+             VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?)",
+        )
+        .bind(uuid::Uuid::new_v4().to_string())
+        .bind(slot)
+        .bind(*pos)
+        .bind(b.enabled as i64)
+        .bind(&b.title)
+        .bind(&b.html)
+        .bind(&b.csp_origins)
+        .bind(now)
+        .bind(now)
+        .execute(&mut **tx)
+        .await
+        .context("insert imported block")?;
+        *pos += 1;
+    }
+    Ok(())
+}
+
 /// Move a block one step within its slot by swapping `position` with
 /// the adjacent block (`up` = toward the front). No-op (returns
 /// `false`) when the block doesn't exist or is already at the slot

--- a/crates/ruscker-admin/src/db/specs.rs
+++ b/crates/ruscker-admin/src/db/specs.rs
@@ -45,24 +45,12 @@ pub async fn import_all(pool: &SqlitePool, config: &Config) -> Result<ImportRepo
         }
     }
 
-    // Landing customization is a singleton — replace it whole.
+    // Landing customization is a singleton — replace it whole, incl.
+    // SEO/analytics columns (via the shared writer) and the custom
+    // HTML blocks, so the full landing config round-trips.
     let lc = &config.proxy.landing_customization;
-    let intro_locales_json = serde_json::to_string(&lc.intro_locales)
-        .context("serialize intro_locales")?;
-    sqlx::query(
-        "UPDATE landing_customization
-            SET header_bg = ?, header_fg = ?, intro = ?,
-                intro_locales_json = ?, updated_at = ?
-          WHERE id = 1",
-    )
-    .bind(&lc.header_bg)
-    .bind(&lc.header_fg)
-    .bind(&lc.intro)
-    .bind(&intro_locales_json)
-    .bind(now)
-    .execute(&mut *tx)
-    .await
-    .context("update landing_customization")?;
+    super::landing::update_in_tx(&mut tx, lc, now).await?;
+    super::landing_blocks::replace_all_in_tx(&mut tx, &lc.blocks, now).await?;
 
     // Persist the rest of `proxy` (everything except specs and
     // landing-customization) + the top-level server / logging

--- a/crates/ruscker-admin/src/routes/admin/landing.rs
+++ b/crates/ruscker-admin/src/routes/admin/landing.rs
@@ -124,6 +124,10 @@ impl LandingForm {
             og_image: empty_to_none(self.og_image),
             analytics_html: empty_to_none(self.analytics_html),
             analytics_origins: empty_to_none(self.analytics_origins),
+            // The landing editor doesn't manage blocks (their own
+            // screen does); `landing::update` ignores this field, so
+            // an empty Vec here never clobbers stored blocks.
+            blocks: Vec::new(),
         }
     }
 }

--- a/crates/ruscker-config/src/lib.rs
+++ b/crates/ruscker-config/src/lib.rs
@@ -42,8 +42,8 @@ pub mod validate;
 
 pub use error::{Error, Result};
 pub use schema::{
-    Config, LandingCustomization, Logging, Proxy, RatePolicy, RoutingStrategy, Server,
-    Spec, SpecKind, SpecKindOverride, TemplateProperties,
+    Config, LandingBlock, LandingCustomization, Logging, Proxy, RatePolicy, RoutingStrategy,
+    Server, Spec, SpecKind, SpecKindOverride, TemplateProperties,
 };
 pub use validate::{CompatWarning, ValidationReport, Warning};
 

--- a/crates/ruscker-config/src/schema.rs
+++ b/crates/ruscker-config/src/schema.rs
@@ -277,6 +277,38 @@ pub struct LandingCustomization {
     /// public landing's policy, not the admin's.
     #[serde(default, rename = "analytics-origins")]
     pub analytics_origins: Option<String>,
+
+    /// Custom HTML blocks rendered in the landing slots (`top` /
+    /// `bottom`). Admin-managed; this field exists so they survive
+    /// `import` / `export` (YAML round-trip). Array order within a
+    /// slot is the render order.
+    #[serde(default)]
+    pub blocks: Vec<LandingBlock>,
+}
+
+/// A custom HTML block on the public landing (admin-authored,
+/// rendered verbatim). See [`LandingCustomization::blocks`].
+#[derive(Debug, Clone, Default, PartialEq, Serialize, Deserialize)]
+#[serde(default)]
+pub struct LandingBlock {
+    /// Where it renders: `top` (after the header) or `bottom` (after
+    /// the card grid).
+    pub slot: String,
+    /// Internal label shown in the admin list (not rendered publicly).
+    pub title: String,
+    /// The HTML, injected verbatim — admin-trusted.
+    pub html: String,
+    /// Space-separated CSP origins this block's content needs.
+    #[serde(rename = "csp-origins")]
+    pub csp_origins: String,
+    /// Whether it renders. A block with no `enabled:` key defaults to
+    /// enabled (the common case when authoring YAML).
+    #[serde(default = "default_true")]
+    pub enabled: bool,
+}
+
+fn default_true() -> bool {
+    true
 }
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]


### PR DESCRIPTION
Second block follow-up (#54): custom HTML blocks were DB-only — they now survive `ruscker import` / `export`. **Bonus fix:** import wasn't persisting the SEO/analytics columns either (its inline landing UPDATE predated #55/#57); both paths now share one writer, so SEO/analytics round-trip on import too.

## What
- **ruscker-config**: `LandingBlock { slot, title, html, csp-origins, enabled }` + `LandingCustomization.blocks: Vec<LandingBlock>`. Array order = render order; `enabled` defaults to `true` when the key is omitted.
- **db::landing**: extracted `update_in_tx` (full column set incl. SEO/analytics); `update` wraps it.
- **db::landing_blocks**: `to_config()` (export mapping) + `replace_all_in_tx(blocks)` (import: clear table + insert per-slot in array order; slot guarded).
- **import_all** calls `landing::update_in_tx` + `landing_blocks::replace_all_in_tx`; **export/reconstruct_config** attaches `list_all().to_config()`.

## Tests / smoke
- `round_trip_preserves_landing_blocks`: import → reconstruct keeps per-slot order, html, `csp-origins`, `enabled=false`; confirms `enabled` defaults true when omitted. 142 admin + 43 config green; i18n parity OK.
- **CLI smoke**: `ruscker import` a YAML with `blocks:` + `seo-title`, then `ruscker export` → both appear in the output YAML.

## Notes
- Export groups blocks by slot (deterministic) — per-slot order is preserved, the cross-slot interleaving isn't (doesn't matter for rendering).
- The landing editor's `into_customization` leaves `blocks` empty, and `landing::update` only touches the singleton columns — so editing landing customization never clobbers stored blocks.

Completes the #54 block follow-ups (reorder #61 + this).

🤖 Generated with [Claude Code](https://claude.com/claude-code)