### PR TITLE
chore: apply clippy --fix across the workspace (part of #84)

### DIFF
--- a/crates/ruscker-admin/src/routes/admin/dashboard.rs
+++ b/crates/ruscker-admin/src/routes/admin/dashboard.rs
@@ -260,7 +260,7 @@ async fn build_snapshot(state: &AppState, locale: Locale) -> DashboardSnapshot {
             .proxy
             .specs
             .iter()
-            .flat_map(|s| reg.replicas_of(&s.id).iter().cloned().collect::<Vec<_>>())
+            .flat_map(|s| reg.replicas_of(&s.id).to_vec())
             .collect()
     };
 
@@ -805,7 +805,7 @@ mod tests {
     #[test]
     fn renders_empty_state_when_no_replicas() {
         let html = render_with(vec![], true);
-        assert!(html.contains("admin-dashboard-no-replicas") == false,
+        assert!(!html.contains("admin-dashboard-no-replicas"),
             "raw key must be translated, not echoed");
         // pt-BR empty-state line is present
         assert!(html.contains("Nenhuma réplica em execução"));

--- a/crates/ruscker-admin/src/routes/admin/spec_form.rs
+++ b/crates/ruscker-admin/src/routes/admin/spec_form.rs
@@ -187,7 +187,7 @@ impl SpecForm {
         // visual, so keep whatever run-kind override `base` carried.
         let kind_override = match dt {
             DisplayType::App => Some(SpecKindOverride::Shiny),
-            DisplayType::Talk | DisplayType::Report => base.and_then(|b| b.kind_override.clone()),
+            DisplayType::Talk | DisplayType::Report => base.and_then(|b| b.kind_override),
             DisplayType::Package | DisplayType::Link => Some(SpecKindOverride::External),
             DisplayType::Api => Some(SpecKindOverride::Api),
         };
@@ -275,7 +275,7 @@ impl SpecForm {
             scale_down_threshold: base.and_then(|b| b.scale_down_threshold),
             scale_down_grace: base.and_then(|b| b.scale_down_grace),
             drain_timeout: base.and_then(|b| b.drain_timeout),
-            routing_strategy: base.and_then(|b| b.routing_strategy.clone()),
+            routing_strategy: base.and_then(|b| b.routing_strategy),
         })
     }
 
@@ -631,7 +631,7 @@ async fn render_form_with_errors(
         mode,
         form,
         errors,
-        logo_images: logo_filenames(&state).await,
+        logo_images: logo_filenames(state).await,
     };
     let body = match page.render() {
         Ok(s) => s,

--- a/crates/ruscker-admin/src/routes/proxy.rs
+++ b/crates/ruscker-admin/src/routes/proxy.rs
@@ -825,7 +825,7 @@ async fn do_forward(
     let upstream_resp = client.request(req).await?;
 
     let (parts, body) = upstream_resp.into_parts();
-    let body = Body::new(body.map_err(|e| std::io::Error::other(e)));
+    let body = Body::new(body.map_err(std::io::Error::other));
     let mut resp = Response::from_parts(parts, body);
     strip_hop_headers(resp.headers_mut());
     Ok(resp)

--- a/crates/ruscker-admin/src/scaler.rs
+++ b/crates/ruscker-admin/src/scaler.rs
@@ -170,7 +170,7 @@ async fn tick(
             .proxy
             .specs
             .iter()
-            .flat_map(|s| reg.replicas_of(&s.id).iter().cloned().collect::<Vec<_>>())
+            .flat_map(|s| reg.replicas_of(&s.id).to_vec())
             .collect()
     };
     update_idle_ticks(idle_ticks, &registry_snap);
@@ -888,7 +888,7 @@ proxy:
         // A: saturated (1/1). B: idle (0/1). count=2, min=1.
         let busy = replica_with_sessions("flappy", 1, 1);
         let idle = replica_with_sessions("flappy", 0, 1);
-        let idle_id = idle.id.clone();
+        let _idle_id = idle.id.clone();
         {
             let mut reg = state.replicas.write().await;
             reg.add(busy);

--- a/crates/ruscker-admin/src/view_model.rs
+++ b/crates/ruscker-admin/src/view_model.rs
@@ -346,6 +346,39 @@ pub fn unique_subjects<'a>(cards: &[CardCtx<'a>]) -> Vec<&'a str> {
     set.into_iter().collect()
 }
 
+/// Build the chip bar with live counts. Only chips that have at
+/// least one matching card are emitted, so the UI never shows
+/// "Reports (0)" — that signal is more useful than the chip itself.
+/// Order matches the mockup's visual order: app, talk, report,
+/// package, api, link.
+pub fn build_type_chips(cards: &[CardCtx<'_>]) -> Vec<TypeChip> {
+    let mut counts: BTreeMap<DisplayType, usize> = BTreeMap::new();
+    for c in cards {
+        *counts.entry(c.display_type).or_default() += 1;
+    }
+    [
+        DisplayType::App,
+        DisplayType::Talk,
+        DisplayType::Report,
+        DisplayType::Package,
+        DisplayType::Api,
+        DisplayType::Link,
+    ]
+    .into_iter()
+    .filter_map(|dt| {
+        let count = *counts.get(&dt).unwrap_or(&0);
+        if count == 0 {
+            None
+        } else {
+            Some(TypeChip {
+                display_type: dt,
+                count,
+            })
+        }
+    })
+    .collect()
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
@@ -422,37 +455,4 @@ mod tests {
         let card = CardCtx::from_spec(&spec);
         assert_eq!(card.cover, None);
     }
-}
-
-/// Build the chip bar with live counts. Only chips that have at
-/// least one matching card are emitted, so the UI never shows
-/// "Reports (0)" — that signal is more useful than the chip itself.
-/// Order matches the mockup's visual order: app, talk, report,
-/// package, api, link.
-pub fn build_type_chips(cards: &[CardCtx<'_>]) -> Vec<TypeChip> {
-    let mut counts: BTreeMap<DisplayType, usize> = BTreeMap::new();
-    for c in cards {
-        *counts.entry(c.display_type).or_default() += 1;
-    }
-    [
-        DisplayType::App,
-        DisplayType::Talk,
-        DisplayType::Report,
-        DisplayType::Package,
-        DisplayType::Api,
-        DisplayType::Link,
-    ]
-    .into_iter()
-    .filter_map(|dt| {
-        let count = *counts.get(&dt).unwrap_or(&0);
-        if count == 0 {
-            None
-        } else {
-            Some(TypeChip {
-                display_type: dt,
-                count,
-            })
-        }
-    })
-    .collect()
 }

--- a/crates/ruscker-config/src/schema.rs
+++ b/crates/ruscker-config/src/schema.rs
@@ -311,21 +311,16 @@ fn default_true() -> bool {
     true
 }
 
-#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize, Default)]
 #[serde(rename_all = "lowercase")]
 pub enum AuthScheme {
+    #[default]
     None,
     #[serde(rename = "openid")]
     OpenId,
     Ldap,
     Saml,
     Simple,
-}
-
-impl Default for AuthScheme {
-    fn default() -> Self {
-        AuthScheme::None
-    }
 }
 
 /// A single spec — an app, API, or external link surfaced on the landing

--- a/crates/ruscker-core/src/routing.rs
+++ b/crates/ruscker-core/src/routing.rs
@@ -31,7 +31,7 @@ impl Router {
     }
 
     /// Pick a replica for a new session.
-    pub fn pick<'a>(&self, replicas: &'a [Replica]) -> RoutingDecision {
+    pub fn pick(&self, replicas: &[Replica]) -> RoutingDecision {
         let accepting: Vec<&Replica> = replicas.iter().filter(|r| r.is_accepting()).collect();
         if accepting.is_empty() {
             return if replicas.is_empty() {

--- a/crates/ruscker-docker/src/lib.rs
+++ b/crates/ruscker-docker/src/lib.rs
@@ -419,7 +419,7 @@ impl ContainerBackend for LocalDockerBackend {
                 ports
                     .iter()
                     .find(|p| p.private_port == inner_port)
-                    .and_then(|p| p.public_port.map(|n| n as u16))
+                    .and_then(|p| p.public_port.map(|n| n))
             });
             let upstream: SocketAddr = match host_port {
                 Some(p) => format!("127.0.0.1:{p}").parse().unwrap(),


### PR DESCRIPTION
Part of audit cleanup **#84**.

Applies the machine-applicable `cargo clippy --fix` suggestions across all crates: `to_vec()` over `iter().cloned().collect()`, dropping redundant casts/closures, `is_some()`/negation idioms, moving items before the test module, `#[derive(Default)]` for `AuthScheme`, etc. Tidied the `AuthScheme` derive into a single attribute (no double blank line). No behaviour change.

All workspace tests green; fmt drift unchanged. The remaining (non-machine-applicable) clippy lints and the robustness nits are handled in the follow-up that closes #84.

🤖 Generated with [Claude Code](https://claude.com/claude-code)