### PR TITLE
fix: audit robustness nits (#84)

### DIFF
--- a/crates/ruscker-admin/src/routes/proxy.rs
+++ b/crates/ruscker-admin/src/routes/proxy.rs
@@ -288,7 +288,8 @@ async fn forward(
             Err(err) => {
                 tracing::error!(spec = %spec.id, error = ?err, "resolve replica failed");
                 return with_cors(
-                    (StatusCode::BAD_GATEWAY, format!("backend error: {err}")).into_response(),
+                    // Detail is logged above; don't leak it to the client.
+                    (StatusCode::BAD_GATEWAY, "backend unavailable").into_response(),
                     cors_on,
                 );
             }
@@ -333,7 +334,8 @@ async fn forward(
                 error = ?err, "forward failed"
             );
             return with_cors(
-                (StatusCode::BAD_GATEWAY, format!("upstream error: {err}")).into_response(),
+                // Detail is logged above; keep the client-facing body generic.
+                (StatusCode::BAD_GATEWAY, "upstream error").into_response(),
                 cors_on,
             );
         }
@@ -841,6 +843,9 @@ const HOP_BY_HOP: &[&str] = &[
     "transfer-encoding",
     "upgrade",
     "host",
+    // Non-standard but widely sent; strip so it can't confuse a
+    // request-smuggling-aware upstream.
+    "proxy-connection",
 ];
 
 fn strip_hop_headers(headers: &mut HeaderMap) {

--- a/crates/ruscker-admin/src/scaler.rs
+++ b/crates/ruscker-admin/src/scaler.rs
@@ -181,6 +181,12 @@ async fn tick(
         specs.iter().map(|s| s.id.as_str()).collect();
     saturation_ticks.retain(|id, _| known_spec_ids.contains(id.as_str()));
     cooldown.retain(|id, _| known_spec_ids.contains(id.as_str()));
+    // GC the per-spec spawn coalescer locks for specs that no longer
+    // exist. Removing the Arc from the map is safe even if a task still
+    // holds a clone — that clone keeps the mutex alive until it's done.
+    state
+        .spawn_locks
+        .retain(|id, _| known_spec_ids.contains(id.as_str()));
 
     for spec in &specs {
         let kind = spec.kind();

--- a/crates/ruscker-cli/src/main.rs
+++ b/crates/ruscker-cli/src/main.rs
@@ -535,6 +535,12 @@ fn format_warning(w: &Warning) -> String {
                  (expected a size like `512m`, `1.5g`, or plain bytes) — no memory limit will be applied"
             )
         }
+        Warning::ZeroSeats { spec_id } => {
+            format!(
+                "spec {spec_id} sets seats-per-container: 0 — a replica then looks \
+                 saturated and idle at once, confusing the auto-scaler; use 1 or more"
+            )
+        }
     }
 }
 

--- a/crates/ruscker-config/src/env.rs
+++ b/crates/ruscker-config/src/env.rs
@@ -28,7 +28,10 @@ use regex::Regex;
 use std::env;
 
 static ENV_VAR_PATTERN: LazyLock<Regex> = LazyLock::new(|| {
-    Regex::new(r"\$\{([A-Z_][A-Z0-9_]*)(?::-([^}]*))?\}").expect("env var regex is valid")
+    // Allow lower- and mixed-case names too (Spring/ShinyProxy do), so a
+    // `${db_password}` reference is interpolated rather than silently
+    // left as literal text.
+    Regex::new(r"\$\{([A-Za-z_][A-Za-z0-9_]*)(?::-([^}]*))?\}").expect("env var regex is valid")
 });
 
 /// Interpolate all `${VAR}` and `${VAR:-default}` references in the input.

--- a/crates/ruscker-config/src/validate.rs
+++ b/crates/ruscker-config/src/validate.rs
@@ -118,6 +118,13 @@ pub enum Warning {
         field: String,
         value: String,
     },
+    /// A containerized spec sets `seats-per-container: 0`. Zero seats
+    /// makes a replica look saturated and idle at the same time, which
+    /// confuses the auto-scaler (it wants to scale up forever). Almost
+    /// always a typo for `1` or more.
+    ZeroSeats {
+        spec_id: String,
+    },
 }
 
 const KNOWN_TYPES: &[&str] = &["app", "package", "talk", "report", "api"];
@@ -364,6 +371,14 @@ fn check_spec(spec: &Spec, warnings: &mut Vec<Warning>) {
             spec_id: spec.id.clone(),
             min,
             max,
+        });
+    }
+
+    // Zero seats on a containerized spec makes the replica look both
+    // saturated and idle — a foot-gun for the scaler.
+    if spec.kind() != crate::schema::SpecKind::External && spec.seats_per_container == Some(0) {
+        warnings.push(Warning::ZeroSeats {
+            spec_id: spec.id.clone(),
         });
     }
 
@@ -653,6 +668,26 @@ proxy:
                     if spec_id == "app1" && field == "limit"
             )),
             "expected InvalidCpuLimit, got {:?}",
+            report.warnings
+        );
+    }
+
+    #[test]
+    fn flags_zero_seats_on_containerized_spec() {
+        let yaml = r#"
+proxy:
+  specs:
+    - id: app1
+      container-image: org/app:1
+      seats-per-container: 0
+"#;
+        let report = Config::from_yaml(yaml).expect("parse").validate();
+        assert!(
+            report
+                .warnings
+                .iter()
+                .any(|w| matches!(w, Warning::ZeroSeats { spec_id } if spec_id == "app1")),
+            "expected ZeroSeats, got {:?}",
             report.warnings
         );
     }


### PR DESCRIPTION
The non-lint half of audit cleanup **#84** (the `clippy --fix` half was #92).

- **Error leakage** — the proxy's `/app//api/` `502` bodies no longer echo internal `{err}` detail to the client (generic "backend unavailable" / "upstream error"); the detail is still `tracing::error!`-logged.
- **`proxy-connection`** — added to the hop-by-hop strip list so it can't confuse a request-smuggling-aware upstream (SECURITY.md §10).
- **`${VAR}` case** — interpolation now accepts lower-/mixed-case names (Spring/ShinyProxy do), so `${db_password}` is interpolated instead of silently left literal.
- **`seats-per-container: 0`** — new `Warning::ZeroSeats` for a containerized spec (zero seats makes a replica look saturated *and* idle, confusing the scaler).
- **`spawn_locks` GC** — the scaler now `retain`s the per-spec coalescer locks against the live spec ids (the leak the stale comment claimed was already handled).

Tests for `ZeroSeats`; workspace builds; all tests green; fmt drift unchanged on every touched file.

Closes #84.

🤖 Generated with [Claude Code](https://claude.com/claude-code)