### PR TITLE
feat: per-spec volumes in the admin Advanced form, wired to Docker (#99)

### DIFF
--- a/crates/ruscker-admin/assets/i18n/en/landing.ftl
+++ b/crates/ruscker-admin/assets/i18n/en/landing.ftl
@@ -373,3 +373,8 @@ spec-help-memory-limit = Max memory, e.g. 512m or 1.5g. Blank = unlimited.
 spec-help-heartbeat = Idle session timeout in milliseconds; -1 never expires. Blank = use the global default.
 admin-blocks-slot-empty = No blocks in this slot yet.
 admin-blocks-drag-hint = Drag the handle to reorder blocks within a slot.
+spec-form-volumes-section = Volumes
+spec-form-volumes = Volume mounts
+spec-form-volumes-help = One bind per line — /host/path:/container/path (append :ro for read-only). Add as many as you need.
+spec-help-volumes = Bind-mount host directories into the container (e.g. a persistent data dir, or a static assets dir the app serves). Admin-only; mounting host paths is root-equivalent.
+spec-form-error-volume = Each volume must be /host:/container (optionally :ro).

--- a/crates/ruscker-admin/assets/i18n/es/landing.ftl
+++ b/crates/ruscker-admin/assets/i18n/es/landing.ftl
@@ -373,3 +373,8 @@ spec-help-memory-limit = Memoria máxima, p. ej. 512m o 1.5g. Vacío = ilimitado
 spec-help-heartbeat = Tiempo de sesión inactiva en milisegundos; -1 nunca expira. Vacío = usa el valor global.
 admin-blocks-slot-empty = Aún no hay bloques en este slot.
 admin-blocks-drag-hint = Arrastra desde el asa para reordenar los bloques dentro del slot.
+spec-form-volumes-section = Volúmenes
+spec-form-volumes = Montajes de volumen
+spec-form-volumes-help = Un bind por línea — /host:/contenedor (usa :ro para solo lectura). Añade tantos como necesites.
+spec-help-volumes = Monta directorios del host en el contenedor (p. ej. datos persistentes, o estáticos que sirve la app). Solo admin; montar rutas del host equivale a root.
+spec-form-error-volume = Cada volumen debe ser /host:/contenedor (opcional :ro).

--- a/crates/ruscker-admin/assets/i18n/fr/landing.ftl
+++ b/crates/ruscker-admin/assets/i18n/fr/landing.ftl
@@ -373,3 +373,8 @@ spec-help-memory-limit = Mémoire max, ex. 512m ou 1.5g. Vide = illimité.
 spec-help-heartbeat = Délai de session inactive en millisecondes ; -1 = jamais. Vide = valeur globale.
 admin-blocks-slot-empty = Aucun bloc dans cet emplacement.
 admin-blocks-drag-hint = Glissez par la poignée pour réordonner les blocs dans un emplacement.
+spec-form-volumes-section = Volumes
+spec-form-volumes = Montages de volume
+spec-form-volumes-help = Un bind par ligne — /hôte:/conteneur (ajoutez :ro pour lecture seule). Ajoutez-en autant que nécessaire.
+spec-help-volumes = Monte des répertoires de l'hôte dans le conteneur (ex. données persistantes, ou statiques servis par l'app). Admin uniquement ; monter des chemins de l'hôte équivaut à root.
+spec-form-error-volume = Chaque volume doit être /hôte:/conteneur (optionnel :ro).

--- a/crates/ruscker-admin/assets/i18n/pt/landing.ftl
+++ b/crates/ruscker-admin/assets/i18n/pt/landing.ftl
@@ -377,3 +377,8 @@ spec-help-memory-limit = Memória máxima, ex.: 512m ou 1.5g. Vazio = ilimitado.
 spec-help-heartbeat = Timeout de sessão ociosa em milissegundos; -1 nunca expira. Vazio = usa o padrão global.
 admin-blocks-slot-empty = Nenhum bloco neste slot ainda.
 admin-blocks-drag-hint = Arraste pela alça para reordenar os blocos dentro do slot.
+spec-form-volumes-section = Volumes
+spec-form-volumes = Montagens de volume
+spec-form-volumes-help = Um bind por linha — /host:/container (use :ro para somente leitura). Adicione quantos precisar.
+spec-help-volumes = Monta diretórios do host no container (ex.: dados persistentes, ou estáticos que o app serve). Só admin; montar caminhos do host equivale a root.
+spec-form-error-volume = Cada volume deve ser /host:/container (opcional :ro).

