### PR TITLE
admin: advanced spec-form section + per-field help modals

### DIFF
--- a/crates/ruscker-admin/assets/i18n/en/landing.ftl
+++ b/crates/ruscker-admin/assets/i18n/en/landing.ftl
@@ -323,3 +323,47 @@ admin-grad-remove-stop = Remove stop
 spec-form-cover = Card cover
 spec-form-cover-auto = Auto (type tint)
 spec-form-cover-auto-help = Uses the card type default tint. Pick Solid or Gradient to customize.
+
+# ── Spec form: advanced section + per-field help (#2) ──────────────
+spec-form-advanced = Advanced
+spec-form-advanced-hint = All optional — leave blank to keep the default.
+spec-form-api-section = API
+spec-form-scaling-section = Scaling
+spec-form-resources-section = Resources
+spec-form-lifecycle-section = Lifecycle
+spec-form-api-port = Container port
+spec-form-api-rate-limit = Rate limit
+spec-form-api-docs-path = Docs path
+spec-form-api-health-path = Health path
+spec-form-api-cors = Enable permissive CORS
+spec-form-min-replicas = Min replicas
+spec-form-max-replicas = Max replicas
+spec-form-concurrent = Requests per replica
+spec-form-cpu-limit = CPU limit
+spec-form-memory-limit = Memory limit
+spec-form-heartbeat = Heartbeat timeout (ms)
+spec-help-kind = What kind of thing this is. Drives routing, the card badge, and whether a container is started.
+spec-help-id = Stable identifier used in the URL (/app/<id>). Lowercase letters, digits, "-" and "_"; can't change after creation.
+spec-help-name = The title shown on the landing card.
+spec-help-desc = Short description on the card. Inline HTML (e.g. a link) is allowed.
+spec-help-logo = Card image — a path under /assets/img/ or an external URL. Blank uses a generated tint.
+spec-help-cover = Card background: an automatic per-kind tint, a solid color, or a gradient.
+spec-help-access = Shows a closed (restricted) or open (public) lock badge. Visual only — the MVP doesn't enforce auth.
+spec-help-state = Active cards show on the landing; inactive ones are hidden.
+spec-help-subject = Topic/area used by the landing's Subject filter (e.g. "Sales", "Research").
+spec-help-image = Docker image to run, as repository:tag (e.g. org/app:latest).
+spec-help-seats = How many concurrent sessions one container serves before another is spawned.
+spec-help-lifetime = Hard cap, in minutes, on how long a container runs before it is recycled.
+spec-help-link = Destination URL for external-link cards — clicking the card navigates here.
+spec-help-updated = Display date on the card (DD/MM/YYYY). Blank stamps today's date.
+spec-help-api-port = Port the API listens on inside the container. Default 8080.
+spec-help-api-rate-limit = Per-client limit at the proxy, as N/unit (e.g. 100/min, 5/s). Over the limit returns 429. Blank = no limit.
+spec-help-api-docs-path = Path where the API serves its OpenAPI/Swagger docs. Default /__docs__.
+spec-help-api-health-path = Path probed for readiness before a replica joins the pool. Default /__healthz__.
+spec-help-api-cors = Add permissive CORS headers and answer preflight requests. Off by default.
+spec-help-min-replicas = Containers kept warm at all times — the pool never scales below this. Default 0.
+spec-help-max-replicas = Upper bound the auto-scaler may spawn up to. Blank = unlimited.
+spec-help-concurrent = Requests one API replica handles before the scaler adds another.
+spec-help-cpu-limit = Max CPU as fractional cores (e.g. 0.5 = half a core). Blank = unlimited.
+spec-help-memory-limit = Max memory, e.g. 512m or 1.5g. Blank = unlimited.
+spec-help-heartbeat = Idle session timeout in milliseconds; -1 never expires. Blank = use the global default.

--- a/crates/ruscker-admin/assets/i18n/es/landing.ftl
+++ b/crates/ruscker-admin/assets/i18n/es/landing.ftl
@@ -323,3 +323,47 @@ admin-grad-remove-stop = Quitar color
 spec-form-cover = Cover de la tarjeta
 spec-form-cover-auto = Auto (color del tipo)
 spec-form-cover-auto-help = Usa el tono por defecto del tipo. Elija Sólido o Degradado para personalizar.
