### PR TITLE
docs: mdBook documentation site + GitHub Pages

### DIFF
--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -1,0 +1,56 @@
+name: docs
+
+# Build the mdBook site and publish it to GitHub Pages
+# (https://strategicprojects.github.io/ruscker/).
+#
+# Requires Pages to be enabled for the repo with source = "GitHub
+# Actions" (Settings → Pages → Build and deployment → Source).
+
+on:
+  push:
+    branches: [main]
+    paths:
+      - "book/**"
+      - "docs/**" # chapters {{#include}} files from docs/
+      - ".github/workflows/docs.yml"
+  workflow_dispatch:
+
+permissions:
+  contents: read
+  pages: write
+  id-token: write
+
+# One concurrent deploy; newer pushes supersede in-flight ones.
+concurrency:
+  group: pages
+  cancel-in-progress: false
+
+jobs:
+  build-and-deploy:
+    runs-on: ubuntu-latest
+    environment:
+      name: github-pages
+      url: ${{ steps.deployment.outputs.page_url }}
+    env:
+      MDBOOK_VERSION: "0.4.40"
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Install mdBook
+        run: |
+          mkdir -p "$HOME/.local/bin"
+          url="https://github.com/rust-lang/mdBook/releases/download/v${MDBOOK_VERSION}/mdbook-v${MDBOOK_VERSION}-x86_64-unknown-linux-gnu.tar.gz"
+          curl -sSL "$url" | tar -xz -C "$HOME/.local/bin"
+          echo "$HOME/.local/bin" >> "$GITHUB_PATH"
+
+      - name: Build the book
+        run: mdbook build book
+
+      - uses: actions/configure-pages@v5
+
+      - uses: actions/upload-pages-artifact@v3
+        with:
+          path: book/book
+
+      - id: deployment
+        uses: actions/deploy-pages@v4

--- a/.gitignore
+++ b/.gitignore
@@ -45,3 +45,6 @@ secrets/
 CLAUDE.md
 **/CLAUDE.md
 .claude/
+
+# mdBook generated site
+/book/book/

--- a/README.md
+++ b/README.md
@@ -11,6 +11,9 @@ Free**. Serves and load-balances containerized interactive web apps
 FastAPI) behind a single proxy, with a custom landing page and an
 admin panel.
 
