### PR TITLE
feat: Ruscker process log in a new admin "Logs" tab (#100)

### DIFF
--- a/crates/ruscker-admin/assets/i18n/en/landing.ftl
+++ b/crates/ruscker-admin/assets/i18n/en/landing.ftl
@@ -378,3 +378,7 @@ spec-form-volumes = Volume mounts
 spec-form-volumes-help = One bind per line — /host/path:/container/path (append :ro for read-only). Add as many as you need.
 spec-help-volumes = Bind-mount host directories into the container (e.g. a persistent data dir, or a static assets dir the app serves). Admin-only; mounting host paths is root-equivalent.
 spec-form-error-volume = Each volume must be /host:/container (optionally :ro).
+admin-nav-logs = Logs
+admin-proclog-title = Logs
+admin-proclog-subtitle = Recent Ruscker process log (live).
+admin-proclog-unavailable = Log buffer not wired (the server started without the logging layer).

--- a/crates/ruscker-admin/assets/i18n/es/landing.ftl
+++ b/crates/ruscker-admin/assets/i18n/es/landing.ftl
@@ -378,3 +378,7 @@ spec-form-volumes = Montajes de volumen
 spec-form-volumes-help = Un bind por línea — /host:/contenedor (usa :ro para solo lectura). Añade tantos como necesites.
 spec-help-volumes = Monta directorios del host en el contenedor (p. ej. datos persistentes, o estáticos que sirve la app). Solo admin; montar rutas del host equivale a root.
 spec-form-error-volume = Cada volumen debe ser /host:/contenedor (opcional :ro).
+admin-nav-logs = Registros
+admin-proclog-title = Registros
+admin-proclog-subtitle = Registro reciente del proceso Ruscker (en vivo).
+admin-proclog-unavailable = Búfer de registro no disponible (el servidor inició sin la capa de logging).

--- a/crates/ruscker-admin/assets/i18n/fr/landing.ftl
+++ b/crates/ruscker-admin/assets/i18n/fr/landing.ftl
@@ -378,3 +378,7 @@ spec-form-volumes = Montages de volume
 spec-form-volumes-help = Un bind par ligne — /hôte:/conteneur (ajoutez :ro pour lecture seule). Ajoutez-en autant que nécessaire.
 spec-help-volumes = Monte des répertoires de l'hôte dans le conteneur (ex. données persistantes, ou statiques servis par l'app). Admin uniquement ; monter des chemins de l'hôte équivaut à root.
 spec-form-error-volume = Chaque volume doit être /hôte:/conteneur (optionnel :ro).
+admin-nav-logs = Journaux
+admin-proclog-title = Journaux
+admin-proclog-subtitle = Journal récent du processus Ruscker (en direct).
+admin-proclog-unavailable = Tampon de journal indisponible (le serveur a démarré sans la couche de journalisation).

--- a/crates/ruscker-admin/assets/i18n/pt/landing.ftl
+++ b/crates/ruscker-admin/assets/i18n/pt/landing.ftl
@@ -382,3 +382,7 @@ spec-form-volumes = Montagens de volume
 spec-form-volumes-help = Um bind por linha — /host:/container (use :ro para somente leitura). Adicione quantos precisar.
 spec-help-volumes = Monta diretórios do host no container (ex.: dados persistentes, ou estáticos que o app serve). Só admin; montar caminhos do host equivale a root.
 spec-form-error-volume = Cada volume deve ser /host:/container (opcional :ro).
+admin-nav-logs = Logs
+admin-proclog-title = Logs
+admin-proclog-subtitle = Log recente do processo Ruscker (ao vivo).
+admin-proclog-unavailable = Buffer de log não disponível (o servidor iniciou sem a camada de logging).

--- a/crates/ruscker-admin/src/lib.rs
+++ b/crates/ruscker-admin/src/lib.rs
@@ -28,6 +28,7 @@ pub mod crypto;
 pub mod db;
 pub mod i18n;
 pub mod images;
+pub mod logbuf;
 pub mod metrics_cache;
 pub mod ratelimit;
 pub mod routes;
