### PR TITLE
chore: bump workspace version to 0.1.0-rc2

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2680,7 +2680,7 @@ dependencies = [
 
 [[package]]
 name = "ruscker-admin"
-version = "0.1.0"
+version = "0.1.0-rc2"
 dependencies = [
  "aes-gcm",
  "anyhow",
@@ -2726,7 +2726,7 @@ dependencies = [
 
 [[package]]
 name = "ruscker-cli"
-version = "0.1.0"
+version = "0.1.0-rc2"
 dependencies = [
  "anyhow",
  "clap",
@@ -2744,7 +2744,7 @@ dependencies = [
 
 [[package]]
 name = "ruscker-config"
-version = "0.1.0"
+version = "0.1.0-rc2"
 dependencies = [
  "chrono",
  "ordered-float",
@@ -2759,7 +2759,7 @@ dependencies = [
 
 [[package]]
 name = "ruscker-core"
-version = "0.1.0"
+version = "0.1.0-rc2"
 dependencies = [
  "async-trait",
  "chrono",
@@ -2772,7 +2772,7 @@ dependencies = [
 
 [[package]]
 name = "ruscker-docker"
-version = "0.1.0"
+version = "0.1.0-rc2"
 dependencies = [
  "anyhow",
  "async-stream",
@@ -2791,7 +2791,7 @@ dependencies = [
 
 [[package]]
 name = "ruscker-proxy"
-version = "0.1.0"
+version = "0.1.0-rc2"
 dependencies = [
  "anyhow",
  "axum",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -10,7 +10,7 @@ members = [
 ]
 
 [workspace.package]
-version = "0.1.0"
+version = "0.1.0-rc2"
 edition = "2021"
 rust-version = "1.85"
 license = "Apache-2.0"


### PR DESCRIPTION
Release candidate 2 of 0.1.0 — bumps the workspace version so `ruscker --version` reports `0.1.0-rc2`, then we tag `v0.1.0-rc2` to exercise the release pipeline with the full audit-fix batch (#74–#84) + post-audit hardening (cargo-audit CI, opaque sessions, WS pump) + install.sh inside.

🤖 Generated with [Claude Code](https://claude.com/claude-code)