+
+# ── Formulario de spec: sección avanzada + ayuda por campo (#2) ────
+spec-form-advanced = Avanzado
+spec-form-advanced-hint = Todo opcional — déjalo vacío para mantener el valor por defecto.
+spec-form-api-section = API
+spec-form-scaling-section = Escalado
+spec-form-resources-section = Recursos
+spec-form-lifecycle-section = Ciclo de vida
+spec-form-api-port = Puerto del contenedor
+spec-form-api-rate-limit = Límite de tasa
+spec-form-api-docs-path = Ruta de docs
+spec-form-api-health-path = Ruta de health
+spec-form-api-cors = Habilitar CORS permisivo
+spec-form-min-replicas = Réplicas mín.
+spec-form-max-replicas = Réplicas máx.
+spec-form-concurrent = Solicitudes por réplica
+spec-form-cpu-limit = Límite de CPU
+spec-form-memory-limit = Límite de memoria
+spec-form-heartbeat = Tiempo de heartbeat (ms)
+spec-help-kind = Qué tipo de elemento es. Define el enrutamiento, la insignia de la tarjeta y si se inicia un contenedor.
+spec-help-id = Identificador estable usado en la URL (/app/<id>). Minúsculas, dígitos, "-" y "_"; no se puede cambiar tras crearlo.
+spec-help-name = El título mostrado en la tarjeta.
+spec-help-desc = Descripción breve en la tarjeta. Se permite HTML en línea (p. ej. un enlace).
+spec-help-logo = Imagen de la tarjeta — una ruta en /assets/img/ o una URL externa. Vacío usa un tono generado.
+spec-help-cover = Fondo de la tarjeta: tono automático por tipo, color sólido o degradado.
+spec-help-access = Muestra un candado (restringido) o abierto (público). Solo visual — el MVP no aplica autenticación.
+spec-help-state = Las tarjetas activas se muestran; las inactivas se ocultan.
+spec-help-subject = Tema/área usada por el filtro Asunto de la portada (p. ej. "Ventas", "Investigación").
+spec-help-image = Imagen Docker a ejecutar, como repositorio:tag (p. ej. org/app:latest).
+spec-help-seats = Cuántas sesiones simultáneas atiende un contenedor antes de crear otro.
+spec-help-lifetime = Límite rígido, en minutos, de cuánto puede ejecutarse un contenedor antes de reciclarse.
+spec-help-link = URL de destino para tarjetas de enlace externo — al hacer clic se navega aquí.
+spec-help-updated = Fecha mostrada en la tarjeta (DD/MM/AAAA). Vacío estampa la fecha de hoy.
+spec-help-api-port = Puerto en el que la API escucha dentro del contenedor. Por defecto 8080.
+spec-help-api-rate-limit = Límite por cliente en el proxy, como N/unidad (p. ej. 100/min, 5/s). Por encima devuelve 429. Vacío = sin límite.
+spec-help-api-docs-path = Ruta donde la API sirve la documentación OpenAPI/Swagger. Por defecto /__docs__.
+spec-help-api-health-path = Ruta consultada para readiness antes de que la réplica entre al pool. Por defecto /__healthz__.
+spec-help-api-cors = Añade cabeceras CORS permisivas y responde al preflight. Desactivado por defecto.
+spec-help-min-replicas = Contenedores siempre activos — el pool nunca baja de aquí. Por defecto 0.
+spec-help-max-replicas = Tope hasta donde el auto-escalado puede crecer. Vacío = ilimitado.
+spec-help-concurrent = Solicitudes que atiende una réplica de API antes de que el escalado añada otra.
+spec-help-cpu-limit = CPU máxima en núcleos fraccionarios (p. ej. 0,5 = medio núcleo). Vacío = ilimitado.
+spec-help-memory-limit = Memoria máxima, p. ej. 512m o 1.5g. Vacío = ilimitado.
+spec-help-heartbeat = Tiempo de sesión inactiva en milisegundos; -1 nunca expira. Vacío = usa el valor global.

--- a/crates/ruscker-admin/assets/i18n/fr/landing.ftl
+++ b/crates/ruscker-admin/assets/i18n/fr/landing.ftl
@@ -323,3 +323,47 @@ admin-grad-remove-stop = Retirer la couleur
 spec-form-cover = Couverture de la carte
 spec-form-cover-auto = Auto (teinte du type)
 spec-form-cover-auto-help = Utilise la teinte par défaut du type. Choisissez Uni ou Dégradé pour personnaliser.
+
+# ── Formulaire de spec : section avancée + aide par champ (#2) ─────
+spec-form-advanced = Avancé
+spec-form-advanced-hint = Tout est optionnel — laissez vide pour garder la valeur par défaut.
+spec-form-api-section = API
+spec-form-scaling-section = Mise à l'échelle
+spec-form-resources-section = Ressources
+spec-form-lifecycle-section = Cycle de vie
+spec-form-api-port = Port du conteneur
+spec-form-api-rate-limit = Limite de débit
+spec-form-api-docs-path = Chemin des docs
+spec-form-api-health-path = Chemin de santé
+spec-form-api-cors = Activer CORS permissif
+spec-form-min-replicas = Réplicas min.
+spec-form-max-replicas = Réplicas max.
+spec-form-concurrent = Requêtes par réplica
+spec-form-cpu-limit = Limite CPU
+spec-form-memory-limit = Limite mémoire
+spec-form-heartbeat = Délai de heartbeat (ms)
+spec-help-kind = Le type d'élément. Détermine le routage, le badge de la carte et si un conteneur est démarré.
+spec-help-id = Identifiant stable utilisé dans l'URL (/app/<id>). Minuscules, chiffres, « - » et « _ » ; non modifiable après création.
+spec-help-name = Le titre affiché sur la carte.
+spec-help-desc = Brève description sur la carte. Le HTML en ligne (ex. un lien) est autorisé.
+spec-help-logo = Image de la carte — un chemin sous /assets/img/ ou une URL externe. Vide : une teinte générée.
+spec-help-cover = Fond de la carte : teinte automatique par type, couleur unie ou dégradé.
+spec-help-access = Affiche un cadenas (restreint) ou ouvert (public). Visuel seulement — le MVP n'impose pas d'authentification.
+spec-help-state = Les cartes actives s'affichent ; les inactives sont masquées.
+spec-help-subject = Thème/domaine utilisé par le filtre Sujet de la page (ex. « Ventes », « Recherche »).
+spec-help-image = Image Docker à exécuter, sous la forme dépôt:tag (ex. org/app:latest).
+spec-help-seats = Combien de sessions simultanées un conteneur sert avant d'en démarrer un autre.
+spec-help-lifetime = Plafond strict, en minutes, de la durée d'exécution d'un conteneur avant recyclage.
+spec-help-link = URL de destination des cartes de lien externe — cliquer navigue ici.
+spec-help-updated = Date affichée sur la carte (JJ/MM/AAAA). Vide : la date du jour est apposée.
+spec-help-api-port = Port d'écoute de l'API dans le conteneur. Par défaut 8080.
+spec-help-api-rate-limit = Limite par client au proxy, sous la forme N/unité (ex. 100/min, 5/s). Au-delà : 429. Vide = sans limite.
+spec-help-api-docs-path = Chemin où l'API sert la doc OpenAPI/Swagger. Par défaut /__docs__.
+spec-help-api-health-path = Chemin sondé pour la disponibilité avant qu'une réplica rejoigne le pool. Par défaut /__healthz__.
+spec-help-api-cors = Ajoute des en-têtes CORS permissifs et répond au préflight. Désactivé par défaut.
+spec-help-min-replicas = Conteneurs gardés actifs en permanence — le pool ne descend jamais en dessous. Par défaut 0.
+spec-help-max-replicas = Plafond jusqu'auquel l'auto-scaler peut monter. Vide = illimité.
+spec-help-concurrent = Requêtes qu'une réplica d'API gère avant que le scaler en ajoute une.
+spec-help-cpu-limit = CPU max en cœurs fractionnaires (ex. 0,5 = un demi-cœur). Vide = illimité.
+spec-help-memory-limit = Mémoire max, ex. 512m ou 1.5g. Vide = illimité.
+spec-help-heartbeat = Délai de session inactive en millisecondes ; -1 = jamais. Vide = valeur globale.

