### PR TITLE
ci(release): pass --repo to gh release create

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -280,7 +280,10 @@ jobs:
           install on Debian/Ubuntu via \`apt install ./ruscker_*.deb\`.
           Each asset ships a matching \`.sha256\`.
           EOF
+          # --repo targets the API directly: this job has no checkout,
+          # so gh can't infer the repo from a local git remote.
           gh release create "${GITHUB_REF_NAME}" dist/* \
+            --repo "$GITHUB_REPOSITORY" \
             --title "Ruscker ${GITHUB_REF_NAME}" \
             --notes-file notes.md \
             --generate-notes \


### PR DESCRIPTION
The `release` job downloads artifacts but doesn't `actions/checkout`, so `gh release create` failed with `fatal: not a git repository` while trying to infer the repo from a local git remote.

Fix: pass `--repo "$GITHUB_REPOSITORY"` so `gh` targets the API directly (no checkout needed).

The `v0.1.0-rc1` run proved the rest end-to-end: native amd64+arm64 builds, the multi-arch image + manifest pushed to ghcr, and the `.deb` + musl tarball artifacts — only this last step failed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)