### PR TITLE
RBAC: Viewer / Editor / Admin roles for the admin portal (#101)

### DIFF
--- a/book/src/admin.md
+++ b/book/src/admin.md
@@ -18,7 +18,27 @@ landing + proxy are served. Rotate the token any time by changing the
 value and restarting.
 
 The footer has the same **language** (pt-BR / en-US / es-ES / fr-FR)
-and **theme** (light / dark / auto) pickers as the public portal.
+and **theme** (light / dark / auto) pickers as the public portal. The
+top-right corner shows your current **access level**.
+
+## Access levels (roles)
+
+Ruscker supports three roles, each with its own token. Set only the
+ones you need — with just `RUSCKER_ADMIN_TOKEN` you get the classic
+single-admin setup.
+
+| Token | Role | Can do |
+|---|---|---|
+| `RUSCKER_ADMIN_TOKEN` (required) | **Admin** | everything |
+| `RUSCKER_EDITOR_TOKEN` (optional) | **Editor** | view + manage Apps and Media; view the Dashboard and stop/restart replicas |
+| `RUSCKER_VIEWER_TOKEN` (optional) | **Viewer** | view the Dashboard only (read-only) |
+
+You log in with whichever token you were given; the panel then shows
+only the sections your role can reach. Enforcement is server-side —
+hiding a nav link is just UX, the routes themselves return `403` for a
+role that isn't allowed. Use **distinct** tokens per role (a token
+shared across roles resolves to the highest one). Credentials, the
+landing editor, custom blocks and the audit log are Admin-only.
 
 ## Screens
 

--- a/crates/ruscker-admin/assets/i18n/en/landing.ftl
+++ b/crates/ruscker-admin/assets/i18n/en/landing.ftl
@@ -62,6 +62,10 @@ admin-blocks-cancel = Cancel
 admin-nav-audit = Audit log
 admin-nav-portal = Back to portal
 admin-nav-logout = Sign out
+role-current = Your access level
+role-viewer = Viewer
+role-editor = Editor
+role-admin = Admin
 
 # Admin dashboard
 admin-dashboard-title = Monitoring dashboard

--- a/crates/ruscker-admin/assets/i18n/es/landing.ftl
+++ b/crates/ruscker-admin/assets/i18n/es/landing.ftl
@@ -62,6 +62,10 @@ admin-blocks-cancel = Cancelar
 admin-nav-audit = Auditoría
 admin-nav-portal = Volver al portal
 admin-nav-logout = Salir
+role-current = Tu nivel de acceso
+role-viewer = Visor
+role-editor = Editor
+role-admin = Administrador
 
 # Admin dashboard
 admin-dashboard-title = Panel de monitoreo

--- a/crates/ruscker-admin/assets/i18n/fr/landing.ftl
+++ b/crates/ruscker-admin/assets/i18n/fr/landing.ftl
@@ -62,6 +62,10 @@ admin-blocks-cancel = Annuler
 admin-nav-audit = Journal
 admin-nav-portal = Retour au portail
 admin-nav-logout = Déconnexion
+role-current = Votre niveau d'accès
+role-viewer = Lecteur
+role-editor = Éditeur
+role-admin = Administrateur
 
 # Admin dashboard
 admin-dashboard-title = Tableau de bord

--- a/crates/ruscker-admin/assets/i18n/pt/landing.ftl
+++ b/crates/ruscker-admin/assets/i18n/pt/landing.ftl
@@ -66,6 +66,10 @@ admin-blocks-cancel = Cancelar
 admin-nav-audit = Auditoria
 admin-nav-portal = Voltar ao portal
 admin-nav-logout = Sair
+role-current = Seu nível de acesso
+role-viewer = Visualizador
+role-editor = Editor
+role-admin = Administrador
 
 # Admin dashboard
 admin-dashboard-title = Painel de monitoramento

--- a/crates/ruscker-admin/src/auth.rs
+++ b/crates/ruscker-admin/src/auth.rs
@@ -1,19 +1,26 @@
-//! Admin authentication — MVP env-var token model.
+//! Admin authentication — env-var token model with three roles.
 //!
-//! Threat model for Phase 2: the operator runs Ruscker on a
-//! private network (or behind a reverse proxy with mTLS).
-//! `RUSCKER_ADMIN_TOKEN` is a long random secret the operator
-//! enters once on `/admin/login`; the server matches it in
-//! constant time and issues an HttpOnly + Strict-SameSite cookie.
+//! Threat model: the operator runs Ruscker on a private network
+//! (or behind a reverse proxy with mTLS). Up to three long random
+//! secrets — `RUSCKER_ADMIN_TOKEN` (required), `RUSCKER_EDITOR_TOKEN`
+//! and `RUSCKER_VIEWER_TOKEN` (both optional) — are entered once on
+//! `/admin/login`. The server constant-time-compares the submitted
+//! token against each and issues an HttpOnly + Strict-SameSite cookie
+//! holding an opaque session id; the session carries the matched
+//! [`Role`].
 //!
-//! Real auth (OIDC, SAML, role-based ACL) lands in Phase 8. Until
-//! then the model is "one token = full admin"; suitable for a
-//! single-operator install, not for shared teams.
+//! Roles (see [`Role`]): **Viewer** (dashboard only), **Editor**
+//! (apps + media + dashboard), **Admin** (everything). With only
+//! `RUSCKER_ADMIN_TOKEN` set the install behaves exactly as before
+//! — one token, full admin — so this is backward-compatible.
 //!
-//! Cookie storage choice: the cookie value IS the token literal.
-//! Server-side sessions are a Phase 2.5 refinement once we have a
-//! session store; today the cookie is bound by `HttpOnly`,
-//! `Secure` (when TLS terminated), and `SameSite=Strict`.
+//! Full multi-user auth (OIDC, SAML, LDAP, per-app ACLs) lands in
+//! Phase 8; this is a lightweight role layer on the token/session
+//! model.
+//!
+//! Cookie: the value is an opaque server-side session id (never the
+//! token), bound by `HttpOnly`, `Secure` (when TLS terminated), and
+//! `SameSite=Strict`. Logout and server restart both revoke it.
 
 use anyhow::Result;
 use axum::extract::FromRequestParts;
@@ -31,55 +38,152 @@ use tower_cookies::Cookies;
 /// audit in DevTools.
 pub const COOKIE_NAME: &str = "ruscker_admin_session";
 
