### PR TITLE
docs: Ruscker logo on the site + fix README dark-mode lockup

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,287 @@
+name: release
+
+# Cut a release by pushing a tag:  git tag v0.1.0 && git push origin v0.1.0
+#
+# Produces, for amd64 + arm64 (built natively — no QEMU, no cross):
+#   - a multi-arch Docker image on ghcr.io (pushed by digest, then
+#     stitched into one manifest list);
+#   - static musl tarballs (ruscker-<ver>-linux-<arch>.tar.gz);
+#   - Debian packages (.deb), built from the same static binary so they
+#     install on any glibc Debian/Ubuntu without libc version pins;
+# and attaches the tarballs + .debs to a GitHub Release.
+#
+# A pre-release tag (anything with a hyphen, e.g. v0.2.0-rc1) is marked
+# as a GitHub pre-release and does NOT move the Docker `latest` tag.
+
+on:
+  push:
+    tags: ["v*"]
+
+permissions:
+  contents: write # create the release + upload assets
+  packages: write # push the image to ghcr.io
+
+jobs:
+  # --------------------------------------------------------------------
+  # Shared, lowercased metadata. ghcr requires a lowercase image path,
+  # but the org slug ("StrategicProjects") is mixed-case — normalize once.
+  # --------------------------------------------------------------------
+  meta:
+    runs-on: ubuntu-24.04
+    outputs:
+      image: ${{ steps.m.outputs.image }}
+      version: ${{ steps.m.outputs.version }}
+      prerelease: ${{ steps.m.outputs.prerelease }}
+    steps:
+      - id: m
+        run: |
+          repo="${GITHUB_REPOSITORY,,}"
+          tag="${GITHUB_REF_NAME}"
+          echo "image=ghcr.io/${repo}" >> "$GITHUB_OUTPUT"
+          echo "version=${tag#v}" >> "$GITHUB_OUTPUT"
+          if [[ "$tag" == *-* ]]; then
+            echo "prerelease=true" >> "$GITHUB_OUTPUT"
+          else
+            echo "prerelease=false" >> "$GITHUB_OUTPUT"
+          fi
+
+  # --------------------------------------------------------------------
+  # Per-arch native build of the static musl binary, then the tarball
+  # and the .deb (cargo-deb, reusing that same binary via --no-build).
+  # --------------------------------------------------------------------
+  artifacts:
+    needs: meta
+    name: artifacts (${{ matrix.arch }})
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          - arch: amd64
+            runner: ubuntu-24.04
+            target: x86_64-unknown-linux-musl
+          - arch: arm64
+            runner: ubuntu-24.04-arm
+            target: aarch64-unknown-linux-musl
+    runs-on: ${{ matrix.runner }}
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Install build deps
+        run: |
+          sudo apt-get update
+          sudo apt-get install -y --no-install-recommends musl-tools pkg-config
+
+      - name: Install Rust toolchain + musl target
+        run: |
+          if ! command -v rustup >/dev/null; then
+            curl --proto '=https' --tlsv1.2 -sSf https://sh.rustup.rs \
+              | sh -s -- -y --default-toolchain none --profile minimal
+            echo "$HOME/.cargo/bin" >> "$GITHUB_PATH"
+            . "$HOME/.cargo/env"
+          fi
+          rustup show                       # installs the pin from rust-toolchain.toml
+          rustup target add ${{ matrix.target }}
+
+      - uses: Swatinem/rust-cache@v2
+        with:
+          key: ${{ matrix.target }}
+
+      - name: Fetch host Tailwind CLI
+        run: |
+          # build.rs runs Tailwind to compile the admin CSS. It's a
+          # build-time tool, so it must be the HOST arch + glibc — the
+          # musl/target build of Tailwind mis-links libstdc++ and won't
+          # run. TAILWIND_BIN short-circuits build.rs's own download.
+          ver=$(grep -oE 'TAILWIND_VERSION: &str = "[^"]+"' \
+                crates/ruscker-admin/build.rs | grep -oE '[0-9]+\.[0-9]+\.[0-9]+')
+          case "$(uname -m)" in
+            x86_64)  asset=tailwindcss-linux-x64 ;;
+            aarch64) asset=tailwindcss-linux-arm64 ;;
+            *) echo "unsupported host arch $(uname -m)"; exit 1 ;;
+          esac
+          curl -fsSL -o "$RUNNER_TEMP/tailwindcss" \
+            "https://github.com/tailwindlabs/tailwindcss/releases/download/v${ver}/${asset}"
+          chmod +x "$RUNNER_TEMP/tailwindcss"
+          echo "TAILWIND_BIN=$RUNNER_TEMP/tailwindcss" >> "$GITHUB_ENV"
+
+      - name: Build static binary
+        env:
+          # sqlite (sqlx) and ring need a musl C compiler; on a native
+          # runner musl-tools provides the matching-arch musl-gcc.
+          CC_x86_64_unknown_linux_musl: musl-gcc
+          CC_aarch64_unknown_linux_musl: musl-gcc
+        run: cargo build --release --target ${{ matrix.target }} --bin ruscker
+
+      - name: Smoke the binary
+        run: ./target/${{ matrix.target }}/release/ruscker --help >/dev/null
+
+      - name: Package tarball
+        run: |
+          v="${{ needs.meta.outputs.version }}"
+          dir="ruscker-${v}-linux-${{ matrix.arch }}"
+          mkdir -p "dist/${dir}"
+          cp "target/${{ matrix.target }}/release/ruscker" "dist/${dir}/"
+          cp README.md "dist/${dir}/" 2>/dev/null || true
+          cp LICENSE* "dist/${dir}/" 2>/dev/null || true
+          cp examples/application.yml "dist/${dir}/application.example.yml"
+          tar -C dist -czf "dist/${dir}.tar.gz" "${dir}"
+          rm -rf "dist/${dir}"
+
+      - name: Install cargo-deb
+        run: cargo install cargo-deb --locked
+
+      - name: Build .deb from the static binary
+        run: |
+          # --no-build reuses the musl binary above; cargo-deb rewrites
+          # the asset path target/release -> target/<triple>/release.
+          # --deb-version pins the package version to the git tag so the
+          # .deb doesn't drift from the workspace Cargo.toml version.
+          cargo deb -p ruscker-cli --target ${{ matrix.target }} --no-build \
+            --deb-version "${{ needs.meta.outputs.version }}-1"
+          find "target/${{ matrix.target }}/debian" -name '*.deb' -exec cp {} dist/ \;
+
+      - name: Checksums
+        run: |
+          cd dist
+          for f in *.tar.gz *.deb; do sha256sum "$f" > "$f.sha256"; done
+          ls -la
+
+      - uses: actions/upload-artifact@v4
+        with:
+          name: artifacts-${{ matrix.arch }}
+          path: dist/*
+          if-no-files-found: error
+
+  # --------------------------------------------------------------------
+  # Per-arch native Docker build, pushed to ghcr by digest (no tag yet).
+  # --------------------------------------------------------------------
+  docker-build:
+    needs: meta
+    name: docker (${{ matrix.arch }})
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          - arch: amd64
+            runner: ubuntu-24.04
+            platform: linux/amd64
+          - arch: arm64
+            runner: ubuntu-24.04-arm
+            platform: linux/arm64
+    runs-on: ${{ matrix.runner }}
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: docker/setup-buildx-action@v3
+
+      - name: Log in to ghcr.io
+        uses: docker/login-action@v3
+        with:
+          registry: ghcr.io
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Build and push by digest
+        id: build
+        uses: docker/build-push-action@v6
+        with:
+          context: .
+          platforms: ${{ matrix.platform }}
+          # provenance off keeps the manifest a single platform entry so
+          # imagetools can stitch the list cleanly.
+          provenance: false
+          outputs: type=image,name=${{ needs.meta.outputs.image }},push-by-digest=true,name-canonical=true,push=true
+
+      - name: Export digest
+        run: |
+          mkdir -p /tmp/digests
+          touch "/tmp/digests/${digest#sha256:}"
+        env:
+          digest: ${{ steps.build.outputs.digest }}
+
+      - uses: actions/upload-artifact@v4
+        with:
+          name: digest-${{ matrix.arch }}
+          path: /tmp/digests/*
+          if-no-files-found: error
+          retention-days: 1
+
+  # --------------------------------------------------------------------
+  # Stitch the per-arch digests into one multi-arch manifest list and
+  # apply the human tags (:X.Y.Z, :X.Y, and :latest for stable tags).
+  # --------------------------------------------------------------------
+  docker-merge:
+    needs: [meta, docker-build]
+    runs-on: ubuntu-24.04
+    steps:
+      - uses: actions/download-artifact@v4
+        with:
+          path: /tmp/digests
+          pattern: digest-*
+          merge-multiple: true
+
+      - uses: docker/setup-buildx-action@v3
+
+      - name: Log in to ghcr.io
+        uses: docker/login-action@v3
+        with:
+          registry: ghcr.io
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Create and push the manifest list
+        working-directory: /tmp/digests
+        run: |
+          image="${{ needs.meta.outputs.image }}"
+          v="${{ needs.meta.outputs.version }}"
+          mm="${v%.*}"
+          tags=(-t "${image}:${v}" -t "${image}:${mm}")
+          if [ "${{ needs.meta.outputs.prerelease }}" = "false" ]; then
+            tags+=(-t "${image}:latest")
+          fi
+          docker buildx imagetools create "${tags[@]}" \
+            $(printf "${image}@sha256:%s " *)
+          docker buildx imagetools inspect "${image}:${v}"
+
+  # --------------------------------------------------------------------
+  # Publish the GitHub Release with the tarballs + .debs + checksums.
+  # --------------------------------------------------------------------
+  release:
+    needs: [meta, artifacts, docker-merge]
+    runs-on: ubuntu-24.04
+    steps:
+      - name: Download artifacts
+        uses: actions/download-artifact@v4
+        with:
+          path: dist
+          pattern: artifacts-*
+          merge-multiple: true
+
+      - name: List assets
+        run: ls -la dist
+
+      - name: Create GitHub Release
+        env:
+          GH_TOKEN: ${{ github.token }}
+        run: |
+          image="${{ needs.meta.outputs.image }}"
+          v="${{ needs.meta.outputs.version }}"
+          pre=""
+          [ "${{ needs.meta.outputs.prerelease }}" = "true" ] && pre="--prerelease"
+          cat > notes.md <<EOF
+          ## Container image
+
+          \`\`\`
+          docker pull ${image}:${v}
+          \`\`\`
+
+          Multi-arch (\`linux/amd64\`, \`linux/arm64\`). The attached
+          \`.tar.gz\` files are static musl binaries; the \`.deb\` files
+          install on Debian/Ubuntu via \`apt install ./ruscker_*.deb\`.
+          Each asset ships a matching \`.sha256\`.
+          EOF
+          gh release create "${GITHUB_REF_NAME}" dist/* \
+            --title "Ruscker ${GITHUB_REF_NAME}" \
+            --notes-file notes.md \
+            --generate-notes \
+            $pre

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 <picture>
   <source media="(prefers-color-scheme: dark)"
-          srcset="crates/ruscker-admin/assets/brand/ruscker-mark-knockout.svg">
+          srcset="crates/ruscker-admin/assets/brand/ruscker-lockup-horizontal-dark.svg">
   <img src="crates/ruscker-admin/assets/brand/ruscker-lockup-horizontal.svg"
        alt="Ruscker" height="56">
 </picture>

--- a/book/book.toml
+++ b/book/book.toml
@@ -8,6 +8,7 @@ src = "src"
 [output.html]
 default-theme = "rust"
 preferred-dark-theme = "ayu"
+additional-css = ["theme/ruscker.css"]
 git-repository-url = "https://github.com/StrategicProjects/ruscker"
 edit-url-template = "https://github.com/StrategicProjects/ruscker/edit/main/book/{path}"
 # Project Pages live under /ruscker/ — set so links/assets resolve there.

--- a/book/src/images/ruscker-lockup-horizontal-dark.svg
+++ b/book/src/images/ruscker-lockup-horizontal-dark.svg
@@ -1,0 +1,8 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 320 80" width="640" height="160" role="img" aria-label="Ruscker">
+  <title>Ruscker — Lockup horizontal (wordmark branco para fundos escuros)</title>
+  <polygon points="14,52 40,40 66,52 40,64" fill="#0F6E56"/>
+  <polygon points="14,40 40,28 66,40 40,52" fill="#1D9E75"/>
+  <polygon points="14,28 40,16 66,28 40,40" fill="#5DCAA5"/>
+  <text x="92" y="59" font-family="Jost, Inter, system-ui, sans-serif" font-weight="500" font-size="56" letter-spacing="-1.2" fill="#F5F5F5">ruscker</text>
+</svg>

--- a/book/src/images/ruscker-lockup-horizontal.svg
+++ b/book/src/images/ruscker-lockup-horizontal.svg
@@ -1,0 +1,8 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 320 80" width="640" height="160" role="img" aria-label="Ruscker">
+  <title>Ruscker — Lockup horizontal</title>
+  <polygon points="14,52 40,40 66,52 40,64" fill="#0F6E56"/>
+  <polygon points="14,40 40,28 66,40 40,52" fill="#1D9E75"/>
+  <polygon points="14,28 40,16 66,28 40,40" fill="#5DCAA5"/>
+  <text x="92" y="59" font-family="Jost, Inter, system-ui, sans-serif" font-weight="500" font-size="56" letter-spacing="-1.2" fill="#1a1a1a">ruscker</text>
+</svg>

--- a/book/src/introduction.md
+++ b/book/src/introduction.md
@@ -1,3 +1,8 @@
+<p align="center">
+  <img class="ruscker-logo ruscker-logo-light" src="images/ruscker-lockup-horizontal.svg" alt="Ruscker">
+  <img class="ruscker-logo ruscker-logo-dark" src="images/ruscker-lockup-horizontal-dark.svg" alt="Ruscker">
+</p>
+
 # Ruscker
 
 **Ruscker** is a lightweight Rust alternative to **ShinyProxy** and

--- a/book/theme/favicon.svg
+++ b/book/theme/favicon.svg
@@ -1,0 +1,8 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 80 80" width="1024" height="1024" role="img" aria-label="Ruscker">
+  <title>Ruscker — App icon</title>
+  <rect x="0" y="0" width="80" height="80" rx="18" fill="#0F6E56"/>
+  <polygon points="20,54 40,44 60,54 40,64" fill="#FFFFFF" opacity="0.35"/>
+  <polygon points="20,44 40,34 60,44 40,54" fill="#FFFFFF" opacity="0.65"/>
+  <polygon points="20,34 40,24 60,34 40,44" fill="#FFFFFF"/>
+</svg>

--- a/book/theme/ruscker.css
+++ b/book/theme/ruscker.css
@@ -1,0 +1,30 @@
+/* Ruscker brand — theme-aware logo swap.
+ *
+ * mdBook toggles the active theme via a class on <html> (light, rust,
+ * coal, navy, ayu) rather than the OS prefers-color-scheme, so the
+ * README's <picture> trick doesn't follow the in-book theme switcher.
+ * We render both wordmark lockups and show the one that contrasts with
+ * the current theme. */
+
+.ruscker-logo {
+  width: 320px;
+  max-width: 80%;
+  height: auto;
+}
+
+/* Default (light + rust): show the dark-text lockup. */
+.ruscker-logo-dark {
+  display: none;
+}
+
+/* Dark themes: hide the dark-text lockup, show the white-text one. */
+html.coal .ruscker-logo-light,
+html.navy .ruscker-logo-light,
+html.ayu .ruscker-logo-light {
+  display: none;
+}
+html.coal .ruscker-logo-dark,
+html.navy .ruscker-logo-dark,
+html.ayu .ruscker-logo-dark {
+  display: inline-block;
+}

