### PR TITLE
fix(auth): opaque server-side admin sessions (#77)

### DIFF
--- a/crates/ruscker-admin/src/auth.rs
+++ b/crates/ruscker-admin/src/auth.rs
@@ -20,8 +20,10 @@ use axum::extract::FromRequestParts;
 use axum::http::request::Parts;
 use axum::http::StatusCode;
 use axum::response::{IntoResponse, Redirect, Response};
+use dashmap::DashMap;
 use std::convert::Infallible;
 use std::sync::Arc;
+use std::time::{Duration, Instant};
 use tower_cookies::Cookies;
 
 /// Cookie name. Distinct prefix `ruscker_admin_` keeps it from
@@ -66,6 +68,68 @@ impl AdminAuth {
             return false;
         };
         ct_eq(expected.as_bytes(), candidate.as_bytes())
+    }
+}
+
+/// Server-side store of opaque admin session ids → expiry.
+///
+/// The cookie holds a random session id, **not** the admin token. That
+/// way a stolen cookie can be revoked (logout, or a server restart) and
+/// never exposes the master token, and logout actually invalidates the
+/// session instead of just clearing the browser's copy.
+#[derive(Debug)]
+pub struct AdminSessions {
+    sessions: DashMap<String, Instant>,
+    ttl: Duration,
+}
+
+impl AdminSessions {
+    pub fn new(ttl: Duration) -> Self {
+        Self {
+            sessions: DashMap::new(),
+            ttl,
+        }
+    }
+
+    /// 24h default lifetime — matches the cookie's `Max-Age`.
+    pub fn default_policy() -> Self {
+        Self::new(Duration::from_secs(24 * 60 * 60))
+    }
+
+    /// Mint a new session and return its opaque id (244 bits of random,
+    /// unguessable). Caller stores the id in the cookie.
+    pub fn create(&self) -> String {
+        let id = format!(
+            "{}{}",
+            uuid::Uuid::new_v4().simple(),
+            uuid::Uuid::new_v4().simple()
+        );
+        self.sessions.insert(id.clone(), Instant::now() + self.ttl);
+        id
+    }
+
+    /// Whether `id` names a live (non-expired) session. Expired entries
+    /// are pruned lazily on lookup.
+    pub fn validate(&self, id: &str) -> bool {
+        match self.sessions.get(id).map(|e| *e.value()) {
+            Some(expiry) if expiry > Instant::now() => true,
+            Some(_) => {
+                self.sessions.remove(id);
+                false
+            }
+            None => false,
+        }
+    }
+
+    /// Invalidate a session (logout).
+    pub fn remove(&self, id: &str) {
+        self.sessions.remove(id);
+    }
+}
+
+impl Default for AdminSessions {
+    fn default() -> Self {
+        Self::default_policy()
     }
 }
 
@@ -203,7 +267,9 @@ impl FromRequestParts<crate::AppState> for AdminSession {
         };
         let candidate = cookies.get(COOKIE_NAME).map(|c| c.value().to_string());
         match candidate {
-            Some(c) if state.admin_auth.matches(&c) => Ok(AdminSession),
+            // The cookie carries an opaque session id, validated against
+            // the server-side store — not the token itself.
+            Some(c) if state.admin_sessions.validate(&c) => Ok(AdminSession),
             _ => Err(Redirect::to("/admin/login").into_response()),
         }
     }