+📖 **Documentation: <https://strategicprojects.github.io/ruscker/>**
+(install · migrating from ShinyProxy · configuration · admin · deploy).
+
 ```
                 ┌──────────────────────┐
                 │       Visitors       │

--- a/book/book.toml
+++ b/book/book.toml
@@ -1,0 +1,21 @@
+[book]
+title = "Ruscker"
+description = "A lightweight Rust alternative to ShinyProxy and Shiny Server Free — host and load-balance containerized apps behind one proxy with a real admin panel."
+authors = ["Ruscker contributors"]
+language = "en"
+src = "src"
+
+[output.html]
+default-theme = "rust"
+preferred-dark-theme = "ayu"
+git-repository-url = "https://github.com/StrategicProjects/ruscker"
+edit-url-template = "https://github.com/StrategicProjects/ruscker/edit/main/book/{path}"
+# Project Pages live under /ruscker/ — set so links/assets resolve there.
+site-url = "/ruscker/"
+
+[output.html.fold]
+enable = true
+level = 1
+
+[output.html.search]
+enable = true

--- a/book/src/SUMMARY.md
+++ b/book/src/SUMMARY.md
@@ -1,0 +1,17 @@
+# Summary
+
+[Introduction](./introduction.md)
+
+# User guide
+
+- [Installation](./installation.md)
+- [Migrating from ShinyProxy](./migrating.md)
+- [Configuration](./configuration.md)
+- [The admin panel](./admin.md)
+- [Deploying in production](./deploying.md)
+- [Troubleshooting](./troubleshooting.md)
+
+# Reference
+
+- [Architecture](./architecture.md)
+- [Security](./security.md)

--- a/book/src/admin.md
+++ b/book/src/admin.md
@@ -1,0 +1,72 @@
+# The admin panel
+
+The admin panel is Ruscker's main advantage over editing YAML by hand.
+It lives at `/admin`, is gated by a token, and needs a SQLite database
+(`serve --db <file>`).
+
+## Logging in
+
+Set `RUSCKER_ADMIN_TOKEN` (the `.deb` generates one on first install
+and prints it once). Browse to `/admin/login` and paste the token.
+Until a token is set, `/admin/*` returns `503` and only the public
+landing + proxy are served. Rotate the token any time by changing the
+value and restarting.
+
+The footer has the same **language** (pt-BR / en-US / es-ES / fr-FR)
+and **theme** (light / dark / auto) pickers as the public portal.
+
+## Screens
+
+### Dashboard
+A live view of running replicas: per-container state, uptime, sessions,
+CPU and memory (refreshed over Server-Sent Events). Stop or restart a
+replica; open its logs. Shows a banner when started without
+`--docker`.
+
+### Apps
+The list of specs (apps, APIs, external links). The add/edit form has a
+type selector, a live card preview, resource limits, registry
+credentials, and a **logo picker** that pulls from the media library
+(no need to type `/assets/img/...` by hand).
+
+### Media
+Upload images (PNG/JPEG → WebP), served at `/assets/img/<file>`. These
+are the card logos and covers.
+
+### Credentials
+A named, AES-256-GCM-encrypted store for registry credentials (needs
+`RUSCKER_MASTER_KEY`). Passwords never appear in the YAML or in the
+panel after saving.
+
+### Landing editor
+Customise the public landing without a custom template:
+
+- **Colours + intro** — header background/foreground, a per-locale
+  intro paragraph.
+- **SEO & sharing** — page title, meta description, `og:image`. The
+  landing `<head>` emits `description` + `og:*` + `twitter:card`.
+- **Analytics** — paste a provider snippet (Plausible, Matomo, GA…)
+  and list its origins; Ruscker widens **only the landing's** CSP so
+  the script can load.
+
+### Blocks
+Custom HTML blocks rendered in the landing `top` (after the header) and
+`bottom` (after the card grid) slots. Create/edit/delete, enable/
+disable, and reorder within a slot with the ↑/↓ buttons. Each block can
+declare CSP origins for any third-party content it embeds.
+
+> Block and analytics HTML is rendered **verbatim** on the public
+> landing. It's admin-only input — the intentional escape hatch — so
+> only paste HTML you trust.
+
+### Audit log
+Every admin mutation (spec/image/credential/landing/block changes,
+imports) is recorded with actor, action, target and timestamp.
+
+## Config vs. database
+
+`serve --config` drives the public landing and the proxy. The admin
+panel reads and writes the SQLite DB. Use `ruscker import` to populate
+the DB from a YAML, and `ruscker export` to round-trip it back — both
+preserve specs, landing customization, SEO/analytics and custom
+blocks.

--- a/book/src/architecture.md
+++ b/book/src/architecture.md
@@ -1,0 +1,6 @@
+# Architecture
+
+The system design below is the same document maintained in the
+repository (`docs/ARCHITECTURE.md`).
+
+{{#include ../../docs/ARCHITECTURE.md}}

--- a/book/src/configuration.md
+++ b/book/src/configuration.md
@@ -1,0 +1,11 @@
+# Configuration
+
+Ruscker is configured with an `application.yml` in the ShinyProxy
+schema, plus a few Ruscker-specific extensions. The full reference
+below is the same document shipped in the repository
+(`docs/YAML_SCHEMA.md`).
+
+Secrets are never written in the YAML — use `${VAR}` interpolation and
+set the variables in the environment (or `/etc/ruscker/ruscker.env`).
+
+{{#include ../../docs/YAML_SCHEMA.md}}

--- a/book/src/deploying.md
+++ b/book/src/deploying.md
@@ -1,0 +1,121 @@
+# Deploying in production
+
+This walks through the production pattern Ruscker was designed for:
+the `.deb` on a Docker host, behind nginx, optionally side-by-side
+with an existing ShinyProxy.
+
+## 1. Install and configure
+
+```sh
+sudo apt install ./ruscker_<version>_amd64.deb
+```
+
+Put your apps in `/etc/ruscker/application.yml` and your secrets in
+`/etc/ruscker/ruscker.env` (read by the unit):
+
+```ini
+RUSCKER_ADMIN_TOKEN=...        # openssl rand -hex 32
+RUSCKER_MASTER_KEY=...         # for the credentials store
+RUSCKER_COOKIE_KEY=...         # keep sticky sessions stable across restarts
+DOCKER_REGISTRY_PASSWORD=...   # referenced as ${DOCKER_REGISTRY_PASSWORD} in the YAML
+```
+
+## 2. Enable the container backend
+
+The shipped unit serves landing + admin + proxy but not the `--docker`
+backend. Enable it with a drop-in (so upgrades don't clobber it):
+
+```sh
+sudo systemctl edit ruscker
+```
+
+```ini
+[Service]
+SupplementaryGroups=docker
+ExecStart=
+ExecStart=/usr/bin/ruscker serve --config /etc/ruscker/application.yml \
+  --bind 127.0.0.1:8090 --docker --db /var/lib/ruscker/ruscker.db
+```
+
+```sh
+sudo systemctl daemon-reload && sudo systemctl restart ruscker
+```
+
+> Adding `ruscker` to the `docker` group is effectively root on the
+> host — the same trade-off ShinyProxy carries.
+
+### On-demand vs. pre-warmed
+
+Ruscker's auto-scaler keeps `min-replicas` (default **1**) warm per
+spec. With many specs that's a lot of idle containers. To match
+ShinyProxy's on-demand behaviour (spawn on first request, reap when
+idle), set `min-replicas: 0` on the specs.
+
+## 3. nginx
+
+Terminate TLS at your edge / load balancer and forward to nginx with
+`X-Forwarded-Proto: https`. A minimal reverse proxy:
+
+```nginx
+server {
+    listen 80;
+    server_name portal.example.gov;
+
+    location / {
+        proxy_pass http://127.0.0.1:8090/;
+        proxy_http_version 1.1;
+        proxy_set_header Upgrade $http_upgrade;       # WebSocket (Shiny)
+        proxy_set_header Connection "upgrade";
+        proxy_read_timeout 600s;
+        proxy_set_header Host              $http_host;
+        proxy_set_header X-Real-IP         $remote_addr;
+        proxy_set_header X-Forwarded-For   $proxy_add_x_forwarded_for;
+        proxy_set_header X-Forwarded-Proto https;
+    }
+}
+```
+
+Set `server.useForwardHeaders: true` in the YAML so Ruscker trusts
+`X-Forwarded-*` (needed for `Secure` cookies and per-client API rate
+limiting).
+
+## 4. Side-by-side with ShinyProxy
+
+To run both during a migration, give ShinyProxy a context path and
+route by prefix:
+
+```nginx
+    # ShinyProxy under /sp/ (set server.servlet.context-path: /sp in its YAML)
+    location /sp/ { proxy_pass http://127.0.0.1:8080; /* + the proxy_set_header lines */ }
+
+    # Ruscker at the root
+    location /    { proxy_pass http://127.0.0.1:8090/; /* + the proxy_set_header lines */ }
+```
+
+Cut over by reloading nginx; roll back by restoring the previous
+config. Keep a backup of the site file and run `nginx -t` before every
+reload.
+
+## 5. Health checks
+
+Point your load balancer / orchestrator at:
+
+- `GET /healthz` — liveness, always `200` (no dependencies).
+- `GET /readyz` — readiness; probes the DB (`SELECT 1`) and the Docker
+  backend, returns `503` while draining or when a dependency is down.
+
+On `SIGTERM` Ruscker flips `/readyz` to `draining`, lets in-flight
+sessions wind down up to `proxy.shutdown-grace-ms`, then exits.
+
+## Upgrading
+
+Build the new `.deb`, copy it over, and reinstall keeping your config:
+
+```sh
+sudo dpkg -i --force-confold ruscker_<version>_amd64.deb
+sudo systemctl restart ruscker
+```
+
+`--force-confold` preserves `ruscker.env` (your token) and the config;
+the systemd drop-in is untouched. New DB migrations apply on the next
+start.

--- a/book/src/installation.md
+++ b/book/src/installation.md
@@ -1,0 +1,87 @@
+# Installation
+
+Ruscker is a single binary. Pick the packaging that fits your host.
+
+## Debian / Ubuntu (`.deb`)
+
+The most ShinyProxy-like install: a systemd service on your Docker
+host.
+
+```sh
+sudo apt install ./ruscker_<version>_amd64.deb
+```
+
+This:
+
+- installs `/usr/bin/ruscker`,
+- creates a `ruscker` system user,
+- installs a hardened `ruscker.service` unit and enables + starts it,
+- drops an example config at `/etc/ruscker/application.yml` and a
+  secrets file at `/etc/ruscker/ruscker.env`,
+- **generates a unique admin token on first install and prints it
+  once** (there is no default password).
+
+```sh
+systemctl status ruscker
+curl http://localhost:8080/healthz
+sudo grep RUSCKER_ADMIN_TOKEN /etc/ruscker/ruscker.env   # your admin token
+```
+
+Edit `/etc/ruscker/application.yml`, put secrets in
+`/etc/ruscker/ruscker.env`, then `sudo systemctl restart ruscker`. See
+[Deploying in production](./deploying.md) to enable the `--docker`
+backend and put it behind nginx.
+
+## Docker
+
+```sh
+docker run --rm -p 8080:8080 \
+  -v "$PWD/application.yml:/etc/ruscker/application.yml:ro" \
+  ghcr.io/strategicprojects/ruscker:latest \
+  serve --config /etc/ruscker/application.yml --bind 0.0.0.0:8080
+```
+
+To let Ruscker spawn app containers (the `--docker` backend), also
+mount the Docker socket and add `--docker`:
+
+```sh
+docker run --rm -p 8080:8080 \
+  -v "$PWD/application.yml:/etc/ruscker/application.yml:ro" \
+  -v /var/run/docker.sock:/var/run/docker.sock \
+  ghcr.io/strategicprojects/ruscker:latest \
+  serve --config /etc/ruscker/application.yml --bind 0.0.0.0:8080 --docker
+```
+
+> Mounting the Docker socket grants control of the host's Docker
+> daemon — the same trade-off ShinyProxy carries. Prefer the `.deb`
+> on the Docker host when you can.
+
+## From source
+
+Requires Rust (the pinned toolchain installs automatically via
+`rust-toolchain.toml`):
+
+```sh
+cargo build --release --bin ruscker
+./target/release/ruscker --help
+```
+
+## The `serve` command
+
+```text
+ruscker serve --config <path> [--bind 0.0.0.0:8080] [--docker]
+              [--db <file>] [--images-dir <dir>] [--log-format json]
+```
+
+| Flag | What it does |
+|---|---|
+| `--config` | Path to the `application.yml`. |
+| `--bind` | Listen address (defaults to the YAML's `proxy.port`). |
+| `--docker` | Enable the container backend (spawn app containers). |
+| `--db` | SQLite file backing the admin panel. Without it, `/admin/*` is read-only-ish and the editor returns 503. |
+| `--images-dir` | Directory served at `/assets/img/`. Auto-discovered from the config / ShinyProxy `template-path` when omitted. |
+| `--log-format` | `text` (default) or `json`. |
+
+Secrets come from the environment: `RUSCKER_ADMIN_TOKEN`,
+`RUSCKER_MASTER_KEY`, `RUSCKER_COOKIE_KEY`,
+`DOCKER_REGISTRY_PASSWORD`.

--- a/book/src/introduction.md
+++ b/book/src/introduction.md
@@ -1,0 +1,57 @@
+# Ruscker
+
+**Ruscker** is a lightweight Rust alternative to **ShinyProxy** and
+**Shiny Server Free**. It hosts and load-balances containerized
+interactive web apps — R/Shiny, Streamlit, Dash, Voilà — and stateless
+HTTP APIs (Plumber2, FastAPI) behind a single proxy, with a custom
+landing page and a real admin panel.
+
+It ships as a **single static binary, no JVM** — so the idle footprint
+is megabytes, not hundreds of megabytes, and startup is instant.
+
+## Why
+
+ShinyProxy is mature but heavy: a JVM that idles at hundreds of MB,
+slow to start, configured by hand-editing YAML and restarting. Shiny
+Server Free doesn't isolate sessions or scale. Ruscker keeps
+ShinyProxy's YAML schema (so migration is friction-free) and adds a
+proper admin panel, a monitoring dashboard, and load balancing.
+
+## In production
+
+Ruscker runs in production at the Pernambuco state government (SEPE),
+serving the **Monitoramento Estratégico** portal. Migrated side-by-side
+with the existing ShinyProxy (now reachable at `/sp/` for comparison),
+the idle footprint dropped from:
+
+> **540 MB (ShinyProxy / JVM) → ~16 MB (Ruscker)** — roughly a 30×
+> reduction, on the same machine, serving the same 31 apps.
+
+The real 31-spec ShinyProxy 3.2.0 config parsed with **no unsupported
+features** and apps spawn on demand.
+
+## What's in the box
+
+- **Reverse proxy + load balancer** with sticky sessions, WebSocket
+  forwarding, per-spec replica pools and an auto-scaler.
+- **Container backend** (Docker) that spawns app containers on demand
+  and reaps idle ones.
+- **Admin panel** — apps CRUD, image/media library, encrypted
+  credentials store, landing-page editor (colors, intros, SEO, social
+  meta, analytics, custom HTML blocks), audit log, and a live
+  monitoring dashboard.
+- **Operations**: `/healthz` + `/readyz` probes, graceful shutdown,
+  structured (JSON) logging, per-API rate limiting + CORS, request
+  body-size limits.
+- **Distribution**: a multi-stage Docker image and a Debian package
+  with a hardened `systemd` unit.
+
+## Where to next
+
+- [Installation](./installation.md) — Docker or the `.deb`.
+- [Migrating from ShinyProxy](./migrating.md) — point Ruscker at your
+  existing `application.yml`.
+- [Configuration](./configuration.md) — the full YAML reference.
+- [The admin panel](./admin.md) — what each screen does.
+- [Deploying in production](./deploying.md) — systemd + nginx,
+  side-by-side with ShinyProxy.

--- a/book/src/migrating.md
+++ b/book/src/migrating.md
@@ -1,0 +1,65 @@
+# Migrating from ShinyProxy
+
+Ruscker reads the **same `application.yml` schema** as ShinyProxy, so
+in most cases you point it at your existing config and it just works.
+
+## 1. Pre-flight check
+
+Before switching anything, ask Ruscker what your config uses:
+
+```sh
+ruscker validate application.yml                 # general report
+ruscker validate --strict-compat application.yml # migration pre-flight
+```
+
+`--strict-compat` lists every ShinyProxy feature your config uses that
+Ruscker does **not** honour (e.g. Kubernetes backend, per-spec
+`volumes`/`environment`, non-`none` authentication) and exits non-zero
+if it finds any. A clean run means a drop-in migration.
+
+> At SEPE, the real 31-spec ShinyProxy 3.2.0 config reported
+> **"no unsupported features"**.
+
+The validator also flags **plaintext credentials** in the YAML — move
+any `docker-registry-password` to `${DOCKER_REGISTRY_PASSWORD}` and set
+the variable in the environment (or `/etc/ruscker/ruscker.env`).
+
+## 2. Card logos
+
+ShinyProxy serves card logos from its `template-path`'s `assets/img/`
+folder. When you run `serve` without `--images-dir`, Ruscker
+auto-discovers them next to the config:
+
+1. `<config-dir>/assets/img/`
+2. `<config-dir>/<template-path>/assets/img/`
+
+So a config left in place finds its logos with no extra flags.
+
+## 3. Side-by-side cutover (recommended)
+
+You don't have to flip everything at once. A safe pattern (used at
+SEPE) keeps ShinyProxy reachable while Ruscker takes the root:
+
+- Run Ruscker on a spare port (e.g. `127.0.0.1:8090`).
+- In nginx, route `/` → Ruscker and `/sp/` → ShinyProxy (give
+  ShinyProxy a `server.servlet.context-path: /sp`).
+- Compare the two live, and roll back by restoring the nginx config if
+  needed.
+
+Because Ruscker uses the **same `/app/{spec}` URL scheme**, existing
+bookmarks keep working after the cutover.
+
+## What Ruscker adds
+
+Beyond parity, you also get: a real admin panel (no more hand-editing
+YAML), a monitoring dashboard, per-API rate-limiting/CORS, health
+probes, graceful shutdown, and a tiny footprint. See
+[The admin panel](./admin.md).
+
+## Not supported (yet)
+
+Authentication schemes other than `none`, the Kubernetes backend, and
+a few per-spec fields (`volumes`, `environment`, `labels`, …) are
+parsed but ignored — `validate --strict-compat` is the source of
+truth. For apps that handle their own auth (the SEPE case), `none` is
+correct: Ruscker just routes traffic.

--- a/book/src/security.md
+++ b/book/src/security.md
@@ -1,0 +1,6 @@
+# Security
+
+The threat model and hardening notes below are the same document
+maintained in the repository (`docs/SECURITY.md`).
+
+{{#include ../../docs/SECURITY.md}}

--- a/book/src/troubleshooting.md
+++ b/book/src/troubleshooting.md
@@ -1,0 +1,60 @@
+# Troubleshooting
+
+## `/admin` returns 503 "RUSCKER_ADMIN_TOKEN is not set"
+No admin token is configured. Set `RUSCKER_ADMIN_TOKEN` (the `.deb`
+generates one — `sudo grep RUSCKER_ADMIN_TOKEN /etc/ruscker/ruscker.env`)
+and restart. The admin pages also need `serve --db <file>`; without it
+the editor/list screens return 503.
+
+## Card logos don't show up
+The images aren't being served at `/assets/img/`. Either pass
+`--images-dir <dir>` pointing at the folder with the image files, or
+keep the config next to its `template-path`'s `assets/img/` so Ruscker
+auto-discovers it. Check: `curl -I http://localhost:8090/assets/img/<file>`.
+With `--db`, you can also upload logos in **Media** and pick them in
+the spec form.
+
+## Apps don't start (proxy returns 503 / 502)
+- `503 no container backend` — you started without `--docker`. Add it
+  (and give the service Docker access).
+- `502` — the container failed to start or pull. Check
+  `docker logs` for the spawned `ruscker-<spec>-<id>` container, and
+  verify registry credentials. Private images need
+  `docker-registry-username` + `docker-registry-password` (the latter
+  via `${DOCKER_REGISTRY_PASSWORD}`).
+
+## A Shiny app loads but the page is broken / no live updates
+Shiny needs WebSockets. Make sure your reverse proxy forwards the
+upgrade headers (`Upgrade` / `Connection "upgrade"`) — see the nginx
+snippet in [Deploying](./deploying.md).
+
+## The admin shows the wrong / old features after an upgrade
+Templates are compiled into the binary, so changes need a **rebuild +
+reinstall**, not just editing files on the server:
+`sudo dpkg -i --force-confold ruscker_<version>_amd64.deb && sudo
+systemctl restart ruscker`.
+
+## `413 Payload Too Large` on an upload
+A `max-body-size` cap is in effect (global `proxy.max-body-size` or a
+per-spec override). Raise it for that spec or globally.
+
+## `429 Too Many Requests` from an API
+The spec's `api.rate-limit` is throttling the caller. The `Retry-After`
+header says when to retry. Behind a proxy, set
+`server.useForwardHeaders: true` so the limiter keys on the real client
+IP (`X-Forwarded-For`) instead of the proxy's.
+
+## Building the `.deb` fails on a locked-down host
+If the host can't reach crates.io / static.rust-lang.org (only Docker
+Hub + GitHub), build the `.deb` off-box — e.g. in a `rust:<ver>`
+container on a machine with full internet, or in CI — and copy the
+artifact over. Docker pulls and the `build.rs` Tailwind download (from
+GitHub) still work from a connected builder.
+
+## Inspecting what's running
+```sh
+systemctl status ruscker
+journalctl -u ruscker -f
+curl -s localhost:8090/readyz
+docker ps --filter label=ruscker.replica_id
+```


### PR DESCRIPTION
A **pkgdown-style documentation site** (the Rust ecosystem's equivalent is **mdBook**) to publish at **https://strategicprojects.github.io/ruscker/**.

## What
- **`book/`** — mdBook source. User-facing chapters written for this PR: **Introduction** (the pitch + the SEPE 540→16 MB result), **Installation** (Docker + `.deb`), **Migrating from ShinyProxy** (`validate --strict-compat`, side-by-side cutover), **The admin panel**, **Deploying in production** (systemd + nginx, on-demand vs pre-warm, health checks, upgrades), **Troubleshooting**.
- **Reference chapters reuse the repo docs** via `{{#include}}` — Configuration → `docs/YAML_SCHEMA.md`, Architecture → `docs/ARCHITECTURE.md`, Security → `docs/SECURITY.md` — so there's a single source of truth (no copy drift).
- **`.github/workflows/docs.yml`** — builds mdBook and deploys to Pages on push to `main` (triggers on `book/**` and `docs/**`). `site-url = /ruscker/` so assets resolve under the project-pages subpath.
- README links to the site; generated `book/book/` is gitignored.

## Smoke
`mdbook build book` locally (mdBook 0.5.3): 13 pages render, every `{{#include}}` resolves (YAML_SCHEMA / ARCHITECTURE / SECURITY inlined), no broken references.

## One manual step (repo settings)
After merge, enable **Settings → Pages → Source = "GitHub Actions"** (one-time) so the workflow can publish. I can also enable it via `gh api` if you'd like — say the word.

## Follow-ups
- Screenshots of the admin/landing in the Introduction/admin chapters.
- An API/usage reference if we later expose a public HTTP API.

🤖 Generated with [Claude Code](https://claude.com/claude-code)