--- a/crates/ruscker-admin/src/routes/admin/spec_form.rs
+++ b/crates/ruscker-admin/src/routes/admin/spec_form.rs
@@ -89,6 +89,8 @@ pub struct SpecForm {
     pub max_replicas: String,
     /// API: concurrent requests a replica handles before scale-up.
     pub concurrent_requests_per_replica: String,
+    /// Bind-mount volumes, one `"/host:/container[:ro]"` per line.
+    pub volumes: String,
     /// API sub-fields (only meaningful for `type: api`).
     pub api_port: String,
     pub api_docs_path: String,
@@ -142,6 +144,11 @@ impl SpecForm {
             concurrent_requests_per_replica: spec
                 .concurrent_requests_per_replica
                 .map(|n| n.to_string())
+                .unwrap_or_default(),
+            volumes: spec
+                .volumes
+                .as_ref()
+                .map(|v| v.join("\n"))
                 .unwrap_or_default(),
             api_port: spec
                 .api
@@ -260,6 +267,7 @@ impl SpecForm {
             min_replicas: parse_opt(&self.min_replicas),
             max_replicas: parse_opt(&self.max_replicas),
             concurrent_requests_per_replica: parse_opt(&self.concurrent_requests_per_replica),
+            volumes: lines_to_vec(&self.volumes),
             // ── Not modelled by the form: preserve from `base` so an
             //    edit never silently drops YAML-imported config. ──────
             container_lifetime: base.and_then(|b| b.container_lifetime),
@@ -339,6 +347,17 @@ impl SpecForm {
             }
         }
 
+        // Each volume line must be valid Docker bind syntax.
+        if self
+            .volumes
+            .lines()
+            .map(str::trim)
+            .filter(|l| !l.is_empty())
+            .any(|l| !ruscker_config::is_valid_volume_bind(l))
+        {
+            errs.push("spec-form-error-volume");
+        }
+
         errs
     }
 }
@@ -360,6 +379,21 @@ fn set_or_remove(map: &mut HashMap<String, YamlValue>, key: &str, val: &str) {
 }
 fn parse_opt<T: std::str::FromStr>(s: &str) -> Option<T> {
     s.trim().parse().ok()
+}
+/// Split a textarea into trimmed, non-empty lines — `None` if all blank.
+/// Used for the volumes field (one `host:container[:ro]` per line).
+fn lines_to_vec(s: &str) -> Option<Vec<String>> {
+    let v: Vec<String> = s
+        .lines()
+        .map(str::trim)
+        .filter(|l| !l.is_empty())
+        .map(String::from)
+        .collect();
+    if v.is_empty() {
+        None
+    } else {
+        Some(v)
+    }
 }
 fn is_kebab_id(s: &str) -> bool {
     !s.is_empty()
@@ -764,6 +798,30 @@ proxy:
         assert!(f
             .validate(FormMode::New)
             .contains(&"spec-form-error-replica-range"));
+    }
+
+    #[test]
+    fn volumes_round_trip_and_validate() {
+        let mut f = valid_form();
+        f.volumes = "/srv/data:/data\n/srv/www:/www:ro\n".into();
+        let spec = f.into_spec(None).expect("into_spec");
+        assert_eq!(
+            spec.volumes,
+            Some(vec![
+                "/srv/data:/data".to_string(),
+                "/srv/www:/www:ro".to_string()
+            ])
+        );
+        // Round-trips back into the textarea (newline-joined).
+        let back = SpecForm::from_spec(&spec);
+        assert_eq!(back.volumes, "/srv/data:/data\n/srv/www:/www:ro");
+
+        // A malformed bind is a form error.
+        let mut bad = valid_form();
+        bad.volumes = "not-a-bind".into();
+        assert!(bad
+            .validate(FormMode::New)
+            .contains(&"spec-form-error-volume"));
     }
 
     #[test]

--- a/crates/ruscker-admin/src/routes/proxy.rs
+++ b/crates/ruscker-admin/src/routes/proxy.rs
@@ -642,7 +642,9 @@ async fn pick_or_spawn(state: &AppState, spec: &Spec) -> anyhow::Result<Replica>
         with_limits = !limits.is_empty(),
         "spawning first replica"
     );