--- a/crates/ruscker-admin/assets/brand/ruscker-lockup-horizontal-dark.svg
+++ b/crates/ruscker-admin/assets/brand/ruscker-lockup-horizontal-dark.svg
@@ -1,0 +1,8 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 320 80" width="640" height="160" role="img" aria-label="Ruscker">
+  <title>Ruscker — Lockup horizontal (wordmark branco para fundos escuros)</title>
+  <polygon points="14,52 40,40 66,52 40,64" fill="#0F6E56"/>
+  <polygon points="14,40 40,28 66,40 40,52" fill="#1D9E75"/>
+  <polygon points="14,28 40,16 66,28 40,40" fill="#5DCAA5"/>
+  <text x="92" y="59" font-family="Jost, Inter, system-ui, sans-serif" font-weight="500" font-size="56" letter-spacing="-1.2" fill="#F5F5F5">ruscker</text>
+</svg>

--- a/docs/BRAND.md
+++ b/docs/BRAND.md
@@ -14,6 +14,7 @@ arquivo, regras de aplicação e proporções de lockup.
 | `ruscker-mark-knockout.svg` | Versão branca para uso sobre fundos escuros |
 | `ruscker-app-icon.svg` | Ícone de app (quadrado arredondado, fundo teal 600, marca branca) |
 | `ruscker-lockup-horizontal.svg` | Marca + wordmark lado a lado — uso em headers, papelaria |
