### PR TITLE
Generify examples/ + scrub SEPE-specific names (pre-public)

### DIFF
--- a/crates/ruscker-admin/assets/i18n/en/landing.ftl
+++ b/crates/ruscker-admin/assets/i18n/en/landing.ftl
@@ -1,6 +1,6 @@
 ### Landing page — en-US
 
-landing-title = Strategic Monitoring
+landing-title = Ruscker
 landing-subtitle = Application and API portal
 
 filter-search-placeholder = Search application…
@@ -249,7 +249,7 @@ admin-audit-family-credential = Credentials
 admin-audit-family-landing = Portal
 admin-audit-actor = Actor
 admin-audit-actor-all = All actors
-admin-audit-target-placeholder = Search target (e.g. spec:auroraprime)
+admin-audit-target-placeholder = Search target (e.g. spec:sales-dashboard)
 admin-audit-apply = Apply
 admin-audit-empty = No changes yet — or the filter matches nothing.
 admin-audit-limit-hint = Showing the 100 most recent matches. Tighten the filter to refine.

--- a/crates/ruscker-admin/assets/i18n/es/landing.ftl
+++ b/crates/ruscker-admin/assets/i18n/es/landing.ftl
@@ -1,6 +1,6 @@
 ### Landing page — es-ES
 
-landing-title = Monitoreo Estratégico
+landing-title = Ruscker
 landing-subtitle = Portal de aplicaciones y APIs
 
 filter-search-placeholder = Buscar aplicación…
@@ -249,7 +249,7 @@ admin-audit-family-credential = Credenciales
 admin-audit-family-landing = Portal
 admin-audit-actor = Autor
 admin-audit-actor-all = Todos los autores
-admin-audit-target-placeholder = Buscar destino (ej: spec:auroraprime)
+admin-audit-target-placeholder = Buscar destino (ej: spec:sales-dashboard)
 admin-audit-apply = Aplicar
 admin-audit-empty = Aún no hay cambios — o el filtro no coincide con nada.
 admin-audit-limit-hint = Mostrando los 100 más recientes. Afine el filtro para reducir.

--- a/crates/ruscker-admin/assets/i18n/fr/landing.ftl
+++ b/crates/ruscker-admin/assets/i18n/fr/landing.ftl
@@ -1,6 +1,6 @@
 ### Landing page — fr-FR
 
-landing-title = Surveillance Stratégique
+landing-title = Ruscker
 landing-subtitle = Portail d'applications et d'APIs
 
 filter-search-placeholder = Rechercher une application…
@@ -249,7 +249,7 @@ admin-audit-family-credential = Identifiants
 admin-audit-family-landing = Portail
 admin-audit-actor = Auteur
 admin-audit-actor-all = Tous les auteurs
-admin-audit-target-placeholder = Rechercher une cible (ex : spec:auroraprime)
+admin-audit-target-placeholder = Rechercher une cible (ex : spec:sales-dashboard)
 admin-audit-apply = Appliquer
 admin-audit-empty = Aucun changement — ou le filtre ne correspond à rien.
 admin-audit-limit-hint = Affichage des 100 plus récents. Affinez le filtre pour réduire.

--- a/crates/ruscker-admin/assets/i18n/pt/landing.ftl
+++ b/crates/ruscker-admin/assets/i18n/pt/landing.ftl
@@ -1,7 +1,7 @@
 ### Landing page — pt-BR
 ### Português brasileiro. Idioma de referência (fallback dos demais).
 
-landing-title = Monitoramento Estratégico
+landing-title = Ruscker
 landing-subtitle = Portal de aplicações e APIs
 
 filter-search-placeholder = Buscar aplicação…
@@ -253,7 +253,7 @@ admin-audit-family-credential = Credenciais
 admin-audit-family-landing = Portal
 admin-audit-actor = Autor
 admin-audit-actor-all = Todos os autores
-admin-audit-target-placeholder = Buscar por alvo (ex: spec:auroraprime)
+admin-audit-target-placeholder = Buscar por alvo (ex: spec:sales-dashboard)
 admin-audit-apply = Aplicar
 admin-audit-empty = Nenhuma alteração ainda — ou o filtro não bate em nada.
 admin-audit-limit-hint = Mostrando os 100 mais recentes que batem com o filtro. Ajuste os filtros para refinar.

