### PR TITLE
fix(ws): decoupled pump with idle watchdog + forwarded handshake (#81)

### DIFF
--- a/crates/ruscker-admin/src/routes/proxy.rs
+++ b/crates/ruscker-admin/src/routes/proxy.rs
@@ -313,11 +313,24 @@ async fn forward(
     //    preceding HTTP request is how WS-only apps stay sticky.
     if let MaybeWs(Some(upgrade)) = ws_upgrade {
         let upstream_ws_url = format!("ws://{}{}", replica.upstream, upstream_path);
+        // Forward the client's session cookie and requested subprotocol
+        // onto the upstream handshake so the app keeps its session.
+        let cookie = req
+            .headers()
+            .get(header::COOKIE)
+            .and_then(|v| v.to_str().ok())
+            .map(String::from);
+        let subprotocols = req
+            .headers()
+            .get(header::SEC_WEBSOCKET_PROTOCOL)
+            .and_then(|v| v.to_str().ok())
+            .map(String::from);
         tracing::debug!(
             spec = %spec.id, replica = %replica.id, url = %upstream_ws_url,
             "ws upgrade"
         );
-        return upgrade.on_upgrade(move |socket| ws::pump(socket, upstream_ws_url));
+        return upgrade
+            .on_upgrade(move |socket| ws::pump(socket, upstream_ws_url, cookie, subprotocols));
     }
 
     // 6. HTTP forward.

--- a/crates/ruscker-proxy/src/ws.rs
+++ b/crates/ruscker-proxy/src/ws.rs
@@ -1,30 +1,78 @@
-//! WebSocket forwarding — the bidirectional pump from the
-//! `ws_spike` example, promoted to a library function. The
-//! upgrade hijack itself happens in the route handler
-//! (`axum::extract::ws::WebSocketUpgrade::on_upgrade`); this
-//! module only owns the pump.
+//! WebSocket forwarding — the bidirectional pump between a client
+//! socket (axum) and the upstream container socket (tokio-tungstenite).
 //!
-//! Frame translation between axum's `Message` and
-//! tokio-tungstenite's `Message` is mechanical but verbose, so
-//! it's contained here behind a single `pump` entry point.
+//! The two directions run as **independent tasks** decoupled from each
+//! other, not a single `select!` loop: in the old loop, awaiting a send
+//! to a slow peer stalled *both* reads (head-of-line blocking), and a
+//! client that opened a socket and never read could pin the connection
+//! forever. Now each direction backpressures only its own producer (the
+//! correct behaviour for stateful Shiny/Streamlit frames — we must not
+//! drop them), an **idle watchdog** reaps a connection with no traffic
+//! either way, and a closing side gets a short grace to drain the other.
+//!
+//! Errors are logged via `tracing` but never propagated — once axum has
+//! returned its 101, there's no HTTP-shaped error left to surface.
+
+use std::sync::atomic::{AtomicU64, Ordering};
+use std::sync::Arc;
+use std::time::Duration;
 
 use axum::extract::ws::{Message as AxMsg, WebSocket};
+use futures_util::stream::{SplitSink, SplitStream};
 use futures_util::{SinkExt, StreamExt};
+use tokio::net::TcpStream;
+use tokio_tungstenite::tungstenite::client::IntoClientRequest;
+use tokio_tungstenite::tungstenite::http::{header, HeaderValue};
 use tokio_tungstenite::tungstenite::Message as TgMsg;
+use tokio_tungstenite::{MaybeTlsStream, WebSocketStream};
 
-/// Connect to `upstream_ws_url` and pump frames between `client`
-/// and the upstream in both directions until either side closes.
-///
-/// `upstream_ws_url` is the full ws:// URL on the upstream
-/// container — e.g. `ws://127.0.0.1:38421/websocket` for a
-/// Shiny app reached at `/app/foo/`.
-///
-/// Errors are logged via `tracing` but never propagated up — once
-/// axum has accepted the upgrade response and returned 101 to
-/// the client, there's no useful HTTP-shaped error to surface
-/// anyway. We just shut the pump down cleanly.
-pub async fn pump(client: WebSocket, upstream_ws_url: String) {
-    let upstream = match tokio_tungstenite::connect_async(&upstream_ws_url).await {
+/// Tear a connection down if neither side sends a frame for this long.
+/// Shiny/Streamlit heartbeat well under this, so it only catches dead or
+/// abandoned sockets.
+const IDLE_TIMEOUT: Duration = Duration::from_secs(600);
+/// How often the watchdog checks for idleness.
+const IDLE_CHECK: Duration = Duration::from_secs(30);
+/// After one side closes, how long the other may keep draining its final
+/// frames (the close handshake, a last burst) before forced teardown.
+const DRAIN_GRACE: Duration = Duration::from_secs(5);
+
+type UpstreamStream = WebSocketStream<MaybeTlsStream<TcpStream>>;
+
+/// Connect to `upstream_ws_url` and pump frames between `client` and the
+/// upstream in both directions until either closes (or the connection
+/// goes idle). `cookie` / `subprotocols` are forwarded onto the upstream
+/// handshake so the app sees the client's session and negotiated
+/// protocol.
+pub async fn pump(
+    client: WebSocket,
+    upstream_ws_url: String,
+    cookie: Option<String>,
+    subprotocols: Option<String>,
+) {
+    let mut request = match upstream_ws_url.as_str().into_client_request() {
+        Ok(r) => r,
+        Err(err) => {
+            tracing::error!(error = ?err, url = %upstream_ws_url, "build upstream ws request failed");
+            return;
+        }
+    };
+    // Forward the client's session cookie and requested subprotocol.
+    if let Some(v) = cookie
+        .as_deref()
+        .and_then(|s| HeaderValue::from_str(s).ok())
+    {
+        request.headers_mut().insert(header::COOKIE, v);
+    }
+    if let Some(v) = subprotocols
+        .as_deref()
+        .and_then(|s| HeaderValue::from_str(s).ok())
+    {
+        request
+            .headers_mut()
+            .insert(header::SEC_WEBSOCKET_PROTOCOL, v);
+    }
+
+    let upstream = match tokio_tungstenite::connect_async(request).await {
         Ok((s, _resp)) => s,
         Err(err) => {
             tracing::error!(error = ?err, url = %upstream_ws_url, "upstream ws connect failed");
@@ -32,63 +80,104 @@ pub async fn pump(client: WebSocket, upstream_ws_url: String) {
         }
     };
 
-    let (mut cli_tx, mut cli_rx) = client.split();
-    let (mut up_tx, mut up_rx) = upstream.split();
+    let (cli_tx, cli_rx) = client.split();
+    let (up_tx, up_rx) = upstream.split();
 
-    loop {
-        tokio::select! {
-            msg = cli_rx.next() => match msg {
-                Some(Ok(AxMsg::Text(t))) => {
-                    let s: String = t.to_string();
-                    if up_tx.send(TgMsg::text(s)).await.is_err() { break; }
-                }
-                Some(Ok(AxMsg::Binary(b))) => {
-                    if up_tx.send(TgMsg::binary(b.to_vec())).await.is_err() { break; }
-                }
-                Some(Ok(AxMsg::Ping(p))) => {
-                    if up_tx.send(TgMsg::Ping(p.to_vec().into())).await.is_err() { break; }
-                }
-                Some(Ok(AxMsg::Pong(p))) => {
-                    if up_tx.send(TgMsg::Pong(p.to_vec().into())).await.is_err() { break; }
-                }
-                Some(Ok(AxMsg::Close(_))) | None => {
-                    let _ = up_tx.send(TgMsg::Close(None)).await;
-                    break;
-                }
-                Some(Err(err)) => {
-                    tracing::debug!(error = ?err, "client ws error");
-                    break;
-                }
-            },
-            msg = up_rx.next() => match msg {
-                Some(Ok(TgMsg::Text(t))) => {
-                    let s: String = t.to_string();
-                    if cli_tx.send(AxMsg::Text(s.into())).await.is_err() { break; }
-                }
-                Some(Ok(TgMsg::Binary(b))) => {
-                    if cli_tx.send(AxMsg::Binary(b.to_vec().into())).await.is_err() { break; }
-                }
-                Some(Ok(TgMsg::Ping(p))) => {
-                    if cli_tx.send(AxMsg::Ping(p.to_vec().into())).await.is_err() { break; }
-                }
-                Some(Ok(TgMsg::Pong(p))) => {
-                    if cli_tx.send(AxMsg::Pong(p.to_vec().into())).await.is_err() { break; }
-                }
-                Some(Ok(TgMsg::Close(_))) | None => {
-                    let _ = cli_tx.send(AxMsg::Close(None)).await;
-                    break;
-                }
-                Some(Ok(TgMsg::Frame(_))) => {
-                    // Raw frames are an opt-in mode of tungstenite
-                    // that we don't enable; treat as a protocol
-                    // violation and tear down.
-                    break;
-                }
-                Some(Err(err)) => {
-                    tracing::debug!(error = ?err, "upstream ws error");
-                    break;
-                }
-            },
+    // Shared last-activity clock (monotonic millis); both directions
+    // touch it, the watchdog reads it.
+    let last = Arc::new(AtomicU64::new(now_ms()));
+
+    let mut c2u = tokio::spawn(client_to_upstream(cli_rx, up_tx, last.clone()));
+    let mut u2c = tokio::spawn(upstream_to_client(up_rx, cli_tx, last.clone()));
+    let mut watchdog = tokio::spawn(idle_watchdog(last));
+
+    // Whichever finishes first wins; give the *other* direction a short
+    // grace to drain before we abort everything.
+    tokio::select! {
+        _ = &mut c2u => { let _ = tokio::time::timeout(DRAIN_GRACE, &mut u2c).await; }
+        _ = &mut u2c => { let _ = tokio::time::timeout(DRAIN_GRACE, &mut c2u).await; }
+        _ = &mut watchdog => {}
+    }
+    c2u.abort();
+    u2c.abort();
+    watchdog.abort();
+}
+
+/// Forward client → upstream until the client closes/errors.
+async fn client_to_upstream(
+    mut rx: SplitStream<WebSocket>,
+    mut tx: SplitSink<UpstreamStream, TgMsg>,
+    last: Arc<AtomicU64>,
+) {
+    while let Some(msg) = rx.next().await {
+        last.store(now_ms(), Ordering::Relaxed);
+        let out = match msg {
+            Ok(AxMsg::Text(t)) => TgMsg::text(t.to_string()),
+            Ok(AxMsg::Binary(b)) => TgMsg::binary(b.to_vec()),
+            Ok(AxMsg::Ping(p)) => TgMsg::Ping(p.to_vec().into()),
+            Ok(AxMsg::Pong(p)) => TgMsg::Pong(p.to_vec().into()),
+            Ok(AxMsg::Close(_)) => break,
+            Err(err) => {
+                tracing::debug!(error = ?err, "client ws error");
+                break;
+            }
+        };
+        if tx.send(out).await.is_err() {
+            break;
         }
     }
+    // Client side ended — ask the upstream to close too.
+    let _ = tx.send(TgMsg::Close(None)).await;
+}
+
+/// Forward upstream → client until the upstream closes/errors.
+async fn upstream_to_client(
+    mut rx: SplitStream<UpstreamStream>,
+    mut tx: SplitSink<WebSocket, AxMsg>,
+    last: Arc<AtomicU64>,
+) {
+    while let Some(msg) = rx.next().await {
+        last.store(now_ms(), Ordering::Relaxed);
+        let out = match msg {
+            Ok(TgMsg::Text(t)) => AxMsg::Text(t.to_string().into()),
+            Ok(TgMsg::Binary(b)) => AxMsg::Binary(b.to_vec().into()),
+            Ok(TgMsg::Ping(p)) => AxMsg::Ping(p.to_vec().into()),
+            Ok(TgMsg::Pong(p)) => AxMsg::Pong(p.to_vec().into()),
+            Ok(TgMsg::Close(_)) => break,
+            // Raw frames are an opt-in tungstenite mode we don't enable.
+            Ok(TgMsg::Frame(_)) => break,
+            Err(err) => {
+                tracing::debug!(error = ?err, "upstream ws error");
+                break;
+            }
+        };
+        if tx.send(out).await.is_err() {
+            break;
+        }
+    }
+    let _ = tx.send(AxMsg::Close(None)).await;
+}
+
+/// Returns when the connection has seen no frames either way for
+/// `IDLE_TIMEOUT`; the caller treats that as a dead socket and tears it
+/// down.
+async fn idle_watchdog(last: Arc<AtomicU64>) {
+    let idle_ms = IDLE_TIMEOUT.as_millis() as u64;
+    loop {
+        tokio::time::sleep(IDLE_CHECK).await;
+        if now_ms().saturating_sub(last.load(Ordering::Relaxed)) >= idle_ms {
+            return;
+        }
+    }
+}
+
+/// Monotonic milliseconds since first call — a cheap clock for the idle
+/// check that needs no wall-clock and fits an `AtomicU64`.
+fn now_ms() -> u64 {
+    use std::sync::OnceLock;
+    static START: OnceLock<std::time::Instant> = OnceLock::new();
+    START
+        .get_or_init(std::time::Instant::now)
+        .elapsed()
+        .as_millis() as u64
 }

--- a/crates/ruscker-proxy/tests/ws_pump.rs
+++ b/crates/ruscker-proxy/tests/ws_pump.rs
@@ -1,0 +1,96 @@
+//! Integration test for the WebSocket pump (#81): a real client WS
+//! connects through an axum app that runs `ws::pump`, which forwards to
+//! a mock echo upstream. Validates bidirectional forwarding and a clean
+//! client-initiated close end-to-end.
+
+use std::time::Duration;
+
+use axum::extract::ws::WebSocketUpgrade;
+use axum::routing::any;
+use axum::Router;
+use futures_util::{SinkExt, StreamExt};
+use tokio::net::TcpListener;
+use tokio_tungstenite::tungstenite::Message;
+
+/// Spawn a mock upstream that echoes text/binary frames back. Returns
+/// its `ws://` URL.
+async fn spawn_echo_upstream() -> String {
+    let listener = TcpListener::bind("127.0.0.1:0").await.unwrap();
+    let addr = listener.local_addr().unwrap();
+    tokio::spawn(async move {
+        if let Ok((stream, _)) = listener.accept().await {
+            let mut ws = tokio_tungstenite::accept_async(stream).await.unwrap();
+            while let Some(Ok(msg)) = ws.next().await {
+                match msg {
+                    Message::Text(_) | Message::Binary(_) => {
+                        if ws.send(msg).await.is_err() {
+                            break;
+                        }
+                    }
+                    Message::Close(_) => break,
+                    _ => {}
+                }
+            }
+        }
+    });
+    format!("ws://{addr}/")
+}
+
+/// Spawn the axum proxy app (one `/ws` route → `ws::pump`). Returns its
+/// bound address.
+async fn spawn_proxy(upstream_url: String) -> std::net::SocketAddr {
+    let app = Router::new().route(
+        "/ws",
+        any(move |ws: WebSocketUpgrade| {
+            let url = upstream_url.clone();
+            async move { ws.on_upgrade(move |sock| ruscker_proxy::ws::pump(sock, url, None, None)) }
+        }),
+    );
+    let listener = TcpListener::bind("127.0.0.1:0").await.unwrap();
+    let addr = listener.local_addr().unwrap();
+    tokio::spawn(async move {
+        axum::serve(listener, app).await.unwrap();
+    });
+    addr
+}
+
+#[tokio::test]
+async fn pump_forwards_both_ways_and_closes_cleanly() {
+    let upstream = spawn_echo_upstream().await;
+    let proxy = spawn_proxy(upstream).await;
+
+    let (mut client, _resp) = tokio_tungstenite::connect_async(format!("ws://{proxy}/ws"))
+        .await
+        .expect("client connects through the proxy");
+
+    // Client → upstream → (echo) → client.
+    client.send(Message::text("hello")).await.unwrap();
+    let reply = tokio::time::timeout(Duration::from_secs(5), client.next())
+        .await
+        .expect("reply within 5s")
+        .expect("a frame")
+        .expect("not an error");
+    assert_eq!(reply.to_text().unwrap(), "hello");
+
+    // A second round-trip — the pump keeps forwarding.
+    client.send(Message::text("world")).await.unwrap();
+    let reply = tokio::time::timeout(Duration::from_secs(5), client.next())
+        .await
+        .expect("reply within 5s")
+        .expect("a frame")
+        .expect("not an error");
+    assert_eq!(reply.to_text().unwrap(), "world");
+
+    // Client closes; the pump should propagate and tear down without
+    // hanging. The stream should end (None) shortly after.
+    client.close(None).await.unwrap();
+    let drained = tokio::time::timeout(Duration::from_secs(5), async {
+        while let Some(frame) = client.next().await {
+            if frame.is_err() {
+                break;
+            }
+        }
+    })
+    .await;
+    assert!(drained.is_ok(), "pump tore down without hanging");
+}


### PR DESCRIPTION
Fixes MED finding **#81** (and the WS items in SECURITY.md §10).

The pump was a single `tokio::select!` loop: awaiting a send to a slow peer stalled **both** reads (head-of-line blocking), and a client that opened a socket and never read pinned the connection forever — exactly the DoS lever the crate's `CLAUDE.md` warns against.

Rewrite as the doc prescribes — **two independent tasks**:
- each direction backpressures only its own producer (the right call for stateful Shiny/Streamlit frames — we must deliver, not drop), so neither stalls the other;
- an **idle watchdog** tears the connection down after 600s with no traffic either way, reaping dead/abandoned sockets;
- on one-sided close, the other gets a 5s **drain grace** to flush its final frames instead of an immediate two-sided abort.

Also forwards the client's `Cookie` and `Sec-WebSocket-Protocol` onto the upstream handshake (built via `into_client_request`) so Shiny apps keep their session and negotiated subprotocol; the handler passes both through.

**Verified:** new integration test `tests/ws_pump.rs` — a real WS client through an axum app running `pump` against a mock echo upstream: two round-trips + a clean client-initiated close with no hang. Full proxy + admin suites green; `ws.rs` and the test are rustfmt-clean.

Closes #81.

🤖 Generated with [Claude Code](https://claude.com/claude-code)