-/// Held in `AppState`. `None` means admin routes are disabled —
-/// they will 503 with a hint to set `RUSCKER_ADMIN_TOKEN`. The
+/// Admin access level. Ordered least → most privileged, so a
+/// `role >= Role::Editor` check reads naturally.
+///
+/// The permission matrix is centralised in
+/// [`Role::can_access_section`] — route guards and the nav both
+/// dispatch on it, so they can't drift. Section names are the same
+/// `nav_section` strings the templates already use.
+#[derive(Clone, Copy, Debug, PartialEq, Eq, PartialOrd, Ord)]
+pub enum Role {
+    /// Read-only: the monitoring dashboard, nothing else.
+    Viewer,
+    /// Manages apps and media (create/edit/delete + uploads) and has
+    /// the full dashboard, including the stop/restart actions.
+    Editor,
+    /// Everything — credentials, landing editor, custom blocks, audit
+    /// log. The historical single-token behaviour.
+    Admin,
+}
+
+impl Role {
+    /// Whether this role may reach the given admin nav section.
+    /// `section` matches the `nav_section` strings used by the
+    /// templates (`dashboard`, `specs`, `images`, `credentials`,
+    /// `landing`, `blocks`, `audit`).
+    pub fn can_access_section(&self, section: &str) -> bool {
+        match section {
+            // Anyone logged in can view the dashboard.
+            "dashboard" => true,
+            // Editors (and admins) manage apps and media.
+            "specs" | "images" => *self >= Role::Editor,
+            // Everything else is admin-only.
+            _ => *self == Role::Admin,
+        }
+    }
+
+    /// Whether this role may perform mutating/operational actions —
+    /// the dashboard's stop/restart, app CRUD, media uploads. Editor
+    /// and Admin can; Viewer is strictly read-only. Used to gate the
+    /// dashboard action buttons (the view itself is open to Viewers).
+    pub fn can_manage(&self) -> bool {
+        *self >= Role::Editor
+    }
+
+    /// The page a freshly-logged-in session of this role lands on.
+    /// The dashboard is visible to every role, so it's home for all.
+    pub fn home(&self) -> &'static str {
+        "/admin/dashboard"
+    }
+
+    /// Fluent message key for the human-readable role label.
+    pub fn label_key(&self) -> &'static str {
+        match self {
+            Role::Viewer => "role-viewer",
+            Role::Editor => "role-editor",
+            Role::Admin => "role-admin",
+        }
+    }
+}
+
+/// Held in `AppState`. One token per [`Role`]; `admin` is required
+/// (when it's `None`, admin routes 503 with a hint to set
+/// `RUSCKER_ADMIN_TOKEN`), `editor` and `viewer` are optional. Each
 /// token is wrapped in `Arc<str>` so cloning [`AppState`] (per
 /// request) doesn't copy the string.
 #[derive(Clone, Debug, Default)]
 pub struct AdminAuth {
-    pub token: Option<Arc<str>>,
+    pub admin: Option<Arc<str>>,
+    pub editor: Option<Arc<str>>,
+    pub viewer: Option<Arc<str>>,
 }
 
 impl AdminAuth {
     pub fn from_env() -> Self {
-        let token = std::env::var("RUSCKER_ADMIN_TOKEN").ok().filter(|s| !s.is_empty());
+        let read = |var: &str| {
+            std::env::var(var)
+                .ok()
+                .filter(|s| !s.is_empty())
+                .map(Arc::from)
+        };
         Self {
-            token: token.map(Arc::from),
+            admin: read("RUSCKER_ADMIN_TOKEN"),
+            editor: read("RUSCKER_EDITOR_TOKEN"),
+            viewer: read("RUSCKER_VIEWER_TOKEN"),
         }
     }
 
+    /// Configure the admin token only (used by tests / programmatic
+    /// setup). Editor and viewer stay unset ⇒ single-admin behaviour.
     pub fn with_token(token: impl Into<String>) -> Self {
         Self {
-            token: Some(Arc::from(token.into())),
+            admin: Some(Arc::from(token.into())),
+            editor: None,
+            viewer: None,
         }
     }
 
+    /// Admin auth is usable iff the admin token is set. The optional
+    /// editor/viewer tokens layer on top but never replace it.
     pub fn is_configured(&self) -> bool {
-        self.token.is_some()
+        self.admin.is_some()
     }
 
-    /// Constant-time compare. Mismatched lengths return false
-    /// without iterating — the length leak is intentional and
-    /// matches every well-known constant-time API. The XOR-fold
-    /// over the body is loop-bounded by `a.len()`, so the time
-    /// depends only on the (public) length, not on the bytes.
-    pub fn matches(&self, candidate: &str) -> bool {
-        let Some(expected) = self.token.as_deref() else {
-            return false;
+    /// Constant-time-compare `candidate` against each configured
+    /// token and return the matched [`Role`], or `None` if it matches
+    /// none. Checked most-privileged first so a token reused across
+    /// levels (a misconfiguration) resolves to the higher role.
+    ///
+    /// Every comparison uses [`ct_eq`]: mismatched lengths short-
+    /// circuit (the length leak is intentional and standard), and the
+    /// XOR-fold over equal-length bytes is data-independent.
+    pub fn role_for(&self, candidate: &str) -> Option<Role> {
+        let matches = |tok: &Option<Arc<str>>| {
+            tok.as_deref()
+                .is_some_and(|t| ct_eq(t.as_bytes(), candidate.as_bytes()))
         };
-        ct_eq(expected.as_bytes(), candidate.as_bytes())
+        if matches(&self.admin) {
+            Some(Role::Admin)
+        } else if matches(&self.editor) {
+            Some(Role::Editor)
+        } else if matches(&self.viewer) {
+            Some(Role::Viewer)
+        } else {
+            None
+        }
     }
 }
 
-/// Server-side store of opaque admin session ids → expiry.
+/// One live admin session: when it expires and the [`Role`] it was
+/// minted with. Copy-cheap so lookups can read it out of the map by
+/// value without holding the shard lock.
+#[derive(Clone, Copy, Debug)]
+struct SessionEntry {
+    expiry: Instant,
+    role: Role,
+}
+
+/// Server-side store of opaque admin session ids → (expiry, role).
 ///
 /// The cookie holds a random session id, **not** the admin token. That
 /// way a stolen cookie can be revoked (logout, or a server restart) and
 /// never exposes the master token, and logout actually invalidates the
-/// session instead of just clearing the browser's copy.
+/// session instead of just clearing the browser's copy. The stored
+/// [`Role`] is what route guards and the nav dispatch on.
 #[derive(Debug)]
 pub struct AdminSessions {
-    sessions: DashMap<String, Instant>,
+    sessions: DashMap<String, SessionEntry>,
     ttl: Duration,
 }
 
@@ -96,28 +200,36 @@ impl AdminSessions {
         Self::new(Duration::from_secs(24 * 60 * 60))
     }
 
-    /// Mint a new session and return its opaque id (244 bits of random,
-    /// unguessable). Caller stores the id in the cookie.
-    pub fn create(&self) -> String {
+    /// Mint a new session for `role` and return its opaque id (244
+    /// bits of random, unguessable). Caller stores the id in the
+    /// cookie.
+    pub fn create(&self, role: Role) -> String {
         let id = format!(
             "{}{}",
             uuid::Uuid::new_v4().simple(),
             uuid::Uuid::new_v4().simple()
         );
-        self.sessions.insert(id.clone(), Instant::now() + self.ttl);
+        self.sessions.insert(
+            id.clone(),
+            SessionEntry {
+                expiry: Instant::now() + self.ttl,
+                role,
+            },
+        );
         id
     }
 
-    /// Whether `id` names a live (non-expired) session. Expired entries
-    /// are pruned lazily on lookup.
-    pub fn validate(&self, id: &str) -> bool {
+    /// The [`Role`] of a live (non-expired) session named by `id`, or
+    /// `None` if the id is unknown or expired. Expired entries are
+    /// pruned lazily on lookup.
+    pub fn validate(&self, id: &str) -> Option<Role> {
         match self.sessions.get(id).map(|e| *e.value()) {
-            Some(expiry) if expiry > Instant::now() => true,
+            Some(entry) if entry.expiry > Instant::now() => Some(entry.role),
             Some(_) => {
                 self.sessions.remove(id);
-                false
+                None
             }
-            None => false,
+            None => None,
         }
     }
 
@@ -233,15 +345,21 @@ pub fn request_is_https(headers: &axum::http::HeaderMap) -> bool {
         .unwrap_or(false)
 }
 
-/// Marker extracted by admin routes to assert that the request is
-/// authenticated. Absence of a valid session redirects to the
-/// login form (303 See Other so re-POST isn't suggested by
-/// browsers).
+/// Extracted by admin routes to assert that the request carries a
+/// valid session; exposes the session's [`Role`]. Absence of a valid
+/// session redirects to the login form (303 See Other so re-POST
+/// isn't suggested by browsers).
+///
+/// This guard accepts **any** role (≥ Viewer) — use it on routes
+/// every logged-in user may reach (the dashboard view). For
+/// privileged routes, wrap it with [`RequireEditor`] / [`RequireAdmin`].
 ///
 /// When the server has NO admin token configured at all, the
 /// extractor returns 503 — admin routes simply cannot work
 /// without a token to compare against.
-pub struct AdminSession;
+pub struct AdminSession {
+    pub role: Role,
+}
 
 impl FromRequestParts<crate::AppState> for AdminSession {
     type Rejection = Response;
@@ -265,20 +383,82 @@ impl FromRequestParts<crate::AppState> for AdminSession {
             Ok(c) => c,
             Err(_) => return Err(Redirect::to("/admin/login").into_response()),
         };
-        let candidate = cookies.get(COOKIE_NAME).map(|c| c.value().to_string());
-        match candidate {
-            // The cookie carries an opaque session id, validated against
-            // the server-side store — not the token itself.
-            Some(c) if state.admin_sessions.validate(&c) => Ok(AdminSession),
-            _ => Err(Redirect::to("/admin/login").into_response()),
+        // The cookie carries an opaque session id, validated against
+        // the server-side store — not the token itself. A live session
+        // yields its role.
+        match cookies.get(COOKIE_NAME).map(|c| c.value().to_string()) {
+            Some(c) => match state.admin_sessions.validate(&c) {
+                Some(role) => Ok(AdminSession { role }),
+                None => Err(Redirect::to("/admin/login").into_response()),
+            },
+            None => Err(Redirect::to("/admin/login").into_response()),
         }
     }
 }
 
-/// Convenience extractor for routes that want to know whether the
-/// caller is authenticated without rejecting — useful for the
-/// `_layout.html` so the navbar can show/hide a "logout" link.
-pub struct MaybeAdminSession(pub bool);
+/// 403 response for an authenticated session that lacks the required
+/// role. Distinct from the login redirect: the caller *is* logged in,
+/// they just can't reach this section.
+fn forbidden() -> Response {
+    (
+        StatusCode::FORBIDDEN,
+        "forbidden — your role can't access this section",
+    )
+        .into_response()
+}
+
+/// Guard for routes that require **at least** [`Role::Editor`]
+/// (apps + media + the dashboard's stop/restart actions). A valid
+/// Viewer session is rejected with 403; an unauthenticated request
+/// still redirects to login. Carries the role for the handler /
+/// template.
+pub struct RequireEditor {
+    pub role: Role,
+}
+
+impl FromRequestParts<crate::AppState> for RequireEditor {
+    type Rejection = Response;
+
+    async fn from_request_parts(
+        parts: &mut Parts,
+        state: &crate::AppState,
+    ) -> Result<Self, Self::Rejection> {
+        let session = AdminSession::from_request_parts(parts, state).await?;
+        if session.role >= Role::Editor {
+            Ok(RequireEditor { role: session.role })
+        } else {
+            Err(forbidden())
+        }
+    }
+}
+
+/// Guard for routes that require [`Role::Admin`] (credentials,
+/// landing editor, custom blocks, audit log). Anything below Admin is
+/// rejected with 403. Carries the role for the handler / template.
+pub struct RequireAdmin {
+    pub role: Role,
+}
+
+impl FromRequestParts<crate::AppState> for RequireAdmin {
+    type Rejection = Response;
+
+    async fn from_request_parts(
+        parts: &mut Parts,
+        state: &crate::AppState,
+    ) -> Result<Self, Self::Rejection> {
+        let session = AdminSession::from_request_parts(parts, state).await?;
+        if session.role == Role::Admin {
+            Ok(RequireAdmin { role: session.role })
+        } else {
+            Err(forbidden())
+        }
+    }
+}
+
+/// Convenience extractor for routes that want to know the caller's
+/// role without rejecting — used by `_layout.html` so the navbar can
+/// gate links and show a "logout". `None` ⇒ not authenticated.
+pub struct MaybeAdminSession(pub Option<Role>);
 
 impl FromRequestParts<crate::AppState> for MaybeAdminSession {
     type Rejection = Infallible;
@@ -288,8 +468,8 @@ impl FromRequestParts<crate::AppState> for MaybeAdminSession {
         state: &crate::AppState,
     ) -> Result<Self, Self::Rejection> {
         match AdminSession::from_request_parts(parts, state).await {
-            Ok(_) => Ok(MaybeAdminSession(true)),
-            Err(_) => Ok(MaybeAdminSession(false)),
+            Ok(s) => Ok(MaybeAdminSession(Some(s.role))),
+            Err(_) => Ok(MaybeAdminSession(None)),
         }
     }
 }
@@ -303,31 +483,96 @@ mod tests {
     #[test]
     fn admin_sessions_create_validate_remove() {
         let s = AdminSessions::default_policy();
-        let id = s.create();
-        assert!(s.validate(&id), "freshly created session is valid");
-        assert!(!s.validate("not-a-real-id"), "unknown id is invalid");
+        let id = s.create(Role::Editor);
+        assert_eq!(
+            s.validate(&id),
+            Some(Role::Editor),
+            "freshly created session is valid and carries its role"
+        );
+        assert_eq!(s.validate("not-a-real-id"), None, "unknown id is invalid");
         s.remove(&id);
-        assert!(!s.validate(&id), "removed (logged-out) session is invalid");
+        assert_eq!(
+            s.validate(&id),
+            None,
+            "removed (logged-out) session is invalid"
+        );
     }
 
     #[test]
     fn admin_sessions_expire() {
         let s = AdminSessions::new(Duration::from_millis(0));
-        let id = s.create();
+        let id = s.create(Role::Admin);
         std::thread::sleep(Duration::from_millis(2));
-        assert!(!s.validate(&id), "expired session is invalid");
+        assert_eq!(s.validate(&id), None, "expired session is invalid");
     }
 
     #[test]
     fn admin_session_ids_are_distinct_and_not_the_token() {
         let s = AdminSessions::default_policy();
-        let a = s.create();
-        let b = s.create();
+        let a = s.create(Role::Viewer);
+        let b = s.create(Role::Viewer);
         assert_ne!(a, b, "each session gets a fresh id");
         assert!(
             a.len() >= 32,
             "id is high-entropy, not a short/guessable value"
         );
+    }
+
+    #[test]
+    fn role_for_resolves_each_token_and_rejects_others() {
+        let auth = AdminAuth {
+            admin: Some(Arc::from("admin-secret")),
+            editor: Some(Arc::from("editor-secret")),
+            viewer: Some(Arc::from("viewer-secret")),
+        };
+        assert_eq!(auth.role_for("admin-secret"), Some(Role::Admin));
+        assert_eq!(auth.role_for("editor-secret"), Some(Role::Editor));
+        assert_eq!(auth.role_for("viewer-secret"), Some(Role::Viewer));
+        assert_eq!(auth.role_for("nope"), None);
+        assert_eq!(auth.role_for(""), None);
+    }
+
+    #[test]
+    fn role_for_admin_only_is_backward_compatible() {
+        // Only RUSCKER_ADMIN_TOKEN set ⇒ single-admin behaviour.
+        let auth = AdminAuth::with_token("only-admin");
+        assert!(auth.is_configured());
+        assert_eq!(auth.role_for("only-admin"), Some(Role::Admin));
+        assert_eq!(auth.role_for("anything-else"), None);
+    }
+
+    #[test]
+    fn role_for_prefers_higher_privilege_on_token_reuse() {
+        // A token reused across levels resolves to the higher role.
+        let auth = AdminAuth {
+            admin: Some(Arc::from("shared")),
+            editor: Some(Arc::from("shared")),
+            viewer: None,
+        };
+        assert_eq!(auth.role_for("shared"), Some(Role::Admin));
+    }
+
+    #[test]
+    fn role_ordering_and_section_matrix() {
+        assert!(Role::Admin > Role::Editor);
+        assert!(Role::Editor > Role::Viewer);
+
+        // Dashboard: everyone.
+        for r in [Role::Viewer, Role::Editor, Role::Admin] {
+            assert!(r.can_access_section("dashboard"));
+        }
+        // Apps + media: Editor and up.
+        for sec in ["specs", "images"] {
+            assert!(!Role::Viewer.can_access_section(sec));
+            assert!(Role::Editor.can_access_section(sec));
+            assert!(Role::Admin.can_access_section(sec));
+        }
+        // Admin-only sections.
+        for sec in ["credentials", "landing", "blocks", "audit"] {
+            assert!(!Role::Viewer.can_access_section(sec));
+            assert!(!Role::Editor.can_access_section(sec));
+            assert!(Role::Admin.can_access_section(sec));
+        }
     }
 
     #[test]

--- a/crates/ruscker-admin/src/lib.rs
+++ b/crates/ruscker-admin/src/lib.rs
@@ -185,11 +185,16 @@ impl AdminServer {
         self
     }
 
-    /// Override the admin token (default: pulled from
+    /// Override the **admin** token (default: pulled from
     /// `RUSCKER_ADMIN_TOKEN` env var). Useful for tests that need
     /// a known token without touching the process environment.
+    ///
+    /// Only the admin token is replaced — the optional `editor` /
+    /// `viewer` tokens that [`auth::AdminAuth::from_env`] already read
+    /// stay intact, so the CLI's `--admin-token` flag (which clap also
+    /// feeds from `RUSCKER_ADMIN_TOKEN`) doesn't wipe the other roles.
     pub fn with_admin_token(mut self, token: impl Into<String>) -> Self {
-        self.state.admin_auth = auth::AdminAuth::with_token(token);
+        self.state.admin_auth.admin = Some(Arc::from(token.into()));
         self
     }
 

--- a/crates/ruscker-admin/src/routes/admin.rs
+++ b/crates/ruscker-admin/src/routes/admin.rs
@@ -122,7 +122,9 @@ async fn login_submit(
         return resp;
     }
 
-    if !state.admin_auth.matches(&form.token) {
+    // Match the token against each configured role token. `None`
+    // ⇒ no token matched ⇒ failed login.
+    let Some(role) = state.admin_auth.role_for(&form.token) else {
         // Count the failure toward the rate-limit window.
         state.login_limiter.record_failure();
         // Re-render the form with the error banner. 401 status so
@@ -145,7 +147,7 @@ async fn login_submit(
         resp.headers_mut()
             .insert("X-Ruscker-Login", "failed".parse().unwrap());
         return resp;
-    }
+    };
 
     // Success — clear the failure window so a few fat-fingered
     // attempts before getting it right don't linger.
@@ -157,7 +159,8 @@ async fn login_submit(
     // — setting it unconditionally would make the browser drop the
     // cookie on the plain-HTTP dev server.
     // Store an opaque session id in the cookie — never the token.
-    let session_id = state.admin_sessions.create();
+    // The session carries the matched role.
+    let session_id = state.admin_sessions.create(role);
     let mut c = Cookie::new(COOKIE_NAME, session_id);
     c.set_path("/");
     c.set_http_only(true);
@@ -166,18 +169,50 @@ async fn login_submit(
     c.set_max_age(Duration::hours(24));
     cookies.add(c);
 
-    // Redirect to the page the operator was trying to reach,
-    // reduced to a same-origin path (no open redirect). Only
-    // honor admin paths; anything else (or the login page
-    // itself) falls back to the dashboard.
+    // Redirect to the page the operator was trying to reach, reduced
+    // to a same-origin path (no open redirect) — but only if this
+    // role can actually reach it; otherwise land on the role's home
+    // (the dashboard, which every role can see). This avoids bouncing
+    // a Viewer straight into a 403.
     let referer = headers.get(REFERER).and_then(|v| v.to_str().ok());
-    let path = super::same_origin_path(referer, "/admin/dashboard");
-    let target = if path.starts_with("/admin/") && !path.starts_with("/admin/login") {
+    let path = super::same_origin_path(referer, role.home());
+    let target = if path.starts_with("/admin/")
+        && !path.starts_with("/admin/login")
+        && role.can_access_section(section_for_admin_path(&path))
+    {
         path
     } else {
-        "/admin/dashboard".to_string()
+        role.home().to_string()
     };
     Redirect::to(&target).into_response()
+}
+
+/// Map an `/admin/...` path to the `nav_section` it belongs to, for
+/// role-gating the post-login redirect. Order matters: the per-replica
+/// logs live under `/admin/dashboard/logs`, so that prefix must be
+/// checked before the standalone daemon-log `/admin/logs`.
+fn section_for_admin_path(path: &str) -> &'static str {
+    if path.starts_with("/admin/dashboard") {
+        "dashboard"
+    } else if path.starts_with("/admin/specs") {
+        "specs"
+    } else if path.starts_with("/admin/media") {
+        "images"
+    } else if path.starts_with("/admin/credentials") {
+        "credentials"
+    } else if path.starts_with("/admin/landing") {
+        "landing"
+    } else if path.starts_with("/admin/blocks") {
+        "blocks"
+    } else if path.starts_with("/admin/audit") {
+        "audit"
+    } else if path.starts_with("/admin/logs") {
+        "logs"
+    } else {
+        // /admin root and anything unrecognised → dashboard (every
+        // role can reach it).
+        "dashboard"
+    }
 }
 
 async fn logout(_: MaybeAdminSession, State(state): State<AppState>, cookies: Cookies) -> Redirect {

--- a/crates/ruscker-admin/src/routes/admin/audit.rs
+++ b/crates/ruscker-admin/src/routes/admin/audit.rs
@@ -15,7 +15,7 @@ use axum::{
 };
 use serde::Deserialize;
 
-use crate::auth::AdminSession;
+use crate::auth::{RequireAdmin, Role};
 use crate::db;
 use crate::db::audit::{ActionFamily, AuditEntry, AuditFilter};
 use crate::i18n::{Locale, Locales};
@@ -48,6 +48,8 @@ struct AuditPage<'a> {
     locales: &'a Locales,
     locales_all: &'static [Locale],
     nav_section: &'static str,
+    /// Current session role (always Admin here) - drives nav gating.
+    role: Role,
     entries: Vec<AuditEntry>,
     filter: AuditQuery,
     /// Distinct actors ever seen — populates the actor select.
@@ -96,7 +98,7 @@ impl<'a> AuditPage<'a> {
 }
 
 async fn index(
-    _: AdminSession,
+    _: RequireAdmin,
     State(state): State<AppState>,
     loc: Locale,
     theme: Theme,
@@ -140,6 +142,7 @@ async fn index(
         locales: &state.locales,
         locales_all: &Locale::ALL,
         nav_section: "audit",
+        role: Role::Admin,
         entries,
         filter: q,
         distinct_actors,

--- a/crates/ruscker-admin/src/routes/admin/blocks.rs
+++ b/crates/ruscker-admin/src/routes/admin/blocks.rs
@@ -15,7 +15,7 @@ use axum::{
 };
 use serde::Deserialize;
 
-use crate::auth::AdminSession;
+use crate::auth::{RequireAdmin, Role};
 use crate::db::landing_blocks::{self, BlockInput, LandingBlock, SLOTS};
 use crate::i18n::{Locale, Locales};
 use crate::theme::Theme;
@@ -41,6 +41,8 @@ struct BlocksPage<'a> {
     locales: &'a Locales,
     locales_all: &'static [Locale],
     nav_section: &'static str,
+    /// Current session role - drives nav gating.
+    role: Role,
     /// Blocks grouped per slot (in `SLOTS` order) so the template can
     /// render one drag-reorder list per slot.
     groups: Vec<SlotGroup>,
@@ -59,7 +61,7 @@ impl BlocksPage<'_> {
 }
 
 async fn index(
-    _: AdminSession,
+    _: RequireAdmin,
     State(state): State<AppState>,
     loc: Locale,
     theme: Theme,
@@ -89,6 +91,7 @@ async fn index(
         locales: &state.locales,
         locales_all: &Locale::ALL,
         nav_section: "blocks",
+        role: Role::Admin,
         groups,
     })
 }
@@ -103,6 +106,8 @@ struct BlockFormPage<'a> {
     locales: &'a Locales,
     locales_all: &'static [Locale],
     nav_section: &'static str,
+    /// Current session role - drives nav gating.
+    role: Role,
     /// "new" or "edit" — drives the form action + heading.
     mode: &'static str,
     /// Empty for a new block.
@@ -122,7 +127,7 @@ impl BlockFormPage<'_> {
 }
 
 async fn new_form(
-    _: AdminSession,
+    _: RequireAdmin,
     State(state): State<AppState>,
     loc: Locale,
     theme: Theme,
@@ -136,6 +141,7 @@ async fn new_form(
         locales: &state.locales,
         locales_all: &Locale::ALL,
         nav_section: "blocks",
+        role: Role::Admin,
         mode: "new",
         id: String::new(),
         slot: "top".into(),
@@ -148,7 +154,7 @@ async fn new_form(
 }
 
 async fn edit_form(
-    _: AdminSession,
+    _: RequireAdmin,
     State(state): State<AppState>,
     loc: Locale,
     theme: Theme,
@@ -171,6 +177,7 @@ async fn edit_form(
         locales: &state.locales,
         locales_all: &Locale::ALL,
         nav_section: "blocks",
+        role: Role::Admin,
         mode: "edit",
         id: block.id,
         slot: block.slot,
@@ -215,7 +222,7 @@ impl BlockForm {
 }
 
 async fn create(
-    _: AdminSession,
+    _: RequireAdmin,
     State(state): State<AppState>,
     Form(form): Form<BlockForm>,
 ) -> Response {
@@ -232,7 +239,7 @@ async fn create(
 }
 
 async fn update(
-    _: AdminSession,
+    _: RequireAdmin,
     State(state): State<AppState>,
     Path(id): Path<String>,
     Form(form): Form<BlockForm>,
@@ -251,7 +258,7 @@ async fn update(
 }
 
 async fn delete(
-    _: AdminSession,
+    _: RequireAdmin,
     State(state): State<AppState>,
     Path(id): Path<String>,
 ) -> Response {
@@ -268,7 +275,7 @@ async fn delete(
 }
 
 async fn move_block(
-    _: AdminSession,
+    _: RequireAdmin,
     State(state): State<AppState>,
     Path((id, dir)): Path<(String, String)>,
 ) -> Response {
@@ -300,7 +307,7 @@ struct ReorderReq {
 /// origin + the `SameSite=Strict` admin cookie cover CSRF. Returns
 /// `204` so the client keeps the DOM order it already rendered.
 async fn reorder(
-    _: AdminSession,
+    _: RequireAdmin,
     State(state): State<AppState>,
     Json(req): Json<ReorderReq>,
 ) -> Response {

--- a/crates/ruscker-admin/src/routes/admin/credentials.rs
+++ b/crates/ruscker-admin/src/routes/admin/credentials.rs
@@ -15,7 +15,7 @@ use axum::{
 };
 use serde::Deserialize;
 
-use crate::auth::AdminSession;
+use crate::auth::{RequireAdmin, Role};
 use crate::db;
 use crate::i18n::{Locale, Locales};
 use crate::theme::Theme;
@@ -35,6 +35,8 @@ struct CredentialsPage<'a> {
     locales: &'a Locales,
     locales_all: &'static [Locale],
     nav_section: &'static str,
+    /// Current session role (always Admin here) - drives nav gating.
+    role: Role,
     credentials: Vec<db::credentials::CredentialMeta>,
     /// Banner shown when the master key isn't configured. When
     /// true, the form is disabled and a hint is rendered.
@@ -50,7 +52,7 @@ impl<'a> CredentialsPage<'a> {
 }
 
 async fn index(
-    _: AdminSession,
+    _: RequireAdmin,
     State(state): State<AppState>,
     loc: Locale,
     theme: Theme,
@@ -81,6 +83,7 @@ async fn render_index(
         locales: &state.locales,
         locales_all: &Locale::ALL,
         nav_section: "credentials",
+        role: Role::Admin,
         credentials,
         key_missing: !state.master_key.is_configured(),
         flash_saved,
@@ -98,7 +101,7 @@ pub struct CredentialForm {
 }
 
 async fn create_or_update(
-    _: AdminSession,
+    _: RequireAdmin,
     State(state): State<AppState>,
     loc: Locale,
     theme: Theme,
@@ -158,7 +161,7 @@ async fn create_or_update(
 }
 
 async fn delete(
-    _: AdminSession,
+    _: RequireAdmin,
     State(state): State<AppState>,
     Path(name): Path<String>,
 ) -> Response {

--- a/crates/ruscker-admin/src/routes/admin/dashboard.rs
+++ b/crates/ruscker-admin/src/routes/admin/dashboard.rs
@@ -35,7 +35,7 @@ use ruscker_core::{Replica, ReplicaId, ReplicaState};
 use std::convert::Infallible;
 use std::time::Duration;
 
-use crate::auth::AdminSession;
+use crate::auth::{AdminSession, RequireEditor, Role};
 use crate::i18n::{Locale, Locales};
 use crate::theme::Theme;
 use crate::AppState;
@@ -137,6 +137,9 @@ struct DashboardPage<'a> {
     locales: &'a Locales,
     locales_all: &'static [Locale],
     nav_section: &'static str,
+    /// Current session role — drives nav gating and whether the
+    /// per-replica stop/restart action buttons render.
+    role: Role,
     /// Inline copy of `DashboardSnapshot` fields. Could be a
     /// nested `snapshot:` field but askama doesn't auto-flatten
     /// and rewriting all `{{ foo }}` to `{{ snapshot.foo }}`
@@ -170,6 +173,8 @@ struct LogsPage<'a> {
     locales: &'a Locales,
     locales_all: &'static [Locale],
     nav_section: &'static str,
+    /// Current session role — drives nav gating.
+    role: Role,
     /// Display name resolved from the spec config (or spec_id
     /// fallback) for the page heading.
     display_name: String,
@@ -214,7 +219,7 @@ fn state_label_key(s: ReplicaState) -> &'static str {
 }
 
 async fn index(
-    _: AdminSession,
+    session: AdminSession,
     State(state): State<AppState>,
     loc: Locale,
     theme: Theme,
@@ -227,6 +232,7 @@ async fn index(
         locales: &state.locales,
         locales_all: &Locale::ALL,
         nav_section: "dashboard",
+        role: session.role,
         backend_connected: snap.backend_connected,
         total_containers: snap.total_containers,
         total_sessions: snap.total_sessions,
@@ -401,7 +407,7 @@ async fn events(
 /// that no longer maps to a container → the backend returns an
 /// error which we surface as 404.
 async fn logs(
-    _: AdminSession,
+    session: AdminSession,
     State(state): State<AppState>,
     loc: Locale,
     theme: Theme,
@@ -464,6 +470,7 @@ async fn logs(
         locales: &state.locales,
         locales_all: &Locale::ALL,
         nav_section: "dashboard",
+        role: session.role,
         display_name,
         spec_id,
         replica_id,
@@ -527,7 +534,7 @@ fn parse_replica_id(s: &str) -> Result<ReplicaId, Response> {
 /// Redirects back to the dashboard so the browser lands on a
 /// fresh render.
 async fn stop_replica(
-    _: AdminSession,
+    _: RequireEditor,
     State(state): State<AppState>,
     Path(replica_id): Path<String>,
 ) -> Response {
@@ -556,7 +563,7 @@ async fn stop_replica(
 /// respawn ~one tick later), restart brings capacity back
 /// right away.
 async fn restart_replica(
-    _: AdminSession,
+    _: RequireEditor,
     State(state): State<AppState>,
     Path(replica_id): Path<String>,
 ) -> Response {
@@ -717,6 +724,7 @@ mod tests {
             locales: &locales,
             locales_all: &Locale::ALL,
             nav_section: "dashboard",
+            role: Role::Admin,
             backend_connected,
             total_containers: rows.len(),
             total_sessions: rows.iter().map(|r| r.sessions_active).sum(),
@@ -742,6 +750,7 @@ mod tests {
             locales: &locales,
             locales_all: &Locale::ALL,
             nav_section: "dashboard",
+            role: Role::Admin,
             display_name: "Aurora Prime".into(),
             spec_id: "sales-dashboard".into(),
             replica_id: "11111111-2222-3333-4444-555555555555".into(),

--- a/crates/ruscker-admin/src/routes/admin/images.rs
+++ b/crates/ruscker-admin/src/routes/admin/images.rs
@@ -20,7 +20,7 @@ use axum::{
     Router,
 };
 
-use crate::auth::AdminSession;
+use crate::auth::{RequireEditor, Role};
 use crate::db;
 use crate::i18n::{Locale, Locales};
 use crate::images;
@@ -54,6 +54,8 @@ struct ImagesPage<'a> {
     locales: &'a Locales,
     locales_all: &'static [Locale],
     nav_section: &'static str,
+    /// Current session role (Editor or Admin) — drives nav gating.
+    role: Role,
     images: Vec<db::images::ImageMeta>,
     /// Set on successful upload — drives a one-shot toast.
     flash_uploaded: Option<String>,
@@ -81,18 +83,19 @@ impl<'a> ImagesPage<'a> {
 }
 
 async fn index(
-    _: AdminSession,
+    editor: RequireEditor,
     State(state): State<AppState>,
     loc: Locale,
     theme: Theme,
 ) -> Response {
-    render_index(&state, loc, theme, None, None).await
+    render_index(&state, loc, theme, editor.role, None, None).await
 }
 
 async fn render_index(
     state: &AppState,
     loc: Locale,
     theme: Theme,
+    role: Role,
     flash_uploaded: Option<String>,
     flash_error: Option<String>,
 ) -> Response {
@@ -116,6 +119,7 @@ async fn render_index(
         locales: &state.locales,
         locales_all: &Locale::ALL,
         nav_section: "images",
+        role,
         images,
         flash_uploaded,
         flash_error,
@@ -124,7 +128,7 @@ async fn render_index(
 }
 
 async fn upload(
-    _: AdminSession,
+    editor: RequireEditor,
     State(state): State<AppState>,
     loc: Locale,
     theme: Theme,
@@ -185,11 +189,19 @@ async fn upload(
         }
     }
 
-    render_index(&state, loc, theme, last_uploaded_name, last_error).await
+    render_index(
+        &state,
+        loc,
+        theme,
+        editor.role,
+        last_uploaded_name,
+        last_error,
+    )
+    .await
 }
 
 async fn delete(
-    _: AdminSession,
+    _: RequireEditor,
     State(state): State<AppState>,
     Path(id): Path<String>,
 ) -> Response {

--- a/crates/ruscker-admin/src/routes/admin/landing.rs
+++ b/crates/ruscker-admin/src/routes/admin/landing.rs
@@ -22,7 +22,7 @@ use ruscker_config::LandingCustomization;
 use serde::Deserialize;
 use std::collections::HashMap;
 
-use crate::auth::AdminSession;
+use crate::auth::{RequireAdmin, Role};
 use crate::db;
 use crate::i18n::{Locale, Locales};
 use crate::theme::Theme;
@@ -40,6 +40,8 @@ struct LandingPage<'a> {
     locales: &'a Locales,
     locales_all: &'static [Locale],
     nav_section: &'static str,
+    /// Current session role (always Admin here) - drives nav gating.
+    role: Role,
     form: LandingForm,
     flash_saved: bool,
     flash_error: Option<String>,
@@ -138,7 +140,7 @@ fn empty_to_none(s: String) -> Option<String> {
 }
 
 async fn index(
-    _: AdminSession,
+    _: RequireAdmin,
     State(state): State<AppState>,
     loc: Locale,
     theme: Theme,
@@ -147,7 +149,7 @@ async fn index(
 }
 
 async fn save(
-    _: AdminSession,
+    _: RequireAdmin,
     State(state): State<AppState>,
     loc: Locale,
     theme: Theme,
@@ -201,6 +203,7 @@ async fn render(
         locales: &state.locales,
         locales_all: &Locale::ALL,
         nav_section: "landing",
+        role: Role::Admin,
         form,
         flash_saved,
         flash_error,

--- a/crates/ruscker-admin/src/routes/admin/logs.rs
+++ b/crates/ruscker-admin/src/routes/admin/logs.rs
@@ -15,7 +15,7 @@ use axum::routing::get;
 use axum::Router;
 use futures_util::Stream;
 
-use crate::auth::AdminSession;
+use crate::auth::{RequireAdmin, Role};
 use crate::i18n::{Locale, Locales};
 use crate::theme::Theme;
 use crate::AppState;
@@ -37,6 +37,8 @@ struct LogsPage<'a> {
     locales: &'a Locales,
     locales_all: &'static [Locale],
     nav_section: &'static str,
+    /// Current session role (always Admin here) - drives nav gating.
+    role: Role,
     /// Current buffered lines, oldest-first. Empty when no buffer is
     /// wired (e.g. started without the CLI's tracing layer).
     lines: Vec<String>,
@@ -51,7 +53,7 @@ impl LogsPage<'_> {
 }
 
 async fn index(
-    _: AdminSession,
+    _: RequireAdmin,
     State(state): State<AppState>,
     loc: Locale,
     theme: Theme,
@@ -66,6 +68,7 @@ async fn index(
         locales: &state.locales,
         locales_all: &Locale::ALL,
         nav_section: "logs",
+        role: Role::Admin,
         lines,
         available,
     })
@@ -75,7 +78,7 @@ async fn index(
 /// already rendered the snapshot, so we start from the live cursor and
 /// only stream what's new.
 async fn stream(
-    _: AdminSession,
+    _: RequireAdmin,
     State(state): State<AppState>,
 ) -> Sse<impl Stream<Item = Result<Event, Infallible>>> {
     use async_stream::stream;

--- a/crates/ruscker-admin/src/routes/admin/spec_form.rs
+++ b/crates/ruscker-admin/src/routes/admin/spec_form.rs
@@ -24,7 +24,7 @@ use serde::{Deserialize, Serialize};
 use serde_yaml_ng::Value as YamlValue;
 use std::collections::HashMap;
 
-use crate::auth::AdminSession;
+use crate::auth::{RequireEditor, Role};
 use crate::db;
 use crate::i18n::{Locale, Locales};
 use crate::theme::Theme;
@@ -446,6 +446,8 @@ struct SpecFormPage<'a> {
     locales: &'a Locales,
     locales_all: &'static [Locale],
     nav_section: &'static str,
+    /// Current session role (Editor or Admin) — drives nav gating.
+    role: Role,
     mode: FormMode,
     form: SpecForm,
     /// Pre-validation errors (Fluent keys) shown above the form.
@@ -495,7 +497,7 @@ async fn logo_filenames(state: &AppState) -> Vec<String> {
 }
 
 async fn new_form(
-    _: AdminSession,
+    editor: RequireEditor,
     State(state): State<AppState>,
     loc: Locale,
     theme: Theme,
@@ -506,6 +508,7 @@ async fn new_form(
         locales: &state.locales,
         locales_all: &Locale::ALL,
         nav_section: "specs",
+        role: editor.role,
         mode: FormMode::New,
         form: SpecForm {
             // Sensible defaults for a new app
@@ -524,7 +527,7 @@ async fn new_form(
 }
 
 async fn edit_form(
-    _: AdminSession,
+    editor: RequireEditor,
     State(state): State<AppState>,
     loc: Locale,
     theme: Theme,
@@ -547,6 +550,7 @@ async fn edit_form(
         locales: &state.locales,
         locales_all: &Locale::ALL,
         nav_section: "specs",
+        role: editor.role,
         mode: FormMode::Edit,
         form: SpecForm::from_spec(&spec),
         errors: Vec::new(),
@@ -556,7 +560,7 @@ async fn edit_form(
 }
 
 async fn create(
-    _: AdminSession,
+    editor: RequireEditor,
     State(state): State<AppState>,
     loc: Locale,
     theme: Theme,
@@ -581,7 +585,16 @@ async fn create(
     }
 
     if !errors.is_empty() {
-        return render_form_with_errors(&state, loc, theme, FormMode::New, form, errors).await;
+        return render_form_with_errors(
+            &state,
+            loc,
+            theme,
+            editor.role,
+            FormMode::New,
+            form,
+            errors,
+        )
+        .await;
     }
 
     let id = form.id.trim().to_string();
@@ -603,7 +616,7 @@ async fn create(
 }
 
 async fn update(
-    _: AdminSession,
+    editor: RequireEditor,
     State(state): State<AppState>,
     loc: Locale,
     theme: Theme,
@@ -621,7 +634,16 @@ async fn update(
 
     let errors = form.validate(FormMode::Edit);
     if !errors.is_empty() {
-        return render_form_with_errors(&state, loc, theme, FormMode::Edit, form, errors).await;
+        return render_form_with_errors(
+            &state,
+            loc,
+            theme,
+            editor.role,
+            FormMode::Edit,
+            form,
+            errors,
+        )
+        .await;
     }
 
     // Load the existing spec as the merge base so fields the form
@@ -653,7 +675,7 @@ async fn update(
 }
 
 async fn delete(
-    _: AdminSession,
+    _: RequireEditor,
     State(state): State<AppState>,
     Path(id): Path<String>,
 ) -> Response {
@@ -673,6 +695,7 @@ async fn render_form_with_errors(
     state: &AppState,
     loc: Locale,
     theme: Theme,
+    role: Role,
     mode: FormMode,
     form: SpecForm,
     errors: Vec<&'static str>,
@@ -683,6 +706,7 @@ async fn render_form_with_errors(
         locales: &state.locales,
         locales_all: &Locale::ALL,
         nav_section: "specs",
+        role,
         mode,
         form,
         errors,

--- a/crates/ruscker-admin/src/routes/admin/specs.rs
+++ b/crates/ruscker-admin/src/routes/admin/specs.rs
@@ -16,7 +16,7 @@ use chrono::{DateTime, Utc};
 use serde::Deserialize;
 use sqlx::FromRow;
 
-use crate::auth::AdminSession;
+use crate::auth::{RequireEditor, Role};
 use crate::i18n::{Locale, Locales};
 use crate::theme::Theme;
 use crate::AppState;
@@ -83,6 +83,8 @@ struct SpecsPage<'a> {
     locales: &'a Locales,
     locales_all: &'static [Locale],
     nav_section: &'static str,
+    /// Current session role (Editor or Admin) — drives nav gating.
+    role: Role,
     specs: Vec<SpecRow>,
     flash: Option<Flash>,
 }
@@ -128,7 +130,7 @@ fn build_flash(locales: &Locales, loc: Locale, q: &SpecsQuery) -> Option<Flash> 
 }
 
 async fn index(
-    _: AdminSession,
+    editor: RequireEditor,
     State(state): State<AppState>,
     loc: Locale,
     theme: Theme,
@@ -164,6 +166,7 @@ async fn index(
         locales: &state.locales,
         locales_all: &Locale::ALL,
         nav_section: "specs",
+        role: editor.role,
         specs,
         flash,
     };
@@ -180,7 +183,7 @@ async fn index(
 /// import is idempotent and never deletes, so re-importing is
 /// safe; a preview is a follow-up.
 async fn import(
-    _: AdminSession,
+    _: RequireEditor,
     State(state): State<AppState>,
     mut multipart: Multipart,
 ) -> Response {

--- a/crates/ruscker-admin/templates/admin/_layout.html
+++ b/crates/ruscker-admin/templates/admin/_layout.html
@@ -30,42 +30,66 @@
     <span>ruscker · admin</span>
   </a>
 
+  {# Nav links are gated by the current session's role — a link is
+     only rendered if `role.can_access_section(...)` allows it. The
+     server-side route guards enforce the same matrix, so hiding a
+     link here is UX, not the security boundary. #}
   <div class="admin-nav-links">
+    {% if role.can_access_section("dashboard") %}
     <a href="/admin/dashboard" class="admin-nav-link {% if nav_section == "dashboard" %}is-active{% endif %}">
       <i class="ti ti-chart-line" aria-hidden="true"></i>
       <span>{{ self.t("admin-nav-dashboard") }}</span>
     </a>
+    {% endif %}
+    {% if role.can_access_section("specs") %}
     <a href="/admin/specs" class="admin-nav-link {% if nav_section == "specs" %}is-active{% endif %}">
       <i class="ti ti-apps" aria-hidden="true"></i>
       <span>{{ self.t("admin-nav-apps") }}</span>
     </a>
+    {% endif %}
+    {% if role.can_access_section("images") %}
     <a href="/admin/media" class="admin-nav-link {% if nav_section == "images" %}is-active{% endif %}">
       <i class="ti ti-photo" aria-hidden="true"></i>
       <span>{{ self.t("admin-nav-images") }}</span>
     </a>
+    {% endif %}
+    {% if role.can_access_section("credentials") %}
     <a href="/admin/credentials" class="admin-nav-link {% if nav_section == "credentials" %}is-active{% endif %}">
       <i class="ti ti-key" aria-hidden="true"></i>
       <span>{{ self.t("admin-nav-credentials") }}</span>
     </a>
+    {% endif %}
+    {% if role.can_access_section("landing") %}
     <a href="/admin/landing" class="admin-nav-link {% if nav_section == "landing" %}is-active{% endif %}">
       <i class="ti ti-layout" aria-hidden="true"></i>
       <span>{{ self.t("admin-nav-landing") }}</span>
     </a>
+    {% endif %}
+    {% if role.can_access_section("blocks") %}
     <a href="/admin/blocks" class="admin-nav-link {% if nav_section == "blocks" %}is-active{% endif %}">
       <i class="ti ti-code" aria-hidden="true"></i>
       <span>{{ self.t("admin-nav-blocks") }}</span>
     </a>
+    {% endif %}
+    {% if role.can_access_section("audit") %}
     <a href="/admin/audit" class="admin-nav-link {% if nav_section == "audit" %}is-active{% endif %}">
       <i class="ti ti-history" aria-hidden="true"></i>
       <span>{{ self.t("admin-nav-audit") }}</span>
     </a>
+    {% endif %}
+    {% if role.can_access_section("logs") %}
     <a href="/admin/logs" class="admin-nav-link {% if nav_section == "logs" %}is-active{% endif %}">
       <i class="ti ti-terminal-2" aria-hidden="true"></i>
       <span>{{ self.t("admin-nav-logs") }}</span>
     </a>
+    {% endif %}
   </div>
 
   <div class="admin-nav-actions">
+    <span class="admin-nav-role" title="{{ self.t("role-current") }}">
+      <i class="ti ti-user-shield" aria-hidden="true"></i>
+      <span>{{ self.t(role.label_key()) }}</span>
+    </span>
     <a href="/" class="admin-nav-link" title="{{ self.t("admin-nav-portal") }}">
       <i class="ti ti-arrow-back-up" aria-hidden="true"></i>
       <span>{{ self.t("admin-nav-portal") }}</span>

--- a/crates/ruscker-admin/templates/admin/dashboard.html
+++ b/crates/ruscker-admin/templates/admin/dashboard.html
@@ -165,7 +165,8 @@
            data-stop-label="{{ self.t("admin-dashboard-action-stop") }}"
            data-restart-label="{{ self.t("admin-dashboard-action-restart") }}"
            data-confirm-stop="{{ self.t("admin-dashboard-confirm-stop") }}"
-           data-confirm-restart="{{ self.t("admin-dashboard-confirm-restart") }}">
+           data-confirm-restart="{{ self.t("admin-dashboard-confirm-restart") }}"
+           data-can-manage="{% if role.can_manage() %}1{% endif %}">
       {% for row in rows %}
         <tr data-replica-id="{{ row.replica_id }}">
           <td><span class="dash-dot {{ row.state_dot }}"></span></td>
@@ -192,6 +193,9 @@
           <td style="white-space: nowrap;">
             <a href="/admin/dashboard/logs/{{ row.replica_id }}" title="{{ self.t("admin-logs-title") }}"
                class="dash-action" style="color: var(--text-muted)"><i class="ti ti-file-text"></i></a>
+            {# stop/restart are operational actions — Editor and Admin
+               only (matched by the RequireEditor route guard). #}
+            {% if role.can_manage() %}
             <form method="post" action="/admin/dashboard/replicas/{{ row.replica_id }}/restart"
                   style="display:inline" onsubmit="return confirm('{{ self.t("admin-dashboard-confirm-restart") }}')">
               <button type="submit" class="dash-action" title="{{ self.t("admin-dashboard-action-restart") }}"><i class="ti ti-refresh"></i></button>
@@ -200,6 +204,7 @@
                   style="display:inline" onsubmit="return confirm('{{ self.t("admin-dashboard-confirm-stop") }}')">
               <button type="submit" class="dash-action dash-action--danger" title="{{ self.t("admin-dashboard-action-stop") }}"><i class="ti ti-player-stop"></i></button>
             </form>
+            {% endif %}
           </td>
         </tr>
       {% endfor %}
@@ -221,6 +226,10 @@
   var restartLabel = ds.restartLabel || 'Restart';
   var confirmStop = ds.confirmStop || 'Stop this replica?';
   var confirmRestart = ds.confirmRestart || 'Restart this replica?';
+  // Only Editor/Admin sessions get the stop/restart action buttons.
+  // The server route guard enforces it regardless; this keeps the
+  // SSE-patched rows consistent with the initial server render.
+  var canManage = !!ds.canManage;
 
   function escapeHtml(s) {
     return String(s).replace(/[&<>"']/g, function (c) {
@@ -240,6 +249,15 @@
     var mem = row.memory_display !== null && row.memory_display !== undefined
       ? escapeHtml(row.memory_display)
       : '<span style="color: var(--text-faint)" title="' + escapeHtml(pendingLabel) + '">—</span>';
+    var actions = !canManage ? '' : ''
+      + '<form method="post" action="/admin/dashboard/replicas/' + encodeURIComponent(row.replica_id)
+        + '/restart" style="display:inline" onsubmit="return confirm(' + JSON.stringify(confirmRestart) + ')">'
+        + '<button type="submit" class="dash-action" title="' + escapeHtml(restartLabel) + '"><i class="ti ti-refresh"></i></button>'
+      + '</form>'
+      + '<form method="post" action="/admin/dashboard/replicas/' + encodeURIComponent(row.replica_id)
+        + '/stop" style="display:inline" onsubmit="return confirm(' + JSON.stringify(confirmStop) + ')">'
+        + '<button type="submit" class="dash-action dash-action--danger" title="' + escapeHtml(stopLabel) + '"><i class="ti ti-player-stop"></i></button>'
+      + '</form>';
     return ''
       + '<td><span class="dash-dot ' + escapeHtml(row.state_dot) + '"></span></td>'
       + '<td>'
@@ -256,14 +274,7 @@
         + '<a href="/admin/dashboard/logs/' + encodeURIComponent(row.replica_id)
           + '" title="' + escapeHtml(logsTitle)
           + '" class="dash-action" style="color: var(--text-muted)"><i class="ti ti-file-text"></i></a>'
-        + '<form method="post" action="/admin/dashboard/replicas/' + encodeURIComponent(row.replica_id)
-          + '/restart" style="display:inline" onsubmit="return confirm(' + JSON.stringify(confirmRestart) + ')">'
-          + '<button type="submit" class="dash-action" title="' + escapeHtml(restartLabel) + '"><i class="ti ti-refresh"></i></button>'
-        + '</form>'
-        + '<form method="post" action="/admin/dashboard/replicas/' + encodeURIComponent(row.replica_id)
-          + '/stop" style="display:inline" onsubmit="return confirm(' + JSON.stringify(confirmStop) + ')">'
-          + '<button type="submit" class="dash-action dash-action--danger" title="' + escapeHtml(stopLabel) + '"><i class="ti ti-player-stop"></i></button>'
-        + '</form>'
+        + actions
       + '</td>';
   }
 

--- a/crates/ruscker-admin/tests/rbac.rs
+++ b/crates/ruscker-admin/tests/rbac.rs
@@ -1,0 +1,204 @@
+//! Integration tests for the role-based route guards (#101).
+//!
+//! These exercise the server-side enforcement, not the nav hiding:
+//! we mint an opaque session for a given [`Role`] directly in the
+//! shared session store, attach it as the admin cookie, and assert
+//! the status code each `/admin/*` route returns.
+//!
+//! No DB / backend is wired, so an *allowed* route falls through to a
+//! `503` (its handler needs `--db` / `--docker`) — which still proves
+//! the guard let the request past. A *denied* route returns `403`
+//! before the handler runs, and an *unauthenticated* request is
+//! redirected to the login form. We assert on those three shapes.
+
+use axum::body::Body;
+use axum::http::{Request, StatusCode};
+use ruscker_admin::auth::{AdminAuth, Role, COOKIE_NAME};
+use ruscker_admin::{router, AppState};
+use ruscker_config::Config;
+use std::sync::Arc;
+use tower::ServiceExt;
+
+const YAML: &str = r#"
+proxy:
+  title: Test
+  specs:
+    - id: myapp
+      display-name: My App
+      container-image: org/app:1
+"#;
+
+fn state() -> AppState {
+    std::env::set_var("DOCKER_REGISTRY_PASSWORD", "test");
+    let config = Config::from_yaml(YAML).expect("parse config");
+    let locales = ruscker_admin::i18n::Locales::load().expect("load locales");
+    AppState {
+        config: Arc::new(config),
+        locales: Arc::new(locales),
+        // Three distinct role tokens configured.
+        admin_auth: AdminAuth {
+            admin: Some("admin-tok".into()),
+            editor: Some("editor-tok".into()),
+            viewer: Some("viewer-tok".into()),
+        },
+        admin_sessions: Default::default(),
+        log_buffer: None,
+        login_limiter: Arc::new(ruscker_admin::auth::LoginRateLimiter::default_policy()),
+        api_limiter: Arc::new(ruscker_admin::ratelimit::ApiRateLimiter::new()),
+        db: None,
+        images_dir: None,
+        master_key: Default::default(),
+        backend: None,
+        replicas: Arc::new(tokio::sync::RwLock::new(Default::default())),
+        cookie_key: ruscker_proxy::sticky::CookieKey::random(),
+        spawn_locks: Arc::new(dashmap::DashMap::new()),
+        sessions: Arc::new(ruscker_admin::sessions::SessionTracker::new()),
+        metrics: ruscker_admin::metrics_cache::MetricsCache::new(),
+        draining: Arc::new(std::sync::atomic::AtomicBool::new(false)),
+    }
+}
+
+/// Mint a live session for `role` in the state's store and return the
+/// cookie header value to send it back. The store is behind an `Arc`
+/// shared with the router built from the same `state`.
+fn cookie_for(state: &AppState, role: Role) -> String {
+    let id = state.admin_sessions.create(role);
+    format!("{COOKIE_NAME}={id}")
+}
+
+async fn send(state: AppState, method: &str, uri: &str, cookie: Option<&str>) -> StatusCode {
+    let app = router(state);
+    let mut builder = Request::builder().method(method).uri(uri);
+    if let Some(c) = cookie {
+        builder = builder.header("cookie", c);
+    }
+    let req = builder.body(Body::empty()).unwrap();
+    app.oneshot(req).await.unwrap().status()
+}
+
+// ── Viewer: dashboard only ──────────────────────────────────────────
+
+#[tokio::test]
+async fn viewer_can_view_dashboard() {
+    let st = state();
+    let c = cookie_for(&st, Role::Viewer);
+    // No DB needed for the dashboard render, so this is a clean 200.
+    assert_eq!(
+        send(st, "GET", "/admin/dashboard", Some(&c)).await,
+        StatusCode::OK
+    );
+}
+
+#[tokio::test]
+async fn viewer_cannot_reach_apps_or_admin_sections() {
+    for uri in [
+        "/admin/specs",
+        "/admin/media",
+        "/admin/credentials",
+        "/admin/landing",
+        "/admin/blocks",
+        "/admin/audit",
+        "/admin/logs",
+    ] {
+        let st = state();
+        let c = cookie_for(&st, Role::Viewer);
+        assert_eq!(
+            send(st, "GET", uri, Some(&c)).await,
+            StatusCode::FORBIDDEN,
+            "viewer must be 403 on {uri}"
+        );
+    }
+}
+
+#[tokio::test]
+async fn viewer_cannot_perform_dashboard_actions() {
+    let st = state();
+    let c = cookie_for(&st, Role::Viewer);
+    let uri = "/admin/dashboard/replicas/11111111-2222-3333-4444-555555555555/stop";
+    assert_eq!(
+        send(st, "POST", uri, Some(&c)).await,
+        StatusCode::FORBIDDEN,
+        "viewer is read-only on the dashboard"
+    );
+}
+
+// ── Editor: apps + media + dashboard actions, but not admin-only ────
+
+#[tokio::test]
+async fn editor_passes_guard_on_apps_and_media() {
+    // Guard lets the request through; the handler then 503s because
+    // no DB is attached. The point is it's NOT a 403.
+    for uri in ["/admin/specs", "/admin/media"] {
+        let st = state();
+        let c = cookie_for(&st, Role::Editor);
+        let status = send(st, "GET", uri, Some(&c)).await;
+        assert_ne!(status, StatusCode::FORBIDDEN, "editor allowed on {uri}");
+        assert_eq!(
+            status,
+            StatusCode::SERVICE_UNAVAILABLE,
+            "guard passed, handler reached (needs --db) on {uri}"
+        );
+    }
+}
+
+#[tokio::test]
+async fn editor_can_perform_dashboard_actions() {
+    // RequireEditor passes; no backend ⇒ 503, but crucially not 403.
+    let st = state();
+    let c = cookie_for(&st, Role::Editor);
+    let uri = "/admin/dashboard/replicas/11111111-2222-3333-4444-555555555555/stop";
+    let status = send(st, "POST", uri, Some(&c)).await;
+    assert_ne!(status, StatusCode::FORBIDDEN, "editor may stop/restart");
+}
+
+#[tokio::test]
+async fn editor_cannot_reach_admin_only_sections() {
+    for uri in [
+        "/admin/credentials",
+        "/admin/landing",
+        "/admin/blocks",
+        "/admin/audit",
+        "/admin/logs",
+    ] {
+        let st = state();
+        let c = cookie_for(&st, Role::Editor);
+        assert_eq!(
+            send(st, "GET", uri, Some(&c)).await,
+            StatusCode::FORBIDDEN,
+            "editor must be 403 on admin-only {uri}"
+        );
+    }
+}
+
+// ── Admin: everything ───────────────────────────────────────────────
+
+#[tokio::test]
+async fn admin_passes_guard_everywhere() {
+    // Each handler 503s for lack of db/backend, but never 403/redirect.
+    for uri in [
+        "/admin/dashboard",
+        "/admin/specs",
+        "/admin/media",
+        "/admin/credentials",
+        "/admin/audit",
+    ] {
+        let st = state();
+        let c = cookie_for(&st, Role::Admin);
+        assert_ne!(
+            send(st, "GET", uri, Some(&c)).await,
+            StatusCode::FORBIDDEN,
+            "admin is never forbidden ({uri})"
+        );
+    }
+}
+
+// ── Unauthenticated: redirect to login, never 403 ───────────────────
+
+#[tokio::test]
+async fn unauthenticated_is_redirected_to_login() {
+    let status = send(state(), "GET", "/admin/specs", None).await;
+    assert!(
+        status.is_redirection(),
+        "no session ⇒ redirect to login, got {status}"
+    );
+}

--- a/docs/SECURITY.md
+++ b/docs/SECURITY.md
@@ -19,6 +19,8 @@ Status: living document. Tracks the Phase 5 security audit
 | Asset | Why it matters |
 |-------|----------------|
 | `RUSCKER_ADMIN_TOKEN` | full admin access — create/edit specs, read audit log, stop containers |
+| `RUSCKER_EDITOR_TOKEN` | (optional) Editor role — apps + media + dashboard actions |
+| `RUSCKER_VIEWER_TOKEN` | (optional) Viewer role — dashboard read-only |
 | `RUSCKER_MASTER_KEY` | decrypts the registry-credential store |
 | `RUSCKER_COOKIE_KEY` | forges sticky-session cookies |
 | Registry credentials (DB) | pull access to private images |
@@ -41,8 +43,9 @@ Status: living document. Tracks the Phase 5 security audit
 
 - Defending against a hostile operator (they own the host +
   Docker daemon + all keys).
-- Multi-tenant isolation between admin roles (one token = full
-  admin).
+- Per-app ACLs and external identity providers (OIDC/SAML/LDAP).
+  Coarse RBAC (Viewer/Editor/Admin) exists (§2); fine-grained,
+  per-spec authorization is Phase 8.
 - TLS termination (delegated to the reverse proxy).
 
 ---
@@ -50,8 +53,10 @@ Status: living document. Tracks the Phase 5 security audit
 ## 2. Authentication & authorization
 
 - **[implemented]** Constant-time token compare —
-  `auth::AdminAuth::matches` → `ct_eq` (XOR-fold, length-checked).
-  Time depends only on the public length, not the bytes.
+  `auth::AdminAuth::role_for` → `ct_eq` (XOR-fold, length-checked).
+  Time depends only on the public length, not the bytes. The
+  candidate is compared against each configured role token
+  (most-privileged first) and resolves to the matched [`Role`].
 - **[implemented]** Login rate limiting —
   `auth::LoginRateLimiter` (global sliding window, default 10
   failures / 60 s). Saturated → `429` + `Retry-After`. Wired in
@@ -61,14 +66,23 @@ Status: living document. Tracks the Phase 5 security audit
   evaded by rotating source addresses.
 - **[implemented]** Admin cookie is `HttpOnly` + `SameSite=Strict`
   + `Secure` (under TLS, see §7) — `routes::admin::login_submit`.
-- **[accepted limitation]** The admin cookie value **is** the
-  token literal (not a signed/opaque session id). An attacker who
-  exfiltrates the cookie has the token. Mitigated by `HttpOnly`
-  (no JS access) + `Secure` + `SameSite=Strict`. A server-side
-  session store is a Phase 2.5 refinement.
-- **[accepted limitation]** No RBAC — one token = full admin.
-  Fine for a single operator; do not share the token across a
-  team.
+- **[implemented]** Opaque server-side sessions (#77) — the cookie
+  carries a random 244-bit session id (`auth::AdminSessions`), never
+  the token. Logout and server restart revoke it; a stolen cookie
+  never exposes the token.
+- **[implemented]** Role-based access control (#101) — three roles
+  with separate env tokens: `RUSCKER_ADMIN_TOKEN` (required ⇒
+  **Admin**, full access), and optional `RUSCKER_EDITOR_TOKEN`
+  (**Editor**: apps + media + dashboard incl. stop/restart) and
+  `RUSCKER_VIEWER_TOKEN` (**Viewer**: dashboard read-only). The
+  matched role rides in the session. Enforcement is **server-side**
+  via the `AdminSession` / `RequireEditor` / `RequireAdmin`
+  extractors on each route group — the permission matrix lives in
+  `Role::can_access_section` / `can_manage`, and the nav only *hides*
+  links it can't reach (UX, not the boundary). Denied → `403`. With
+  only the admin token set, behaviour is identical to the previous
+  single-token model (backward-compatible). Per-app ACLs and external
+  IdPs (OIDC/SAML/LDAP) remain Phase 8.
 - **[accepted limitation]** Login lockout can be triggered by a
   flood of bad attempts (the global limiter's trade-off). Self-
   heals within the 60 s window.
@@ -243,10 +257,16 @@ ruscker serve --bind 127.0.0.1:8080 ...
 ### Secrets (env vars — never in YAML)
 
 ```bash
-export RUSCKER_ADMIN_TOKEN=$(openssl rand -hex 32)   # 256-bit
+export RUSCKER_ADMIN_TOKEN=$(openssl rand -hex 32)   # 256-bit — Admin
 export RUSCKER_MASTER_KEY=$(openssl rand -hex 32)    # AES-256 key
 export RUSCKER_COOKIE_KEY=$(openssl rand -hex 32)    # sticky HMAC key
+# Optional extra roles (RBAC, §2) — omit for the single-admin model:
+export RUSCKER_EDITOR_TOKEN=$(openssl rand -hex 32)  # Editor: apps + media
+export RUSCKER_VIEWER_TOKEN=$(openssl rand -hex 32)  # Viewer: dashboard only
 ```
+
+Use **distinct** tokens per role; sharing one across roles resolves
+to the highest privilege.
 
 - Set `RUSCKER_COOKIE_KEY` explicitly in prod — without it the
   sticky key is randomized per process, invalidating all sessions

--- a/packaging/ruscker.env.example
+++ b/packaging/ruscker.env.example
@@ -4,12 +4,21 @@
 #
 # Uncomment and fill the values you need, then `systemctl restart ruscker`.
 
-# Admin panel token. On first .deb install a strong random value is
-# generated here automatically and printed once (no default password).
-# Until a token is set, /admin/* returns 503 and only the public
-# landing + proxy are served. To set/rotate manually:
-#   openssl rand -hex 32
+# Admin panel token (Admin role — full access). On first .deb install
+# a strong random value is generated here automatically and printed
+# once (no default password). Until a token is set, /admin/* returns
+# 503 and only the public landing + proxy are served. To set/rotate
+# manually:  openssl rand -hex 32
 #RUSCKER_ADMIN_TOKEN=
+
+# Optional extra access levels (RBAC). Set distinct tokens to hand out
+# limited logins without sharing the admin token:
+#   Editor — create/edit apps, upload media, dashboard + stop/restart
+#   Viewer — read-only dashboard, nothing else
+# Omit both for the single-admin model. Generate each with:
+#   openssl rand -hex 32
+#RUSCKER_EDITOR_TOKEN=
+#RUSCKER_VIEWER_TOKEN=
 
 # Master key for the encrypted credentials store (AES-256-GCM).
 # Required only if you use the admin credentials store. Hex (64 chars)


### PR DESCRIPTION
Closes #101.

Replaces the single *"one token = full admin"* model with three roles, each with its own env token, **enforced server-side**.

## Roles (`auth::Role`, ordered Viewer < Editor < Admin)

| Section / action | Viewer | Editor | Admin |
|---|:--:|:--:|:--:|
| Dashboard — view (page, SSE, per-replica logs) | ✓ | ✓ | ✓ |
| Dashboard — stop / restart replica | ✗ | ✓ | ✓ |
| Apps — view + CRUD + import (`/admin/specs/*`) | ✗ | ✓ | ✓ |
| Media — view / upload / delete (`/admin/media/*`) | ✗ | ✓ | ✓ |
| Credentials / Landing / Blocks / Audit / daemon Logs | ✗ | ✗ | ✓ |

Per the open question in the issue, **Editor can stop/restart** replicas (confirmed with the user).

## Authentication (approach A — backward-compatible)

- `RUSCKER_ADMIN_TOKEN` (required ⇒ **Admin**), plus optional `RUSCKER_EDITOR_TOKEN` / `RUSCKER_VIEWER_TOKEN`.
- `AdminAuth` holds one token per role; `role_for()` constant-time-compares the candidate against each (most-privileged first) and returns the matched `Role`. **With only the admin token set, behaviour is identical to before.**
- Fixed the CLI `--admin-token` (which clap also feeds from `RUSCKER_ADMIN_TOKEN`) so it overrides *only* the admin token instead of wiping the editor/viewer tokens that `from_env()` read.

## Sessions + guards

- `AdminSessions` now stores `(expiry, Role)`; `validate()` → `Option<Role>`. The opaque cookie (from #77) carries the role.
- Extractors: `AdminSession` (any role, carries it) · `RequireEditor` (≥ Editor) · `RequireAdmin` (== Admin), applied per route group. Denied ⇒ `403`; unauthenticated ⇒ login redirect.
- Permission matrix centralised in `Role::can_access_section` / `can_manage` so guards and nav can't drift.

## Nav + UI

- `_layout.html` hides links the role can't reach + shows a role chip; dashboard stop/restart buttons gated by `role.can_manage()` in **both** the server render and the SSE patcher (`data-can-manage`).
- Post-login redirect lands on a page the role can actually reach (no bouncing a Viewer into a 403).

## Tests + docs

- `auth` unit tests (`role_for`, ordering, section matrix) + new `tests/rbac.rs` integration suite exercising the full guard matrix per role via minted sessions. **287 tests green.**
- **Live HTTP smoke per role** (3 tokens, real server): `viewer → dash=200 specs=403 media=403 creds=403 stop=403`; `editor → dash=200 specs=200 media=200 creds=403 stop=503`; `admin → all 200 / stop=503` (503 = guard passed, no `--docker`). Nav HTML confirmed to hide links + show the right chip per role.
- `SECURITY.md` §1/§2/§9, `book/src/admin.md`, packaging env template, i18n role labels ×4 locales.
- fmt-drift: no edited file increased its hunk count vs `main`; new `tests/rbac.rs` is rustfmt-clean.

## Out of scope (Phase 8)
Per-app ACLs, external IdPs (OIDC/SAML/LDAP), user self-registration, a users table.

🤖 Generated with [Claude Code](https://claude.com/claude-code)