--- a/crates/ruscker-admin/assets/i18n/pt/landing.ftl
+++ b/crates/ruscker-admin/assets/i18n/pt/landing.ftl
@@ -327,3 +327,47 @@ admin-grad-remove-stop = Remover cor
 spec-form-cover = Cover do card
 spec-form-cover-auto = Auto (cor do tipo)
 spec-form-cover-auto-help = Usa o tom padrão do tipo do card. Escolha Sólida ou Gradiente para personalizar.
+
+# ── Formulário de spec: seção avançada + ajuda por campo (#2) ──────
+spec-form-advanced = Avançado
+spec-form-advanced-hint = Tudo opcional — deixe em branco para manter o padrão.
+spec-form-api-section = API
+spec-form-scaling-section = Escala
+spec-form-resources-section = Recursos
+spec-form-lifecycle-section = Ciclo de vida
+spec-form-api-port = Porta do container
+spec-form-api-rate-limit = Limite de taxa
+spec-form-api-docs-path = Caminho dos docs
+spec-form-api-health-path = Caminho de health
+spec-form-api-cors = Habilitar CORS permissivo
+spec-form-min-replicas = Réplicas mín.
+spec-form-max-replicas = Réplicas máx.
+spec-form-concurrent = Requisições por réplica
+spec-form-cpu-limit = Limite de CPU
+spec-form-memory-limit = Limite de memória
+spec-form-heartbeat = Timeout de heartbeat (ms)
+spec-help-kind = Que tipo de coisa é. Define o roteamento, o selo do card e se um container é iniciado.
+spec-help-id = Identificador estável usado na URL (/app/<id>). Minúsculas, dígitos, "-" e "_"; não pode mudar após criado.
+spec-help-name = O título exibido no card da landing.
+spec-help-desc = Descrição curta no card. HTML inline (ex.: um link) é permitido.
+spec-help-logo = Imagem do card — um caminho em /assets/img/ ou uma URL externa. Em branco, usa um tom gerado.
+spec-help-cover = Fundo do card: tom automático por tipo, cor sólida ou gradiente.
+spec-help-access = Mostra um cadeado (restrito) ou aberto (público). Apenas visual — o MVP não impõe autenticação.
+spec-help-state = Cards ativos aparecem na landing; inativos ficam ocultos.
+spec-help-subject = Assunto/área usado pelo filtro Assunto da landing (ex.: "Vendas", "Pesquisa").
+spec-help-image = Imagem Docker a executar, como repositório:tag (ex.: org/app:latest).
+spec-help-seats = Quantas sessões simultâneas um container atende antes de subir outro.
+spec-help-lifetime = Limite rígido, em minutos, de quanto tempo um container roda antes de ser reciclado.
+spec-help-link = URL de destino para cards de link externo — clicar no card navega para cá.
+spec-help-updated = Data exibida no card (DD/MM/AAAA). Em branco, carimba a data de hoje.
+spec-help-api-port = Porta em que a API escuta dentro do container. Padrão 8080.
+spec-help-api-rate-limit = Limite por cliente no proxy, como N/unidade (ex.: 100/min, 5/s). Acima do limite retorna 429. Vazio = sem limite.
+spec-help-api-docs-path = Caminho onde a API serve a documentação OpenAPI/Swagger. Padrão /__docs__.
+spec-help-api-health-path = Caminho consultado para readiness antes da réplica entrar no pool. Padrão /__healthz__.
+spec-help-api-cors = Adiciona cabeçalhos CORS permissivos e responde ao preflight. Desligado por padrão.
+spec-help-min-replicas = Containers mantidos sempre quentes — o pool nunca desce abaixo disso. Padrão 0.
+spec-help-max-replicas = Teto até onde o auto-scaler pode subir. Vazio = ilimitado.
+spec-help-concurrent = Requisições que uma réplica de API atende antes do scaler adicionar outra.
+spec-help-cpu-limit = CPU máxima em núcleos fracionários (ex.: 0,5 = meio núcleo). Vazio = ilimitado.
+spec-help-memory-limit = Memória máxima, ex.: 512m ou 1.5g. Vazio = ilimitado.
+spec-help-heartbeat = Timeout de sessão ociosa em milissegundos; -1 nunca expira. Vazio = usa o padrão global.

--- a/crates/ruscker-admin/assets/tailwind/input.css
+++ b/crates/ruscker-admin/assets/tailwind/input.css
@@ -642,6 +642,58 @@ body {
 }
 textarea.spec-form-input { resize: vertical; min-height: 64px; }
 