@@ -233,6 +299,36 @@ mod tests {
     use super::*;
     use axum::http::HeaderMap;
     use std::time::Duration;
+
+    #[test]
+    fn admin_sessions_create_validate_remove() {
+        let s = AdminSessions::default_policy();
+        let id = s.create();
+        assert!(s.validate(&id), "freshly created session is valid");
+        assert!(!s.validate("not-a-real-id"), "unknown id is invalid");
+        s.remove(&id);
+        assert!(!s.validate(&id), "removed (logged-out) session is invalid");
+    }
+
+    #[test]
+    fn admin_sessions_expire() {
+        let s = AdminSessions::new(Duration::from_millis(0));
+        let id = s.create();
+        std::thread::sleep(Duration::from_millis(2));
+        assert!(!s.validate(&id), "expired session is invalid");
+    }
+
+    #[test]
+    fn admin_session_ids_are_distinct_and_not_the_token() {
+        let s = AdminSessions::default_policy();
+        let a = s.create();
+        let b = s.create();
+        assert_ne!(a, b, "each session gets a fresh id");
+        assert!(
+            a.len() >= 32,
+            "id is high-entropy, not a short/guessable value"
+        );
+    }
 
     #[test]
     fn ct_eq_basics() {

--- a/crates/ruscker-admin/src/lib.rs
+++ b/crates/ruscker-admin/src/lib.rs
@@ -44,6 +44,10 @@ pub struct AppState {
     pub config: Arc<Config>,
     pub locales: Arc<i18n::Locales>,
     pub admin_auth: auth::AdminAuth,
+    /// Opaque server-side admin session store. The cookie holds a
+    /// random session id (not the token); shared so every cloned
+    /// `AppState` sees the same live sessions.
+    pub admin_sessions: Arc<auth::AdminSessions>,
     /// Global rate limiter for `/admin/login` — bounds brute
     /// force against the admin token. Shared (Arc) so every
     /// cloned `AppState` sees the same window.
@@ -139,6 +143,7 @@ impl AdminServer {
             config: Arc::new(config),
             locales: Arc::new(locales),
             admin_auth: auth::AdminAuth::from_env(),
+            admin_sessions: Arc::new(auth::AdminSessions::default_policy()),
             login_limiter: Arc::new(auth::LoginRateLimiter::default_policy()),
             api_limiter: Arc::new(ratelimit::ApiRateLimiter::new()),
             db: None,

--- a/crates/ruscker-admin/src/routes/admin.rs
+++ b/crates/ruscker-admin/src/routes/admin.rs
@@ -154,7 +154,9 @@ async fn login_submit(
     // HTTPS (signalled by the reverse proxy via X-Forwarded-Proto)
     // — setting it unconditionally would make the browser drop the
     // cookie on the plain-HTTP dev server.
-    let mut c = Cookie::new(COOKIE_NAME, form.token);
+    // Store an opaque session id in the cookie — never the token.
+    let session_id = state.admin_sessions.create();
+    let mut c = Cookie::new(COOKIE_NAME, session_id);
     c.set_path("/");
     c.set_http_only(true);
     c.set_same_site(tower_cookies::cookie::SameSite::Strict);
@@ -176,8 +178,12 @@ async fn login_submit(
     Redirect::to(&target).into_response()
 }
 
-async fn logout(_: MaybeAdminSession, cookies: Cookies) -> Redirect {
-    // Remove sets an expired cookie with the same name+path.
+async fn logout(_: MaybeAdminSession, State(state): State<AppState>, cookies: Cookies) -> Redirect {
+    // Invalidate the session server-side so a copied cookie is dead too,
+    // then clear the browser's copy.
+    if let Some(c) = cookies.get(COOKIE_NAME) {
+        state.admin_sessions.remove(c.value());
+    }
     let mut c = Cookie::new(COOKIE_NAME, "");
     c.set_path("/");
     cookies.remove(c);

--- a/crates/ruscker-admin/src/routes/proxy.rs
+++ b/crates/ruscker-admin/src/routes/proxy.rs
@@ -1070,6 +1070,7 @@ mod tests {
                 crate::i18n::Locales::load().expect("load locales"),
             ),
             admin_auth: Default::default(),
+            admin_sessions: Default::default(),
             login_limiter: StdArc::new(crate::auth::LoginRateLimiter::default_policy()),
             api_limiter: StdArc::new(crate::ratelimit::ApiRateLimiter::new()),
             db: None,

--- a/crates/ruscker-admin/src/scaler.rs
+++ b/crates/ruscker-admin/src/scaler.rs
@@ -518,6 +518,7 @@ mod tests {
             config: Arc::new(cfg),
             locales: Arc::new(crate::i18n::Locales::load().expect("load locales")),
             admin_auth: Default::default(),
+            admin_sessions: Default::default(),
             login_limiter: Arc::new(crate::auth::LoginRateLimiter::default_policy()),
             api_limiter: Arc::new(crate::ratelimit::ApiRateLimiter::new()),
             db: None,

--- a/crates/ruscker-admin/tests/api_policies.rs
+++ b/crates/ruscker-admin/tests/api_policies.rs
@@ -43,6 +43,7 @@ fn state() -> AppState {
         config: Arc::new(config),
         locales: Arc::new(locales),
         admin_auth: Default::default(),
+        admin_sessions: Default::default(),
         login_limiter: Arc::new(ruscker_admin::auth::LoginRateLimiter::default_policy()),
         api_limiter: Arc::new(ruscker_admin::ratelimit::ApiRateLimiter::new()),
         db: None,

--- a/crates/ruscker-admin/tests/health_probes.rs
+++ b/crates/ruscker-admin/tests/health_probes.rs
@@ -27,6 +27,7 @@ fn base_state() -> AppState {
         config: Arc::new(config),
         locales: Arc::new(locales),
         admin_auth: Default::default(),
+        admin_sessions: Default::default(),
         login_limiter: Arc::new(ruscker_admin::auth::LoginRateLimiter::default_policy()),
         api_limiter: Arc::new(ruscker_admin::ratelimit::ApiRateLimiter::new()),
         db: None,

--- a/crates/ruscker-admin/tests/landing_render.rs
+++ b/crates/ruscker-admin/tests/landing_render.rs
@@ -25,6 +25,7 @@ fn app_state() -> AppState {
         config: Arc::new(config),
         locales: Arc::new(locales),
         admin_auth: Default::default(),
+        admin_sessions: Default::default(),
         login_limiter: std::sync::Arc::new(ruscker_admin::auth::LoginRateLimiter::default_policy()),
         api_limiter: std::sync::Arc::new(ruscker_admin::ratelimit::ApiRateLimiter::new()),
         db: None,

--- a/crates/ruscker-admin/tests/max_body_size.rs
+++ b/crates/ruscker-admin/tests/max_body_size.rs
@@ -42,6 +42,7 @@ fn state() -> AppState {
         config: Arc::new(config),
         locales: Arc::new(locales),
         admin_auth: Default::default(),
+        admin_sessions: Default::default(),
         login_limiter: Arc::new(ruscker_admin::auth::LoginRateLimiter::default_policy()),
         api_limiter: Arc::new(ruscker_admin::ratelimit::ApiRateLimiter::new()),
         db: None,


### PR DESCRIPTION
Fixes MED finding **#77** — the root multiplier flagged in the audit.

The admin session cookie stored the literal `RUSCKER_ADMIN_TOKEN`, so any cookie-theft path (XSS on a same-origin page, a captured `Cookie:` header, a shared machine) leaked the **master secret** for the full 24h, with no revocation short of rotating the env var + restarting. "Logout" only cleared the browser's copy.

`AdminSessions` is a server-side `DashMap<session_id, expiry>`:
- login mints a **random opaque id** (244 bits), stores it with a 24h TTL, and puts that id — not the token — in the cookie;
- the `AdminSession` extractor validates the id against the store (expired entries pruned lazily on lookup);
- logout removes the id server-side, so a copied cookie is genuinely dead.

The token now only appears at the login compare, never in the browser. (Still `HttpOnly` + `SameSite=Strict` + `Secure`-when-TLS.)

**Verified:** unit tests (create/validate/remove, expiry, id distinctness/entropy; admin suite 156 → 159); HTTP smoke — login → cookie is a 64-char id ≠ token → `/admin/dashboard` 200 → logout 303 → **reusing the old cookie → 303 (revoked server-side)**; fmt drift unchanged.

Closes #77.

🤖 Generated with [Claude Code](https://claude.com/claude-code)