-    let mut req = ruscker_core::SpawnRequest::new(&spec.id, image).with_limits(limits);
+    let mut req = ruscker_core::SpawnRequest::new(&spec.id, image)
+        .with_limits(limits)
+        .with_volumes(spec.volumes.clone().unwrap_or_default());
     if let Some(port) = inner_port {
         req = req.with_port(port);
     }

--- a/crates/ruscker-admin/src/scaler.rs
+++ b/crates/ruscker-admin/src/scaler.rs
@@ -423,7 +423,9 @@ async fn spawn_one(
 
     let creds = crate::routes::proxy::resolve_creds(state, spec).await;
     let limits = crate::routes::proxy::limits_from_spec(spec);
-    let mut req = ruscker_core::SpawnRequest::new(&spec.id, image).with_limits(limits);
+    let mut req = ruscker_core::SpawnRequest::new(&spec.id, image)
+        .with_limits(limits)
+        .with_volumes(spec.volumes.clone().unwrap_or_default());
     if let Some(port) = inner_port {
         req = req.with_port(port);
     }

--- a/crates/ruscker-admin/templates/admin/spec_form.html
+++ b/crates/ruscker-admin/templates/admin/spec_form.html
@@ -449,6 +449,19 @@
             </div>
           </div>
 
+          {# Volumes — one bind per line, as many as needed #}
+          <div class="spec-form-subsection">{{ self.t("spec-form-volumes-section") }}</div>
+          <div class="spec-form-field">
+            <div class="spec-form-label-row">
+              <label for="f-volumes" class="spec-form-label">{{ self.t("spec-form-volumes") }}</label>
+              {% call help(self.t("spec-help-volumes")) %}{% endcall %}
+            </div>
+            <textarea id="f-volumes" name="volumes" rows="3"
+                      placeholder="/srv/myapp/data:/data&#10;/srv/myapp/www:/www:ro"
+                      class="spec-form-input spec-form-input--mono">{{ form.volumes }}</textarea>
+            <div class="spec-form-help">{{ self.t("spec-form-volumes-help") }}</div>
+          </div>
+
           {# Lifecycle #}
           <div class="spec-form-subsection">{{ self.t("spec-form-lifecycle-section") }}</div>
           <div class="spec-form-field">

--- a/crates/ruscker-cli/src/main.rs
+++ b/crates/ruscker-cli/src/main.rs
@@ -541,6 +541,12 @@ fn format_warning(w: &Warning) -> String {
                  saturated and idle at once, confusing the auto-scaler; use 1 or more"
             )
         }
+        Warning::InvalidVolume { spec_id, value } => {
+            format!(
+                "spec {spec_id} has an invalid volume `{value}` \
+                 (expected `/host:/container` or `/host:/container:ro`) — the mount will be skipped"
+            )
+        }
     }
 }
 

--- a/crates/ruscker-config/src/lib.rs
+++ b/crates/ruscker-config/src/lib.rs
@@ -45,7 +45,7 @@ pub use schema::{
     is_valid_memory_size, ApiSpec, Config, LandingBlock, LandingCustomization, Logging, Proxy,
     RatePolicy, RoutingStrategy, Server, Spec, SpecKind, SpecKindOverride, TemplateProperties,
 };
-pub use validate::{CompatWarning, ValidationReport, Warning};
+pub use validate::{is_valid_volume_bind, CompatWarning, ValidationReport, Warning};
 
 use std::path::Path;
 