+/* Inline field help — a small "?" that toggles a popover with a
+   plain-language explanation of the parameter. Used on every field. */
+.spec-form-label-row {
+  display: flex; align-items: center; gap: 5px; margin-bottom: 4px;
+}
+.spec-form-label-row .spec-form-label { margin-bottom: 0; }
+.field-help { position: relative; display: inline-flex; line-height: 1; }
+.field-help-btn {
+  display: inline-flex; align-items: center; justify-content: center;
+  width: 15px; height: 15px; padding: 0;
+  border: 0.5px solid var(--border); border-radius: 50%;
+  background: var(--surface-soft); color: var(--text-faint);
+  font-size: 10px; font-weight: 600; cursor: help;
+}
+.field-help-btn:hover {
+  color: var(--color-teal-600); border-color: var(--color-teal-600);
+}
+.field-help-pop {
+  position: absolute; top: calc(100% + 6px); left: 0; z-index: 40;
+  width: 250px; max-width: 72vw;
+  background: var(--surface); color: var(--text);
+  border: 0.5px solid var(--border); border-radius: 8px;
+  box-shadow: 0 8px 28px rgba(0, 0, 0, 0.18);
+  padding: 9px 11px;
+  font-size: 11.5px; font-weight: 400; line-height: 1.5;
+  text-transform: none; letter-spacing: normal;
+}
+
+/* Advanced (collapsible) section: API, scaling, resources, lifecycle. */
+.spec-form-advanced {
+  margin-top: 18px; padding-top: 4px;
+  border-top: 0.5px solid var(--border);
+}
+.spec-form-advanced-toggle {
+  display: flex; align-items: center; gap: 6px;
+  width: 100%; padding: 8px 0;
+  background: none; border: 0; cursor: pointer;
+  color: var(--text-muted);
+  font-size: 11px; font-weight: 500;
+  text-transform: uppercase; letter-spacing: 0.06em;
+}
+.spec-form-advanced-toggle .chevron { transition: transform 0.15s ease; }
+.spec-form-advanced-toggle.is-open .chevron { transform: rotate(90deg); }
+.spec-form-subsection {
+  font-size: 11px; font-weight: 500; color: var(--text-faint);
+  margin: 14px 0 8px;
+}
+.spec-form-check {
+  display: flex; align-items: center; gap: 8px;
+  font-size: 12.5px; color: var(--text);
+}
+
 /* Type picker — 6 cards, equal columns */
 .kind-picker {
   display: grid;

--- a/crates/ruscker-admin/src/routes/admin/spec_form.rs
+++ b/crates/ruscker-admin/src/routes/admin/spec_form.rs
@@ -19,7 +19,7 @@ use axum::{
     Router,
 };
 use chrono::Utc;
-use ruscker_config::{Spec, SpecKindOverride, TemplateProperties};
+use ruscker_config::{ApiSpec, Spec, SpecKindOverride, TemplateProperties};
 use serde::{Deserialize, Serialize};
 use serde_yaml_ng::Value as YamlValue;
 use std::collections::HashMap;
@@ -75,6 +75,27 @@ pub struct SpecForm {
     pub link: String,
     pub seats_per_container: String,
     pub max_lifetime: String,
+
+    // ── Advanced (collapsible). Empty string ⇒ keep the schema
+    //    default; nothing here is required. ──────────────────────
+    /// `heartbeat-timeout` override in ms; `-1` = never expire.
+    pub heartbeat_timeout: String,
+    /// Fractional CPUs, e.g. `0.5` (`container-cpu-limit`).
+    pub container_cpu_limit: String,
+    /// Memory cap, e.g. `512m` / `1.5g` (`container-memory-limit`).
+    pub container_memory_limit: String,
+    /// Replica pool floor / ceiling (`min`/`max-replicas`).
+    pub min_replicas: String,
+    pub max_replicas: String,
+    /// API: concurrent requests a replica handles before scale-up.
+    pub concurrent_requests_per_replica: String,
+    /// API sub-fields (only meaningful for `type: api`).
+    pub api_port: String,
+    pub api_docs_path: String,
+    pub api_health_path: String,
+    pub api_rate_limit: String,
+    /// Checkbox: non-empty ("on") ⇒ permissive CORS enabled.
+    pub api_cors: String,
 }
 
 impl SpecForm {
@@ -107,6 +128,47 @@ impl SpecForm {
                 .map(|n| n.to_string())
                 .unwrap_or_default(),
             max_lifetime: spec.max_lifetime.map(|n| n.to_string()).unwrap_or_default(),
+            heartbeat_timeout: spec
+                .heartbeat_timeout
+                .map(|n| n.to_string())
+                .unwrap_or_default(),
+            container_cpu_limit: spec
+                .container_cpu_limit
+                .map(|n| n.to_string())
+                .unwrap_or_default(),
+            container_memory_limit: spec.container_memory_limit.clone().unwrap_or_default(),
+            min_replicas: spec.min_replicas.map(|n| n.to_string()).unwrap_or_default(),
+            max_replicas: spec.max_replicas.map(|n| n.to_string()).unwrap_or_default(),
+            concurrent_requests_per_replica: spec
+                .concurrent_requests_per_replica
+                .map(|n| n.to_string())
+                .unwrap_or_default(),
+            api_port: spec
+                .api
+                .as_ref()
+                .and_then(|a| a.port)
+                .map(|n| n.to_string())
+                .unwrap_or_default(),
+            api_docs_path: spec
+                .api
+                .as_ref()
+                .and_then(|a| a.docs_path.clone())
+                .unwrap_or_default(),
+            api_health_path: spec
+                .api
+                .as_ref()
+                .and_then(|a| a.health_path.clone())
+                .unwrap_or_default(),
+            api_rate_limit: spec
+                .api
+                .as_ref()
+                .and_then(|a| a.rate_limit.clone())
+                .unwrap_or_default(),
+            api_cors: if spec.api.as_ref().map(|a| a.cors).unwrap_or(false) {
+                "on".into()
+            } else {
+                String::new()
+            },
         }
     }
 
@@ -166,6 +228,30 @@ impl SpecForm {
             _ => empty_to_none(&self.container_image),
         };
 
+        // Advanced API block: built for API specs, or whenever any
+        // API field was filled in (empty otherwise ⇒ schema defaults).
+        let cors = !self.api_cors.trim().is_empty();
+        let api_filled = cors
+            || [
+                &self.api_port,
+                &self.api_docs_path,
+                &self.api_health_path,
+                &self.api_rate_limit,
+            ]
+            .iter()
+            .any(|s| !s.trim().is_empty());
+        let api = if matches!(dt, DisplayType::Api) || api_filled {
+            Some(ApiSpec {
+                port: parse_opt(&self.api_port),
+                docs_path: empty_to_none(&self.api_docs_path),
+                health_path: empty_to_none(&self.api_health_path),
+                rate_limit: empty_to_none(&self.api_rate_limit),
+                cors,
+            })
+        } else {
+            None
+        };
+
         Ok(Spec {
             id: self.id.trim().to_string(),
             display_name: empty_to_none(&self.display_name),
@@ -174,28 +260,28 @@ impl SpecForm {
             seats_per_container: parse_opt(&self.seats_per_container),
             max_lifetime: parse_opt(&self.max_lifetime),
             container_lifetime: None,
-            heartbeat_timeout: None,
+            heartbeat_timeout: parse_opt(&self.heartbeat_timeout),
             stop_on_logout: None,
             docker_registry_username: None,
             docker_registry_password: None,
             docker_registry_domain: None,
             docker_registry_credential: None,
-            container_cpu_limit: None,
+            container_cpu_limit: parse_opt(&self.container_cpu_limit),
             container_cpu_request: None,
-            container_memory_limit: None,
+            container_memory_limit: empty_to_none(&self.container_memory_limit),
             container_memory_request: None,
             max_body_size: None,
             template_properties: TemplateProperties(tp_map),
             kind_override,
-            api: None,
-            min_replicas: None,
-            max_replicas: None,
+            api,
+            min_replicas: parse_opt(&self.min_replicas),
+            max_replicas: parse_opt(&self.max_replicas),
             scale_up_threshold: None,
             scale_down_threshold: None,
             scale_down_grace: None,
             drain_timeout: None,
             routing_strategy: None,
-            concurrent_requests_per_replica: None,
+            concurrent_requests_per_replica: parse_opt(&self.concurrent_requests_per_replica),
         })
     }
 

--- a/crates/ruscker-admin/templates/admin/spec_form.html
+++ b/crates/ruscker-admin/templates/admin/spec_form.html
@@ -4,6 +4,17 @@
   {% if mode.is_new() %}{{ self.t("spec-form-title-new") }}{% else %}{{ form.id }} · Ruscker{% endif %}
 {% endblock %}
 
+{# Reusable inline help: a "?" that toggles a popover explaining the
+   field. `text` is the already-localized explanation (macros can't
+   reach `self.t`, so the caller resolves it). #}
+{% macro help(text) %}
+<span class="field-help" x-data="{ o: false }" @keydown.escape.window="o = false">
+  <button type="button" class="field-help-btn" @click="o = !o" @click.outside="o = false"
+          :aria-expanded="o" aria-label="{{ text }}">?</button>
+  <span class="field-help-pop" x-show="o" x-cloak x-transition.opacity>{{ text }}</span>
+</span>
+{% endmacro %}
+
 {% block content %}
 
 <div x-data="ruscker.specForm({{ form_initial_json() }})" x-cloak>
@@ -46,9 +57,12 @@
           class="spec-form-fields"
           autocomplete="off">
 
-      {# Type picker — 4 cards #}
+      {# Type picker — 6 cards #}
       <div class="spec-form-section">
-        <div class="spec-form-label">{{ self.t("spec-form-kind") }}</div>
+        <div class="spec-form-label-row">
+          <div class="spec-form-label">{{ self.t("spec-form-kind") }}</div>
+          {% call help(self.t("spec-help-kind")) %}{% endcall %}
+        </div>
         <div class="kind-picker">
           {% for k in display_type_options() %}
             <label class="kind-picker-card" :class="form.display_type === '{{ k.0 }}' ? 'is-active' : ''">
@@ -63,7 +77,10 @@
       <div class="spec-form-section-title">{{ self.t("spec-form-identity") }}</div>
 
       <div class="spec-form-field">
-        <label for="f-id" class="spec-form-label">{{ self.t("spec-form-id") }}</label>
+        <div class="spec-form-label-row">
+          <label for="f-id" class="spec-form-label">{{ self.t("spec-form-id") }}</label>
+          {% call help(self.t("spec-help-id")) %}{% endcall %}
+        </div>
         <input id="f-id" type="text" name="id"
                value="{{ form.id }}"
                x-model="form.id"
@@ -76,7 +93,10 @@
       </div>
 
       <div class="spec-form-field">
-        <label for="f-name" class="spec-form-label">{{ self.t("spec-form-name") }}</label>
+        <div class="spec-form-label-row">
+          <label for="f-name" class="spec-form-label">{{ self.t("spec-form-name") }}</label>
+          {% call help(self.t("spec-help-name")) %}{% endcall %}
+        </div>
         <input id="f-name" type="text" name="display_name"
                value="{{ form.display_name }}"
                x-model="form.display_name"
@@ -85,7 +105,10 @@
       </div>
 
       <div class="spec-form-field">
-        <label for="f-desc" class="spec-form-label">{{ self.t("spec-form-desc") }}</label>
+        <div class="spec-form-label-row">
+          <label for="f-desc" class="spec-form-label">{{ self.t("spec-form-desc") }}</label>
+          {% call help(self.t("spec-help-desc")) %}{% endcall %}
+        </div>
         <textarea id="f-desc" name="description"
                   x-model="form.description"
                   rows="3"
@@ -95,7 +118,10 @@
       <div class="spec-form-section-title">{{ self.t("spec-form-visual") }}</div>
 
       <div class="spec-form-field">
-        <label for="f-logo" class="spec-form-label">{{ self.t("spec-form-logo") }}</label>
+        <div class="spec-form-label-row">
+          <label for="f-logo" class="spec-form-label">{{ self.t("spec-form-logo") }}</label>
+          {% call help(self.t("spec-help-logo")) %}{% endcall %}
+        </div>
         <input id="f-logo" type="text" name="logo"
                value="{{ form.logo }}"
                x-model="form.logo"
@@ -124,7 +150,10 @@
 
       {# ── Card cover (#11) — Auto tint / Solid / Gradient ───── #}
       <div class="spec-form-field">
-        <label class="spec-form-label">{{ self.t("spec-form-cover") }}</label>
+        <div class="spec-form-label-row">
+          <label class="spec-form-label">{{ self.t("spec-form-cover") }}</label>
+          {% call help(self.t("spec-help-cover")) %}{% endcall %}
+        </div>
         <div class="grad-modes" role="tablist">
           <button type="button" class="grad-mode" :class="coverMode === 'auto' ? 'is-active' : ''"
                   @click="setCoverMode('auto')">{{ self.t("spec-form-cover-auto") }}</button>
@@ -185,21 +214,30 @@
 
       <div class="grid grid-cols-3 gap-3">
         <div class="spec-form-field">
-          <label for="f-access" class="spec-form-label">{{ self.t("spec-form-access") }}</label>
+          <div class="spec-form-label-row">
+            <label for="f-access" class="spec-form-label">{{ self.t("spec-form-access") }}</label>
+            {% call help(self.t("spec-help-access")) %}{% endcall %}
+          </div>
           <select id="f-access" name="access" x-model="form.access" class="spec-form-input">
             <option value="lock">🔒 {{ self.t("filter-access-restricted") }}</option>
             <option value="lock_open">🔓 {{ self.t("filter-access-public") }}</option>
           </select>
         </div>
         <div class="spec-form-field">
-          <label for="f-state" class="spec-form-label">{{ self.t("spec-form-state") }}</label>
+          <div class="spec-form-label-row">
+            <label for="f-state" class="spec-form-label">{{ self.t("spec-form-state") }}</label>
+            {% call help(self.t("spec-help-state")) %}{% endcall %}
+          </div>
           <select id="f-state" name="state" x-model="form.state" class="spec-form-input">
             <option value="active">{{ self.t("spec-form-state-active") }}</option>
             <option value="inactive">{{ self.t("spec-form-state-inactive") }}</option>
           </select>
         </div>
         <div class="spec-form-field">
-          <label for="f-subject" class="spec-form-label">{{ self.t("spec-form-subject") }}</label>
+          <div class="spec-form-label-row">
+            <label for="f-subject" class="spec-form-label">{{ self.t("spec-form-subject") }}</label>
+            {% call help(self.t("spec-help-subject")) %}{% endcall %}
+          </div>
           <input id="f-subject" type="text" name="subject"
                  value="{{ form.subject }}"
                  x-model="form.subject"
@@ -220,7 +258,10 @@
           <div class="spec-form-section-title">{{ self.t("spec-form-container") }}</div>
 
           <div class="spec-form-field">
-            <label for="f-img" class="spec-form-label">{{ self.t("spec-form-image") }}</label>
+            <div class="spec-form-label-row">
+              <label for="f-img" class="spec-form-label">{{ self.t("spec-form-image") }}</label>
+              {% call help(self.t("spec-help-image")) %}{% endcall %}
+            </div>
             <input id="f-img" type="text" name="container_image"
                    value="{{ form.container_image }}"
                    x-model="form.container_image"
@@ -230,7 +271,10 @@
 
           <div class="grid grid-cols-2 gap-3">
             <div class="spec-form-field">
-              <label for="f-seats" class="spec-form-label">{{ self.t("spec-form-seats") }}</label>
+              <div class="spec-form-label-row">
+                <label for="f-seats" class="spec-form-label">{{ self.t("spec-form-seats") }}</label>
+                {% call help(self.t("spec-help-seats")) %}{% endcall %}
+              </div>
               <input id="f-seats" type="number" name="seats_per_container"
                      value="{{ form.seats_per_container }}"
                      min="1"
@@ -238,7 +282,10 @@
                      class="spec-form-input">
             </div>
             <div class="spec-form-field">
-              <label for="f-lifetime" class="spec-form-label">{{ self.t("spec-form-lifetime") }}</label>
+              <div class="spec-form-label-row">
+                <label for="f-lifetime" class="spec-form-label">{{ self.t("spec-form-lifetime") }}</label>
+                {% call help(self.t("spec-help-lifetime")) %}{% endcall %}
+              </div>
               <input id="f-lifetime" type="number" name="max_lifetime"
                      value="{{ form.max_lifetime }}"
                      min="1"
@@ -254,7 +301,10 @@
         <div>
           <div class="spec-form-section-title">{{ self.t("spec-form-link-section") }}</div>
           <div class="spec-form-field">
-            <label for="f-link" class="spec-form-label">{{ self.t("spec-form-link") }}</label>
+            <div class="spec-form-label-row">
+              <label for="f-link" class="spec-form-label">{{ self.t("spec-form-link") }}</label>
+              {% call help(self.t("spec-help-link")) %}{% endcall %}
+            </div>
             <input id="f-link" type="url" name="link"
                    value="{{ form.link }}"
                    x-model="form.link"
@@ -266,7 +316,10 @@
 
       <div class="spec-form-section-title">{{ self.t("spec-form-meta") }}</div>
       <div class="spec-form-field">
-        <label for="f-updated" class="spec-form-label">{{ self.t("spec-form-updated") }}</label>
+        <div class="spec-form-label-row">
+          <label for="f-updated" class="spec-form-label">{{ self.t("spec-form-updated") }}</label>
+          {% call help(self.t("spec-help-updated")) %}{% endcall %}
+        </div>
         <input id="f-updated" type="text" name="updated"
                value="{{ form.updated }}"
                x-model="form.updated"
@@ -274,6 +327,139 @@
                pattern="\d{2}/\d{2}/\d{4}"
                class="spec-form-input spec-form-input--mono">
         <div class="spec-form-help">{{ self.t("spec-form-updated-help") }}</div>
+      </div>
+
+      {# ── Advanced (collapsible): API, scaling, resources, lifecycle.
+           Every field is optional — leaving it blank keeps the schema
+           default, so casual operators never have to open this. ──── #}
+      <div class="spec-form-advanced">
+        <button type="button" class="spec-form-advanced-toggle"
+                :class="advancedOpen ? 'is-open' : ''"
+                @click="advancedOpen = !advancedOpen"
+                :aria-expanded="advancedOpen">
+          <i class="ti ti-chevron-right chevron" aria-hidden="true"></i>
+          {{ self.t("spec-form-advanced") }}
+        </button>
+
+        <div x-show="advancedOpen" x-cloak x-transition>
+          <div class="spec-form-help" style="margin:0 0 4px">{{ self.t("spec-form-advanced-hint") }}</div>
+
+          {# API — only relevant for type: api #}
+          <template x-if="isApi()">
+            <div>
+              <div class="spec-form-subsection">{{ self.t("spec-form-api-section") }}</div>
+
+              <div class="grid grid-cols-2 gap-3">
+                <div class="spec-form-field">
+                  <div class="spec-form-label-row">
+                    <label for="f-api-port" class="spec-form-label">{{ self.t("spec-form-api-port") }}</label>
+                    {% call help(self.t("spec-help-api-port")) %}{% endcall %}
+                  </div>
+                  <input id="f-api-port" type="number" name="api_port" min="1" max="65535"
+                         value="{{ form.api_port }}" placeholder="8080" class="spec-form-input">
+                </div>
+                <div class="spec-form-field">
+                  <div class="spec-form-label-row">
+                    <label for="f-api-rate" class="spec-form-label">{{ self.t("spec-form-api-rate-limit") }}</label>
+                    {% call help(self.t("spec-help-api-rate-limit")) %}{% endcall %}
+                  </div>
+                  <input id="f-api-rate" type="text" name="api_rate_limit"
+                         value="{{ form.api_rate_limit }}" placeholder="100/min"
+                         class="spec-form-input spec-form-input--mono">
+                </div>
+                <div class="spec-form-field">
+                  <div class="spec-form-label-row">
+                    <label for="f-api-docs" class="spec-form-label">{{ self.t("spec-form-api-docs-path") }}</label>
+                    {% call help(self.t("spec-help-api-docs-path")) %}{% endcall %}
+                  </div>
+                  <input id="f-api-docs" type="text" name="api_docs_path"
+                         value="{{ form.api_docs_path }}" placeholder="/__docs__"
+                         class="spec-form-input spec-form-input--mono">
+                </div>
+                <div class="spec-form-field">
+                  <div class="spec-form-label-row">
+                    <label for="f-api-health" class="spec-form-label">{{ self.t("spec-form-api-health-path") }}</label>
+                    {% call help(self.t("spec-help-api-health-path")) %}{% endcall %}
+                  </div>
+                  <input id="f-api-health" type="text" name="api_health_path"
+                         value="{{ form.api_health_path }}" placeholder="/__healthz__"
+                         class="spec-form-input spec-form-input--mono">
+                </div>
+              </div>
+
+              <div class="spec-form-field">
+                <label class="spec-form-check">
+                  <input type="checkbox" name="api_cors" value="on"
+                         {% if !form.api_cors.is_empty() %}checked{% endif %}>
+                  {{ self.t("spec-form-api-cors") }}
+                  {% call help(self.t("spec-help-api-cors")) %}{% endcall %}
+                </label>
+              </div>
+            </div>
+          </template>
+
+          {# Scaling — replica pool #}
+          <div class="spec-form-subsection">{{ self.t("spec-form-scaling-section") }}</div>
+          <div class="grid grid-cols-3 gap-3">
+            <div class="spec-form-field">
+              <div class="spec-form-label-row">
+                <label for="f-min-rep" class="spec-form-label">{{ self.t("spec-form-min-replicas") }}</label>
+                {% call help(self.t("spec-help-min-replicas")) %}{% endcall %}
+              </div>
+              <input id="f-min-rep" type="number" name="min_replicas" min="0"
+                     value="{{ form.min_replicas }}" placeholder="0" class="spec-form-input">
+            </div>
+            <div class="spec-form-field">
+              <div class="spec-form-label-row">
+                <label for="f-max-rep" class="spec-form-label">{{ self.t("spec-form-max-replicas") }}</label>
+                {% call help(self.t("spec-help-max-replicas")) %}{% endcall %}
+              </div>
+              <input id="f-max-rep" type="number" name="max_replicas" min="1"
+                     value="{{ form.max_replicas }}" placeholder="3" class="spec-form-input">
+            </div>
+            <div class="spec-form-field">
+              <div class="spec-form-label-row">
+                <label for="f-concurrent" class="spec-form-label">{{ self.t("spec-form-concurrent") }}</label>
+                {% call help(self.t("spec-help-concurrent")) %}{% endcall %}
+              </div>
+              <input id="f-concurrent" type="number" name="concurrent_requests_per_replica" min="1"
+                     value="{{ form.concurrent_requests_per_replica }}" placeholder="100" class="spec-form-input">
+            </div>
+          </div>
+
+          {# Resources — per-container limits #}
+          <div class="spec-form-subsection">{{ self.t("spec-form-resources-section") }}</div>
+          <div class="grid grid-cols-2 gap-3">
+            <div class="spec-form-field">
+              <div class="spec-form-label-row">
+                <label for="f-cpu" class="spec-form-label">{{ self.t("spec-form-cpu-limit") }}</label>
+                {% call help(self.t("spec-help-cpu-limit")) %}{% endcall %}
+              </div>
+              <input id="f-cpu" type="text" name="container_cpu_limit"
+                     value="{{ form.container_cpu_limit }}" placeholder="0.5" class="spec-form-input">
+            </div>
+            <div class="spec-form-field">
+              <div class="spec-form-label-row">
+                <label for="f-mem" class="spec-form-label">{{ self.t("spec-form-memory-limit") }}</label>
+                {% call help(self.t("spec-help-memory-limit")) %}{% endcall %}
+              </div>
+              <input id="f-mem" type="text" name="container_memory_limit"
+                     value="{{ form.container_memory_limit }}" placeholder="512m"
+                     class="spec-form-input spec-form-input--mono">
+            </div>
+          </div>
+
+          {# Lifecycle #}
+          <div class="spec-form-subsection">{{ self.t("spec-form-lifecycle-section") }}</div>
+          <div class="spec-form-field">
+            <div class="spec-form-label-row">
+              <label for="f-heartbeat" class="spec-form-label">{{ self.t("spec-form-heartbeat") }}</label>
+              {% call help(self.t("spec-help-heartbeat")) %}{% endcall %}
+            </div>
+            <input id="f-heartbeat" type="number" name="heartbeat_timeout" min="-1"
+                   value="{{ form.heartbeat_timeout }}" placeholder="3600000" class="spec-form-input">
+          </div>
+        </div>
       </div>
     </form>
 
@@ -338,6 +524,21 @@
 window.ruscker = window.ruscker || {};
 window.ruscker.specForm = (initial) => ({
   form: initial,
+  // Open the Advanced section on load if it already carries any value,
+  // so edits to existing advanced config are visible.
+  advancedOpen: !!(
+    (initial.heartbeat_timeout || '').toString().trim() ||
+    (initial.container_cpu_limit || '').toString().trim() ||
+    (initial.container_memory_limit || '').trim() ||
+    (initial.min_replicas || '').toString().trim() ||
+    (initial.max_replicas || '').toString().trim() ||
+    (initial.concurrent_requests_per_replica || '').toString().trim() ||
+    (initial.api_port || '').toString().trim() ||
+    (initial.api_rate_limit || '').trim() ||
+    (initial.api_docs_path || '').trim() ||
+    (initial.api_health_path || '').trim() ||
+    (initial.api_cors || '').trim()
+  ),
   // Card-cover editing mode: 'auto' (kind tint, empty cover),
   // 'solid' (color), 'gradient' (builder). Seeded from any
   // existing `cover` value.
@@ -372,6 +573,9 @@ window.ruscker.specForm = (initial) => ({
   },
   needsLink() {
     return ['link', 'package'].includes(this.form.display_type);
+  },
+  isApi() {
+    return this.form.display_type === 'api';
   },
   badgeText() {
     const map = {

--- a/crates/ruscker-config/src/lib.rs
+++ b/crates/ruscker-config/src/lib.rs
@@ -42,8 +42,8 @@ pub mod validate;
 
 pub use error::{Error, Result};
 pub use schema::{
-    Config, LandingBlock, LandingCustomization, Logging, Proxy, RatePolicy, RoutingStrategy,
-    Server, Spec, SpecKind, SpecKindOverride, TemplateProperties,
+    ApiSpec, Config, LandingBlock, LandingCustomization, Logging, Proxy, RatePolicy,
+    RoutingStrategy, Server, Spec, SpecKind, SpecKindOverride, TemplateProperties,
 };
 pub use validate::{CompatWarning, ValidationReport, Warning};
 


### PR DESCRIPTION
The admin spec form only covered presentation + basic container fields, so the claim "everything is configurable in the admin" wasn't true — API tuning, replica pools, resource limits and the heartbeat override were YAML-only. This closes that gap and adds help to every field.

## Advanced section (collapsible)

All fields optional — blank keeps the schema default, so casual operators never have to open it.

- **API** (shown only for `type: api`) — container port, `rate-limit`, `docs-path`, `health-path`, permissive `cors`.
- **Scaling** — `min`/`max-replicas`, `concurrent-requests-per-replica`.
- **Resources** — `container-cpu-limit` (fractional cores), `container-memory-limit`.
- **Lifecycle** — `heartbeat-timeout` (`-1` = never).

`SpecForm` gains the fields; `from_spec`/`into_spec` round-trip them (building `ApiSpec` for API specs or whenever an API field is filled). The section auto-opens on edit when any advanced value is already set. `ApiSpec` is now re-exported from `ruscker-config`.

## Per-field help

A reusable Askama `{% macro help(text) %}` renders an Alpine "?" popover next to **every** field label (25 in total), each with a plain-language explanation. 42 new i18n keys (advanced labels + 25 help texts) added across all four locales.

## Verification

- `cargo build` (Askama compiles the template), 142 admin tests, `i18n-check.sh` parity, fmt drift unchanged.
- **Real HTTP smoke**: `serve` → `POST /admin/login` (303) → `GET /admin/specs/new` (200) — confirmed 25 help popovers, the Advanced toggle, all new fields (`api_*`, `min_replicas`, `container_cpu_limit`, `heartbeat_timeout`), and the pt-BR help copy rendering.

🤖 Generated with [Claude Code](https://claude.com/claude-code)