### PR TITLE
fix(admin): validate numeric/limit spec-form fields (#79, #83)

### DIFF
--- a/crates/ruscker-admin/assets/i18n/en/landing.ftl
+++ b/crates/ruscker-admin/assets/i18n/en/landing.ftl
@@ -163,6 +163,10 @@ spec-form-error-id-required = ID is required.
 spec-form-error-id-shape = ID must start with a letter and contain only letters, digits, "_" and "-".
 spec-form-error-id-duplicate = An app with that ID already exists.
 spec-form-error-name-required = Display name is required.
+spec-form-error-number = A numeric field has a non-numeric value.
+spec-form-error-cpu = CPU limit must be a positive number (e.g. 0.5).
+spec-form-error-memory = Memory limit must be a size like 512m or 1.5g.
+spec-form-error-replica-range = Max replicas must be greater than or equal to min replicas.
 
 # Admin image library
 admin-images-title = Media library

--- a/crates/ruscker-admin/assets/i18n/es/landing.ftl
+++ b/crates/ruscker-admin/assets/i18n/es/landing.ftl
@@ -163,6 +163,10 @@ spec-form-error-id-required = El ID es obligatorio.
 spec-form-error-id-shape = El ID debe empezar con una letra y contener solo letras, números, "_" y "-".
 spec-form-error-id-duplicate = Ya existe una aplicación con ese ID.
 spec-form-error-name-required = El nombre visible es obligatorio.
+spec-form-error-number = Un campo numérico tiene un valor no numérico.
+spec-form-error-cpu = El límite de CPU debe ser un número positivo (ej.: 0.5).
+spec-form-error-memory = El límite de memoria debe ser un tamaño como 512m o 1.5g.
+spec-form-error-replica-range = Réplicas máx. debe ser mayor o igual que réplicas mín.
 
 # Admin image library
 admin-images-title = Biblioteca multimedia

--- a/crates/ruscker-admin/assets/i18n/fr/landing.ftl
+++ b/crates/ruscker-admin/assets/i18n/fr/landing.ftl
@@ -163,6 +163,10 @@ spec-form-error-id-required = L'ID est obligatoire.
 spec-form-error-id-shape = L'ID doit commencer par une lettre et contenir uniquement lettres, chiffres, "_" et "-".
 spec-form-error-id-duplicate = Une application avec cet ID existe déjà.
 spec-form-error-name-required = Le nom d'affichage est obligatoire.
+spec-form-error-number = Un champ numérique a une valeur non numérique.
+spec-form-error-cpu = La limite CPU doit être un nombre positif (ex. 0.5).
+spec-form-error-memory = La limite mémoire doit être une taille comme 512m ou 1.5g.
+spec-form-error-replica-range = Le max de réplicas doit être supérieur ou égal au min.
 
 # Admin image library
 admin-images-title = Bibliothèque de médias

--- a/crates/ruscker-admin/assets/i18n/pt/landing.ftl
+++ b/crates/ruscker-admin/assets/i18n/pt/landing.ftl
@@ -167,6 +167,10 @@ spec-form-error-id-required = ID é obrigatório.
 spec-form-error-id-shape = ID deve começar com letra e conter apenas letras, números, "_" e "-".
 spec-form-error-id-duplicate = Já existe uma aplicação com esse ID.
 spec-form-error-name-required = Nome de exibição é obrigatório.
+spec-form-error-number = Um campo numérico tem valor não numérico.
+spec-form-error-cpu = O limite de CPU deve ser um número positivo (ex.: 0.5).
+spec-form-error-memory = O limite de memória deve ser um tamanho como 512m ou 1.5g.
+spec-form-error-replica-range = Réplicas máx. deve ser maior ou igual a réplicas mín.
 
 # Admin image library
 admin-images-title = Biblioteca de mídia

--- a/crates/ruscker-admin/src/routes/admin/spec_form.rs
+++ b/crates/ruscker-admin/src/routes/admin/spec_form.rs
@@ -294,6 +294,51 @@ impl SpecForm {
         if matches!(mode, FormMode::New) && self.id.trim().is_empty() {
             // duplicate-id check happens later (needs DB access)
         }
+
+        // Numeric fields: a non-empty but unparseable value used to be
+        // silently dropped to None (= schema default). Flag it instead,
+        // so a pt-BR `0,5` CPU or a typo'd count doesn't quietly mean
+        // "no limit / default".
+        let int_fields = [
+            &self.seats_per_container,
+            &self.max_lifetime,
+            &self.heartbeat_timeout,
+            &self.min_replicas,
+            &self.max_replicas,
+            &self.concurrent_requests_per_replica,
+            &self.api_port,
+        ];
+        if int_fields
+            .iter()
+            .any(|v| !v.trim().is_empty() && v.trim().parse::<i64>().is_err())
+        {
+            errs.push("spec-form-error-number");
+        }
+
+        // CPU must be a positive, finite number of cores (catches `0,5`).
+        if !self.container_cpu_limit.trim().is_empty()
+            && !matches!(self.container_cpu_limit.trim().parse::<f64>(), Ok(v) if v.is_finite() && v > 0.0)
+        {
+            errs.push("spec-form-error-cpu");
+        }
+
+        // Memory must be a Docker-style size (catches the `512mb` typo).
+        if !self.container_memory_limit.trim().is_empty()
+            && !ruscker_config::is_valid_memory_size(self.container_memory_limit.trim())
+        {
+            errs.push("spec-form-error-memory");
+        }
+
+        // Replica pool: max must be >= min when both are given.
+        if let (Ok(min), Ok(max)) = (
+            self.min_replicas.trim().parse::<u32>(),
+            self.max_replicas.trim().parse::<u32>(),
+        ) {
+            if max < min {
+                errs.push("spec-form-error-replica-range");
+            }
+        }
+
         errs
     }
 }