@@ -75,6 +76,10 @@ pub struct AppState {
     /// 503 with a hint that no backend is wired (Phase 1/2 mode,
     /// landing-only).
     pub backend: Option<std::sync::Arc<dyn ruscker_core::ContainerBackend>>,
+
+    /// Recent Ruscker log lines for the admin "Logs" tab. `None` when no
+    /// log buffer was wired (e.g. tests, or non-`serve` commands).
+    pub log_buffer: Option<logbuf::LogBuffer>,
 
     /// Live registry of running replicas, keyed by spec id.
     /// Shared across handlers via an RwLock; writes happen only
@@ -150,6 +155,7 @@ impl AdminServer {
             images_dir: None,
             master_key: crypto::MasterKey::from_env().context("load master key")?,
             backend: None,
+            log_buffer: None,
             replicas: std::sync::Arc::new(tokio::sync::RwLock::new(
                 ruscker_core::ReplicaRegistry::new(),
             )),
@@ -192,6 +198,13 @@ impl AdminServer {
     pub fn with_master_key(mut self, raw: impl AsRef<str>) -> Result<Self> {
         self.state.master_key = crypto::MasterKey::from_str(raw.as_ref())?;
         Ok(self)
+    }
+
+    /// Wire the in-memory log buffer feeding the admin "Logs" tab.
+    /// Created and populated by a `tracing` layer in `ruscker-cli`.
+    pub fn with_log_buffer(mut self, buffer: logbuf::LogBuffer) -> Self {
+        self.state.log_buffer = Some(buffer);
+        self
     }
 
     /// Attach a container backend (e.g. `LocalDockerBackend`).

--- a/crates/ruscker-admin/src/logbuf.rs
+++ b/crates/ruscker-admin/src/logbuf.rs
@@ -1,0 +1,105 @@
+//! In-memory ring buffer of recent Ruscker log lines (#100).
+//!
+//! A `tracing` layer (wired in `ruscker-cli`) pushes each formatted log
+//! line here; the admin "Logs" tab reads a snapshot and follows new
+//! lines over SSE. It's a bounded *recent tail* — lost on restart;
+//! journald / `docker logs` / `container-log-path` remain the durable
+//! source. No `tracing` dependency lives here on purpose: the writer
+//! that feeds it is owned by the CLI.
+
+use std::collections::VecDeque;
+use std::sync::{Arc, Mutex};
+
+/// Monotonic, gap-tolerant line sequence — lets the SSE follower ask
+/// "anything after seq N?" even though old lines are evicted.
+struct Inner {
+    lines: VecDeque<(u64, String)>,
+    next_seq: u64,
+    cap: usize,
+}
+
+/// A cheap, clonable handle to the shared ring buffer.
+#[derive(Clone)]
+pub struct LogBuffer {
+    inner: Arc<Mutex<Inner>>,
+}
+
+impl LogBuffer {
+    /// New buffer retaining at most `cap` lines.
+    pub fn new(cap: usize) -> Self {
+        Self {
+            inner: Arc::new(Mutex::new(Inner {
+                lines: VecDeque::with_capacity(cap.min(1024)),
+                next_seq: 0,
+                cap: cap.max(1),
+            })),
+        }
+    }
+
+    /// Append one line, evicting the oldest if at capacity.
+    pub fn push_line(&self, line: impl Into<String>) {
+        let mut g = self.inner.lock().unwrap();
+        let seq = g.next_seq;
+        g.next_seq += 1;
+        g.lines.push_back((seq, line.into()));
+        while g.lines.len() > g.cap {
+            g.lines.pop_front();
+        }
+    }
+
+    /// Current snapshot, oldest-first — for the initial page render.
+    pub fn snapshot(&self) -> Vec<String> {
+        let g = self.inner.lock().unwrap();
+        g.lines.iter().map(|(_, l)| l.clone()).collect()
+    }
+
+    /// The next sequence number that will be assigned — an SSE follower
+    /// records this at connect and asks [`Self::since`] for anything past
+    /// it.
+    pub fn cursor(&self) -> u64 {
+        self.inner.lock().unwrap().next_seq
+    }
+
+    /// Lines with `seq >= after`, plus the new cursor. Lines evicted
+    /// since `after` are simply absent (a tail, not a guaranteed log).
+    pub fn since(&self, after: u64) -> (Vec<String>, u64) {
+        let g = self.inner.lock().unwrap();
+        let new: Vec<String> = g
+            .lines
+            .iter()
+            .filter(|(seq, _)| *seq >= after)
+            .map(|(_, l)| l.clone())
+            .collect();
+        (new, g.next_seq)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn caps_and_evicts_oldest() {
+        let b = LogBuffer::new(3);
+        for i in 0..5 {
+            b.push_line(format!("line {i}"));
+        }
+        let snap = b.snapshot();
+        assert_eq!(snap, vec!["line 2", "line 3", "line 4"], "kept the last 3");
+    }
+
+    #[test]
+    fn since_returns_only_new_lines() {
+        let b = LogBuffer::new(100);
+        b.push_line("a");
+        b.push_line("b");
+        let cursor = b.cursor(); // after a, b
+        b.push_line("c");
+        let (new, next) = b.since(cursor);
+        assert_eq!(new, vec!["c"], "only the line after the cursor");
+        assert!(next > cursor);
+        // Nothing new past the latest cursor.
+        let (empty, _) = b.since(next);
+        assert!(empty.is_empty());
+    }
+}

--- a/crates/ruscker-admin/src/routes/admin.rs
+++ b/crates/ruscker-admin/src/routes/admin.rs
@@ -27,6 +27,7 @@ pub mod credentials;
 pub mod dashboard;
 pub mod images;
 pub mod landing;
+pub mod logs;
 pub mod spec_form;
 pub mod specs;
 
@@ -43,6 +44,7 @@ pub fn routes() -> Router<AppState> {
         .merge(landing::routes())
         .merge(blocks::routes())
         .merge(audit::routes())
+        .merge(logs::routes())
 }
 
 // ── Templates ────────────────────────────────────────────────────

--- a/crates/ruscker-admin/src/routes/admin/logs.rs
+++ b/crates/ruscker-admin/src/routes/admin/logs.rs
@@ -1,0 +1,103 @@
+//! Admin > Logs — the Ruscker process log (the `tracing` stream),
+//! tailed from the in-memory ring buffer (#100). Read-only; admin-only.
+//!
+//! `GET /admin/logs` renders the current snapshot; `GET
+//! /admin/logs/stream` is an SSE feed of new lines (the page follows).
+
+use std::convert::Infallible;
+use std::time::Duration;
+
+use askama::Template;
+use axum::extract::State;
+use axum::response::sse::{Event, KeepAlive, Sse};
+use axum::response::Response;
+use axum::routing::get;
+use axum::Router;
+use futures_util::Stream;
+
+use crate::auth::AdminSession;
+use crate::i18n::{Locale, Locales};
+use crate::theme::Theme;
+use crate::AppState;
+
+const TICK: Duration = Duration::from_secs(1);
+const KEEPALIVE: Duration = Duration::from_secs(15);
+
+pub fn routes() -> Router<AppState> {
+    Router::new()
+        .route("/admin/logs", get(index))
+        .route("/admin/logs/stream", get(stream))
+}
+
+#[derive(Template)]
+#[template(path = "admin/process_logs.html")]
+struct LogsPage<'a> {
+    locale: Locale,
+    theme: Theme,
+    locales: &'a Locales,
+    locales_all: &'static [Locale],
+    nav_section: &'static str,
+    /// Current buffered lines, oldest-first. Empty when no buffer is
+    /// wired (e.g. started without the CLI's tracing layer).
+    lines: Vec<String>,
+    /// Whether a log buffer is actually wired.
+    available: bool,
+}
+
+impl LogsPage<'_> {
+    fn t(&self, key: &str) -> String {
+        self.locales.t(self.locale, key, None)
+    }
+}
+
+async fn index(
+    _: AdminSession,
+    State(state): State<AppState>,
+    loc: Locale,
+    theme: Theme,
+) -> Response {
+    let (lines, available) = match &state.log_buffer {
+        Some(b) => (b.snapshot(), true),
+        None => (Vec::new(), false),
+    };
+    super::render(&LogsPage {
+        locale: loc,
+        theme,
+        locales: &state.locales,
+        locales_all: &Locale::ALL,
+        nav_section: "logs",
+        lines,
+        available,
+    })
+}
+
+/// SSE feed of lines appended since the client connected. The page
+/// already rendered the snapshot, so we start from the live cursor and
+/// only stream what's new.
+async fn stream(
+    _: AdminSession,
+    State(state): State<AppState>,
+) -> Sse<impl Stream<Item = Result<Event, Infallible>>> {
+    use async_stream::stream;
+    let buf = state.log_buffer.clone();
+    let s = stream! {
+        let Some(buf) = buf else {
+            // No buffer wired — nothing to stream; keep-alive holds the
+            // connection so the client doesn't error-loop.
+            std::future::pending::<()>().await;
+            return;
+        };
+        let mut cursor = buf.cursor();
+        let mut ticker = tokio::time::interval(TICK);
+        ticker.set_missed_tick_behavior(tokio::time::MissedTickBehavior::Skip);
+        loop {
+            ticker.tick().await;
+            let (new, next) = buf.since(cursor);
+            cursor = next;
+            if !new.is_empty() {
+                yield Ok::<_, Infallible>(Event::default().data(new.join("\n")));
+            }
+        }
+    };
+    Sse::new(s).keep_alive(KeepAlive::new().interval(KEEPALIVE))
+}

--- a/crates/ruscker-admin/src/routes/proxy.rs
+++ b/crates/ruscker-admin/src/routes/proxy.rs
@@ -1086,6 +1086,7 @@ mod tests {
             ),
             admin_auth: Default::default(),
             admin_sessions: Default::default(),
+            log_buffer: None,
             login_limiter: StdArc::new(crate::auth::LoginRateLimiter::default_policy()),
             api_limiter: StdArc::new(crate::ratelimit::ApiRateLimiter::new()),
             db: None,

--- a/crates/ruscker-admin/src/scaler.rs
+++ b/crates/ruscker-admin/src/scaler.rs
@@ -521,6 +521,7 @@ mod tests {
             locales: Arc::new(crate::i18n::Locales::load().expect("load locales")),
             admin_auth: Default::default(),
             admin_sessions: Default::default(),
+            log_buffer: None,
             login_limiter: Arc::new(crate::auth::LoginRateLimiter::default_policy()),
             api_limiter: Arc::new(crate::ratelimit::ApiRateLimiter::new()),
             db: None,

--- a/crates/ruscker-admin/templates/admin/_layout.html
+++ b/crates/ruscker-admin/templates/admin/_layout.html
@@ -59,6 +59,10 @@
       <i class="ti ti-history" aria-hidden="true"></i>
       <span>{{ self.t("admin-nav-audit") }}</span>
     </a>
+    <a href="/admin/logs" class="admin-nav-link {% if nav_section == "logs" %}is-active{% endif %}">
+      <i class="ti ti-terminal-2" aria-hidden="true"></i>
+      <span>{{ self.t("admin-nav-logs") }}</span>
+    </a>
   </div>
 
   <div class="admin-nav-actions">

--- a/crates/ruscker-admin/templates/admin/process_logs.html
+++ b/crates/ruscker-admin/templates/admin/process_logs.html
@@ -1,0 +1,55 @@
+{% extends "admin/_layout.html" %}
+
+{% block title %}{{ self.t("admin-proclog-title") }} · Ruscker{% endblock %}
+
+{% block content %}
+
+<style>
+  .proclog-pre {
+    background: var(--surface-soft, #1113);
+    border: 0.5px solid var(--border);
+    border-radius: 10px;
+    padding: 14px 16px;
+    margin-top: 12px;
+    font-family: ui-monospace, SFMono-Regular, Menlo, monospace;
+    font-size: 12px;
+    line-height: 1.5;
+    color: var(--text);
+    height: 70vh;
+    overflow: auto;
+    white-space: pre-wrap;
+    word-break: break-word;
+  }
+</style>
+
+<div class="flex items-end justify-between mb-1">
+  <div>
+    <h1 class="text-xl font-medium tracking-tight">{{ self.t("admin-proclog-title") }}</h1>
+    <p class="text-xs text-[color:var(--text-muted)] mt-1">{{ self.t("admin-proclog-subtitle") }}</p>
+  </div>
+</div>
+
+{% if !available %}
+  <p class="text-sm text-[color:var(--text-faint)] py-8 text-center">{{ self.t("admin-proclog-unavailable") }}</p>
+{% else %}
+  <pre id="proclog" class="proclog-pre">{% for line in lines %}{{ line }}
+{% endfor %}</pre>
+
+  <script>
+  (function () {
+    const box = document.getElementById('proclog');
+    const nearBottom = () => box.scrollHeight - box.scrollTop - box.clientHeight < 48;
+    box.scrollTop = box.scrollHeight; // start pinned to the newest line
+    const es = new EventSource('/admin/logs/stream');
+    es.onmessage = (e) => {
+      const stick = nearBottom();
+      // Append as text nodes — never parse log content as HTML.
+      box.appendChild(document.createTextNode(e.data + '\n'));
+      if (stick) box.scrollTop = box.scrollHeight;
+    };
+    es.onerror = () => { /* EventSource auto-reconnects */ };
+  })();
+  </script>
+{% endif %}
+
+{% endblock %}

--- a/crates/ruscker-admin/tests/api_policies.rs
+++ b/crates/ruscker-admin/tests/api_policies.rs
@@ -44,6 +44,7 @@ fn state() -> AppState {
         locales: Arc::new(locales),
         admin_auth: Default::default(),
         admin_sessions: Default::default(),
+        log_buffer: None,
         login_limiter: Arc::new(ruscker_admin::auth::LoginRateLimiter::default_policy()),
         api_limiter: Arc::new(ruscker_admin::ratelimit::ApiRateLimiter::new()),
         db: None,

--- a/crates/ruscker-admin/tests/health_probes.rs
+++ b/crates/ruscker-admin/tests/health_probes.rs
@@ -28,6 +28,7 @@ fn base_state() -> AppState {
         locales: Arc::new(locales),
         admin_auth: Default::default(),
         admin_sessions: Default::default(),
+        log_buffer: None,
         login_limiter: Arc::new(ruscker_admin::auth::LoginRateLimiter::default_policy()),
         api_limiter: Arc::new(ruscker_admin::ratelimit::ApiRateLimiter::new()),
         db: None,

--- a/crates/ruscker-admin/tests/landing_render.rs
+++ b/crates/ruscker-admin/tests/landing_render.rs
@@ -26,6 +26,7 @@ fn app_state() -> AppState {
         locales: Arc::new(locales),
         admin_auth: Default::default(),
         admin_sessions: Default::default(),
+        log_buffer: None,
         login_limiter: std::sync::Arc::new(ruscker_admin::auth::LoginRateLimiter::default_policy()),
         api_limiter: std::sync::Arc::new(ruscker_admin::ratelimit::ApiRateLimiter::new()),
         db: None,

--- a/crates/ruscker-admin/tests/max_body_size.rs
+++ b/crates/ruscker-admin/tests/max_body_size.rs
@@ -43,6 +43,7 @@ fn state() -> AppState {
         locales: Arc::new(locales),
         admin_auth: Default::default(),
         admin_sessions: Default::default(),
+        log_buffer: None,
         login_limiter: Arc::new(ruscker_admin::auth::LoginRateLimiter::default_policy()),
         api_limiter: Arc::new(ruscker_admin::ratelimit::ApiRateLimiter::new()),
         db: None,

--- a/crates/ruscker-cli/src/main.rs
+++ b/crates/ruscker-cli/src/main.rs
@@ -155,7 +155,7 @@ enum Command {
 
 fn main() -> Result<()> {
     let cli = Cli::parse();
-    init_tracing(cli.verbose, cli.log_format);
+    let log_buffer = init_tracing(cli.verbose, cli.log_format);
 
     match cli.command {
         Command::Validate {
@@ -169,7 +169,7 @@ fn main() -> Result<()> {
         Command::Import { path, db } => cmd_import(&path, &db),
         Command::Export { db } => cmd_export(&db),
         Command::Serve { config, bind, images_dir, db, admin_token, master_key, docker } => {
-            cmd_serve(&config, bind, images_dir, db, admin_token, master_key, docker)
+            cmd_serve(&config, bind, images_dir, db, admin_token, master_key, docker, log_buffer)
         }
     }
 }
@@ -265,6 +265,7 @@ fn cmd_serve(
     admin_token: Option<String>,
     master_key: Option<String>,
     docker: bool,
+    log_buffer: ruscker_admin::logbuf::LogBuffer,
 ) -> Result<()> {
     let config = Config::from_file(config_path).with_context(|| {
         format!("failed to load config from {}", config_path.display())
@@ -295,7 +296,7 @@ fn cmd_serve(
         .build()?;
 
     rt.block_on(async {
-        let mut server = ruscker_admin::AdminServer::new(addr, config)?;
+        let mut server = ruscker_admin::AdminServer::new(addr, config)?.with_log_buffer(log_buffer);
         if let Some(dir) = images_dir {
             server = server.with_images_dir(dir);
         }
@@ -318,7 +319,15 @@ fn cmd_serve(
     })
 }
 
-fn init_tracing(verbosity: u8, format: LogFormat) {
+/// Initialise tracing and return the in-memory log buffer feeding the
+/// admin "Logs" tab. Logs go to stdout (text or JSON) **and** to a
+/// bounded ring buffer (always plain text), both behind the same
+/// `EnvFilter`. Only `serve` consumes the returned buffer; other
+/// commands just let it collect harmlessly.
+fn init_tracing(verbosity: u8, format: LogFormat) -> ruscker_admin::logbuf::LogBuffer {
+    use tracing_subscriber::layer::SubscriberExt;
+    use tracing_subscriber::util::SubscriberInitExt;
+
     let level = match verbosity {
         0 => "warn",
         1 => "info",
@@ -328,20 +337,91 @@ fn init_tracing(verbosity: u8, format: LogFormat) {
     // `RUST_LOG` always wins when set (operators expect it); the
     // verbosity flag only sets the default filter.
     let env = std::env::var("RUST_LOG").unwrap_or_else(|_| format!("ruscker={level}"));
-    let builder = tracing_subscriber::fmt().with_env_filter(env);
+    let filter = tracing_subscriber::EnvFilter::new(env);
+
+    let buffer = ruscker_admin::logbuf::LogBuffer::new(2000);
+    let registry = tracing_subscriber::registry().with(filter);
+    // The ring-buffer layer is inlined per arm: the two stdout formats
+    // give the layered subscriber different types, so its `S` parameter
+    // must be inferred independently at each call site.
     match format {
-        // `.json()` and the default formatter return different
-        // builder types, so each arm must call `.init()` itself.
-        LogFormat::Text => builder.with_target(false).init(),
-        LogFormat::Json => builder
-            // Keep the module target in structured logs — it's a
-            // cheap, high-value field for filtering in a shipper.
-            .json()
-            // Lift the event's fields to the top level instead of
-            // nesting them under `"fields"`, so queries like
-            // `addr="…"` work without a path prefix.
-            .flatten_event(true)
+        LogFormat::Text => registry
+            .with(tracing_subscriber::fmt::layer().with_target(false))
+            .with(
+                tracing_subscriber::fmt::layer()
+                    .with_ansi(false)
+                    .with_target(false)
+                    .with_writer(BufMakeWriter(buffer.clone())),
+            )
             .init(),
+        LogFormat::Json => registry
+            // Keep the module target + lift fields to the top level so
+            // `addr="…"` queries work without a path prefix in a shipper.
+            .with(tracing_subscriber::fmt::layer().json().flatten_event(true))
+            .with(
+                tracing_subscriber::fmt::layer()
+                    .with_ansi(false)
+                    .with_target(false)
+                    .with_writer(BufMakeWriter(buffer.clone())),
+            )
+            .init(),
+    }
+    buffer
+}
+
+/// `MakeWriter` that funnels formatted log lines into the [`LogBuffer`].
+#[derive(Clone)]
+struct BufMakeWriter(ruscker_admin::logbuf::LogBuffer);
+
+impl<'a> tracing_subscriber::fmt::MakeWriter<'a> for BufMakeWriter {
+    type Writer = BufLineWriter;
+    fn make_writer(&'a self) -> Self::Writer {
+        BufLineWriter {
+            buf: self.0.clone(),
+            pending: Vec::new(),
+        }
+    }
+}
+
+/// Per-event writer: accumulates bytes and pushes each complete line
+/// (the fmt layer writes one newline-terminated line per event).
+struct BufLineWriter {
+    buf: ruscker_admin::logbuf::LogBuffer,
+    pending: Vec<u8>,
+}
+
+impl BufLineWriter {
+    fn drain_lines(&mut self) {
+        while let Some(pos) = self.pending.iter().position(|&b| b == b'\n') {
+            let line: Vec<u8> = self.pending.drain(..=pos).collect();
+            let s = String::from_utf8_lossy(&line);
+            let s = s.trim_end();
+            if !s.is_empty() {
+                self.buf.push_line(s.to_string());
+            }
+        }
+    }
+}
+
+impl std::io::Write for BufLineWriter {
+    fn write(&mut self, data: &[u8]) -> std::io::Result<usize> {
+        self.pending.extend_from_slice(data);
+        self.drain_lines();
+        Ok(data.len())
+    }
+    fn flush(&mut self) -> std::io::Result<()> {
+        Ok(())
+    }
+}
+
+impl Drop for BufLineWriter {
+    fn drop(&mut self) {
+        // Flush a trailing line with no newline (defensive).
+        let s = String::from_utf8_lossy(&self.pending);
+        let s = s.trim_end();
+        if !s.is_empty() {
+            self.buf.push_line(s.to_string());
+        }
     }
 }
 


### PR DESCRIPTION
Closes **#100**. Surfaces the **daemon's own `tracing` log** (proxy, scaler, errors/warnings) in the admin — distinct from the **Audit** tab (mutations) and the **Dashboard** per-replica container logs.

## How
- **`logbuf::LogBuffer`** — a bounded (2 000-line) in-memory ring buffer with a gap-tolerant cursor (`snapshot` / `cursor` / `since`) for the SSE follower. No `tracing` dependency (the writer that feeds it lives in the CLI).
- **CLI** — `init_tracing` now builds a layered subscriber: the stdout fmt layer (text/json) **plus** a plain-text fmt layer feeding the buffer, both behind the same `EnvFilter`; it returns the buffer and `serve` threads it into `AppState` via `with_log_buffer`.
- **Routes** — `GET /admin/logs` renders the snapshot in a `<pre>` (auto-scroll; lines appended as **text nodes**, never parsed as HTML); `GET /admin/logs/stream` is an SSE feed of lines since connect. New **Logs** nav link, admin-only, own template (`process_logs.html`, kept separate from the per-replica `logs.html`). 4 i18n keys × 4 locales.

## Verified
- Unit tests: `LogBuffer` cap/eviction + `since` cursor.
- **Live smoke**: `/admin/logs` renders real startup lines; the SSE stream delivered **20 frames** of live log lines (`spawning first replica`, `pulling image`, `scale-up spawn failed`, …) while traffic flowed; stream content-type `text/event-stream`.
- Workspace tests green (admin 163); fmt drift unchanged; new files rustfmt-clean.

Closes #100.

🤖 Generated with [Claude Code](https://claude.com/claude-code)