+| `ruscker-lockup-horizontal-dark.svg` | Igual, com o wordmark branco — uso sobre fundos escuros (README dark, tema escuro da doc) |
 | `ruscker-lockup-vertical.svg` | Marca acima do wordmark — uso em avatares, social, app store |
 | `ruscker-wordmark.svg` | Só o texto — uso quando o ícone seria redundante (em watermarks, footer minimalista) |
 


### PR DESCRIPTION
## What

Adds the Ruscker wordmark logo to the mdBook site (which had none) and fixes the README's dark-theme logo.

- **README**: the dark-mode `<picture>` source previously fell back to the bare knockout *mark* (no wordmark). It now uses a proper horizontal lockup with a white wordmark, so the full logo shows on both light and dark GitHub themes.
- **Book**: a centred lockup banner at the top of the introduction + the **Ruscker app icon as the favicon**.
- **New brand asset** `ruscker-lockup-horizontal-dark.svg` (white wordmark, for dark backgrounds), documented in `docs/BRAND.md`.

## Theme-aware in mdBook

mdBook switches themes via a class on `<html>` (`light`/`rust`/`coal`/`navy`/`ayu`), **not** the OS `prefers-color-scheme`, so the README's `<picture>` trick wouldn't follow the in-book theme toggle. A small `book/theme/ruscker.css` renders both lockups and shows the white-wordmark one on the dark themes (coal/navy/ayu), the dark-wordmark one otherwise.

## Verified

`mdbook build` (0.5.3) → both lockup SVGs, the favicon (confirmed to be the teal app icon), and `ruscker.css` are emitted and linked from `index.html`. The `docs.yml` Pages workflow will publish it on merge to `main`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)