@@ -680,5 +725,57 @@ proxy:
         assert_eq!(spec.container_lifetime, None);
         assert_eq!(spec.docker_registry_username, None);
         assert_eq!(spec.max_body_size, None);
+    }
+
+    fn valid_form() -> SpecForm {
+        SpecForm {
+            id: "ok".into(),
+            display_name: "Ok".into(),
+            display_type: "app".into(),
+            state: "active".into(),
+            access: "lock".into(),
+            ..Default::default()
+        }
+    }
+
+    // #79/#83: malformed numbers used to silently default; now they're
+    // form errors instead of "no limit / default".
+    #[test]
+    fn validate_rejects_malformed_numbers() {
+        let mut f = valid_form();
+        f.container_cpu_limit = "0,5".into(); // pt-BR comma
+        assert!(f.validate(FormMode::New).contains(&"spec-form-error-cpu"));
+
+        let mut f = valid_form();
+        f.container_memory_limit = "512mb".into(); // typo
+        assert!(f
+            .validate(FormMode::New)
+            .contains(&"spec-form-error-memory"));
+
+        let mut f = valid_form();
+        f.seats_per_container = "ten".into();
+        assert!(f
+            .validate(FormMode::New)
+            .contains(&"spec-form-error-number"));
+
+        let mut f = valid_form();
+        f.min_replicas = "5".into();
+        f.max_replicas = "2".into();
+        assert!(f
+            .validate(FormMode::New)
+            .contains(&"spec-form-error-replica-range"));
+    }
+
+    #[test]
+    fn validate_accepts_good_numbers() {
+        let mut f = valid_form();
+        f.container_cpu_limit = "0.5".into();
+        f.container_memory_limit = "512m".into();
+        f.seats_per_container = "10".into();
+        f.min_replicas = "1".into();
+        f.max_replicas = "3".into();
+        f.heartbeat_timeout = "-1".into();
+        let errs = f.validate(FormMode::New);
+        assert!(errs.is_empty(), "expected no errors, got {errs:?}");
     }
 }

--- a/crates/ruscker-config/src/lib.rs
+++ b/crates/ruscker-config/src/lib.rs
@@ -42,8 +42,8 @@ pub mod validate;
 
 pub use error::{Error, Result};
 pub use schema::{
-    ApiSpec, Config, LandingBlock, LandingCustomization, Logging, Proxy, RatePolicy,
-    RoutingStrategy, Server, Spec, SpecKind, SpecKindOverride, TemplateProperties,
+    is_valid_memory_size, ApiSpec, Config, LandingBlock, LandingCustomization, Logging, Proxy,
+    RatePolicy, RoutingStrategy, Server, Spec, SpecKind, SpecKindOverride, TemplateProperties,
 };
 pub use validate::{CompatWarning, ValidationReport, Warning};
 

--- a/crates/ruscker-config/src/schema.rs
+++ b/crates/ruscker-config/src/schema.rs
@@ -655,6 +655,14 @@ impl Spec {
 /// We deliberately use binary (1024-based) units to match the
 /// ShinyProxy / Docker convention. Operators who type `512m`
 /// expect ~512 MiB, not ~512 MB.
+/// Whether `s` parses as a Docker-style memory size (`"512m"`, `"1.5g"`,
+/// plain bytes). Public so the admin form can validate the field with
+/// the same rules the runtime uses, instead of silently accepting a
+/// typo like `512mb`.
+pub fn is_valid_memory_size(s: &str) -> bool {
+    parse_memory_string(s).is_some()
+}
+
 fn parse_memory_string(s: &str) -> Option<i64> {
     let s = s.trim();
     if s.is_empty() {


### PR DESCRIPTION
Fixes MED findings **#79** and **#83**.

`SpecForm`'s numeric fields went through `parse_opt` (`.parse().ok()`), so a non-empty but unparseable value was **silently dropped to `None`** (= schema default). A pt-BR operator typing `0,5` for CPU got "no limit" instead of half a core; `512mb` memory and inverted replica ranges slipped through too — only caught later by the CLI validator (#83).

`SpecForm::validate` now blocks the save and shows an error for:
- any integer field (seats, lifetime, heartbeat, min/max replicas, concurrent, API port) that's non-empty and non-numeric;
- a CPU limit that isn't a positive finite number (catches `0,5`);
- a memory limit that isn't a Docker-style size (catches `512mb`), via the new public `ruscker_config::is_valid_memory_size`;
- `max-replicas < min-replicas` (#83).

4 new i18n error keys × 4 locales.

**Verified:** unit tests for each rejection + a valid form passing (admin 151 → 153); i18n parity; HTTP smoke — `container_cpu_limit=0,5` → **422**, valid `0.5`/`512m` → **303**; fmt drift unchanged.

Closes #79. Closes #83.

🤖 Generated with [Claude Code](https://claude.com/claude-code)