--- a/crates/ruscker-config/src/schema.rs
+++ b/crates/ruscker-config/src/schema.rs
@@ -430,6 +430,14 @@ pub struct Spec {
     #[serde(rename = "max-body-size")]
     pub max_body_size: Option<String>,
 
+    /// Bind-mount volumes for the container, in Docker syntax —
+    /// `"/host:/container"` or `"/host:/container:ro"`. ShinyProxy-
+    /// compatible (`volumes:` is a list of such strings). The local
+    /// Docker backend maps these to `HostConfig.binds`. Bind-mounting
+    /// host paths is powerful and admin-only — see SECURITY.md.
+    #[serde(default)]
+    pub volumes: Option<Vec<String>>,
+
     /// Free-form properties consumed by the landing page template.
     /// Common keys: `logo`, `icon`, `type`, `updated`, `state`, `link`.
     #[serde(rename = "template-properties", default)]
@@ -1030,6 +1038,7 @@ proxy:
             container_memory_limit: None,
             container_memory_request: None,
             max_body_size: None,
+            volumes: None,
             template_properties: TemplateProperties::default(),
             kind_override: None,
             api: None,
@@ -1067,6 +1076,7 @@ proxy:
             container_memory_limit: None,
             container_memory_request: None,
             max_body_size: None,
+            volumes: None,
             template_properties: TemplateProperties::default(),
             kind_override: None,
             api: None,
@@ -1104,6 +1114,7 @@ proxy:
             container_memory_limit: None,
             container_memory_request: None,
             max_body_size: None,
+            volumes: None,
             template_properties: TemplateProperties::default(),
             kind_override: Some(SpecKindOverride::Api),
             api: None,

--- a/crates/ruscker-config/src/validate.rs
+++ b/crates/ruscker-config/src/validate.rs
@@ -125,6 +125,13 @@ pub enum Warning {
     ZeroSeats {
         spec_id: String,
     },
+    /// A `volumes` entry isn't valid Docker bind syntax — expected
+    /// `"/host:/container"` (optionally `":ro"`), with an absolute
+    /// container path. The mount would be silently skipped.
+    InvalidVolume {
+        spec_id: String,
+        value: String,
+    },
 }
 
 const KNOWN_TYPES: &[&str] = &["app", "package", "talk", "report", "api"];
@@ -217,7 +224,6 @@ const UNSUPPORTED_SPEC_FIELDS: &[(&str, &str)] = &[
         "network-connections",
         "container network wiring is not implemented (phase 3.5)",
     ),
-    ("volumes", "volume mounts are not implemented (phase 3)"),
     (
         "environment",
         "per-spec environment injection is not implemented (phase 3)",
@@ -473,6 +479,33 @@ fn check_spec(spec: &Spec, warnings: &mut Vec<Warning>) {
             }
         }
     }
+
+    // Volume bind syntax: "/host:/container[:ro]" with an absolute
+    // container path. A malformed entry would be silently skipped.
+    if let Some(vols) = &spec.volumes {
+        for v in vols {
+            if !is_valid_volume_bind(v) {
+                warnings.push(Warning::InvalidVolume {
+                    spec_id: spec.id.clone(),
+                    value: v.clone(),
+                });
+            }
+        }
+    }
+}
+
+/// A Docker bind spec: `host:container` plus an optional `:ro`/`:rw`
+/// mode, with a non-empty host and an absolute container path. Public so
+/// the admin form validates with the same rule.
+pub fn is_valid_volume_bind(v: &str) -> bool {
+    let parts: Vec<&str> = v.split(':').collect();
+    let host_ok = parts.first().is_some_and(|h| !h.trim().is_empty());
+    let container_ok = parts.get(1).is_some_and(|c| c.starts_with('/'));
+    let mode_ok = match parts.get(2) {
+        None => true,
+        Some(m) => matches!(m.trim(), "ro" | "rw"),
+    };
+    parts.len() <= 3 && host_ok && container_ok && mode_ok
 }
 
 fn collect_stats(config: &Config) -> Stats {
@@ -693,6 +726,30 @@ proxy:
     }
 
     #[test]
+    fn flags_malformed_volume_but_accepts_valid_ones() {
+        let yaml = r#"
+proxy:
+  specs:
+    - id: app1
+      container-image: org/app:1
+      volumes:
+        - "/srv/data:/data"
+        - "/srv/www:/www:ro"
+        - "not-a-bind"
+"#;
+        let report = Config::from_yaml(yaml).expect("parse").validate();
+        let bad: Vec<&str> = report
+            .warnings
+            .iter()
+            .filter_map(|w| match w {
+                Warning::InvalidVolume { value, .. } => Some(value.as_str()),
+                _ => None,
+            })
+            .collect();
+        assert_eq!(bad, vec!["not-a-bind"], "only the malformed bind warns");
+    }
+
+    #[test]
     fn accepts_valid_cpu_and_memory_limits() {
         let yaml = r#"
 proxy:
@@ -790,7 +847,11 @@ proxy:
             })
             .collect();
         assert!(fields.contains(&"port"), "fields: {fields:?}");
