### PR TITLE
docs: admin configures every spec field — state it accurately

### DIFF
--- a/README.md
+++ b/README.md
@@ -88,10 +88,12 @@ What's in the box:
   rewriting so unmodified Shiny/Streamlit apps work behind a subpath.
 - **Container backend** (Docker) that spawns app containers on demand,
   applies per-container CPU/memory limits, and reaps idle ones.
-- **Admin panel** — apps CRUD, image/media library, encrypted
-  credentials store, a landing-page editor (colors, intros, SEO, social
-  meta, analytics, custom HTML blocks), an audit log, and a live SSE
-  dashboard (CPU/memory, logs, stop/restart).
+- **Admin panel** — full apps CRUD (every spec field editable from the
+  form, including API/scaling/resource/lifecycle settings, with inline
+  help), image/media library, encrypted credentials store, a
+  landing-page editor (colors, intros, SEO, social meta, analytics,
+  custom HTML blocks), an audit log, and a live SSE dashboard
+  (CPU/memory, logs, stop/restart).
 - **Operations** — `/healthz` + `/readyz` probes, graceful shutdown,
   structured (JSON) logging, per-API rate limiting + CORS, request
   body-size limits, `validate --strict-compat` migration pre-flight.

--- a/book/src/admin.md
+++ b/book/src/admin.md
@@ -4,6 +4,11 @@ The admin panel is Ruscker's main advantage over editing YAML by hand.
 It lives at `/admin`, is gated by a token, and needs a SQLite database
 (`serve --db <file>`).
 
+**Everything is configurable from the web UI** — every spec field
+(including API, scaling, resource and lifecycle settings), the media
+library, encrypted credentials, and the whole landing page. YAML
+import/export exists for migration and backups, not as a requirement.
+
 ## Logging in
 
 Set `RUSCKER_ADMIN_TOKEN` (the `.deb` generates one on first install
@@ -24,10 +29,24 @@ replica; open its logs. Shows a banner when started without
 `--docker`.
 
 ### Apps
-The list of specs (apps, APIs, external links). The add/edit form has a
-type selector, a live card preview, resource limits, registry
-credentials, and a **logo picker** that pulls from the media library
-(no need to type `/assets/img/...` by hand).
+The list of specs — apps, APIs and external links — with create, edit
+and delete. The add/edit form has a type selector, a **live card
+preview**, and a **logo picker** that pulls from the media library (no
+need to type `/assets/img/...` by hand). A **"?" help popover** on every
+field explains what it does.
+
+Under a collapsible **Advanced** section, every remaining spec option is
+editable too — so an app can be configured end-to-end from the web UI,
+without touching YAML:
+
+- **API** (for `type: api`) — container port, rate limit, docs/health
+  paths, permissive CORS.
+- **Scaling** — min/max replicas and concurrent requests per replica.
+- **Resources** — per-container CPU and memory limits.
+- **Lifecycle** — the heartbeat (idle-session) timeout.
+
+Every advanced field is optional; leaving it blank keeps Ruscker's
+default, so the section stays out of the way until you need it.
 
 ### Media
 Upload images (PNG/JPEG → WebP), served at `/assets/img/<file>`. These


### PR DESCRIPTION
Follow-up to #70. Now that the advanced spec-form section covers the full spec (API, scaling, resources, lifecycle), the docs can accurately say the admin manages everything.

- **Book admin page** — a lead line ("Everything is configurable from the web UI…") and an expanded **Apps** section documenting the collapsible **Advanced** section + the per-field "?" help. Also fixed the old wording that implied registry credentials live in the spec form — they're in the separate, AES-encrypted Credentials store.
- **README** — the admin bullet now notes every spec field is editable from the form with inline help.

Verified with `mdbook build`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)