--- a/crates/ruscker-admin/src/db/audit.rs
+++ b/crates/ruscker-admin/src/db/audit.rs
@@ -22,7 +22,7 @@ pub struct AuditEntry {
     pub actor: Option<String>,
     /// e.g. `spec.update`, `image.upload`, `credential.delete`.
     pub action: String,
-    /// e.g. `spec:auroraprime`, `image:abc-123`. `None` for
+    /// e.g. `spec:sales-dashboard`, `image:abc-123`. `None` for
     /// global events (system imports).
     pub target: Option<String>,
     /// Parsed `diff_json`. `None` when the column was NULL or
@@ -191,16 +191,16 @@ mod tests {
     #[tokio::test]
     async fn target_substring_filter() {
         let pool = open_memory().await.unwrap();
-        seed(&pool, "spec.update", Some("spec:auroraprime"), None).await;
-        seed(&pool, "spec.update", Some("spec:creches"), None).await;
+        seed(&pool, "spec.update", Some("spec:sales-dashboard"), None).await;
+        seed(&pool, "spec.update", Some("spec:ops-report"), None).await;
 
         let f = AuditFilter {
-            target_contains: Some("aurora".into()),
+            target_contains: Some("sales".into()),
             ..AuditFilter::new()
         };
         let v = list(&pool, &f).await.unwrap();
         assert_eq!(v.len(), 1);
-        assert_eq!(v[0].target.as_deref(), Some("spec:auroraprime"));
+        assert_eq!(v[0].target.as_deref(), Some("spec:sales-dashboard"));
     }
 
     #[tokio::test]

--- a/crates/ruscker-admin/src/db/credentials.rs
+++ b/crates/ruscker-admin/src/db/credentials.rs
@@ -216,7 +216,7 @@ mod tests {
     async fn upsert_then_fetch_round_trip() {
         let pool = open_memory().await.unwrap();
         let key = fixed_key();
-        upsert(&pool, &key, "docker-hub", "docker.io", "milkway", "hunter2", Some("admin"))
+        upsert(&pool, &key, "docker-hub", "docker.io", "acme", "hunter2", Some("admin"))
             .await
             .unwrap();
         let pw = fetch_password(&pool, &key, "docker-hub").await.unwrap();
@@ -227,13 +227,13 @@ mod tests {
     async fn list_does_not_contain_passwords() {
         let pool = open_memory().await.unwrap();
         let key = fixed_key();
-        upsert(&pool, &key, "dh", "docker.io", "milkway", "topsecret", None)
+        upsert(&pool, &key, "dh", "docker.io", "acme", "topsecret", None)
             .await
             .unwrap();
         let metas = list_all(&pool).await.unwrap();
         assert_eq!(metas.len(), 1);
         assert_eq!(metas[0].name, "dh");
-        assert_eq!(metas[0].username, "milkway");
+        assert_eq!(metas[0].username, "acme");
         // (No way to access the password field — CredentialMeta
         // doesn't have one. Compile-time guarantee.)
     }
@@ -242,8 +242,8 @@ mod tests {
     async fn upsert_replaces_password() {
         let pool = open_memory().await.unwrap();
         let key = fixed_key();
-        upsert(&pool, &key, "dh", "docker.io", "milkway", "old", None).await.unwrap();
-        let replaced = upsert(&pool, &key, "dh", "docker.io", "milkway", "new", None).await.unwrap();
+        upsert(&pool, &key, "dh", "docker.io", "acme", "old", None).await.unwrap();
+        let replaced = upsert(&pool, &key, "dh", "docker.io", "acme", "new", None).await.unwrap();
         assert!(replaced);
         let pw = fetch_password(&pool, &key, "dh").await.unwrap().unwrap();
         assert_eq!(pw.as_str(), "new");
@@ -253,7 +253,7 @@ mod tests {
     async fn delete_then_fetch_returns_none() {
         let pool = open_memory().await.unwrap();
         let key = fixed_key();
-        upsert(&pool, &key, "dh", "docker.io", "milkway", "x", None).await.unwrap();
+        upsert(&pool, &key, "dh", "docker.io", "acme", "x", None).await.unwrap();
         assert!(delete_one(&pool, "dh", None).await.unwrap());
         assert!(fetch_password(&pool, &key, "dh").await.unwrap().is_none());
     }

--- a/crates/ruscker-admin/src/db/landing.rs
+++ b/crates/ruscker-admin/src/db/landing.rs
@@ -182,15 +182,15 @@ mod tests {
     async fn seo_fields_roundtrip() {
         let pool = open_memory().await.unwrap();
         let mut lc = LandingCustomization::default();
-        lc.seo_title = Some("Portal SEPE".into());
-        lc.seo_description = Some("Monitoramento estratégico do estado".into());
+        lc.seo_title = Some("Demo Portal".into());
+        lc.seo_description = Some("Demo portal description".into());
         lc.og_image = Some("/assets/img/og.png".into());
         update(&pool, &lc, Some("admin")).await.unwrap();
         let got = fetch(&pool).await.unwrap();
-        assert_eq!(got.seo_title.as_deref(), Some("Portal SEPE"));
+        assert_eq!(got.seo_title.as_deref(), Some("Demo Portal"));
         assert_eq!(
             got.seo_description.as_deref(),
-            Some("Monitoramento estratégico do estado")
+            Some("Demo portal description")
         );
         assert_eq!(got.og_image.as_deref(), Some("/assets/img/og.png"));
     }

--- a/crates/ruscker-admin/src/db/specs.rs
+++ b/crates/ruscker-admin/src/db/specs.rs
@@ -338,19 +338,20 @@ mod tests {
     }
 
     #[tokio::test]
-    async fn imports_31_specs_then_roundtrip_is_unchanged() {
+    async fn imports_all_specs_then_roundtrip_is_unchanged() {
         let pool = open_memory().await.unwrap();
         let cfg = Config::from_yaml(&fixture_yaml()).unwrap();
+        let n = cfg.proxy.specs.len();
 
         let r1 = import_all(&pool, &cfg).await.unwrap();
-        assert_eq!(r1.created, 31, "first import inserts all");
+        assert_eq!(r1.created, n, "first import inserts all");
         assert_eq!(r1.updated, 0);
         assert_eq!(r1.unchanged, 0);
 
         let r2 = import_all(&pool, &cfg).await.unwrap();
         assert_eq!(r2.created, 0, "second import sees them as existing");
         assert_eq!(r2.updated, 0, "no changes → no version bumps");
-        assert_eq!(r2.unchanged, 31);
+        assert_eq!(r2.unchanged, n);
 
         // Audit log got both import events.
         let audit_count: (i64,) = sqlx::query_as(
@@ -372,7 +373,7 @@ mod tests {
         cfg.proxy.specs[0].description = Some("Updated description".to_string());
         let r = import_all(&pool, &cfg).await.unwrap();
         assert_eq!(r.updated, 1);
-        assert_eq!(r.unchanged, 30);
+        assert_eq!(r.unchanged, cfg.proxy.specs.len() - 1);
 
         let (version,): (i64,) = sqlx::query_as("SELECT version FROM specs WHERE id = ?")
             .bind(&cfg.proxy.specs[0].id)

--- a/crates/ruscker-admin/src/routes/admin/audit.rs
+++ b/crates/ruscker-admin/src/routes/admin/audit.rs
@@ -31,7 +31,7 @@ pub struct AuditQuery {
     /// "spec" | "image" | "credential" | "landing" | "" (all)
     #[serde(default)]
     pub family: String,
-    /// Substring match against target (`spec:auroraprime`,
+    /// Substring match against target (`spec:sales-dashboard`,
     /// `image:abc-123`, …).
     #[serde(default)]
     pub target: String,

--- a/crates/ruscker-admin/src/routes/admin/dashboard.rs
+++ b/crates/ruscker-admin/src/routes/admin/dashboard.rs
@@ -743,7 +743,7 @@ mod tests {
             locales_all: &Locale::ALL,
             nav_section: "dashboard",
             display_name: "Aurora Prime".into(),
-            spec_id: "auroraprime".into(),
+            spec_id: "sales-dashboard".into(),
             replica_id: "11111111-2222-3333-4444-555555555555".into(),
             lines,
         };
@@ -757,7 +757,7 @@ mod tests {
             "worker process 1 started".into(),
         ]);
         assert!(html.contains("Aurora Prime"));
-        assert!(html.contains("auroraprime"));
+        assert!(html.contains("sales-dashboard"));
         assert!(html.contains("11111111-2222-3333-4444-555555555555"));
         assert!(html.contains("starting nginx"));
         assert!(html.contains("worker process 1 started"));

--- a/crates/ruscker-admin/src/routes/rewrite.rs
+++ b/crates/ruscker-admin/src/routes/rewrite.rs
@@ -22,10 +22,10 @@
 //! <img src="/img/spinner.gif">
 //! ```
 //!
-//! All three are root-relative; behind `/app/auroraprime/` the
+//! All three are root-relative; behind `/app/sales-dashboard/` the
 //! browser dispatches them as `/sockjs/info` etc. and hits
 //! Ruscker, which has no route for those paths. With this
-//! pass they become `/app/auroraprime/sockjs/info` and route
+//! pass they become `/app/sales-dashboard/sockjs/info` and route
 //! back through the same proxy handler that served the page.
 //!
 //! ## Runtime URL interception (JS shim)
@@ -137,7 +137,7 @@ fn rewrite_url(value: &str, base_path: &str) -> Option<String> {
 ///
 /// `base_path` should be the user-visible URL prefix the app
 /// is mounted at, **with a trailing slash** — e.g.
-/// `/app/auroraprime/`.
+/// `/app/sales-dashboard/`.
 ///
 /// Name kept as `inject_base_href` for source-compat with the
 /// proxy handler that calls this; the function now does both
@@ -390,8 +390,8 @@ mod tests {
             Some("/app/x/lib/foo.css")
         );
         assert_eq!(
-            rewrite_url("/sockjs/info", "/app/auroraprime/").as_deref(),
-            Some("/app/auroraprime/sockjs/info")
+            rewrite_url("/sockjs/info", "/app/sales-dashboard/").as_deref(),
+            Some("/app/sales-dashboard/sockjs/info")
         );
     }
 

--- a/crates/ruscker-admin/tests/landing_render.rs
+++ b/crates/ruscker-admin/tests/landing_render.rs
@@ -59,18 +59,24 @@ async fn landing_renders_default_locale() {
     let (status, body) = get_with_cookie(None).await;
     assert_eq!(status, StatusCode::OK);
     assert!(body.contains(r#"<html lang="pt""#), "default locale is pt-BR");
-    assert!(body.contains("Monitoramento Estratégico"));
-    // 31 specs in examples/application.yml → 31 cards rendered.
+    // seo-title from the example landing-customization drives <title>.
+    assert!(body.contains("Ruscker Demo Portal"));
+    // Per-locale intro (pt) from landing-customization.intro-locales.
+    assert!(body.contains("demonstração"), "pt intro should render");
+    // 8 specs in examples/application.yml → 8 cards rendered.
     // Cards are <a class="rcard"> in the v2 layout.
-    assert_eq!(body.matches(r#"class="rcard"#).count(), 31);
+    assert_eq!(body.matches(r#"class="rcard"#).count(), 8);
 }
 
 #[tokio::test]
 async fn landing_honors_locale_cookie() {
-    for (cookie, lang, title) in [
-        ("ruscker_locale=en", "en", "Strategic Monitoring"),
-        ("ruscker_locale=es", "es", "Monitoreo Estratégico"),
-        ("ruscker_locale=fr", "fr", "Surveillance Stratégique"),
+    // Distinctive substrings from the per-locale intro in the example's
+    // landing-customization.intro-locales — proves the locale cookie
+    // drives the rendered copy.
+    for (cookie, lang, intro) in [
+        ("ruscker_locale=en", "en", "filters below"),
+        ("ruscker_locale=es", "es", "demostración"),
+        ("ruscker_locale=fr", "fr", "démonstration"),
     ] {
         let (status, body) = get_with_cookie(Some(cookie)).await;
         assert_eq!(status, StatusCode::OK, "locale {lang}");
@@ -79,8 +85,8 @@ async fn landing_honors_locale_cookie() {
             "{lang}: html lang attribute missing"
         );
         assert!(
-            body.contains(title),
-            "{lang}: title {title:?} not in body"
+            body.contains(intro),
+            "{lang}: intro {intro:?} not in body"
         );
     }
 }

--- a/crates/ruscker-config/src/schema.rs
+++ b/crates/ruscker-config/src/schema.rs
@@ -241,8 +241,8 @@ pub struct LandingCustomization {
     /// ```yaml
     /// landing-customization:
     ///   intro-locales:
-    ///     pt: "Bem-vindo ao Monitoramento Estratégico..."
-    ///     en: "Welcome to Strategic Monitoring..."
+    ///     pt: "Bem-vindo ao portal..."
+    ///     en: "Welcome to the portal..."
     /// ```
     #[serde(default, rename = "intro-locales")]
     pub intro_locales: std::collections::HashMap<String, String>,

--- a/crates/ruscker-config/tests/shinyproxy_compat.rs
+++ b/crates/ruscker-config/tests/shinyproxy_compat.rs
@@ -1,8 +1,11 @@
-//! Integration test: load the real (sanitized) `application.yml` from
+//! Integration test: load the example `application.yml` from
 //! `examples/` and verify it parses correctly.
 //!
-//! This is the most important test in the codebase — if this breaks,
-//! existing ShinyProxy users can't migrate.
+//! This is the most important test in the codebase — it's the
+//! ShinyProxy-compatibility contract. The example is a generic but
+//! comprehensive config exercising every spec kind, env-var
+//! interpolation, template properties, and the Ruscker extensions. If
+//! this breaks, existing ShinyProxy users can't migrate.
 
 use ruscker_config::{Config, SpecKind};
 use std::path::PathBuf;
@@ -23,27 +26,27 @@ fn load_with_env() -> Config {
 }
 
 #[test]
-fn parses_full_sepe_config() {
+fn parses_example_config() {
     let config = load_with_env();
-    assert_eq!(config.proxy.title.trim(), "Monitoramento Estratégico");
+    assert_eq!(config.proxy.title.trim(), "Ruscker Demo Portal");
     assert_eq!(config.proxy.landing_page, "/");
     assert!(config.proxy.hide_navbar);
     assert_eq!(config.proxy.heartbeat_rate, 10_000);
     assert_eq!(config.proxy.heartbeat_timeout, 3_600_000);
     // `shutdown-grace-ms` is a Ruscker extension absent from the
-    // SEPE config — it must fall back to the 30s default.
+    // example — it must fall back to the 30s default.
     assert_eq!(config.proxy.shutdown_grace_ms, 30_000);
     assert_eq!(config.proxy.port, 8080);
     assert_eq!(config.proxy.bind_address, "127.0.0.1");
 }
 
 #[test]
-fn loads_all_31_specs() {
+fn loads_all_specs() {
     let config = load_with_env();
     assert_eq!(
         config.proxy.specs.len(),
-        31,
-        "expected 31 specs, found {}",
+        8,
+        "expected 8 specs, found {}",
         config.proxy.specs.len()
     );
 }
@@ -51,111 +54,108 @@ fn loads_all_31_specs() {
 #[test]
 fn classifies_specs_correctly() {
     let config = load_with_env();
+    let count = |k: SpecKind| config.proxy.specs.iter().filter(|s| s.kind() == k).count();
 
-    let containerized: Vec<_> = config
-        .proxy
-        .specs
-        .iter()
-        .filter(|s| s.container_image.is_some())
-        .collect();
-    let external: Vec<_> = config
-        .proxy
-        .specs
-        .iter()
-        .filter(|s| s.container_image.is_none())
-        .collect();
+    assert_eq!(count(SpecKind::Shiny), 5, "expected 5 Shiny specs");
+    assert_eq!(count(SpecKind::Api), 1, "expected 1 API spec");
+    assert_eq!(count(SpecKind::External), 2, "expected 2 external specs");
 
-    assert_eq!(
-        containerized.len(),
-        17,
-        "expected 17 specs with container-image"
-    );
-    assert_eq!(external.len(), 14, "expected 14 specs without container");
-
-    for spec in containerized {
-        assert_eq!(spec.kind(), SpecKind::Shiny, "spec {} should be Shiny", spec.id);
-        assert!(
-            spec.needs_sticky_sessions(),
-            "spec {} should need sticky sessions",
-            spec.id
-        );
-    }
-    for spec in external {
-        assert_eq!(spec.kind(), SpecKind::External, "spec {} should be External", spec.id);
+    // Interactive apps need sticky sessions; APIs and external links don't.
+    for spec in &config.proxy.specs {
+        match spec.kind() {
+            SpecKind::Shiny => assert!(
+                spec.needs_sticky_sessions(),
+                "spec {} should need sticky sessions",
+                spec.id
+            ),
+            SpecKind::External => {
+                assert!(
+                    spec.container_image.is_none(),
+                    "external spec {} should have no container-image",
+                    spec.id
+                );
+                assert!(!spec.needs_sticky_sessions(), "spec {} should not be sticky", spec.id);
+            }
+            _ => {}
+        }
     }
 }
 
 #[test]
 fn env_interpolation_works_on_credentials() {
     let config = load_with_env();
-    let creches = config
+    let ops = config
         .proxy
         .specs
         .iter()
-        .find(|s| s.id == "creches")
-        .expect("creches spec must exist");
+        .find(|s| s.id == "ops-report")
+        .expect("ops-report spec must exist");
     assert_eq!(
-        creches.docker_registry_password.as_deref(),
+        ops.docker_registry_password.as_deref(),
         Some("test-pat-not-real"),
         "${{DOCKER_REGISTRY_PASSWORD}} should have been interpolated"
     );
-    assert_eq!(creches.docker_registry_username.as_deref(), Some("milkway"));
+    assert_eq!(ops.docker_registry_username.as_deref(), Some("acme"));
 }
 
 #[test]
 fn template_properties_preserved_with_html() {
     let config = load_with_env();
-    let aurora = config
+    let app = config
         .proxy
         .specs
         .iter()
-        .find(|s| s.id == "auroraprime")
-        .expect("auroraprime spec must exist");
+        .find(|s| s.id == "sales-dashboard")
+        .expect("sales-dashboard spec must exist");
 
     assert_eq!(
-        aurora.template_properties.get_str("logo"),
-        Some("/assets/img/auroraprime.png")
+        app.template_properties.get_str("logo"),
+        Some("/assets/img/sales.png")
     );
-    assert_eq!(aurora.template_properties.type_field(), Some("app"));
-    assert_eq!(aurora.template_properties.state(), "active");
-    assert!(aurora.template_properties.get_str("link").is_some());
-    assert!(aurora
-        .description
-        .as_deref()
-        .unwrap()
-        .contains("Governo de Pernambuco"));
+    assert_eq!(app.template_properties.type_field(), Some("app"));
+    assert_eq!(app.template_properties.state(), "active");
+    // Inline HTML in the description is preserved verbatim.
+    assert!(app.description.as_deref().unwrap().contains("<a href="));
+}
+
+#[test]
+fn external_link_spec_carries_a_link() {
+    let config = load_with_env();
+    let handbook = config
+        .proxy
+        .specs
+        .iter()
+        .find(|s| s.id == "handbook")
+        .expect("handbook spec must exist");
+    assert_eq!(handbook.kind(), SpecKind::External);
+    assert!(handbook.template_properties.get_str("link").is_some());
 }
 
 #[test]
 fn heartbeat_override_negative_one_preserved() {
     let config = load_with_env();
-    let hortensias = config
+    let longrun = config
         .proxy
         .specs
         .iter()
-        .find(|s| s.id == "hortensias")
-        .expect("hortensias spec must exist");
-    assert_eq!(hortensias.heartbeat_timeout, Some(-1));
+        .find(|s| s.id == "longrun-model")
+        .expect("longrun-model spec must exist");
+    assert_eq!(longrun.heartbeat_timeout, Some(-1));
 }
 
 #[test]
-fn validation_finds_no_embedded_credentials_after_sanitization() {
+fn validation_finds_no_embedded_credentials() {
     let config = load_with_env();
     let report = config.validate();
 
     let embedded: Vec<_> = report
         .warnings
         .iter()
-        .filter(|w| {
-            matches!(
-                w,
-                ruscker_config::Warning::EmbeddedCredential { .. }
-            )
-        })
+        .filter(|w| matches!(w, ruscker_config::Warning::EmbeddedCredential { .. }))
         .collect();
     assert!(
         embedded.is_empty(),
-        "the sanitized YAML uses ${{VAR}} form throughout, expected no \
+        "the example uses ${{VAR}} form throughout, expected no \
         EmbeddedCredential warnings, found: {:?}",
         embedded
     );
@@ -165,9 +165,9 @@ fn validation_finds_no_embedded_credentials_after_sanitization() {
 fn stats_report_matches_yaml() {
     let config = load_with_env();
     let report = config.validate();
-    assert_eq!(report.stats.total_specs, 31);
-    assert_eq!(*report.stats.by_kind.get("shiny").unwrap_or(&0), 17);
-    assert_eq!(*report.stats.by_kind.get("external").unwrap_or(&0), 14);
+    assert_eq!(report.stats.total_specs, 8);
+    assert_eq!(*report.stats.by_kind.get("shiny").unwrap_or(&0), 5);
+    assert_eq!(*report.stats.by_kind.get("external").unwrap_or(&0), 2);
 }
 
 #[test]

--- a/crates/ruscker-proxy/src/sticky.rs
+++ b/crates/ruscker-proxy/src/sticky.rs
@@ -219,7 +219,7 @@ mod tests {
     fn sample() -> StickySession {
         StickySession {
             session_id: Uuid::parse_str("11111111-1111-1111-1111-111111111111").unwrap(),
-            spec_id: "auroraprime".into(),
+            spec_id: "sales-dashboard".into(),
             replica_id: ReplicaId(
                 Uuid::parse_str("22222222-2222-2222-2222-222222222222").unwrap(),
             ),

--- a/examples/application.yml
+++ b/examples/application.yml
@@ -1,543 +1,138 @@
+# Ruscker example configuration — a generic, comprehensive reference.
+#
+# It uses the ShinyProxy `application.yml` schema (so existing configs
+# migrate as-is) plus Ruscker extensions (type: api, min/max-replicas,
+# landing-customization, …). See docs/YAML_SCHEMA.md for the full
+# reference. NEVER put secrets here — use ${ENV_VAR} interpolation.
+
 server:
   useForwardHeaders: true
-  secure-cookies: true  
+  secure-cookies: true
   forward-headers-strategy: native
-  servlet.session.timeout: 3600  
+  servlet.session.timeout: 3600
 
 proxy:
-  title: Monitoramento Estratégico 
+  title: Ruscker Demo Portal
   landing-page: /
   hide-navbar: true
-  template-path: templates/mlk  
+  template-path: templates/default
   heartbeat-rate: 10000
   heartbeat-timeout: 3600000
-  container-wait-time: 360000
-  container-log-path: ./logs  
+  container-wait-time: 60000
+  container-log-path: ./logs
   port: 8080
-  bind-address: 127.0.0.1 # Add this under the proxy entry  
-  authentication: none  # use openid auth framework
+  bind-address: 127.0.0.1
+  authentication: none   # MVP: apps handle their own auth
 
-  # Ruscker extension — visual customization of the public landing.
-  # The same knobs are exposed in the admin landing-page editor in
-  # Phase 2 (docs/mockups/admin-landing-editor.html).
+  # Ruscker extension — customize the public landing without a custom
+  # template. The same knobs are exposed in the admin landing editor.
   landing-customization:
     header-bg: "#0f6e56"
     header-fg: "#ffffff"
+    seo-title: "Ruscker Demo Portal"
+    seo-description: "Demo portal serving Shiny apps, an API and external links."
     intro-locales:
-      pt: "Portal oficial das aplicações, painéis, relatórios, apresentações e APIs do Monitoramento Estratégico do Governo de Pernambuco. Use os filtros abaixo para encontrar o que precisa."
-      en: "Official portal for applications, dashboards, reports, presentations and APIs of the Pernambuco State Government's Strategic Monitoring. Use the filters below to find what you need."
-      es: "Portal oficial de las aplicaciones, paneles, informes, presentaciones y APIs del Monitoreo Estratégico del Gobierno de Pernambuco. Use los filtros abajo para encontrar lo que necesita."
-      fr: "Portail officiel des applications, tableaux de bord, rapports, présentations et APIs de la Surveillance Stratégique du Gouvernement de Pernambouc. Utilisez les filtres ci-dessous pour trouver ce dont vous avez besoin."
+      pt: "Portal de demonstração do Ruscker. Use os filtros abaixo para encontrar apps, APIs e links."
+      en: "Ruscker demo portal. Use the filters below to find apps, APIs and links."
+      es: "Portal de demostración de Ruscker. Use los filtros para encontrar apps, APIs y enlaces."
+      fr: "Portail de démonstration de Ruscker. Utilisez les filtres pour trouver apps, APIs et liens."
 
   specs:
 
-    - id: auroraprime
-      display-name: Aurora Prime
-      description: Painel de monitoramento das iniciativas estratégicas do Governo de Pernambuco. Desenvolvimento e manutenção do aurora foi transferido para a <a href="https://resultados.seplag.pe.gov.br/" style="text-decoration:none;color:#1a1a1a;font-weight:500;letter-spacing:0.3px;transition:color 0.2s ease;" onmouseover="this.style.color='#0056b3'" onmouseout="this.style.color='#1a1a1a'"><span style="font-weight:600;">Secretaria Executiva de Gestão para Resultados – SEGPR</span></a>
-      container-image: milkway/auroraprime-app:latest
-      #minimum-seats-available: 1
+    # ── Shiny / interactive apps ─────────────────────────────────
+    - id: sales-dashboard
+      display-name: Sales Dashboard
+      description: A Shiny dashboard. Maintained by the <a href="https://example.com/team" style="color:#0f6e56;font-weight:600;">Data Team</a>.
+      container-image: org/sales-dashboard:latest
       seats-per-container: 10
       max-lifetime: 360
-      container-lifetime: 360        
+      container-lifetime: 360
       template-properties:
-        logo: "/assets/img/auroraprime.png"
+        logo: "/assets/img/sales.png"
         icon: lock
         type: app
         updated: "18/05/2025"
         state: active
-        tema: "Gestão"
-        link: https://resultados.seplag.pe.gov.br/app/aurora  
-          
-    - id: creches
-      display-name: Painel Creches
-      description: "Painel de monitoramento da iniciativa de construção de 250 creches."
-      container-image: milkway/creches-app:latest
-      docker-registry-username: milkway
+        tema: "Sales"
+
+    - id: ops-report
+      display-name: Operations Report
+      description: "Weekly operations report (private image — credentials via env var)."
+      container-image: registry.example.com/acme/ops-report:latest
+      docker-registry-username: acme
       docker-registry-password: ${DOCKER_REGISTRY_PASSWORD}
-      docker-registry-domain: docker.io
-      #minimum-seats-available: 1
+      docker-registry-domain: registry.example.com
       seats-per-container: 10
-      max-lifetime: 360
-      container-lifetime: 360  
       template-properties:
-        logo: "/assets/img/creches_painel.png"
-        icon: lock
-        type: app
-        updated: "01/12/2024"  
-        link: https://apps.sepe.pe.gov.br/cl/creches
-        state: active  
-        tema: "Políticas Públicas"
-
-          #    - id: epti
-          # display-name: EPTI
-          # description: "Painel para avalização da rede intermunicipal de transporte."
-          # container-image: milkway/epti-app:latest  
-          # seats-per-container: 5
-          # docker-registry-username: milkway
-          # docker-registry-password: ${DOCKER_REGISTRY_PASSWORD}
-          #  docker-registry-domain: docker.io  
-          # template-properties:
-          #  logo: "/assets/img/epti_1.png"
-          #  icon: lock
-          #  type: app
-          #  updated: "03/12/2024"
-          #  state: active
-
-    - id: hortensias
-      display-name: Hortensias
-      description: "Aplicativo para monitoramento de contratos."
-      container-image: milkway/hortensias-app:latest
-      heartbeat-timeout: -1
-      stop-on-logout: false
-      #minimum-seats-available: 1
-      seats-per-container: 10
-      max-lifetime: 360
-      container-lifetime: 360  
-      docker-registry-username: milkway
-      docker-registry-password: ${DOCKER_REGISTRY_PASSWORD}
-      docker-registry-domain: docker.io  
-      template-properties:
-        logo: "/assets/img/hortensias_1.png"
-        icon: lock
-        type: app
-        updated: "29/01/2025"
-        state: active  
-        tema: "Gestão"
-
-    - id: mulungu
-      display-name: Mulungu
-      description: Mulungu é um aplicativo de monitoramento das obras do DER-PE. Desenvolvimento e manutenção do mulungu foi transferido para a <a href="https://resultados.seplag.pe.gov.br/" style="text-decoration:none;color:#1a1a1a;font-weight:500;letter-spacing:0.3px;transition:color 0.2s ease;" onmouseover="this.style.color='#0056b3'" onmouseout="this.style.color='#1a1a1a'"><span style="font-weight:600;">Secretaria Executiva de Gestão para Resultados – SEGPR</span></a>  #que permite acompanhar em tempo real o progresso, os custos e o status das intervenções de infraestrutura em Pernambuco. Inspirado em um verbo de raiz –ng–, que sugere “se corrigir” ou “se endireitar”, e também na tradição banto de designar “companheiro de viagem” ou “irmão de jornada”, 
-      container-image: milkway/mulungu-app:latest
-      #minimum-seats-available: 1
-      seats-per-container: 10
-      max-lifetime: 360
-      container-lifetime: 360  
-      template-properties:
-        logo: "/assets/img/mulungu.png"
-        icon: lock
-        type: app
-        updated: "18/05/2025"
-        state: active          
-        tema: "Infraestrutura e Mobilidade"
-        link: https://resultados.seplag.pe.gov.br/app/mulungu  
-
-    - id: nassau
-      display-name: Nassau
-      description: "Painel para administração de usuários e acessos aos aplicativos da Secretaria Executiva de Monitoramento Estratégico."
-      container-image: milkway/nassau-app:latest
-      stop-on-logout: false
-      #minimum-seats-available: 1
-      seats-per-container: 10
-      max-lifetime: 360
-      container-lifetime: 360  
-      docker-registry-username: milkway
-      docker-registry-password: ${DOCKER_REGISTRY_PASSWORD}
-      docker-registry-domain: docker.io
-      template-properties:
-        logo: "/assets/img/nassau_3.png"
-        icon: lock
-        type: app
-        updated: "29/01/2025"
-        state: active  
-        tema: "Gestão"
-
-    - id: peabiru
-      display-name: Peabiru
-      description: "Aplicativo que monitora, em tempo real, os alertas do Waze para as rodovias estaduais e federais de Pernambuco, oferecendo informações atualizadas sobre trânsito, incidentes e condições das vias."
-      container-image: milkway/peabiru-app:latest
-      stop-on-logout: false
-      #minimum-seats-available: 1
-      seats-per-container: 10
-      max-lifetime: 360
-      container-lifetime: 360  
-      docker-registry-username: milkway
-      docker-registry-password: ${DOCKER_REGISTRY_PASSWORD}
-      docker-registry-domain: docker.io
-      template-properties:
-        logo: "/assets/img/waze_rodovias.png"
+        logo: "/assets/img/ops.png"
         icon: lock_open
-        type: app
-        updated: "17/03/2025"
-        state: active  
-        tema: "Infraestrutura e Mobilidade"
-
-
-    - id: pikup
-      display-name: Pikup
-      description: "Aplicativo para construção de diagramas em SVG para apresentações e relatórios usando o pikchr, interpretador desenvolvido por D. Richard Hipp tendo como referência a linguagem PIC criada por Brian Kernighan."
-      container-image: milkway/pikup-app:latest
-      #minimum-seats-available: 1
-      seats-per-container: 10
-      max-lifetime: 360
-      container-lifetime: 360  
-      stop-on-logout: false
-      docker-registry-username: milkway
-      docker-registry-password: ${DOCKER_REGISTRY_PASSWORD}
-      docker-registry-domain: docker.io  
-      template-properties:
-        logo: "/assets/img/pikup_1.png"
-        icon: lock_open
-        type: app
-        updated: "19/02/2025"
-        state: active
-        tema: "Gestão"
-
-    # ======== PACKAGES ========
-    - id: bigdatape
-      display-name: "BigDataPE"
-      description: "Pacote com funções para acessar os dados no portal BigDataPE."
-      template-properties:
-        logo: "/assets/img/bigdatape.png"
-        icon: lock_open
-        type: package
-        updated: "14/12/2024"
-        link: https://monitoramento.sepe.pe.gov.br/bigdatape
-        state: active          
-        tema: "Gestão"
-
-    - id: diario
-      display-name: "diario"
-      description: "Pacote em R que fornece um conjunto de funções para armazenar tokens de API de maneira segura e interagir com a API do sistema diariodeobras.net."
-      template-properties:
-        logo: "/assets/img/diario.png"
-        icon: lock_open
-        type: package
-        updated: "30/12/2024"
-        link: https://monitoramento.sepe.pe.gov.br/diario
-        state: active
-        tema: "Gestão"
-    
-    - id: cardargus
-      display-name: "cardargus"
-      description: "Pacote R para criação de cards visuais em SVG e PNG, com tipografia moderna, layout responsivo e integração com knitr e R Markdown. Ideal para relatórios, dashboards e visualizações institucionais com identidade visual consistente."
-      template-properties:
-        logo: "/assets/img/cardargus.png"
-        icon: lock_open
-        type: package
-        updated: "03/02/2026"
-        link: https://monitoramento.sepe.pe.gov.br/cardargus
-        state: active
-        tema: "Gestão"
-
-    - id: evolution
-      display-name: "evolution"
-      description: "Pacote R para integrar com a API do Evolution Cloud, permitindo enviar e receber mensagens no WhatsApp e construir respostas automáticas em apps com plumber."
-      template-properties:
-        logo: "/assets/img/logo_evolution.png"
-        icon: lock_open
-        type: package
-        updated: "12/11/2025"
-        link: https://monitoramento.sepe.pe.gov.br/evolution
-        state: active
-        tema: "Gestão"
-
-    - id: ibger
-      display-name: "ibger"
-      description: "Interface moderna e intuitiva para a API SIDRA do IBGE, no estilo tidyverse com httr2 e cli. Permite baixar dados do IPCA e outras tabelas com filtros naturais por localização, item e período."
-      template-properties:
-        logo: "/assets/img/ibger_logo.png"
-        icon: lock_open
-        type: package
-        updated: "20/02/2026"
-        link: https://monitoramento.sepe.pe.gov.br/ibger
-        state: active       
-        tema: "Gestão"
-
-    - id: pikchr
-      display-name: Pikchr
-      description: "Pacote para construção de diagramas em linguagem PIC/Pikchr no R."
-      template-properties:
-        logo: "/assets/img/pikchr_1.png"
-        icon: lock_open
-        type: package
-        updated: "30/11/2024"
-        link: https://monitoramento.sepe.pe.gov.br/pikchr
-        state: active          
-        tema: "Gestão"
-
-    - id: pixr
-      display-name: "pixr"
-      description: "Pacote R para acesso à API de Dados Abertos do PIX do Banco Central do Brasil. Permite consultar estatísticas de chaves PIX, transações por município, volume de transações e dados de fraudes. Suporta filtros OData, retorna tibbles e integra-se ao tidyverse."
-      template-properties:
-        logo: "/assets/img/pixr.png"
-        icon: lock_open
-        type: package
-        updated: "03/02/2026"
-        link: https://monitoramento.sepe.pe.gov.br/pixr
-        state: active
-        tema: "Gestão"
-
-
-    - id: plug
-      display-name: "Plug"
-      description: "Pacote R que fornece uma interface simples e segura para integração com o Plug, permitindo o gerenciamento de credenciais, autenticação automática via tokens e execução de consultas SQL personalizadas."
-      template-properties:
-        logo: "/assets/img/plug.png"
-        icon: lock_open
-        type: package
-        updated: "26/12/2024"
-        link: https://monitoramento.sepe.pe.gov.br/plug
-        state: active      
-        tema: "Gestão"
-
-    - id: rapidfuzz
-      display-name: RapidFuzz
-      description: "Pacote para cálculo de similaridades e distâncias entre textos."
-      template-properties:
-        logo: "/assets/img/rapidfuzz_1.png"
-        icon: lock_open
-        type: package 
-        updated: "01/12/2023"  
-        link: https://monitoramento.sepe.pe.gov.br/rapidfuzz
-        state: active  
-        tema: "Gestão"
-
-    - id: signer
-      display-name: SigneR
-      description: "Pacote para assinatura digital de arquivos PDF no R."
-      template-properties:
-        logo: "/assets/img/signer.png"
-        icon: lock
-        type: package
-        updated: "01/09/2024"  
-        link: https://monitoramento.sepe.pe.gov.br/signer
-        state: active  
-        tema: "Gestão"
-
-    - id: vialactea
-      display-name: "Vialáctea"
-      description: "Pacote com conjunto de modelos e funções utilizadas pela Secretaria Executiva de Monitoramento Estratégico."
-      template-properties:
-        logo: "/assets/img/vialactea.png"
-        icon: lock
-        type: package
-        updated: "01/12/2024"  
-        link: https://monitoramento.sepe.pe.gov.br/vialactea
-        state: active  
-        tema: "Gestão"
-
-    - id: webdav
-      display-name: WebDAV
-      description: "Pacote para gerenciamento de arquivos em servidores do tipo OwnCloud (Drive PE)."
-      template-properties:
-        logo: "/assets/img/webdav_1.png"
-        icon: lock_open
-        type: package
-        updated: "30/11/2024"  
-        link: https://monitoramento.sepe.pe.gov.br/webdav
-        state: active
-        tema: "Gestão"
-
-    - id: whapi
-      display-name: whapi
-      description: "Pacote R para integrar com a API Whapi.Cloud, permitindo enviar e receber mensagens no WhatsApp e construir respostas automáticas em apps com plumber."
-      template-properties:
-        logo: "/assets/img/logo_whapi_2.png" 
-        icon: lock_open
-        type: package
-        updated: "11/09/2025"
-        link: https://monitoramento.sepe.pe.gov.br/whapi
-        state: active
-        tema: "Gestão"
-
-    # ======== TALKS ========
-    - id: contratos_sers_talk
-      display-name: Diagnóstico Contratos SERS
-      description: "Apresentação diagnóstico dos contratos SERS - Secretaria de Saúde"
-      container-image: milkway/tk_contratos_sers-app:latest
-      stop-on-logout: false
-      #minimum-seats-available: 1
-      seats-per-container: 10
-      max-lifetime: 360
-      container-lifetime: 360  
-      template-properties:
-        logo: "/assets/img/contratos_sers.png"
-        icon: lock
-        type: talk
-        updated: "18/02/2025"
-        state: active  
-        tema: "Saúde Pública"
-
-    - id: hortensias_conseplan
-      display-name: Hortensias – CONSEPLAN
-      description: "Apresentação do projeto Hortensias no 1. Congresso CONSEPLAN, Brasília – DF, 2025."
-      stop-on-logout: false
-      #minimum-seats-available: 1
-      seats-per-container: 10
-      max-lifetime: 360
-      container-lifetime: 360  
-      template-properties:
-        logo: "/assets/img/hortensias_3.png"
-        icon: lock_open
-        type: talk
-        updated: "15/05/2025"
-        link: https://monitoramento.sepe.pe.gov.br/talks/hortensias/
-        state: active  
-        tema: "Gestão"
-
-    - id: maternidades_talk
-      display-name: Localização de Maternidades
-      description: "Apresentação do relatório de localização de maternidades para o Estado de Pernambuco."
-      stop-on-logout: false
-      #minimum-seats-available: 1
-      seats-per-container: 10
-      max-lifetime: 360
-      container-lifetime: 360  
-      container-image: milkway/tkmat-app:latest  
-      template-properties:
-        logo: "/assets/img/maternidades_1.png"
-        icon: lock
-        type: talk
-        updated: "01/11/2023"
-        state: active
-        tema: "Saúde Pública"
-
-    - id: produtividade_talk
-      display-name: Produtividade Médica
-      description: "Apresentação sobre novo modelo de gratificação por produtividade para médicos."
-      container-image: milkway/tkprod-app:latest
-      stop-on-logout: false
-      #minimum-seats-available: 1
-      seats-per-container: 10
-      max-lifetime: 360
-      container-lifetime: 360  
-      template-properties:
-        logo: "/assets/img/grat.png"
-        icon: lock
-        type: talk
-        updated: "23/12/2024"
-        state: active      
-        tema: "Saúde Pública"
-
-    - id: redipe_talk
-      display-name: REDIPPE
-      description: "Apresentação sobre a REDIPPE (Rede Estadual de Dados de Investimentos Públicos de Pernambuco), uma plataforma que integra, padroniza e divulga informações sobre recursos aplicados pelo Estado, promovendo transparência, eficiência e controle social dos gastos públicos."
-      container-image: milkway/tkredippe-app:latest
-      stop-on-logout: false
-      #minimum-seats-available: 1
-      seats-per-container: 10
-      max-lifetime: 360
-      container-lifetime: 360  
-      template-properties:
-        logo: "/assets/img/redippe.jpeg"
-        icon: lock
-        type: talk
-        updated: "18/03/2025"
-        state: active
-        tema: "Gestão"
-
-    - id: tarifa_talk
-      display-name: Tarifa Única
-      description: "Apresentação do relatório sobre Bilhete Único para a RMR."
-      container-image: milkway/tktarifa-app:latest
-      stop-on-logout: false
-      #minimum-seats-available: 1
-      seats-per-container: 10
-      max-lifetime: 360
-      container-lifetime: 360  
-      template-properties:
-        logo: "/assets/img/tarifa.png"
-        icon: lock
-        type: talk
-        updated: "01/11/2023"
-        state: active      
-        tema: "Infraestrutura e Mobilidade"
-
-    # ======== REPORTS ========
-    - id: creches_report
-      display-name: "Creches"
-      description: "Relatório sobre a necessidade de creches nos municípios de Pernambuco."
-      container-image: milkway/rpcreches-app:latest  
-      stop-on-logout: false
-      #minimum-seats-available: 1
-      seats-per-container: 10
-      max-lifetime: 360
-      container-lifetime: 360  
-      template-properties:
-        logo: "/assets/img/creches_1.png"
-        icon: lock
         type: report
-        updated: "10/12/2023"
-        state: active        
-        tema: "Políticas Públicas"
-
-    - id: maternidades_report
-      display-name: "Localização de Maternidades"
-      description: "Relatório sobre o problema de localização de maternidades no Estado de Pernambuco."
-      container-image: milkway/rpmat-app:latest
-      stop-on-logout: false
-      #minimum-seats-available: 1
-      seats-per-container: 10
-      max-lifetime: 360
-      container-lifetime: 360  
-      template-properties:
-        logo: "/assets/img/maternidades_2.png"
-        icon: lock
-        type: report
-        updated: "01/11/2023"
         state: active
-        tema: "Saúde Pública"
+        tema: "Operations"
 
-    # ======== INACTIVES ========
-
-    - id: amparo
-      display-name: Amparo
-      description: "Painel para monitoramento das obras do DER-PE."
-      container-image: milkway/amparo-app:latest
-      docker-registry-username: milkway
-      docker-registry-password: ${DOCKER_REGISTRY_PASSWORD}
-      docker-registry-domain: docker.io
-      #minimum-seats-available: 1
-      seats-per-container: 10
-      max-lifetime: 360
-      container-lifetime: 360  
+    - id: survey
+      display-name: Survey App
+      description: "A respondent survey."
+      container-image: org/survey:latest
+      seats-per-container: 5
       template-properties:
-        logo: "/assets/img/der2_1.png"
-        icon: lock
         type: app
-        updated: "27/01/2025"
+        state: active
+        tema: "Research"
+
+    - id: longrun-model
+      display-name: Long-running Model
+      description: "A session that should never be reaped while open."
+      container-image: org/longrun-model:latest
+      heartbeat-timeout: -1            # never expire
+      container-memory-limit: 512m
+      container-cpu-limit: 1.0
+      template-properties:
+        type: app
+        state: active
+        tema: "Research"
+
+    - id: legacy-viewer
+      display-name: Legacy Viewer
+      description: "Kept around but hidden from the landing."
+      container-image: org/legacy-viewer:latest
+      template-properties:
+        type: app
         state: inactive
-        tema: "Infraestrutura e Mobilidade"
 
-    - id: aurora
-      display-name: Aurora
-      description: "Painel de monitoramento das iniciativas estratégicas do Governo de Pernambuco."
-      container-image: milkway/aurora-app:latest
-      docker-registry-username: milkway
-      docker-registry-password: ${DOCKER_REGISTRY_PASSWORD}
-      docker-registry-domain: docker.io
-      #minimum-seats-available: 1
-      seats-per-container: 10
-      max-lifetime: 360
-      container-lifetime: 360  
+    # ── Stateless API (Plumber / FastAPI) ────────────────────────
+    - id: data-api
+      display-name: Data API
+      description: "A Plumber API with proxy-side rate limiting + CORS."
+      container-image: org/data-api:latest
+      type: api
+      api:
+        port: 8000
+        docs-path: /__docs__
+        health-path: /__healthz__
+        rate-limit: 100/min
+        cors: true
+      min-replicas: 1
+      max-replicas: 3
       template-properties:
-        logo: "/assets/img/aurora_1.png"
-        icon: lock
-        type: app
-        updated: "01/04/2025"
-        state: inactive   
-        tema: "Gestão"
-      
-    - id: epti
-      display-name: EPTI
-      description: "Painel para avalização da rede intermunicipal de transporte."
-      container-image: milkway/epti-app:latest
-      #minimum-seats-available: 1
-      seats-per-container: 10
-      max-lifetime: 360
-      container-lifetime: 360  
-      docker-registry-username: milkway
-      docker-registry-password: ${DOCKER_REGISTRY_PASSWORD}
-      docker-registry-domain: docker.io
+        type: api
+        state: active
+        tema: "Data"
+
+    # ── External links (no container) ────────────────────────────
+    - id: handbook
+      display-name: Handbook
+      description: "Team handbook (external site)."
       template-properties:
-        logo: "/assets/img/epti_1.png"
-        icon: lock
-        type: app
-        updated: "03/12/2024"
-        state: inactive
-        tema: "Infraestrutura e Mobilidade"
+        type: package
+        icon: lock_open
+        state: active
+        link: https://example.com/handbook
 
-
-logging:
-  file:
-    name: logs/shinyproxy.log
+    - id: status-page
+      display-name: Status Page
+      description: "Service status (external)."
+      template-properties:
+        type: talk
+        state: active
+        link: https://status.example.com


### PR DESCRIPTION
## Why

Prerequisite to making the repo public: the example `application.yml`
was the **real SEPE app catalog**, and a handful of test fixtures /
UI placeholders / doc-comments echoed the same internal app names and
Docker Hub org. None are secrets, but together they leak the production
app inventory. This generifies all of it.

## What

- **`examples/application.yml`** → a generic, comprehensive reference
  config (8 specs: 5 Shiny, 1 API, 2 external). Still exercises every
  spec kind, `${DOCKER_REGISTRY_PASSWORD}` interpolation, container
  CPU/memory limits, `heartbeat-timeout: -1`, an inactive spec, and the
  landing-customization knobs (SEO + per-locale intros). 581 → ~140 lines.
- **i18n** `landing-title` (pt/en/es/fr): `Monitoramento Estratégico`/…
  → `Ruscker` (generic default portal name).
- **Test fixtures / placeholders / doc-comments**:
  `spec:auroraprime`/`creches` → `spec:sales-dashboard`/`ops-report`;
  credentials username `milkway` → `acme`;
  rewrite paths `/app/auroraprime/` → `/app/sales-dashboard/`;
  dashboard/sticky test ids; landing.rs SEO test strings.

## Deliberately untouched

- **`migrations/0001_initial.sql`** — editing it (even comments) changes
  the sqlx checksum and would break existing DBs, **including prod**.
  The two `auroraprime` mentions there are SQL comments only.
- **Doc-comments naming SEPE as the project's origin** — public context
  (the book introduction already states it proudly), not inventory.

## Verification

- `cargo test` — all crates green (admin 142, config compat, etc.).
- `scripts/i18n-check.sh` — key parity OK.
- `ruscker validate examples/application.yml` — no warnings, no embedded
  credentials.
- `ruscker validate … --strict-compat` — no unsupported features.
- fmt drift unchanged on every touched `.rs` (compat test even dropped 3→1).

🤖 Generated with [Claude Code](https://claude.com/claude-code)