-        assert!(fields.contains(&"volumes"), "fields: {fields:?}");
+        // `volumes` is now a supported field — it must NOT be flagged.
+        assert!(
+            !fields.contains(&"volumes"),
+            "volumes is supported now, should not be flagged: {fields:?}"
+        );
         assert!(
             fields.contains(&"kubernetes-pod-patches"),
             "fields: {fields:?}"

--- a/crates/ruscker-core/src/lib.rs
+++ b/crates/ruscker-core/src/lib.rs
@@ -128,6 +128,10 @@ pub struct SpawnRequest {
     pub creds: Option<RegistryCredentials>,
     /// All-`None` (or omitted via `Default`) → no limits applied.
     pub limits: ResourceLimits,
+    /// Bind-mount specs in Docker syntax (`"/host:/container[:ro]"`).
+    /// Empty → no binds. The local backend maps these to
+    /// `HostConfig.binds`.
+    pub volumes: Vec<String>,
 }
 
 impl SpawnRequest {
@@ -138,6 +142,7 @@ impl SpawnRequest {
             inner_port: None,
             creds: None,
             limits: ResourceLimits::default(),
+            volumes: Vec::new(),
         }
     }
 
@@ -151,6 +156,10 @@ impl SpawnRequest {
     }
     pub fn with_limits(mut self, limits: ResourceLimits) -> Self {
         self.limits = limits;
+        self
+    }
+    pub fn with_volumes(mut self, volumes: Vec<String>) -> Self {
+        self.volumes = volumes;
         self
     }
 }

--- a/crates/ruscker-docker/src/lib.rs
+++ b/crates/ruscker-docker/src/lib.rs
@@ -166,6 +166,9 @@ impl LocalDockerBackend {
 
         let mut host_config = HostConfig {
             port_bindings: Some(port_bindings),
+            // Bind-mount volumes, in Docker's "/host:/container[:ro]"
+            // syntax — passed straight through. Empty → no binds.
+            binds: (!req.volumes.is_empty()).then(|| req.volumes.clone()),
             ..Default::default()
         };
         // Apply resource limits if the spec set any. Empty limits

--- a/docs/YAML_SCHEMA.md
+++ b/docs/YAML_SCHEMA.md
@@ -100,7 +100,16 @@ A spec describes one app, API, or external link. Every spec has an
   docker-registry-username: acme
   docker-registry-password: ${DOCKER_REGISTRY_PASSWORD}   # use env vars!
   docker-registry-domain: docker.io
+  volumes:                            # bind mounts (ShinyProxy-compatible)
+    - /srv/myapp/data:/data           #   persistent data
+    - /srv/myapp/www:/www:ro          #   static assets, read-only
 ```
+
+`volumes` is a list of Docker bind specs (`/host:/container`, optionally
+`:ro`/`:rw`), mapped to the container's `HostConfig.binds`. Add as many
+as needed; editable in the admin **Advanced** form (one per line).
+**Bind-mounting host paths is root-equivalent and admin-only** — see
+`SECURITY.md`.
 
 ### External link specs (no container)
 


### PR DESCRIPTION
Closes **#99**. Operators can now add **bind-mount volumes** when creating/editing an app, in the **Advanced** section — as many as needed (data dir, static `/www`/`/assets` dir, …). Ruscker mounts them; the container serves/uses them.

## Changes
- **Schema** — `Spec.volumes: Option<Vec<String>>`, ShinyProxy-compatible (`/host:/container[:ro]`). Dropped the `strict-compat` "volumes not implemented" warning (now supported).
- **Validation** — `Warning::InvalidVolume` + public `is_valid_volume_bind` (host:container, absolute container path, optional `ro`/`rw`) + CLI formatter.
- **Admin form** — a **Volumes** textarea (one bind per line) in Advanced with `?` help; `SpecForm` round-trips it; `validate` rejects a malformed bind. Form-owned per the #74 merge model.
- **Backend** — `SpawnRequest.volumes` + `with_volumes`; both spawn paths (proxy + scaler) pass `spec.volumes`; `LocalDockerBackend` maps them to `HostConfig.binds`.
- i18n (5 keys × 4 locales) + `YAML_SCHEMA.md`.

## Verified
- Unit tests: config parse, form round-trip, malformed → error, `compat_scan` no longer flags `volumes`.
- **Live Docker smoke**: an app with `"/tmp/x:/data:ro"` spawns through the proxy (`/api/...` → 200), and `docker inspect` shows the mount — Source→Destination correct, **read-only honored** (`RW:false`).
- Workspace tests green (admin 161, config 48); i18n parity; fmt drift unchanged.

**Note:** Ruscker serving a static dir *itself* (bypassing the container) is the deferred follow-up; this issue is about mounting. Bind-mounting host paths is admin-only / root-equivalent (documented).

Closes #99.

🤖 Generated with [Claude Code](https://claude.com/claude-code)