### PR TITLE
User accounts: admin-managed users with password login (#107)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -159,6 +159,18 @@ dependencies = [
 ]
 
 [[package]]
+name = "argon2"
+version = "0.5.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3c3610892ee6e0cbce8ae2700349fcf8f98adb0dbfbee85aec3c9179d29cc072"
+dependencies = [
+ "base64ct",
+ "blake2",
+ "cpufeatures 0.2.17",
+ "password-hash",
+]
+
+[[package]]
 name = "arrayvec"
 version = "0.7.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -420,6 +432,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "72b3254f16251a8381aa12e40e3c4d2f0199f8c6508fbecb9d91f575e0fbb8c6"
 
 [[package]]
+name = "base64ct"
+version = "1.8.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2af50177e190e07a26ab74f8b1efbfe2ef87da2116221318cb1c2e82baf7de06"
+
+[[package]]
 name = "basic-toml"
 version = "0.1.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -450,6 +468,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7eff00be299a18769011411c9def0d827e8f2d7bf0c3dbf53633147a8867fd1f"
 dependencies = [
  "no_std_io2",
+]
+
+[[package]]
+name = "blake2"
+version = "0.10.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "46502ad458c9a52b69d4d4d32775c788b7a1b85e8bc9d482d92250fc0e3f8efe"
+dependencies = [
+ "digest 0.10.7",
 ]
 
 [[package]]
@@ -919,6 +946,7 @@ checksum = "9ed9a281f7bc9b7576e61468ba615a66a5c8cfdff42420a70aa82701a3b1e292"
 dependencies = [
  "block-buffer 0.10.4",
  "crypto-common 0.1.7",
+ "subtle",
 ]
 
 [[package]]
@@ -2260,6 +2288,17 @@ dependencies = [
 ]
 
 [[package]]
+name = "password-hash"
+version = "0.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "346f04948ba92c43e8469c1ee6736c7563d71012b17d40745260fe106aac2166"
+dependencies = [
+ "base64ct",
+ "rand_core 0.6.4",
+ "subtle",
+]
+
+[[package]]
 name = "paste"
 version = "1.0.15"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2684,6 +2723,7 @@ version = "0.1.0-rc2"
 dependencies = [
  "aes-gcm",
  "anyhow",
+ "argon2",
  "askama",
  "async-stream",
  "async-trait",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -91,6 +91,9 @@ base64 = "0.22"
 aes-gcm = "0.10"
 zeroize = "1.8"
 hex = "0.4"
+# Password hashing for admin user accounts (argon2id). `std` pulls in
+# the OsRng salt generator via password-hash.
+argon2 = { version = "0.5", features = ["std"] }
 
 # Testing
 pretty_assertions = "1.4"

--- a/book/src/admin.md
+++ b/book/src/admin.md
@@ -11,34 +11,38 @@ import/export exists for migration and backups, not as a requirement.
 
 ## Logging in
 
-Set `RUSCKER_ADMIN_TOKEN` (the `.deb` generates one on first install
-and prints it once). Browse to `/admin/login` and paste the token.
-Until a token is set, `/admin/*` returns `503` and only the public
-landing + proxy are served. Rotate the token any time by changing the
-value and restarting.
+On first run, set `RUSCKER_ADMIN_TOKEN` (the `.deb` generates one on
+install and prints it once) and browse to `/admin/login`: with no
+accounts yet you're asked for the **token**, then walked through
+creating the first **admin account** (username + password). After that
+everyone signs in with their account at `/admin/login`. The token stays
+as a **break-glass** login (`/admin/login?token=1`) so you can never be
+locked out. Until a token is set, `/admin/*` returns `503` and only the
+public landing + proxy are served.
 
 The footer has the same **language** (pt-BR / en-US / es-ES / fr-FR)
 and **theme** (light / dark / auto) pickers as the public portal. The
 top-right corner shows your current **access level**.
 
-## Access levels (roles)
+## Users and access levels (roles)
 
-Ruscker supports three roles, each with its own token. Set only the
-ones you need — with just `RUSCKER_ADMIN_TOKEN` you get the classic
-single-admin setup.
+Each person gets their own account (username + password). Admins manage
+accounts under **Users** (`/admin/users`): create one, assign a role,
+reset a password, or remove it. A new user gets an initial password you
+choose and is asked — once, on first login — whether to change it.
 
-| Token | Role | Can do |
-|---|---|---|
-| `RUSCKER_ADMIN_TOKEN` (required) | **Admin** | everything |
-| `RUSCKER_EDITOR_TOKEN` (optional) | **Editor** | view + manage Apps and Media; view the Dashboard and stop/restart replicas |
-| `RUSCKER_VIEWER_TOKEN` (optional) | **Viewer** | view the Dashboard only (read-only) |
+| Role | Can do |
+|---|---|
+| **Viewer** | view the Dashboard only (read-only) |
+| **Editor** | view + manage Apps and Media; view the Dashboard and stop/restart replicas |
+| **Admin** | everything, including managing users, credentials, the landing editor, custom blocks and the audit log |
 
-You log in with whichever token you were given; the panel then shows
-only the sections your role can reach. Enforcement is server-side —
-hiding a nav link is just UX, the routes themselves return `403` for a
-role that isn't allowed. Use **distinct** tokens per role (a token
-shared across roles resolves to the highest one). Credentials, the
-landing editor, custom blocks and the audit log are Admin-only.
+The panel shows only the sections your role can reach. Enforcement is
+server-side — hiding a nav link is just UX; the routes themselves
+return `403` for a role that isn't allowed. The audit log records the
+acting username. A **last-admin guard** stops you deleting or demoting
+the only remaining admin (so the portal can't be locked out); the
+`RUSCKER_ADMIN_TOKEN` break-glass login is the other safety net.
 
 ## Screens
 

--- a/crates/ruscker-admin/Cargo.toml
+++ b/crates/ruscker-admin/Cargo.toml
@@ -63,6 +63,9 @@ zeroize = { workspace = true }
 hex = { workspace = true }
 base64 = { workspace = true }
 
+# User accounts — password hashing (argon2id)
+argon2 = { workspace = true }
+
 [dev-dependencies]
 pretty_assertions = { workspace = true }
 insta = { workspace = true }

--- a/crates/ruscker-admin/assets/i18n/en/landing.ftl
+++ b/crates/ruscker-admin/assets/i18n/en/landing.ftl
@@ -67,6 +67,60 @@ role-viewer = Viewer
 role-editor = Editor
 role-admin = Admin
 
+# — Username/password login + token bootstrap (#107)
+admin-login-help-user = Sign in with your username and password.
+admin-login-username-label = Username
+admin-login-username-placeholder = your username
+admin-login-password-label = Password
+admin-login-password-placeholder = your password
+admin-login-error-credentials = Invalid username or password.
+admin-login-use-token = Sign in with admin token
+admin-login-use-password = Back to password sign-in
+# — First-admin setup
+admin-setup-title = Create the admin account
+admin-setup-help = This is the first run. Choose a username and password for the administrator.
+admin-setup-error = Could not create the account. Check the details.
+admin-setup-password-label = Password
+admin-setup-submit = Create admin
+# — Password change / first login
+admin-pw-title = Change password
+admin-pw-help = Set a new password for your account.
+admin-pw-first-prompt = You're using a password set by an administrator. Would you like to change it now?
+admin-pw-current-label = Current password
+admin-pw-new-label = New password
+admin-pw-confirm-label = Confirm password
+admin-pw-error-current = Current password is incorrect.
+admin-pw-error-mismatch = Passwords don't match.
+admin-pw-error-short = Password must be at least 8 characters.
+admin-pw-submit = Save password
+admin-pw-keep = Keep current password
+# — User management (admin)
+admin-nav-users = Users
+admin-users-title = Users
+admin-users-subtitle = Create and manage who can sign in, and at which level.
+admin-users-new = New user
+admin-users-create = Create
+admin-users-initial-password = Initial password
+admin-users-initial-password-hint = The user is asked whether to change it on first login.
+admin-users-role = Role
+admin-users-col-user = User
+admin-users-col-role = Role
+admin-users-col-created = Created
+admin-users-col-actions = Actions
+admin-users-you = you
+admin-users-must-change = Still using the initial password
+admin-users-save-role = Save role
+admin-users-new-password = new password
+admin-users-reset-password = Reset password
+admin-users-delete = Remove user
+admin-users-confirm-delete = Remove this user?
+admin-users-flash-created = User created.
+admin-users-flash-saved = Changes saved.
+admin-users-flash-deleted = User removed.
+admin-users-flash-last-admin = Can't remove or demote the last administrator.
+admin-users-flash-bad-input = Invalid input (empty username or password under 8 characters).
+admin-users-flash-exists = A user with that name already exists.
+
 # Admin dashboard
 admin-dashboard-title = Monitoring dashboard
 admin-dashboard-subtitle = Live container and session state

--- a/crates/ruscker-admin/assets/i18n/es/landing.ftl
+++ b/crates/ruscker-admin/assets/i18n/es/landing.ftl
@@ -67,6 +67,60 @@ role-viewer = Visor
 role-editor = Editor
 role-admin = Administrador
 
+# — Inicio de sesión usuario/contraseña + bootstrap por token (#107)
+admin-login-help-user = Inicia sesión con tu usuario y contraseña.
+admin-login-username-label = Usuario
+admin-login-username-placeholder = tu usuario
+admin-login-password-label = Contraseña
+admin-login-password-placeholder = tu contraseña
+admin-login-error-credentials = Usuario o contraseña inválidos.
+admin-login-use-token = Entrar con token de administrador
+admin-login-use-password = Volver al inicio con contraseña
+# — Configuración del primer admin
+admin-setup-title = Crea la cuenta de administrador
+admin-setup-help = Es la primera vez. Elige un usuario y una contraseña para el administrador.
+admin-setup-error = No se pudo crear la cuenta. Revisa los datos.
+admin-setup-password-label = Contraseña
+admin-setup-submit = Crear administrador
+# — Cambio de contraseña / primer acceso
+admin-pw-title = Cambiar contraseña
+admin-pw-help = Define una nueva contraseña para tu cuenta.
+admin-pw-first-prompt = Estás usando una contraseña asignada por un administrador. ¿Quieres cambiarla ahora?
+admin-pw-current-label = Contraseña actual
+admin-pw-new-label = Nueva contraseña
+admin-pw-confirm-label = Confirmar contraseña
+admin-pw-error-current = La contraseña actual es incorrecta.
+admin-pw-error-mismatch = Las contraseñas no coinciden.
+admin-pw-error-short = La contraseña debe tener al menos 8 caracteres.
+admin-pw-submit = Guardar contraseña
+admin-pw-keep = Mantener la contraseña actual
+# — Gestión de usuarios (admin)
+admin-nav-users = Usuarios
+admin-users-title = Usuarios
+admin-users-subtitle = Crea y gestiona quién accede al panel y con qué nivel.
+admin-users-new = Nuevo usuario
+admin-users-create = Crear
+admin-users-initial-password = Contraseña inicial
+admin-users-initial-password-hint = Se le preguntará si desea cambiarla en el primer acceso.
+admin-users-role = Nivel
+admin-users-col-user = Usuario
+admin-users-col-role = Nivel
+admin-users-col-created = Creado
+admin-users-col-actions = Acciones
+admin-users-you = tú
+admin-users-must-change = Aún usa la contraseña inicial
+admin-users-save-role = Guardar nivel
+admin-users-new-password = nueva contraseña
+admin-users-reset-password = Restablecer contraseña
+admin-users-delete = Eliminar usuario
+admin-users-confirm-delete = ¿Eliminar este usuario?
+admin-users-flash-created = Usuario creado.
+admin-users-flash-saved = Cambios guardados.
+admin-users-flash-deleted = Usuario eliminado.
+admin-users-flash-last-admin = No se puede eliminar ni degradar al último administrador.
+admin-users-flash-bad-input = Datos inválidos (usuario vacío o contraseña de menos de 8 caracteres).
+admin-users-flash-exists = Ya existe un usuario con ese nombre.
+
 # Admin dashboard
 admin-dashboard-title = Panel de monitoreo
 admin-dashboard-subtitle = Estado de contenedores y sesiones en tiempo real

--- a/crates/ruscker-admin/assets/i18n/fr/landing.ftl
+++ b/crates/ruscker-admin/assets/i18n/fr/landing.ftl
@@ -67,6 +67,60 @@ role-viewer = Lecteur
 role-editor = Éditeur
 role-admin = Administrateur
 
+# — Connexion identifiant/mot de passe + bootstrap par token (#107)
+admin-login-help-user = Connectez-vous avec votre identifiant et votre mot de passe.
+admin-login-username-label = Identifiant
+admin-login-username-placeholder = votre identifiant
+admin-login-password-label = Mot de passe
+admin-login-password-placeholder = votre mot de passe
+admin-login-error-credentials = Identifiant ou mot de passe invalide.
+admin-login-use-token = Se connecter avec le token administrateur
+admin-login-use-password = Revenir à la connexion par mot de passe
+# — Configuration du premier admin
+admin-setup-title = Créez le compte administrateur
+admin-setup-help = C'est le premier lancement. Choisissez un identifiant et un mot de passe pour l'administrateur.
+admin-setup-error = Impossible de créer le compte. Vérifiez les informations.
+admin-setup-password-label = Mot de passe
+admin-setup-submit = Créer l'administrateur
+# — Changement de mot de passe / première connexion
+admin-pw-title = Changer le mot de passe
+admin-pw-help = Définissez un nouveau mot de passe pour votre compte.
+admin-pw-first-prompt = Vous utilisez un mot de passe défini par un administrateur. Voulez-vous le changer maintenant ?
+admin-pw-current-label = Mot de passe actuel
+admin-pw-new-label = Nouveau mot de passe
+admin-pw-confirm-label = Confirmer le mot de passe
+admin-pw-error-current = Le mot de passe actuel est incorrect.
+admin-pw-error-mismatch = Les mots de passe ne correspondent pas.
+admin-pw-error-short = Le mot de passe doit comporter au moins 8 caractères.
+admin-pw-submit = Enregistrer le mot de passe
+admin-pw-keep = Conserver le mot de passe actuel
+# — Gestion des utilisateurs (admin)
+admin-nav-users = Utilisateurs
+admin-users-title = Utilisateurs
+admin-users-subtitle = Créez et gérez qui peut se connecter, et à quel niveau.
+admin-users-new = Nouvel utilisateur
+admin-users-create = Créer
+admin-users-initial-password = Mot de passe initial
+admin-users-initial-password-hint = Il lui sera demandé s'il veut le changer à la première connexion.
+admin-users-role = Niveau
+admin-users-col-user = Utilisateur
+admin-users-col-role = Niveau
+admin-users-col-created = Créé le
+admin-users-col-actions = Actions
+admin-users-you = vous
+admin-users-must-change = Utilise encore le mot de passe initial
+admin-users-save-role = Enregistrer le niveau
+admin-users-new-password = nouveau mot de passe
+admin-users-reset-password = Réinitialiser le mot de passe
+admin-users-delete = Supprimer l'utilisateur
+admin-users-confirm-delete = Supprimer cet utilisateur ?
+admin-users-flash-created = Utilisateur créé.
+admin-users-flash-saved = Modifications enregistrées.
+admin-users-flash-deleted = Utilisateur supprimé.
+admin-users-flash-last-admin = Impossible de supprimer ou rétrograder le dernier administrateur.
+admin-users-flash-bad-input = Données invalides (identifiant vide ou mot de passe de moins de 8 caractères).
+admin-users-flash-exists = Un utilisateur portant ce nom existe déjà.
+
 # Admin dashboard
 admin-dashboard-title = Tableau de bord
 admin-dashboard-subtitle = État des conteneurs et des sessions en temps réel

--- a/crates/ruscker-admin/assets/i18n/pt/landing.ftl
+++ b/crates/ruscker-admin/assets/i18n/pt/landing.ftl
@@ -71,6 +71,60 @@ role-viewer = Visualizador
 role-editor = Editor
 role-admin = Administrador
 
+# — Login por usuário/senha + bootstrap por token (#107)
+admin-login-help-user = Entre com seu usuário e senha.
+admin-login-username-label = Usuário
+admin-login-username-placeholder = seu usuário
+admin-login-password-label = Senha
+admin-login-password-placeholder = sua senha
+admin-login-error-credentials = Usuário ou senha inválidos.
+admin-login-use-token = Entrar com token de administrador
+admin-login-use-password = Voltar ao login por senha
+# — Configuração do primeiro admin
+admin-setup-title = Crie a conta de administrador
+admin-setup-help = Esta é a primeira vez. Escolha um usuário e uma senha para o administrador.
+admin-setup-error = Não foi possível criar a conta. Verifique os dados.
+admin-setup-password-label = Senha
+admin-setup-submit = Criar administrador
+# — Troca de senha / primeiro acesso
+admin-pw-title = Alterar senha
+admin-pw-help = Defina uma nova senha para a sua conta.
+admin-pw-first-prompt = Você está usando uma senha definida pelo administrador. Deseja trocá-la agora?
+admin-pw-current-label = Senha atual
+admin-pw-new-label = Nova senha
+admin-pw-confirm-label = Confirme a senha
+admin-pw-error-current = Senha atual incorreta.
+admin-pw-error-mismatch = As senhas não coincidem.
+admin-pw-error-short = A senha deve ter ao menos 8 caracteres.
+admin-pw-submit = Salvar senha
+admin-pw-keep = Manter a senha atual
+# — Gestão de usuários (admin)
+admin-nav-users = Usuários
+admin-users-title = Usuários
+admin-users-subtitle = Crie e gerencie quem acessa o painel e com qual nível.
+admin-users-new = Novo usuário
+admin-users-create = Criar
+admin-users-initial-password = Senha inicial
+admin-users-initial-password-hint = O usuário será consultado se quer trocá-la no primeiro acesso.
+admin-users-role = Nível
+admin-users-col-user = Usuário
+admin-users-col-role = Nível
+admin-users-col-created = Criado em
+admin-users-col-actions = Ações
+admin-users-you = você
+admin-users-must-change = Ainda usa a senha inicial
+admin-users-save-role = Salvar nível
+admin-users-new-password = nova senha
+admin-users-reset-password = Redefinir senha
+admin-users-delete = Remover usuário
+admin-users-confirm-delete = Remover este usuário?
+admin-users-flash-created = Usuário criado.
+admin-users-flash-saved = Alterações salvas.
+admin-users-flash-deleted = Usuário removido.
+admin-users-flash-last-admin = Não é possível remover ou rebaixar o último administrador.
+admin-users-flash-bad-input = Dados inválidos (usuário vazio ou senha com menos de 8 caracteres).
+admin-users-flash-exists = Já existe um usuário com esse nome.
+
 # Admin dashboard
 admin-dashboard-title = Painel de monitoramento
 admin-dashboard-subtitle = Estado dos containers e sessões em tempo real

--- a/crates/ruscker-admin/migrations/0006_users.sql
+++ b/crates/ruscker-admin/migrations/0006_users.sql
@@ -1,0 +1,21 @@
+-- Admin user accounts with per-user password login (real RBAC).
+--
+-- Roles mirror `auth::Role` ('viewer' | 'editor' | 'admin'). Passwords
+-- are stored only as argon2id PHC hashes — never plaintext. The
+-- `RUSCKER_ADMIN_TOKEN` env var remains a break-glass bootstrap that
+-- always grants an Admin session and seeds the first account here.
+--
+-- `must_change_password` drives the optional "want to change your
+-- password?" prompt on a user's first login (set when an admin assigns
+-- an initial password; cleared after the prompt is answered once).
+-- `username` is stored lowercased and is unique.
+CREATE TABLE users (
+    id                   TEXT    PRIMARY KEY,
+    username             TEXT    NOT NULL UNIQUE,
+    password_hash        TEXT    NOT NULL,
+    role                 TEXT    NOT NULL,
+    must_change_password INTEGER NOT NULL DEFAULT 0,
+    created_at           TEXT    NOT NULL,
+    updated_at           TEXT    NOT NULL,
+    created_by           TEXT
+);

--- a/crates/ruscker-admin/src/auth.rs
+++ b/crates/ruscker-admin/src/auth.rs
@@ -1,26 +1,26 @@
-//! Admin authentication — env-var token model with three roles.
+//! Admin authentication — per-user accounts + a break-glass token.
 //!
-//! Threat model: the operator runs Ruscker on a private network
-//! (or behind a reverse proxy with mTLS). Up to three long random
-//! secrets — `RUSCKER_ADMIN_TOKEN` (required), `RUSCKER_EDITOR_TOKEN`
-//! and `RUSCKER_VIEWER_TOKEN` (both optional) — are entered once on
-//! `/admin/login`. The server constant-time-compares the submitted
-//! token against each and issues an HttpOnly + Strict-SameSite cookie
-//! holding an opaque session id; the session carries the matched
-//! [`Role`].
+//! Threat model: the operator runs Ruscker on a private network (or
+//! behind a reverse proxy with mTLS). Each person signs in with a
+//! **username + password** backed by the `users` table (see
+//! [`crate::db::users`]; passwords are argon2id-hashed). The session
+//! carries the user's [`Role`] and username.
 //!
-//! Roles (see [`Role`]): **Viewer** (dashboard only), **Editor**
-//! (apps + media + dashboard), **Admin** (everything). With only
-//! `RUSCKER_ADMIN_TOKEN` set the install behaves exactly as before
-//! — one token, full admin — so this is backward-compatible.
+//! `RUSCKER_ADMIN_TOKEN` is the **break-glass** path: it always grants
+//! an Admin session and, on a fresh install with no accounts, drives
+//! the first-admin setup. It's the recovery route so an operator can
+//! never be locked out — treat it as a sensitive secret. When it isn't
+//! set, admin routes 503.
 //!
-//! Full multi-user auth (OIDC, SAML, LDAP, per-app ACLs) lands in
-//! Phase 8; this is a lightweight role layer on the token/session
-//! model.
+//! Roles (see [`Role`]): **Viewer** (dashboard only), **Editor** (apps
+//! + media + dashboard), **Admin** (everything, incl. user
+//! management). External IdPs (OIDC/SAML/LDAP) and per-app ACLs land
+//! in Phase 8.
 //!
 //! Cookie: the value is an opaque server-side session id (never the
-//! token), bound by `HttpOnly`, `Secure` (when TLS terminated), and
-//! `SameSite=Strict`. Logout and server restart both revoke it.
+//! token or password), bound by `HttpOnly`, `Secure` (when TLS
+//! terminated), and `SameSite=Strict`. Logout and server restart both
+//! revoke it.
 
 use anyhow::Result;
 use axum::extract::FromRequestParts;
@@ -95,83 +95,90 @@ impl Role {
             Role::Admin => "role-admin",
         }
     }
+
+    /// Lowercase wire/DB form (`users.role`, form values).
+    pub fn as_str(&self) -> &'static str {
+        match self {
+            Role::Viewer => "viewer",
+            Role::Editor => "editor",
+            Role::Admin => "admin",
+        }
+    }
+
+    /// Parse the lowercase form back to a [`Role`]. Unknown ⇒ `None`.
+    pub fn parse(s: &str) -> Option<Role> {
+        match s {
+            "viewer" => Some(Role::Viewer),
+            "editor" => Some(Role::Editor),
+            "admin" => Some(Role::Admin),
+            _ => None,
+        }
+    }
 }
 
-/// Held in `AppState`. One token per [`Role`]; `admin` is required
-/// (when it's `None`, admin routes 503 with a hint to set
-/// `RUSCKER_ADMIN_TOKEN`), `editor` and `viewer` are optional. Each
-/// token is wrapped in `Arc<str>` so cloning [`AppState`] (per
-/// request) doesn't copy the string.
+/// The break-glass admin token, held in `AppState`. `RUSCKER_ADMIN_TOKEN`
+/// always grants an emergency Admin session (and bootstraps the first
+/// account when no admin user exists yet — see [`crate::db::users`]).
+/// `None` means admin routes are disabled (503). The token is wrapped
+/// in `Arc<str>` so cloning [`AppState`] (per request) doesn't copy it.
+///
+/// Per-user Editor/Viewer access lives in the `users` table, not here —
+/// this is purely the bootstrap / break-glass path.
 #[derive(Clone, Debug, Default)]
 pub struct AdminAuth {
     pub admin: Option<Arc<str>>,
-    pub editor: Option<Arc<str>>,
-    pub viewer: Option<Arc<str>>,
 }
 
 impl AdminAuth {
     pub fn from_env() -> Self {
-        let read = |var: &str| {
-            std::env::var(var)
+        Self {
+            admin: std::env::var("RUSCKER_ADMIN_TOKEN")
                 .ok()
                 .filter(|s| !s.is_empty())
-                .map(Arc::from)
-        };
-        Self {
-            admin: read("RUSCKER_ADMIN_TOKEN"),
-            editor: read("RUSCKER_EDITOR_TOKEN"),
-            viewer: read("RUSCKER_VIEWER_TOKEN"),
+                .map(Arc::from),
         }
     }
 
-    /// Configure the admin token only (used by tests / programmatic
-    /// setup). Editor and viewer stay unset ⇒ single-admin behaviour.
+    /// Configure the admin token (used by tests / the CLI flag).
     pub fn with_token(token: impl Into<String>) -> Self {
         Self {
             admin: Some(Arc::from(token.into())),
-            editor: None,
-            viewer: None,
         }
     }
 
-    /// Admin auth is usable iff the admin token is set. The optional
-    /// editor/viewer tokens layer on top but never replace it.
+    /// Admin auth is usable iff the break-glass token is set.
     pub fn is_configured(&self) -> bool {
         self.admin.is_some()
     }
 
-    /// Constant-time-compare `candidate` against each configured
-    /// token and return the matched [`Role`], or `None` if it matches
-    /// none. Checked most-privileged first so a token reused across
-    /// levels (a misconfiguration) resolves to the higher role.
-    ///
-    /// Every comparison uses [`ct_eq`]: mismatched lengths short-
-    /// circuit (the length leak is intentional and standard), and the
-    /// XOR-fold over equal-length bytes is data-independent.
-    pub fn role_for(&self, candidate: &str) -> Option<Role> {
-        let matches = |tok: &Option<Arc<str>>| {
-            tok.as_deref()
-                .is_some_and(|t| ct_eq(t.as_bytes(), candidate.as_bytes()))
-        };
-        if matches(&self.admin) {
-            Some(Role::Admin)
-        } else if matches(&self.editor) {
-            Some(Role::Editor)
-        } else if matches(&self.viewer) {
-            Some(Role::Viewer)
-        } else {
-            None
-        }
+    /// Constant-time compare `candidate` against the break-glass token.
+    /// `true` ⇒ grant an Admin session. [`ct_eq`] short-circuits on a
+    /// length mismatch (intentional, standard) and is data-independent
+    /// over equal-length bytes.
+    pub fn matches_token(&self, candidate: &str) -> bool {
+        self.admin
+            .as_deref()
+            .is_some_and(|t| ct_eq(t.as_bytes(), candidate.as_bytes()))
     }
 }
 
-/// One live admin session: when it expires and the [`Role`] it was
-/// minted with. Copy-cheap so lookups can read it out of the map by
-/// value without holding the shard lock.
-#[derive(Clone, Copy, Debug)]
+/// One live admin session: when it expires, the [`Role`] it was minted
+/// with, and the acting identity. `actor` is the DB username for a
+/// password login, or `None` for a break-glass token session (no user
+/// account behind it).
+#[derive(Clone, Debug)]
 struct SessionEntry {
     expiry: Instant,
     role: Role,
+    actor: Option<String>,
+}
+
+/// What [`AdminSessions::validate`] yields for a live session — the
+/// role and acting identity carried by the extractors.
+#[derive(Clone, Debug)]
+pub struct SessionInfo {
+    pub role: Role,
+    pub actor: Option<String>,
 }
 
 /// Server-side store of opaque admin session ids → (expiry, role).
@@ -200,10 +207,11 @@ impl AdminSessions {
         Self::new(Duration::from_secs(24 * 60 * 60))
     }
 
-    /// Mint a new session for `role` and return its opaque id (244
-    /// bits of random, unguessable). Caller stores the id in the
-    /// cookie.
-    pub fn create(&self, role: Role) -> String {
+    /// Mint a new session for `role`/`actor` and return its opaque id
+    /// (244 bits of random, unguessable). Caller stores the id in the
+    /// cookie. `actor` is the DB username (or `None` for a break-glass
+    /// token session).
+    pub fn create(&self, role: Role, actor: Option<String>) -> String {
         let id = format!(
             "{}{}",
             uuid::Uuid::new_v4().simple(),
@@ -214,17 +222,24 @@ impl AdminSessions {
             SessionEntry {
                 expiry: Instant::now() + self.ttl,
                 role,
+                actor,
             },
         );
         id
     }
 
-    /// The [`Role`] of a live (non-expired) session named by `id`, or
-    /// `None` if the id is unknown or expired. Expired entries are
-    /// pruned lazily on lookup.
-    pub fn validate(&self, id: &str) -> Option<Role> {
-        match self.sessions.get(id).map(|e| *e.value()) {
-            Some(entry) if entry.expiry > Instant::now() => Some(entry.role),
+    /// The [`SessionInfo`] of a live (non-expired) session named by
+    /// `id`, or `None` if the id is unknown or expired. Expired entries
+    /// are pruned lazily on lookup.
+    pub fn validate(&self, id: &str) -> Option<SessionInfo> {
+        let info = self.sessions.get(id).map(|e| {
+            let v = e.value();
+            (v.expiry, v.role, v.actor.clone())
+        });
+        match info {
+            Some((expiry, role, actor)) if expiry > Instant::now() => {
+                Some(SessionInfo { role, actor })
+            }
             Some(_) => {
                 self.sessions.remove(id);
                 None
@@ -359,6 +374,17 @@ pub fn request_is_https(headers: &axum::http::HeaderMap) -> bool {
 /// without a token to compare against.
 pub struct AdminSession {
     pub role: Role,
+    /// DB username for a password login, or `None` for a break-glass
+    /// token session. Use [`AdminSession::actor`] for audit logging.
+    pub actor: Option<String>,
+}
+
+impl AdminSession {
+    /// The actor string to record in the audit log: the username, or
+    /// `"token"` for a break-glass token session.
+    pub fn actor(&self) -> &str {
+        self.actor.as_deref().unwrap_or("token")
+    }
 }
 
 impl FromRequestParts<crate::AppState> for AdminSession {
@@ -385,10 +411,13 @@ impl FromRequestParts<crate::AppState> for AdminSession {
         };
         // The cookie carries an opaque session id, validated against
         // the server-side store — not the token itself. A live session
-        // yields its role.
+        // yields its role + actor.
         match cookies.get(COOKIE_NAME).map(|c| c.value().to_string()) {
             Some(c) => match state.admin_sessions.validate(&c) {
-                Some(role) => Ok(AdminSession { role }),
+                Some(info) => Ok(AdminSession {
+                    role: info.role,
+                    actor: info.actor,
+                }),
                 None => Err(Redirect::to("/admin/login").into_response()),
             },
             None => Err(Redirect::to("/admin/login").into_response()),
@@ -414,6 +443,13 @@ fn forbidden() -> Response {
 /// template.
 pub struct RequireEditor {
     pub role: Role,
+    pub actor: Option<String>,
+}
+
+impl RequireEditor {
+    pub fn actor(&self) -> &str {
+        self.actor.as_deref().unwrap_or("token")
+    }
 }
 
 impl FromRequestParts<crate::AppState> for RequireEditor {
@@ -425,7 +461,10 @@ impl FromRequestParts<crate::AppState> for RequireEditor {
     ) -> Result<Self, Self::Rejection> {
         let session = AdminSession::from_request_parts(parts, state).await?;
         if session.role >= Role::Editor {
-            Ok(RequireEditor { role: session.role })
+            Ok(RequireEditor {
+                role: session.role,
+                actor: session.actor,
+            })
         } else {
             Err(forbidden())
         }
@@ -437,6 +476,13 @@ impl FromRequestParts<crate::AppState> for RequireEditor {
 /// rejected with 403. Carries the role for the handler / template.
 pub struct RequireAdmin {
     pub role: Role,
+    pub actor: Option<String>,
+}
+
+impl RequireAdmin {
+    pub fn actor(&self) -> &str {
+        self.actor.as_deref().unwrap_or("token")
+    }
 }
 
 impl FromRequestParts<crate::AppState> for RequireAdmin {
@@ -448,7 +494,10 @@ impl FromRequestParts<crate::AppState> for RequireAdmin {
     ) -> Result<Self, Self::Rejection> {
         let session = AdminSession::from_request_parts(parts, state).await?;
         if session.role == Role::Admin {
-            Ok(RequireAdmin { role: session.role })
+            Ok(RequireAdmin {
+                role: session.role,
+                actor: session.actor,
+            })
         } else {
             Err(forbidden())
         }
@@ -483,17 +532,17 @@ mod tests {
     #[test]
     fn admin_sessions_create_validate_remove() {
         let s = AdminSessions::default_policy();
-        let id = s.create(Role::Editor);
-        assert_eq!(
-            s.validate(&id),
-            Some(Role::Editor),
-            "freshly created session is valid and carries its role"
+        let id = s.create(Role::Editor, Some("alice".into()));
+        let info = s.validate(&id).expect("freshly created session is valid");
+        assert_eq!(info.role, Role::Editor);
+        assert_eq!(info.actor.as_deref(), Some("alice"));
+        assert!(
+            s.validate("not-a-real-id").is_none(),
+            "unknown id is invalid"
         );
-        assert_eq!(s.validate("not-a-real-id"), None, "unknown id is invalid");
         s.remove(&id);
-        assert_eq!(
-            s.validate(&id),
-            None,
+        assert!(
+            s.validate(&id).is_none(),
             "removed (logged-out) session is invalid"
         );
     }
@@ -501,16 +550,16 @@ mod tests {
     #[test]
     fn admin_sessions_expire() {
         let s = AdminSessions::new(Duration::from_millis(0));
-        let id = s.create(Role::Admin);
+        let id = s.create(Role::Admin, None);
         std::thread::sleep(Duration::from_millis(2));
-        assert_eq!(s.validate(&id), None, "expired session is invalid");
+        assert!(s.validate(&id).is_none(), "expired session is invalid");
     }
 
     #[test]
     fn admin_session_ids_are_distinct_and_not_the_token() {
         let s = AdminSessions::default_policy();
-        let a = s.create(Role::Viewer);
-        let b = s.create(Role::Viewer);
+        let a = s.create(Role::Viewer, None);
+        let b = s.create(Role::Viewer, None);
         assert_ne!(a, b, "each session gets a fresh id");
         assert!(
             a.len() >= 32,
@@ -519,37 +568,15 @@ mod tests {
     }
 
     #[test]
-    fn role_for_resolves_each_token_and_rejects_others() {
-        let auth = AdminAuth {
-            admin: Some(Arc::from("admin-secret")),
-            editor: Some(Arc::from("editor-secret")),
-            viewer: Some(Arc::from("viewer-secret")),
-        };
-        assert_eq!(auth.role_for("admin-secret"), Some(Role::Admin));
-        assert_eq!(auth.role_for("editor-secret"), Some(Role::Editor));
-        assert_eq!(auth.role_for("viewer-secret"), Some(Role::Viewer));
-        assert_eq!(auth.role_for("nope"), None);
-        assert_eq!(auth.role_for(""), None);
-    }
-
-    #[test]
-    fn role_for_admin_only_is_backward_compatible() {
-        // Only RUSCKER_ADMIN_TOKEN set ⇒ single-admin behaviour.
-        let auth = AdminAuth::with_token("only-admin");
+    fn matches_token_is_constant_time_exact() {
+        let auth = AdminAuth::with_token("admin-secret");
         assert!(auth.is_configured());
-        assert_eq!(auth.role_for("only-admin"), Some(Role::Admin));
-        assert_eq!(auth.role_for("anything-else"), None);
-    }
-
-    #[test]
-    fn role_for_prefers_higher_privilege_on_token_reuse() {
-        // A token reused across levels resolves to the higher role.
-        let auth = AdminAuth {
-            admin: Some(Arc::from("shared")),
-            editor: Some(Arc::from("shared")),
-            viewer: None,
-        };
-        assert_eq!(auth.role_for("shared"), Some(Role::Admin));
+        assert!(auth.matches_token("admin-secret"));
+        assert!(!auth.matches_token("admin-secre")); // length mismatch
+        assert!(!auth.matches_token("nope"));
+        assert!(!auth.matches_token(""));
+        // Unconfigured never matches.
+        assert!(!AdminAuth::default().matches_token("anything"));
     }
 
     #[test]

--- a/crates/ruscker-admin/src/db.rs
+++ b/crates/ruscker-admin/src/db.rs
@@ -80,3 +80,4 @@ pub mod images;
 pub mod landing;
 pub mod landing_blocks;
 pub mod specs;
+pub mod users;

--- a/crates/ruscker-admin/src/db/users.rs
+++ b/crates/ruscker-admin/src/db/users.rs
@@ -1,0 +1,441 @@
+//! Admin user accounts — per-user password login + roles.
+//!
+//! Passwords are stored only as argon2id PHC hashes; plaintext never
+//! touches the disk. The [`crate::auth::Role`] of each user drives the
+//! same route guards as the env-token model it replaces. The
+//! `RUSCKER_ADMIN_TOKEN` env var stays a break-glass bootstrap (see
+//! [`crate::auth::AdminAuth`]) — it always grants an Admin session and
+//! seeds the first account.
+//!
+//! All write paths attach an `audit_log` row in the same transaction
+//! (mirroring the rest of `db::*`), tagged with the acting username.
+
+use anyhow::{Context, Result};
+use argon2::password_hash::rand_core::OsRng;
+use argon2::password_hash::{PasswordHash, PasswordHasher, PasswordVerifier, SaltString};
+use argon2::Argon2;
+use chrono::{DateTime, Utc};
+use sqlx::SqlitePool;
+
+use crate::auth::Role;
+
+/// A user row without the password hash — safe to render.
+#[derive(Debug, Clone)]
+pub struct UserRow {
+    pub id: String,
+    pub username: String,
+    pub role: Role,
+    pub must_change_password: bool,
+    pub created_at: DateTime<Utc>,
+    pub created_by: Option<String>,
+}
+
+/// Normalize a username for storage/lookup: trimmed + lowercased.
+/// Usernames are case-insensitive and unique.
+pub fn normalize_username(raw: &str) -> String {
+    raw.trim().to_lowercase()
+}
+
+/// Hash a plaintext password with argon2id and a fresh random salt,
+/// returning the PHC string to store.
+pub fn hash_password(plain: &str) -> Result<String> {
+    let salt = SaltString::generate(&mut OsRng);
+    Argon2::default()
+        .hash_password(plain.as_bytes(), &salt)
+        .map(|h| h.to_string())
+        .map_err(|e| anyhow::anyhow!("hash password: {e}"))
+}
+
+/// Verify a plaintext password against a stored PHC hash. Returns
+/// `false` on any parse/verify failure — argon2's verify is the
+/// constant-time comparison.
+pub fn verify_password(plain: &str, phc: &str) -> bool {
+    match PasswordHash::new(phc) {
+        Ok(parsed) => Argon2::default()
+            .verify_password(plain.as_bytes(), &parsed)
+            .is_ok(),
+        Err(_) => false,
+    }
+}
+
+/// Number of users with the Admin role. Used to block removing or
+/// demoting the last admin (lockout protection).
+pub async fn count_admins(pool: &SqlitePool) -> Result<i64> {
+    let (n,): (i64,) = sqlx::query_as("SELECT COUNT(*) FROM users WHERE role = 'admin'")
+        .fetch_one(pool)
+        .await
+        .context("count admins")?;
+    Ok(n)
+}
+
+/// Whether any admin account exists yet. Drives the bootstrap flow:
+/// with no admin user, login falls back to the break-glass token and
+/// the setup wizard.
+pub async fn any_admin_exists(pool: &SqlitePool) -> Result<bool> {
+    Ok(count_admins(pool).await? > 0)
+}
+
+/// Whether any user at all exists (used by the login page to decide
+/// between the bootstrap and the normal form).
+pub async fn any_user_exists(pool: &SqlitePool) -> Result<bool> {
+    let (n,): (i64,) = sqlx::query_as("SELECT COUNT(*) FROM users")
+        .fetch_one(pool)
+        .await
+        .context("count users")?;
+    Ok(n > 0)
+}
+
+/// Map a `(username, role, must_change, created_at, created_by)` tuple
+/// to a [`UserRow`]. An unknown role string falls back to Viewer (the
+/// least-privileged) so a hand-tampered DB can't escalate.
+fn row_from(
+    id: String,
+    username: String,
+    role: String,
+    must_change: i64,
+    created_at: DateTime<Utc>,
+    created_by: Option<String>,
+) -> UserRow {
+    UserRow {
+        id,
+        username,
+        role: Role::parse(&role).unwrap_or(Role::Viewer),
+        must_change_password: must_change != 0,
+        created_at,
+        created_by,
+    }
+}
+
+/// List all users (no hashes), most-recent first.
+pub async fn list_all(pool: &SqlitePool) -> Result<Vec<UserRow>> {
+    let rows: Vec<(String, String, String, i64, DateTime<Utc>, Option<String>)> = sqlx::query_as(
+        "SELECT id, username, role, must_change_password, created_at, created_by
+           FROM users
+          ORDER BY created_at DESC, username ASC",
+    )
+    .fetch_all(pool)
+    .await
+    .context("list users")?;
+    Ok(rows
+        .into_iter()
+        .map(|(id, u, r, m, c, by)| row_from(id, u, r, m, c, by))
+        .collect())
+}
+
+/// Fetch one user by (normalized) username, without the hash.
+pub async fn fetch(pool: &SqlitePool, username: &str) -> Result<Option<UserRow>> {
+    let username = normalize_username(username);
+    let row: Option<(String, String, String, i64, DateTime<Utc>, Option<String>)> = sqlx::query_as(
+        "SELECT id, username, role, must_change_password, created_at, created_by
+               FROM users WHERE username = ?",
+    )
+    .bind(&username)
+    .fetch_optional(pool)
+    .await
+    .with_context(|| format!("fetch user {username}"))?;
+    Ok(row.map(|(id, u, r, m, c, by)| row_from(id, u, r, m, c, by)))
+}
+
+/// Verify a login. Returns the [`UserRow`] on a correct password,
+/// `None` on unknown username or wrong password (indistinguishable to
+/// the caller). Always runs an argon2 verify — even for an unknown
+/// user, against a dummy hash — so response time doesn't reveal
+/// whether the username exists.
+pub async fn verify_login(
+    pool: &SqlitePool,
+    username: &str,
+    password: &str,
+) -> Result<Option<UserRow>> {
+    let username = normalize_username(username);
+    let row: Option<(
+        String,
+        String,
+        String,
+        i64,
+        DateTime<Utc>,
+        Option<String>,
+        String,
+    )> = sqlx::query_as(
+        "SELECT id, username, role, must_change_password, created_at, created_by, password_hash
+               FROM users WHERE username = ?",
+    )
+    .bind(&username)
+    .fetch_optional(pool)
+    .await
+    .with_context(|| format!("login lookup {username}"))?;
+
+    match row {
+        Some((id, u, r, m, c, by, hash)) if verify_password(password, &hash) => {
+            Ok(Some(row_from(id, u, r, m, c, by)))
+        }
+        Some(_) => Ok(None),
+        None => {
+            // Spend the same argon2 verify time on an unknown username
+            // so response timing doesn't reveal whether it exists.
+            let _ = verify_password(password, dummy_hash());
+            Ok(None)
+        }
+    }
+}
+
+/// A real argon2id hash of a throwaway password, computed once, used
+/// only to keep unknown-username logins as slow as real ones.
+fn dummy_hash() -> &'static str {
+    use std::sync::OnceLock;
+    static H: OnceLock<String> = OnceLock::new();
+    H.get_or_init(|| hash_password("ruscker-timing-decoy").expect("hash dummy"))
+}
+
+/// Create a new user. `must_change` marks the optional first-login
+/// password-change prompt. Errors if the username already exists.
+pub async fn create(
+    pool: &SqlitePool,
+    username: &str,
+    password: &str,
+    role: Role,
+    must_change: bool,
+    actor: Option<&str>,
+) -> Result<()> {
+    let username = normalize_username(username);
+    let hash = hash_password(password)?;
+    let now = Utc::now();
+    let id = uuid::Uuid::new_v4().to_string();
+
+    let mut tx = pool.begin().await.context("begin user tx")?;
+    sqlx::query(
+        "INSERT INTO users
+           (id, username, password_hash, role, must_change_password,
+            created_at, updated_at, created_by)
+         VALUES (?, ?, ?, ?, ?, ?, ?, ?)",
+    )
+    .bind(&id)
+    .bind(&username)
+    .bind(&hash)
+    .bind(role.as_str())
+    .bind(must_change as i64)
+    .bind(now)
+    .bind(now)
+    .bind(actor)
+    .execute(&mut *tx)
+    .await
+    .with_context(|| format!("insert user {username}"))?;
+
+    audit(&mut tx, actor, "user.create", &username, &role, now).await?;
+    tx.commit().await.context("commit user create")?;
+    Ok(())
+}
+
+/// Replace a user's password and set/clear the must-change prompt.
+pub async fn set_password(
+    pool: &SqlitePool,
+    username: &str,
+    new_password: &str,
+    must_change: bool,
+    actor: Option<&str>,
+) -> Result<()> {
+    let username = normalize_username(username);
+    let hash = hash_password(new_password)?;
+    let now = Utc::now();
+
+    let mut tx = pool.begin().await.context("begin password tx")?;
+    let res = sqlx::query(
+        "UPDATE users
+            SET password_hash = ?, must_change_password = ?, updated_at = ?
+          WHERE username = ?",
+    )
+    .bind(&hash)
+    .bind(must_change as i64)
+    .bind(now)
+    .bind(&username)
+    .execute(&mut *tx)
+    .await
+    .with_context(|| format!("set password for {username}"))?;
+    if res.rows_affected() == 0 {
+        anyhow::bail!("user {username} not found");
+    }
+
+    sqlx::query(
+        "INSERT INTO audit_log (actor, action, target, diff_json, occurred_at)
+         VALUES (?, 'user.password', ?, NULL, ?)",
+    )
+    .bind(actor)
+    .bind(format!("user:{username}"))
+    .bind(now)
+    .execute(&mut *tx)
+    .await
+    .context("audit password change")?;
+
+    tx.commit().await.context("commit password change")?;
+    Ok(())
+}
+
+/// Change a user's role.
+pub async fn set_role(
+    pool: &SqlitePool,
+    username: &str,
+    role: Role,
+    actor: Option<&str>,
+) -> Result<()> {
+    let username = normalize_username(username);
+    let now = Utc::now();
+
+    let mut tx = pool.begin().await.context("begin role tx")?;
+    let res = sqlx::query("UPDATE users SET role = ?, updated_at = ? WHERE username = ?")
+        .bind(role.as_str())
+        .bind(now)
+        .bind(&username)
+        .execute(&mut *tx)
+        .await
+        .with_context(|| format!("set role for {username}"))?;
+    if res.rows_affected() == 0 {
+        anyhow::bail!("user {username} not found");
+    }
+
+    audit(&mut tx, actor, "user.role", &username, &role, now).await?;
+    tx.commit().await.context("commit role change")?;
+    Ok(())
+}
+
+/// Clear the first-login password-change prompt once it's been
+/// answered (whether or not the user actually changed it). No audit —
+/// it's a benign per-user UI flag.
+pub async fn clear_must_change(pool: &SqlitePool, username: &str) -> Result<()> {
+    let username = normalize_username(username);
+    sqlx::query("UPDATE users SET must_change_password = 0 WHERE username = ?")
+        .bind(&username)
+        .execute(pool)
+        .await
+        .with_context(|| format!("clear must-change for {username}"))?;
+    Ok(())
+}
+
+/// Delete a user.
+pub async fn delete(pool: &SqlitePool, username: &str, actor: Option<&str>) -> Result<()> {
+    let username = normalize_username(username);
+    let now = Utc::now();
+
+    let mut tx = pool.begin().await.context("begin user delete")?;
+    let res = sqlx::query("DELETE FROM users WHERE username = ?")
+        .bind(&username)
+        .execute(&mut *tx)
+        .await
+        .with_context(|| format!("delete user {username}"))?;
+    if res.rows_affected() == 0 {
+        anyhow::bail!("user {username} not found");
+    }
+
+    sqlx::query(
+        "INSERT INTO audit_log (actor, action, target, diff_json, occurred_at)
+         VALUES (?, 'user.delete', ?, NULL, ?)",
+    )
+    .bind(actor)
+    .bind(format!("user:{username}"))
+    .bind(now)
+    .execute(&mut *tx)
+    .await
+    .context("audit user delete")?;
+
+    tx.commit().await.context("commit user delete")?;
+    Ok(())
+}
+
+/// Shared audit insert for create/role changes (records the new role
+/// in `diff_json`).
+async fn audit(
+    tx: &mut sqlx::Transaction<'_, sqlx::Sqlite>,
+    actor: Option<&str>,
+    action: &str,
+    username: &str,
+    role: &Role,
+    now: DateTime<Utc>,
+) -> Result<()> {
+    sqlx::query(
+        "INSERT INTO audit_log (actor, action, target, diff_json, occurred_at)
+         VALUES (?, ?, ?, ?, ?)",
+    )
+    .bind(actor)
+    .bind(action)
+    .bind(format!("user:{username}"))
+    .bind(serde_json::json!({ "role": role.as_str() }).to_string())
+    .bind(now)
+    .execute(&mut **tx)
+    .await
+    .context("audit user op")?;
+    Ok(())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    async fn pool() -> SqlitePool {
+        crate::db::open_memory().await.expect("memory db")
+    }
+
+    #[test]
+    fn hash_and_verify_roundtrip() {
+        let h = hash_password("s3cret-pw").unwrap();
+        assert!(verify_password("s3cret-pw", &h));
+        assert!(!verify_password("wrong", &h));
+        assert!(!verify_password("s3cret-pw", "not-a-phc-string"));
+    }
+
+    #[tokio::test]
+    async fn create_then_verify_login() {
+        let p = pool().await;
+        create(&p, "Alice", "pw-alice", Role::Editor, true, Some("admin"))
+            .await
+            .unwrap();
+        // Username is case-insensitive.
+        let u = verify_login(&p, "alice", "pw-alice").await.unwrap();
+        let u = u.expect("login ok");
+        assert_eq!(u.username, "alice");
+        assert_eq!(u.role, Role::Editor);
+        assert!(u.must_change_password);
+        // Wrong password / unknown user ⇒ None.
+        assert!(verify_login(&p, "alice", "nope").await.unwrap().is_none());
+        assert!(verify_login(&p, "ghost", "pw").await.unwrap().is_none());
+    }
+
+    #[tokio::test]
+    async fn admin_count_and_roles() {
+        let p = pool().await;
+        assert!(!any_admin_exists(&p).await.unwrap());
+        create(&p, "root", "pw", Role::Admin, false, None)
+            .await
+            .unwrap();
+        create(&p, "ed", "pw", Role::Editor, false, None)
+            .await
+            .unwrap();
+        assert_eq!(count_admins(&p).await.unwrap(), 1);
+        assert!(any_admin_exists(&p).await.unwrap());
+        // Promote editor → admin.
+        set_role(&p, "ed", Role::Admin, Some("root")).await.unwrap();
+        assert_eq!(count_admins(&p).await.unwrap(), 2);
+    }
+
+    #[tokio::test]
+    async fn duplicate_username_rejected() {
+        let p = pool().await;
+        create(&p, "dup", "pw", Role::Viewer, false, None)
+            .await
+            .unwrap();
+        assert!(create(&p, "DUP", "pw2", Role::Viewer, false, None)
+            .await
+            .is_err());
+    }
+
+    #[tokio::test]
+    async fn set_password_clears_must_change() {
+        let p = pool().await;
+        create(&p, "bob", "init-pw", Role::Viewer, true, Some("admin"))
+            .await
+            .unwrap();
+        set_password(&p, "bob", "new-pw", false, Some("bob"))
+            .await
+            .unwrap();
+        let u = verify_login(&p, "bob", "new-pw").await.unwrap().unwrap();
+        assert!(!u.must_change_password);
+        assert!(verify_login(&p, "bob", "init-pw").await.unwrap().is_none());
+    }
+}

--- a/crates/ruscker-admin/src/routes/admin.rs
+++ b/crates/ruscker-admin/src/routes/admin.rs
@@ -6,7 +6,7 @@
 
 use askama::Template;
 use axum::{
-    extract::{Form, State},
+    extract::{Form, Query, State},
     http::{header::REFERER, HeaderMap, StatusCode},
     response::{Html, IntoResponse, Redirect, Response},
     routing::{get, post},
@@ -16,7 +16,8 @@ use serde::Deserialize;
 use tower_cookies::cookie::time::Duration;
 use tower_cookies::{Cookie, Cookies};
 
-use crate::auth::{AdminSession, MaybeAdminSession, COOKIE_NAME};
+use crate::auth::{AdminSession, MaybeAdminSession, RequireAdmin, Role, COOKIE_NAME};
+use crate::db;
 use crate::i18n::{Locale, Locales};
 use crate::theme::Theme;
 use crate::AppState;
@@ -30,12 +31,24 @@ pub mod landing;
 pub mod logs;
 pub mod spec_form;
 pub mod specs;
+pub mod users;
 
 pub fn routes() -> Router<AppState> {
     Router::new()
         .route("/admin", get(redirect_to_dashboard))
+        // Username/password login is the primary path; the admin token
+        // is a break-glass that always grants an Admin session (and
+        // bootstraps the first account).
         .route("/admin/login", get(login_form).post(login_submit))
+        .route("/admin/login/token", post(token_login))
         .route("/admin/logout", post(logout))
+        // First-admin bootstrap (only when no admin user exists).
+        .route("/admin/setup", get(setup_form).post(setup_submit))
+        // Self-service password change + first-login prompt.
+        .route(
+            "/admin/account/password",
+            get(password_form).post(password_submit),
+        )
         .merge(dashboard::routes())
         .merge(specs::routes())
         .merge(spec_form::routes())
@@ -45,6 +58,7 @@ pub fn routes() -> Router<AppState> {
         .merge(blocks::routes())
         .merge(audit::routes())
         .merge(logs::routes())
+        .merge(users::routes())
 }
 
 // ── Templates ────────────────────────────────────────────────────
@@ -56,12 +70,52 @@ struct LoginPage<'a> {
     theme: Theme,
     locales: &'a Locales,
     locales_all: &'static [Locale],
-    /// "wrong-token" when the previous submit failed, otherwise empty.
-    /// Drives the inline error banner.
+    /// Inline error banner key: "" | "wrong-login" | "wrong-token".
     error: &'static str,
+    /// `true` ⇒ render the break-glass **token** form (bootstrap or
+    /// `?token=1`); `false` ⇒ the username/password form.
+    bootstrap: bool,
 }
 
 impl LoginPage<'_> {
+    fn t(&self, key: &str) -> String {
+        self.locales.t(self.locale, key, None)
+    }
+}
+
+#[derive(Template)]
+#[template(path = "admin/setup.html")]
+struct SetupPage<'a> {
+    locale: Locale,
+    theme: Theme,
+    locales: &'a Locales,
+    locales_all: &'static [Locale],
+    /// "" | "mismatch" | "short" | "exists" | "db".
+    error: &'static str,
+}
+
+impl SetupPage<'_> {
+    fn t(&self, key: &str) -> String {
+        self.locales.t(self.locale, key, None)
+    }
+}
+
+#[derive(Template)]
+#[template(path = "admin/account_password.html")]
+struct AccountPasswordPage<'a> {
+    locale: Locale,
+    theme: Theme,
+    locales: &'a Locales,
+    locales_all: &'static [Locale],
+    nav_section: &'static str,
+    role: Role,
+    /// First-login prompt — shows the "keep current password" skip.
+    first: bool,
+    /// "" | "wrong-current" | "mismatch" | "short".
+    error: &'static str,
+}
+
+impl AccountPasswordPage<'_> {
     fn t(&self, key: &str) -> String {
         self.locales.t(self.locale, key, None)
     }
@@ -73,26 +127,100 @@ async fn redirect_to_dashboard(_: AdminSession) -> Redirect {
     Redirect::to("/admin/dashboard")
 }
 
+/// Issue the admin session cookie. 24h lifetime; `Secure` only under
+/// TLS (signalled by `X-Forwarded-Proto`) so the plain-HTTP dev server
+/// doesn't make the browser drop it. The value is an opaque session id.
+fn issue_session_cookie(cookies: &Cookies, headers: &HeaderMap, session_id: String) {
+    let mut c = Cookie::new(COOKIE_NAME, session_id);
+    c.set_path("/");
+    c.set_http_only(true);
+    c.set_same_site(tower_cookies::cookie::SameSite::Strict);
+    c.set_secure(crate::auth::request_is_https(headers));
+    c.set_max_age(Duration::hours(24));
+    cookies.add(c);
+}
+
+/// 429 + Retry-After when the shared login rate-limit window is full.
+fn rate_limited() -> Response {
+    let mut resp = (
+        StatusCode::TOO_MANY_REQUESTS,
+        "too many login attempts — try again shortly",
+    )
+        .into_response();
+    resp.headers_mut()
+        .insert(axum::http::header::RETRY_AFTER, "60".parse().unwrap());
+    resp
+}
+
+/// Whether `/admin/login` should show the break-glass **token** form
+/// rather than username/password: forced via `?token=1`, or because
+/// there's no DB / no user accounts yet (fresh install).
+async fn show_token_form(state: &AppState, force_token: bool) -> bool {
+    if force_token {
+        return true;
+    }
+    match state.db.as_ref() {
+        Some(pool) => !db::users::any_user_exists(pool).await.unwrap_or(false),
+        None => true,
+    }
+}
+
+#[derive(Debug, Deserialize)]
+pub struct LoginQuery {
+    /// `?token=1` forces the break-glass token form.
+    pub token: Option<String>,
+}
+
 async fn login_form(
     State(state): State<AppState>,
     loc: Locale,
     theme: Theme,
+    Query(q): Query<LoginQuery>,
 ) -> Response {
+    let bootstrap = show_token_form(&state, q.token.is_some()).await;
     let page = LoginPage {
         locale: loc,
         theme,
         locales: &state.locales,
         locales_all: &Locale::ALL,
         error: "",
+        bootstrap,
     };
     render(&page)
 }
 
-#[derive(Debug, Deserialize)]
-pub struct LoginForm {
-    pub token: String,
+fn login_error(
+    state: &AppState,
+    loc: Locale,
+    theme: Theme,
+    error: &'static str,
+    bootstrap: bool,
+) -> Response {
+    let page = LoginPage {
+        locale: loc,
+        theme,
+        locales: &state.locales,
+        locales_all: &Locale::ALL,
+        error,
+        bootstrap,
+    };
+    let body = match page.render() {
+        Ok(s) => s,
+        Err(_) => return (StatusCode::INTERNAL_SERVER_ERROR, "render").into_response(),
+    };
+    let mut resp = (StatusCode::UNAUTHORIZED, Html(body)).into_response();
+    resp.headers_mut()
+        .insert("X-Ruscker-Login", "failed".parse().unwrap());
+    resp
 }
 
+#[derive(Debug, Deserialize)]
+pub struct LoginForm {
+    pub username: String,
+    pub password: String,
+}
+
+/// Primary login: username + password against the `users` table.
 async fn login_submit(
     State(state): State<AppState>,
     cookies: Cookies,
@@ -108,83 +236,314 @@ async fn login_submit(
         )
             .into_response();
     }
-
-    // Rate limit: bound brute force against the token. Saturated
-    // window → 429 with Retry-After, before we even compare.
     if !state.login_limiter.allow() {
-        let mut resp = (
-            StatusCode::TOO_MANY_REQUESTS,
-            "too many login attempts — try again shortly",
-        )
-            .into_response();
-        resp.headers_mut()
-            .insert(axum::http::header::RETRY_AFTER, "60".parse().unwrap());
-        return resp;
+        return rate_limited();
     }
 
-    // Match the token against each configured role token. `None`
-    // ⇒ no token matched ⇒ failed login.
-    let Some(role) = state.admin_auth.role_for(&form.token) else {
-        // Count the failure toward the rate-limit window.
+    // Username/password login needs the user store. Without a DB the
+    // only way in is the break-glass token.
+    let Some(pool) = state.db.as_ref() else {
+        return login_error(&state, loc, theme, "wrong-login", false);
+    };
+
+    let user = match db::users::verify_login(pool, &form.username, &form.password).await {
+        Ok(Some(u)) => u,
+        Ok(None) => {
+            state.login_limiter.record_failure();
+            return login_error(&state, loc, theme, "wrong-login", false);
+        }
+        Err(e) => {
+            tracing::error!(error = ?e, "login lookup failed");
+            return (StatusCode::INTERNAL_SERVER_ERROR, "login error").into_response();
+        }
+    };
+
+    state.login_limiter.record_success();
+    let session_id = state
+        .admin_sessions
+        .create(user.role, Some(user.username.clone()));
+    issue_session_cookie(&cookies, &headers, session_id);
+
+    // First login with an admin-assigned password ⇒ ask whether to
+    // change it.
+    if user.must_change_password {
+        return Redirect::to("/admin/account/password").into_response();
+    }
+
+    let referer = headers.get(REFERER).and_then(|v| v.to_str().ok());
+    let path = super::same_origin_path(referer, user.role.home());
+    let target = if path.starts_with("/admin/")
+        && !path.starts_with("/admin/login")
+        && user.role.can_access_section(section_for_admin_path(&path))
+    {
+        path
+    } else {
+        user.role.home().to_string()
+    };
+    Redirect::to(&target).into_response()
+}
+
+#[derive(Debug, Deserialize)]
+pub struct TokenForm {
+    pub token: String,
+}
+
+/// Break-glass login with `RUSCKER_ADMIN_TOKEN`. Always grants an
+/// Admin session (actor = `None` ⇒ "token" in the audit log). If no
+/// admin account exists yet, it routes to the first-admin setup.
+async fn token_login(
+    State(state): State<AppState>,
+    cookies: Cookies,
+    loc: Locale,
+    theme: Theme,
+    headers: HeaderMap,
+    Form(form): Form<TokenForm>,
+) -> Response {
+    if !state.admin_auth.is_configured() {
+        return (
+            StatusCode::SERVICE_UNAVAILABLE,
+            "RUSCKER_ADMIN_TOKEN is not set — admin disabled",
+        )
+            .into_response();
+    }
+    if !state.login_limiter.allow() {
+        return rate_limited();
+    }
+    if !state.admin_auth.matches_token(&form.token) {
         state.login_limiter.record_failure();
-        // Re-render the form with the error banner. 401 status so
-        // CLI clients / tests can distinguish.
-        let page = LoginPage {
+        cookies.remove(Cookie::new(COOKIE_NAME, ""));
+        return login_error(&state, loc, theme, "wrong-token", true);
+    }
+
+    state.login_limiter.record_success();
+    let session_id = state.admin_sessions.create(Role::Admin, None);
+    issue_session_cookie(&cookies, &headers, session_id);
+
+    // No admin account yet (and a DB to create one in) ⇒ run setup.
+    let need_setup = match state.db.as_ref() {
+        Some(pool) => !db::users::any_admin_exists(pool).await.unwrap_or(false),
+        None => false,
+    };
+    if need_setup {
+        Redirect::to("/admin/setup").into_response()
+    } else {
+        Redirect::to("/admin/dashboard").into_response()
+    }
+}
+
+/// Minimum length for an admin-set or self-chosen password.
+const MIN_PASSWORD_LEN: usize = 8;
+
+// ── First-admin setup ────────────────────────────────────────────
+
+async fn setup_form(
+    _: RequireAdmin,
+    State(state): State<AppState>,
+    loc: Locale,
+    theme: Theme,
+) -> Response {
+    // Setup is admin-gated and only meaningful before the first admin
+    // account exists. Once one does, send the operator to the dashboard.
+    if let Some(pool) = state.db.as_ref() {
+        if db::users::any_admin_exists(pool).await.unwrap_or(false) {
+            return Redirect::to("/admin/dashboard").into_response();
+        }
+    } else {
+        return (
+            StatusCode::SERVICE_UNAVAILABLE,
+            "no database — start with --db",
+        )
+            .into_response();
+    }
+    render(&SetupPage {
+        locale: loc,
+        theme,
+        locales: &state.locales,
+        locales_all: &Locale::ALL,
+        error: "",
+    })
+}
+
+#[derive(Debug, Deserialize)]
+pub struct SetupForm {
+    pub username: String,
+    pub password: String,
+    pub confirm: String,
+}
+
+async fn setup_submit(
+    _: RequireAdmin,
+    State(state): State<AppState>,
+    cookies: Cookies,
+    loc: Locale,
+    theme: Theme,
+    headers: HeaderMap,
+    Form(form): Form<SetupForm>,
+) -> Response {
+    let Some(pool) = state.db.as_ref() else {
+        return (
+            StatusCode::SERVICE_UNAVAILABLE,
+            "no database — start with --db",
+        )
+            .into_response();
+    };
+    // Guard re-setup: only valid while no admin exists.
+    if db::users::any_admin_exists(pool).await.unwrap_or(false) {
+        return Redirect::to("/admin/dashboard").into_response();
+    }
+
+    let setup_err = |error: &'static str| {
+        render(&SetupPage {
             locale: loc,
             theme,
             locales: &state.locales,
             locales_all: &Locale::ALL,
-            error: "wrong-token",
-        };
-        let body = match page.render() {
-            Ok(s) => s,
-            Err(_) => return (StatusCode::INTERNAL_SERVER_ERROR, "render").into_response(),
-        };
-        let mut resp = (StatusCode::UNAUTHORIZED, Html(body)).into_response();
-        // Failed login also clears any stale cookie.
-        cookies.remove(Cookie::new(COOKIE_NAME, ""));
-        // 401 keeps the URL at /admin/login so the user can retry.
-        resp.headers_mut()
-            .insert("X-Ruscker-Login", "failed".parse().unwrap());
-        return resp;
+            error,
+        })
     };
+    let username = db::users::normalize_username(&form.username);
+    if username.is_empty() {
+        return setup_err("exists"); // empty username reuses the generic field error
+    }
+    if form.password.len() < MIN_PASSWORD_LEN {
+        return setup_err("short");
+    }
+    if form.password != form.confirm {
+        return setup_err("mismatch");
+    }
 
-    // Success — clear the failure window so a few fat-fingered
-    // attempts before getting it right don't linger.
-    state.login_limiter.record_success();
-
-    // Set the cookie. 24h lifetime; re-login required after that.
-    // `Secure` is set only when the original request came over
-    // HTTPS (signalled by the reverse proxy via X-Forwarded-Proto)
-    // — setting it unconditionally would make the browser drop the
-    // cookie on the plain-HTTP dev server.
-    // Store an opaque session id in the cookie — never the token.
-    // The session carries the matched role.
-    let session_id = state.admin_sessions.create(role);
-    let mut c = Cookie::new(COOKIE_NAME, session_id);
-    c.set_path("/");
-    c.set_http_only(true);
-    c.set_same_site(tower_cookies::cookie::SameSite::Strict);
-    c.set_secure(crate::auth::request_is_https(&headers));
-    c.set_max_age(Duration::hours(24));
-    cookies.add(c);
-
-    // Redirect to the page the operator was trying to reach, reduced
-    // to a same-origin path (no open redirect) — but only if this
-    // role can actually reach it; otherwise land on the role's home
-    // (the dashboard, which every role can see). This avoids bouncing
-    // a Viewer straight into a 403.
-    let referer = headers.get(REFERER).and_then(|v| v.to_str().ok());
-    let path = super::same_origin_path(referer, role.home());
-    let target = if path.starts_with("/admin/")
-        && !path.starts_with("/admin/login")
-        && role.can_access_section(section_for_admin_path(&path))
+    if let Err(e) = db::users::create(
+        pool,
+        &username,
+        &form.password,
+        Role::Admin,
+        false,
+        Some("token"),
+    )
+    .await
     {
-        path
-    } else {
-        role.home().to_string()
+        tracing::error!(error = ?e, "create first admin failed");
+        return setup_err("exists");
+    }
+
+    // Swap the break-glass token session for a real account session.
+    if let Some(c) = cookies.get(COOKIE_NAME) {
+        state.admin_sessions.remove(c.value());
+    }
+    let session_id = state.admin_sessions.create(Role::Admin, Some(username));
+    issue_session_cookie(&cookies, &headers, session_id);
+    Redirect::to("/admin/dashboard").into_response()
+}
+
+// ── Self-service password change + first-login prompt ─────────────
+
+async fn password_form(
+    session: AdminSession,
+    State(state): State<AppState>,
+    loc: Locale,
+    theme: Theme,
+) -> Response {
+    // Break-glass token sessions have no account to change.
+    let Some(actor) = session.actor.clone() else {
+        return Redirect::to("/admin/dashboard").into_response();
     };
-    Redirect::to(&target).into_response()
+    let first = match state.db.as_ref() {
+        Some(pool) => db::users::fetch(pool, &actor)
+            .await
+            .ok()
+            .flatten()
+            .map(|u| u.must_change_password)
+            .unwrap_or(false),
+        None => false,
+    };
+    render(&AccountPasswordPage {
+        locale: loc,
+        theme,
+        locales: &state.locales,
+        locales_all: &Locale::ALL,
+        nav_section: "",
+        role: session.role,
+        first,
+        error: "",
+    })
+}
+
+#[derive(Debug, Deserialize)]
+pub struct PasswordForm {
+    pub current: String,
+    pub new_password: String,
+    pub confirm: String,
+    /// Present (any value) when the user clicked "keep current" on the
+    /// first-login prompt.
+    pub skip: Option<String>,
+}
+
+async fn password_submit(
+    session: AdminSession,
+    State(state): State<AppState>,
+    loc: Locale,
+    theme: Theme,
+    Form(form): Form<PasswordForm>,
+) -> Response {
+    let Some(actor) = session.actor.clone() else {
+        return Redirect::to("/admin/dashboard").into_response();
+    };
+    let Some(pool) = state.db.as_ref() else {
+        return (
+            StatusCode::SERVICE_UNAVAILABLE,
+            "no database — start with --db",
+        )
+            .into_response();
+    };
+
+    // First-login "keep current password" — just clear the prompt.
+    if form.skip.is_some() {
+        let _ = db::users::clear_must_change(pool, &actor).await;
+        return Redirect::to("/admin/dashboard").into_response();
+    }
+
+    let first = db::users::fetch(pool, &actor)
+        .await
+        .ok()
+        .flatten()
+        .map(|u| u.must_change_password)
+        .unwrap_or(false);
+    let pw_err = |error: &'static str| {
+        render(&AccountPasswordPage {
+            locale: loc,
+            theme,
+            locales: &state.locales,
+            locales_all: &Locale::ALL,
+            nav_section: "",
+            role: session.role,
+            first,
+            error,
+        })
+    };
+
+    if form.new_password.len() < MIN_PASSWORD_LEN {
+        return pw_err("short");
+    }
+    if form.new_password != form.confirm {
+        return pw_err("mismatch");
+    }
+    // Verify the current password before allowing a change.
+    if db::users::verify_login(pool, &actor, &form.current)
+        .await
+        .ok()
+        .flatten()
+        .is_none()
+    {
+        return pw_err("wrong-current");
+    }
+
+    if let Err(e) =
+        db::users::set_password(pool, &actor, &form.new_password, false, Some(&actor)).await
+    {
+        tracing::error!(error = ?e, "password change failed");
+        return (StatusCode::INTERNAL_SERVER_ERROR, "save failed").into_response();
+    }
+    Redirect::to("/admin/dashboard").into_response()
 }
 
 /// Map an `/admin/...` path to the `nav_section` it belongs to, for

--- a/crates/ruscker-admin/src/routes/admin/blocks.rs
+++ b/crates/ruscker-admin/src/routes/admin/blocks.rs
@@ -222,14 +222,14 @@ impl BlockForm {
 }
 
 async fn create(
-    _: RequireAdmin,
+    admin: RequireAdmin,
     State(state): State<AppState>,
     Form(form): Form<BlockForm>,
 ) -> Response {
     let Some(pool) = state.db.as_ref() else {
         return no_db();
     };
-    match landing_blocks::insert(pool, &form.into_input(), Some("admin")).await {
+    match landing_blocks::insert(pool, &form.into_input(), Some(admin.actor())).await {
         Ok(_) => Redirect::to("/admin/blocks").into_response(),
         Err(e) => {
             tracing::error!(error = ?e, "create block failed");
@@ -239,7 +239,7 @@ async fn create(
 }
 
 async fn update(
-    _: RequireAdmin,
+    admin: RequireAdmin,
     State(state): State<AppState>,
     Path(id): Path<String>,
     Form(form): Form<BlockForm>,
@@ -247,7 +247,7 @@ async fn update(
     let Some(pool) = state.db.as_ref() else {
         return no_db();
     };
-    match landing_blocks::update(pool, &id, &form.into_input(), Some("admin")).await {
+    match landing_blocks::update(pool, &id, &form.into_input(), Some(admin.actor())).await {
         Ok(true) => Redirect::to("/admin/blocks").into_response(),
         Ok(false) => (StatusCode::NOT_FOUND, "block not found").into_response(),
         Err(e) => {
@@ -258,14 +258,14 @@ async fn update(
 }
 
 async fn delete(
-    _: RequireAdmin,
+    admin: RequireAdmin,
     State(state): State<AppState>,
     Path(id): Path<String>,
 ) -> Response {
     let Some(pool) = state.db.as_ref() else {
         return no_db();
     };
-    match landing_blocks::delete(pool, &id, Some("admin")).await {
+    match landing_blocks::delete(pool, &id, Some(admin.actor())).await {
         Ok(_) => Redirect::to("/admin/blocks").into_response(),
         Err(e) => {
             tracing::error!(error = ?e, id, "delete block failed");
@@ -275,7 +275,7 @@ async fn delete(
 }
 
 async fn move_block(
-    _: RequireAdmin,
+    admin: RequireAdmin,
     State(state): State<AppState>,
     Path((id, dir)): Path<(String, String)>,
 ) -> Response {
@@ -287,7 +287,7 @@ async fn move_block(
         "down" => false,
         _ => return (StatusCode::BAD_REQUEST, "dir must be up|down").into_response(),
     };
-    match landing_blocks::move_block(pool, &id, up, Some("admin")).await {
+    match landing_blocks::move_block(pool, &id, up, Some(admin.actor())).await {
         Ok(_) => Redirect::to("/admin/blocks").into_response(),
         Err(e) => {
             tracing::error!(error = ?e, id, "move block failed");
@@ -307,14 +307,14 @@ struct ReorderReq {
 /// origin + the `SameSite=Strict` admin cookie cover CSRF. Returns
 /// `204` so the client keeps the DOM order it already rendered.
 async fn reorder(
-    _: RequireAdmin,
+    admin: RequireAdmin,
     State(state): State<AppState>,
     Json(req): Json<ReorderReq>,
 ) -> Response {
     let Some(pool) = state.db.as_ref() else {
         return no_db();
     };
-    match landing_blocks::reorder(pool, &req.slot, &req.ids, Some("admin")).await {
+    match landing_blocks::reorder(pool, &req.slot, &req.ids, Some(admin.actor())).await {
         Ok(true) => StatusCode::NO_CONTENT.into_response(),
         Ok(false) => (StatusCode::BAD_REQUEST, "unknown slot").into_response(),
         Err(e) => {

--- a/crates/ruscker-admin/src/routes/admin/credentials.rs
+++ b/crates/ruscker-admin/src/routes/admin/credentials.rs
@@ -101,7 +101,7 @@ pub struct CredentialForm {
 }
 
 async fn create_or_update(
-    _: RequireAdmin,
+    admin: RequireAdmin,
     State(state): State<AppState>,
     loc: Locale,
     theme: Theme,
@@ -148,7 +148,7 @@ async fn create_or_update(
         &registry,
         form.username.trim(),
         &form.password,
-        Some("admin"),
+        Some(admin.actor()),
     )
     .await
     {
@@ -161,14 +161,14 @@ async fn create_or_update(
 }
 
 async fn delete(
-    _: RequireAdmin,
+    admin: RequireAdmin,
     State(state): State<AppState>,
     Path(name): Path<String>,
 ) -> Response {
     let Some(pool) = state.db.as_ref() else {
         return (StatusCode::SERVICE_UNAVAILABLE, "no db").into_response();
     };
-    match db::credentials::delete_one(pool, &name, Some("admin")).await {
+    match db::credentials::delete_one(pool, &name, Some(admin.actor())).await {
         Ok(_) => Redirect::to("/admin/credentials").into_response(),
         Err(err) => {
             tracing::error!(error = ?err, name, "credential delete failed");

--- a/crates/ruscker-admin/src/routes/admin/images.rs
+++ b/crates/ruscker-admin/src/routes/admin/images.rs
@@ -178,7 +178,7 @@ async fn upload(
             }
         };
         let stored_name = processed.filename.clone();
-        match db::images::insert(pool, processed, Some("admin")).await {
+        match db::images::insert(pool, processed, Some(editor.actor())).await {
             Ok(_id) => {
                 last_uploaded_name = Some(stored_name);
             }
@@ -201,14 +201,14 @@ async fn upload(
 }
 
 async fn delete(
-    _: RequireEditor,
+    editor: RequireEditor,
     State(state): State<AppState>,
     Path(id): Path<String>,
 ) -> Response {
     let Some(pool) = state.db.as_ref() else {
         return (StatusCode::SERVICE_UNAVAILABLE, "no db").into_response();
     };
-    match db::images::delete_one(pool, &id, Some("admin")).await {
+    match db::images::delete_one(pool, &id, Some(editor.actor())).await {
         Ok(_) => Redirect::to("/admin/media").into_response(),
         Err(err) => {
             tracing::error!(error = ?err, id, "image delete failed");

--- a/crates/ruscker-admin/src/routes/admin/landing.rs
+++ b/crates/ruscker-admin/src/routes/admin/landing.rs
@@ -149,7 +149,7 @@ async fn index(
 }
 
 async fn save(
-    _: RequireAdmin,
+    admin: RequireAdmin,
     State(state): State<AppState>,
     loc: Locale,
     theme: Theme,
@@ -159,7 +159,7 @@ async fn save(
         return (StatusCode::SERVICE_UNAVAILABLE, "no db").into_response();
     };
     let lc = form.into_customization();
-    match db::landing::update(pool, &lc, Some("admin")).await {
+    match db::landing::update(pool, &lc, Some(admin.actor())).await {
         Ok(_) => render(&state, loc, theme, Some(LandingForm::from_customization(&lc)), true, None).await,
         Err(err) => {
             tracing::error!(error = ?err, "landing update failed");

--- a/crates/ruscker-admin/src/routes/admin/spec_form.rs
+++ b/crates/ruscker-admin/src/routes/admin/spec_form.rs
@@ -606,7 +606,7 @@ async fn create(
         }
     };
 
-    match db::specs::upsert_one(pool, &spec, Some("admin")).await {
+    match db::specs::upsert_one(pool, &spec, Some(editor.actor())).await {
         Ok(_) => Redirect::to(&format!("/admin/specs/{}/edit", id)).into_response(),
         Err(e) => {
             tracing::error!(error = ?e, "save failed");
@@ -665,7 +665,7 @@ async fn update(
         }
     };
 
-    match db::specs::upsert_one(pool, &spec, Some("admin")).await {
+    match db::specs::upsert_one(pool, &spec, Some(editor.actor())).await {
         Ok(_) => Redirect::to(&format!("/admin/specs/{}/edit", id)).into_response(),
         Err(e) => {
             tracing::error!(error = ?e, "save failed");
@@ -675,14 +675,14 @@ async fn update(
 }
 
 async fn delete(
-    _: RequireEditor,
+    editor: RequireEditor,
     State(state): State<AppState>,
     Path(id): Path<String>,
 ) -> Response {
     let Some(pool) = state.db.as_ref() else {
         return (StatusCode::SERVICE_UNAVAILABLE, "no db").into_response();
     };
-    match db::specs::delete_one(pool, &id, Some("admin")).await {
+    match db::specs::delete_one(pool, &id, Some(editor.actor())).await {
         Ok(_) => Redirect::to("/admin/specs").into_response(),
         Err(e) => {
             tracing::error!(error = ?e, id, "delete failed");

--- a/crates/ruscker-admin/src/routes/admin/users.rs
+++ b/crates/ruscker-admin/src/routes/admin/users.rs
@@ -1,0 +1,259 @@
+//! User-account management — Admin only.
+//!
+//! Create/edit/delete the per-user accounts that back password login
+//! (see [`crate::db::users`]). Guarded by [`RequireAdmin`]; the nav
+//! link is hidden for non-admins. A **last-admin guard** prevents
+//! deleting or demoting the only remaining admin, so an operator can't
+//! lock the role out of the portal.
+
+use askama::Template;
+use axum::{
+    extract::{Form, Path, Query, State},
+    http::StatusCode,
+    response::{IntoResponse, Redirect, Response},
+    routing::{get, post},
+    Router,
+};
+use serde::Deserialize;
+
+use crate::auth::{RequireAdmin, Role};
+use crate::db;
+use crate::i18n::{Locale, Locales};
+use crate::theme::Theme;
+use crate::AppState;
+
+pub fn routes() -> Router<AppState> {
+    Router::new()
+        .route("/admin/users", get(index).post(create))
+        .route("/admin/users/{username}/role", post(set_role))
+        .route("/admin/users/{username}/password", post(reset_password))
+        .route("/admin/users/{username}/delete", post(delete))
+}
+
+#[derive(Template)]
+#[template(path = "admin/users.html")]
+struct UsersPage<'a> {
+    locale: Locale,
+    theme: Theme,
+    locales: &'a Locales,
+    locales_all: &'static [Locale],
+    nav_section: &'static str,
+    role: Role,
+    users: Vec<db::users::UserRow>,
+    /// Username of the logged-in admin — flags the "you" row.
+    me: String,
+    /// "" | "saved" | "created" | "deleted" | "last-admin" | "bad-input" | "exists"
+    flash: &'static str,
+}
+
+impl UsersPage<'_> {
+    fn t(&self, key: &str) -> String {
+        self.locales.t(self.locale, key, None)
+    }
+
+    /// Human label for a role (Fluent).
+    fn role_label(&self, role: &Role) -> String {
+        self.t(role.label_key())
+    }
+
+    /// The three roles, for the create/edit selectors.
+    fn all_roles(&self) -> [Role; 3] {
+        [Role::Viewer, Role::Editor, Role::Admin]
+    }
+}
+
+#[derive(Debug, Deserialize)]
+pub struct UsersQuery {
+    pub flash: Option<String>,
+}
+
+fn redirect_flash(flash: &str) -> Response {
+    Redirect::to(&format!("/admin/users?flash={flash}")).into_response()
+}
+
+async fn index(
+    admin: RequireAdmin,
+    State(state): State<AppState>,
+    loc: Locale,
+    theme: Theme,
+    Query(q): Query<UsersQuery>,
+) -> Response {
+    let Some(pool) = state.db.as_ref() else {
+        return (
+            StatusCode::SERVICE_UNAVAILABLE,
+            "database not attached — start with --db <path>",
+        )
+            .into_response();
+    };
+    let users = match db::users::list_all(pool).await {
+        Ok(u) => u,
+        Err(e) => {
+            tracing::error!(error = ?e, "list users failed");
+            return (StatusCode::INTERNAL_SERVER_ERROR, "db error").into_response();
+        }
+    };
+    let flash = match q.flash.as_deref() {
+        Some("saved") => "saved",
+        Some("created") => "created",
+        Some("deleted") => "deleted",
+        Some("last-admin") => "last-admin",
+        Some("bad-input") => "bad-input",
+        Some("exists") => "exists",
+        _ => "",
+    };
+    let page = UsersPage {
+        locale: loc,
+        theme,
+        locales: &state.locales,
+        locales_all: &Locale::ALL,
+        nav_section: "users",
+        role: admin.role,
+        users,
+        me: admin.actor().to_string(),
+        flash,
+    };
+    super::render(&page)
+}
+
+#[derive(Debug, Deserialize)]
+pub struct CreateForm {
+    pub username: String,
+    pub password: String,
+    pub role: String,
+}
+
+const MIN_PASSWORD_LEN: usize = 8;
+
+async fn create(
+    admin: RequireAdmin,
+    State(state): State<AppState>,
+    Form(form): Form<CreateForm>,
+) -> Response {
+    let Some(pool) = state.db.as_ref() else {
+        return (StatusCode::SERVICE_UNAVAILABLE, "no db").into_response();
+    };
+    let username = db::users::normalize_username(&form.username);
+    let role = Role::parse(&form.role).unwrap_or(Role::Viewer);
+    if username.is_empty() || form.password.len() < MIN_PASSWORD_LEN {
+        return redirect_flash("bad-input");
+    }
+    // New accounts get the "change your password?" prompt on first login.
+    match db::users::create(
+        pool,
+        &username,
+        &form.password,
+        role,
+        true,
+        Some(admin.actor()),
+    )
+    .await
+    {
+        Ok(()) => redirect_flash("created"),
+        Err(e) => {
+            tracing::warn!(error = ?e, %username, "create user failed");
+            redirect_flash("exists")
+        }
+    }
+}
+
+#[derive(Debug, Deserialize)]
+pub struct RoleForm {
+    pub role: String,
+}
+
+async fn set_role(
+    admin: RequireAdmin,
+    State(state): State<AppState>,
+    Path(username): Path<String>,
+    Form(form): Form<RoleForm>,
+) -> Response {
+    let Some(pool) = state.db.as_ref() else {
+        return (StatusCode::SERVICE_UNAVAILABLE, "no db").into_response();
+    };
+    let new_role = Role::parse(&form.role).unwrap_or(Role::Viewer);
+
+    // Last-admin guard: don't let the only admin be demoted.
+    if would_strip_last_admin(pool, &username, Some(new_role)).await {
+        return redirect_flash("last-admin");
+    }
+    match db::users::set_role(pool, &username, new_role, Some(admin.actor())).await {
+        Ok(()) => redirect_flash("saved"),
+        Err(e) => {
+            tracing::warn!(error = ?e, %username, "set role failed");
+            redirect_flash("bad-input")
+        }
+    }
+}
+
+#[derive(Debug, Deserialize)]
+pub struct ResetForm {
+    pub password: String,
+}
+
+async fn reset_password(
+    admin: RequireAdmin,
+    State(state): State<AppState>,
+    Path(username): Path<String>,
+    Form(form): Form<ResetForm>,
+) -> Response {
+    let Some(pool) = state.db.as_ref() else {
+        return (StatusCode::SERVICE_UNAVAILABLE, "no db").into_response();
+    };
+    if form.password.len() < MIN_PASSWORD_LEN {
+        return redirect_flash("bad-input");
+    }
+    // Admin-assigned password ⇒ prompt the user to change it next login.
+    match db::users::set_password(pool, &username, &form.password, true, Some(admin.actor())).await
+    {
+        Ok(()) => redirect_flash("saved"),
+        Err(e) => {
+            tracing::warn!(error = ?e, %username, "reset password failed");
+            redirect_flash("bad-input")
+        }
+    }
+}
+
+async fn delete(
+    admin: RequireAdmin,
+    State(state): State<AppState>,
+    Path(username): Path<String>,
+) -> Response {
+    let Some(pool) = state.db.as_ref() else {
+        return (StatusCode::SERVICE_UNAVAILABLE, "no db").into_response();
+    };
+    // Last-admin guard: deleting the only admin would lock everyone out.
+    if would_strip_last_admin(pool, &username, None).await {
+        return redirect_flash("last-admin");
+    }
+    match db::users::delete(pool, &username, Some(admin.actor())).await {
+        Ok(()) => redirect_flash("deleted"),
+        Err(e) => {
+            tracing::warn!(error = ?e, %username, "delete user failed");
+            redirect_flash("bad-input")
+        }
+    }
+}
+
+/// Would changing `username`'s role to `new_role` (or deleting it when
+/// `new_role` is `None`) leave the portal with zero admins? True ⇒ the
+/// caller must refuse.
+async fn would_strip_last_admin(
+    pool: &sqlx::SqlitePool,
+    username: &str,
+    new_role: Option<Role>,
+) -> bool {
+    // Only relevant if the target is currently an admin.
+    let target = match db::users::fetch(pool, username).await {
+        Ok(Some(u)) => u,
+        _ => return false,
+    };
+    if target.role != Role::Admin {
+        return false;
+    }
+    // Staying admin is always fine.
+    if new_role == Some(Role::Admin) {
+        return false;
+    }
+    // Removing/demoting an admin is only a problem when it's the last.
+    db::users::count_admins(pool).await.unwrap_or(0) <= 1
+}

--- a/crates/ruscker-admin/templates/admin/_layout.html
+++ b/crates/ruscker-admin/templates/admin/_layout.html
@@ -77,6 +77,12 @@
       <span>{{ self.t("admin-nav-audit") }}</span>
     </a>
     {% endif %}
+    {% if role.can_access_section("users") %}
+    <a href="/admin/users" class="admin-nav-link {% if nav_section == "users" %}is-active{% endif %}">
+      <i class="ti ti-users" aria-hidden="true"></i>
+      <span>{{ self.t("admin-nav-users") }}</span>
+    </a>
+    {% endif %}
     {% if role.can_access_section("logs") %}
     <a href="/admin/logs" class="admin-nav-link {% if nav_section == "logs" %}is-active{% endif %}">
       <i class="ti ti-terminal-2" aria-hidden="true"></i>

--- a/crates/ruscker-admin/templates/admin/account_password.html
+++ b/crates/ruscker-admin/templates/admin/account_password.html
@@ -1,0 +1,53 @@
+{% extends "admin/_layout.html" %}
+
+{% block title %}{{ self.t("admin-pw-title") }} · Ruscker{% endblock %}
+
+{% block content %}
+<div class="max-w-md mx-auto">
+  <h1 class="text-xl font-medium tracking-tight">{{ self.t("admin-pw-title") }}</h1>
+
+  {% if first %}
+    <p class="text-sm text-[color:var(--text-muted)] mt-2">{{ self.t("admin-pw-first-prompt") }}</p>
+  {% else %}
+    <p class="text-sm text-[color:var(--text-muted)] mt-2">{{ self.t("admin-pw-help") }}</p>
+  {% endif %}
+
+  {% if error != "" %}
+    <div class="admin-login-error mt-3" role="alert">
+      <i class="ti ti-alert-circle" aria-hidden="true"></i>
+      {% if error == "wrong-current" %}{{ self.t("admin-pw-error-current") }}
+      {% else if error == "mismatch" %}{{ self.t("admin-pw-error-mismatch") }}
+      {% else %}{{ self.t("admin-pw-error-short") }}{% endif %}
+    </div>
+  {% endif %}
+
+  <form method="post" action="/admin/account/password" class="flex flex-col gap-3 mt-4" autocomplete="off">
+    <label class="admin-login-field">
+      <span class="admin-login-label">{{ self.t("admin-pw-current-label") }}</span>
+      <input type="password" name="current" required autocomplete="current-password">
+    </label>
+    <label class="admin-login-field">
+      <span class="admin-login-label">{{ self.t("admin-pw-new-label") }}</span>
+      <input type="password" name="new_password" required autocomplete="new-password">
+    </label>
+    <label class="admin-login-field">
+      <span class="admin-login-label">{{ self.t("admin-pw-confirm-label") }}</span>
+      <input type="password" name="confirm" required autocomplete="new-password">
+    </label>
+
+    <div class="flex items-center gap-3 mt-1">
+      <button type="submit" class="admin-login-btn" style="width:auto">
+        <i class="ti ti-key" aria-hidden="true"></i>
+        {{ self.t("admin-pw-submit") }}
+      </button>
+      {% if first %}
+        {# First-login prompt: let the user keep the assigned password. #}
+        <button type="submit" name="skip" value="1"
+                class="text-sm text-[color:var(--text-muted)] underline">
+          {{ self.t("admin-pw-keep") }}
+        </button>
+      {% endif %}
+    </div>
+  </form>
+</div>
+{% endblock %}

--- a/crates/ruscker-admin/templates/admin/login.html
+++ b/crates/ruscker-admin/templates/admin/login.html
@@ -12,7 +12,8 @@
 </head>
 <body class="min-h-screen flex flex-col items-center justify-center px-4">
 
-<form method="post" action="/admin/login" class="admin-login-card" autocomplete="off">
+<form method="post" action="{% if bootstrap %}/admin/login/token{% else %}/admin/login{% endif %}"
+      class="admin-login-card" autocomplete="off">
 
   <div class="admin-login-brand">
     <svg viewBox="0 0 80 80" width="48" height="48" aria-hidden="true">
@@ -24,20 +25,37 @@
   </div>
 
   <h1 class="text-lg font-medium tracking-tight">{{ self.t("admin-login-title") }}</h1>
-  <p class="text-xs text-[color:var(--text-muted)]">{{ self.t("admin-login-help") }}</p>
+  <p class="text-xs text-[color:var(--text-muted)]">
+    {% if bootstrap %}{{ self.t("admin-login-help") }}{% else %}{{ self.t("admin-login-help-user") }}{% endif %}
+  </p>
 
-  {% if error == "wrong-token" %}
+  {% if error == "wrong-token" || error == "wrong-login" %}
     <div class="admin-login-error" role="alert">
       <i class="ti ti-alert-circle" aria-hidden="true"></i>
-      {{ self.t("admin-login-error-wrong") }}
+      {% if error == "wrong-login" %}{{ self.t("admin-login-error-credentials") }}{% else %}{{ self.t("admin-login-error-wrong") }}{% endif %}
     </div>
   {% endif %}
 
-  <label class="admin-login-field">
-    <span class="admin-login-label">{{ self.t("admin-login-token-label") }}</span>
-    <input type="password" name="token" required autofocus
-           placeholder="{{ self.t("admin-login-token-placeholder") }}">
-  </label>
+  {% if bootstrap %}
+    {# Break-glass / first-run: authenticate with the admin token. #}
+    <label class="admin-login-field">
+      <span class="admin-login-label">{{ self.t("admin-login-token-label") }}</span>
+      <input type="password" name="token" required autofocus
+             placeholder="{{ self.t("admin-login-token-placeholder") }}">
+    </label>
+  {% else %}
+    {# Normal: per-user account. #}
+    <label class="admin-login-field">
+      <span class="admin-login-label">{{ self.t("admin-login-username-label") }}</span>
+      <input type="text" name="username" required autofocus autocapitalize="none"
+             autocomplete="username" placeholder="{{ self.t("admin-login-username-placeholder") }}">
+    </label>
+    <label class="admin-login-field">
+      <span class="admin-login-label">{{ self.t("admin-login-password-label") }}</span>
+      <input type="password" name="password" required autocomplete="current-password"
+             placeholder="{{ self.t("admin-login-password-placeholder") }}">
+    </label>
+  {% endif %}
 
   <button type="submit" class="admin-login-btn">
     <i class="ti ti-login" aria-hidden="true"></i>
@@ -45,6 +63,11 @@
   </button>
 
   <div class="admin-login-footer">
+    {% if bootstrap %}
+      <a href="/admin/login">{{ self.t("admin-login-use-password") }}</a>
+    {% else %}
+      <a href="/admin/login?token=1">{{ self.t("admin-login-use-token") }}</a>
+    {% endif %}
     <a href="/">{{ self.t("admin-login-back-portal") }}</a>
     <form method="post" action="/__set/locale" class="contents">
       {% for loc in locales_all %}

--- a/crates/ruscker-admin/templates/admin/setup.html
+++ b/crates/ruscker-admin/templates/admin/setup.html
@@ -1,0 +1,70 @@
+<!doctype html>
+<html lang="{{ locale.code() }}"{% match theme.data_attr() %}{% when Some with (t) %} data-theme="{{ t }}"{% when None %}{% endmatch %}>
+<head>
+<meta charset="utf-8">
+<meta name="viewport" content="width=device-width,initial-scale=1">
+<meta name="theme-color" content="#0f6e56">
+<meta name="robots" content="noindex,nofollow">
+<title>{{ self.t("admin-setup-title") }} · Ruscker</title>
+<link rel="icon" type="image/svg+xml" href="/favicon.svg">
+<link rel="stylesheet" href="/assets/styles.css">
+<link rel="stylesheet" href="/assets/icons/tabler-icons.min.css">
+</head>
+<body class="min-h-screen flex flex-col items-center justify-center px-4">
+
+<form method="post" action="/admin/setup" class="admin-login-card" autocomplete="off">
+
+  <div class="admin-login-brand">
+    <svg viewBox="0 0 80 80" width="48" height="48" aria-hidden="true">
+      <polygon points="14,52 40,40 66,52 40,64" fill="#0F6E56"/>
+      <polygon points="14,40 40,28 66,40 40,52" fill="#1D9E75"/>
+      <polygon points="14,28 40,16 66,28 40,40" fill="#5DCAA5"/>
+    </svg>
+    <div class="brand-wordmark text-base">ruscker · admin</div>
+  </div>
+
+  <h1 class="text-lg font-medium tracking-tight">{{ self.t("admin-setup-title") }}</h1>
+  <p class="text-xs text-[color:var(--text-muted)]">{{ self.t("admin-setup-help") }}</p>
+
+  {% if error != "" %}
+    <div class="admin-login-error" role="alert">
+      <i class="ti ti-alert-circle" aria-hidden="true"></i>
+      {% if error == "mismatch" %}{{ self.t("admin-pw-error-mismatch") }}
+      {% else if error == "short" %}{{ self.t("admin-pw-error-short") }}
+      {% else %}{{ self.t("admin-setup-error") }}{% endif %}
+    </div>
+  {% endif %}
+
+  <label class="admin-login-field">
+    <span class="admin-login-label">{{ self.t("admin-login-username-label") }}</span>
+    <input type="text" name="username" required autofocus autocapitalize="none"
+           autocomplete="username" placeholder="admin">
+  </label>
+  <label class="admin-login-field">
+    <span class="admin-login-label">{{ self.t("admin-setup-password-label") }}</span>
+    <input type="password" name="password" required autocomplete="new-password">
+  </label>
+  <label class="admin-login-field">
+    <span class="admin-login-label">{{ self.t("admin-pw-confirm-label") }}</span>
+    <input type="password" name="confirm" required autocomplete="new-password">
+  </label>
+
+  <button type="submit" class="admin-login-btn">
+    <i class="ti ti-user-check" aria-hidden="true"></i>
+    {{ self.t("admin-setup-submit") }}
+  </button>
+
+  <div class="admin-login-footer">
+    <form method="post" action="/__set/locale" class="contents">
+      {% for loc in locales_all %}
+        <button type="submit" name="locale" value="{{ loc.code() }}"
+                class="admin-login-locale {% if *loc == locale %}is-active{% endif %}">
+          {{ loc.code()|upper }}
+        </button>
+      {% endfor %}
+    </form>
+  </div>
+</form>
+
+</body>
+</html>

--- a/crates/ruscker-admin/templates/admin/users.html
+++ b/crates/ruscker-admin/templates/admin/users.html
@@ -1,0 +1,100 @@
+{% extends "admin/_layout.html" %}
+
+{% block title %}{{ self.t("admin-users-title") }} · Ruscker{% endblock %}
+
+{% block content %}
+<div class="flex items-end justify-between mb-3">
+  <div>
+    <h1 class="text-xl font-medium tracking-tight">{{ self.t("admin-users-title") }}</h1>
+    <p class="text-xs text-[color:var(--text-muted)] mt-1">{{ self.t("admin-users-subtitle") }}</p>
+  </div>
+</div>
+
+{% if flash != "" %}
+  <div class="admin-login-error mb-3" role="status"
+       style="{% if flash == "last-admin" || flash == "bad-input" || flash == "exists" %}{% else %}background:rgba(29,158,117,0.12);color:var(--text-primary){% endif %}">
+    <i class="ti ti-info-circle" aria-hidden="true"></i>
+    {% if flash == "created" %}{{ self.t("admin-users-flash-created") }}
+    {% else if flash == "saved" %}{{ self.t("admin-users-flash-saved") }}
+    {% else if flash == "deleted" %}{{ self.t("admin-users-flash-deleted") }}
+    {% else if flash == "last-admin" %}{{ self.t("admin-users-flash-last-admin") }}
+    {% else if flash == "exists" %}{{ self.t("admin-users-flash-exists") }}
+    {% else %}{{ self.t("admin-users-flash-bad-input") }}{% endif %}
+  </div>
+{% endif %}
+
+{# ── Create a new user ─────────────────────────────────────────── #}
+<form method="post" action="/admin/users" class="rcard" style="padding:16px;margin-bottom:20px" autocomplete="off">
+  <div class="text-sm font-medium mb-2">{{ self.t("admin-users-new") }}</div>
+  <div class="flex flex-wrap items-end gap-3">
+    <label class="admin-login-field" style="margin:0">
+      <span class="admin-login-label">{{ self.t("admin-login-username-label") }}</span>
+      <input type="text" name="username" required autocapitalize="none" placeholder="jane">
+    </label>
+    <label class="admin-login-field" style="margin:0">
+      <span class="admin-login-label">{{ self.t("admin-users-initial-password") }}</span>
+      <input type="text" name="password" required autocomplete="off" placeholder="••••••••">
+    </label>
+    <label class="admin-login-field" style="margin:0">
+      <span class="admin-login-label">{{ self.t("admin-users-role") }}</span>
+      <select name="role">
+        {% for r in self.all_roles() %}
+          <option value="{{ r.as_str() }}"{% if r == Role::Viewer %} selected{% endif %}>{{ self.role_label(r) }}</option>
+        {% endfor %}
+      </select>
+    </label>
+    <button type="submit" class="admin-login-btn" style="width:auto">
+      <i class="ti ti-user-plus" aria-hidden="true"></i>
+      {{ self.t("admin-users-create") }}
+    </button>
+  </div>
+  <p class="text-xs text-[color:var(--text-faint)] mt-2">{{ self.t("admin-users-initial-password-hint") }}</p>
+</form>
+
+{# ── Existing users ────────────────────────────────────────────── #}
+<table class="w-full text-sm" style="border-collapse:collapse">
+  <thead>
+    <tr class="text-left text-[color:var(--text-muted)]" style="border-bottom:0.5px solid var(--border)">
+      <th class="py-2">{{ self.t("admin-users-col-user") }}</th>
+      <th>{{ self.t("admin-users-col-role") }}</th>
+      <th>{{ self.t("admin-users-col-created") }}</th>
+      <th style="text-align:right">{{ self.t("admin-users-col-actions") }}</th>
+    </tr>
+  </thead>
+  <tbody>
+    {% for u in users %}
+      <tr style="border-bottom:0.5px solid var(--border)">
+        <td class="py-2">
+          <span class="font-medium">{{ u.username }}</span>
+          {% if u.username == me %}<span class="text-xs text-[color:var(--text-faint)]"> ({{ self.t("admin-users-you") }})</span>{% endif %}
+          {% if u.must_change_password %}<i class="ti ti-alert-triangle" title="{{ self.t("admin-users-must-change") }}" style="color:var(--text-faint)"></i>{% endif %}
+        </td>
+        <td>
+          <form method="post" action="/admin/users/{{ u.username }}/role" style="display:flex;gap:6px;align-items:center">
+            <select name="role">
+              {% for r in self.all_roles() %}
+                <option value="{{ r.as_str() }}"{% if r == u.role %} selected{% endif %}>{{ self.role_label(r) }}</option>
+              {% endfor %}
+            </select>
+            <button type="submit" class="dash-action" title="{{ self.t("admin-users-save-role") }}"><i class="ti ti-check"></i></button>
+          </form>
+        </td>
+        <td class="dash-mono text-[color:var(--text-muted)]">{{ u.created_at.format("%Y-%m-%d") }}</td>
+        <td style="text-align:right;white-space:nowrap">
+          {# Reset password — reveals a tiny inline form. #}
+          <form method="post" action="/admin/users/{{ u.username }}/password"
+                style="display:inline-flex;gap:4px;align-items:center" autocomplete="off">
+            <input type="text" name="password" placeholder="{{ self.t("admin-users-new-password") }}"
+                   style="width:120px" autocomplete="off">
+            <button type="submit" class="dash-action" title="{{ self.t("admin-users-reset-password") }}"><i class="ti ti-key"></i></button>
+          </form>
+          <form method="post" action="/admin/users/{{ u.username }}/delete" style="display:inline"
+                onsubmit="return confirm('{{ self.t("admin-users-confirm-delete") }}')">
+            <button type="submit" class="dash-action dash-action--danger" title="{{ self.t("admin-users-delete") }}"><i class="ti ti-trash"></i></button>
+          </form>
+        </td>
+      </tr>
+    {% endfor %}
+  </tbody>
+</table>
+{% endblock %}

--- a/crates/ruscker-admin/tests/rbac.rs
+++ b/crates/ruscker-admin/tests/rbac.rs
@@ -35,11 +35,9 @@ fn state() -> AppState {
     AppState {
         config: Arc::new(config),
         locales: Arc::new(locales),
-        // Three distinct role tokens configured.
+        // Break-glass admin token configured.
         admin_auth: AdminAuth {
             admin: Some("admin-tok".into()),
-            editor: Some("editor-tok".into()),
-            viewer: Some("viewer-tok".into()),
         },
         admin_sessions: Default::default(),
         log_buffer: None,
@@ -62,7 +60,7 @@ fn state() -> AppState {
 /// cookie header value to send it back. The store is behind an `Arc`
 /// shared with the router built from the same `state`.
 fn cookie_for(state: &AppState, role: Role) -> String {
-    let id = state.admin_sessions.create(role);
+    let id = state.admin_sessions.create(role, Some("test-user".into()));
     format!("{COOKIE_NAME}={id}")
 }
 

--- a/crates/ruscker-admin/tests/user_accounts.rs
+++ b/crates/ruscker-admin/tests/user_accounts.rs
@@ -1,0 +1,150 @@
+//! Integration tests for the user-account auth flow (#107): token
+//! bootstrap, username/password login, and the last-admin guard.
+//!
+//! Uses a real temp-file SQLite (the lib's in-memory helper is
+//! test-private) and `Router::oneshot`. Sessions for the guard test
+//! are minted directly in the shared store, the same trick as
+//! `rbac.rs`.
+
+use axum::body::Body;
+use axum::http::{Request, StatusCode};
+use ruscker_admin::auth::{AdminAuth, Role, COOKIE_NAME};
+use ruscker_admin::{router, AppState};
+use ruscker_config::Config;
+use std::sync::Arc;
+use tower::ServiceExt;
+
+const YAML: &str = "proxy:\n  title: Test\n  specs: []\n";
+
+async fn state_with_db() -> (AppState, sqlx::SqlitePool) {
+    std::env::set_var("DOCKER_REGISTRY_PASSWORD", "test");
+    let path = std::env::temp_dir().join(format!("ruscker-users-{}.db", uuid::Uuid::new_v4()));
+    let pool = ruscker_admin::db::open(&path).await.expect("open db");
+    let config = Config::from_yaml(YAML).expect("parse config");
+    let locales = ruscker_admin::i18n::Locales::load().expect("load locales");
+    let state = AppState {
+        config: Arc::new(config),
+        locales: Arc::new(locales),
+        admin_auth: AdminAuth::with_token("break-glass-tok"),
+        admin_sessions: Default::default(),
+        log_buffer: None,
+        login_limiter: Arc::new(ruscker_admin::auth::LoginRateLimiter::default_policy()),
+        api_limiter: Arc::new(ruscker_admin::ratelimit::ApiRateLimiter::new()),
+        db: Some(pool.clone()),
+        images_dir: None,
+        master_key: Default::default(),
+        backend: None,
+        replicas: Arc::new(tokio::sync::RwLock::new(Default::default())),
+        cookie_key: ruscker_proxy::sticky::CookieKey::random(),
+        spawn_locks: Arc::new(dashmap::DashMap::new()),
+        sessions: Arc::new(ruscker_admin::sessions::SessionTracker::new()),
+        metrics: ruscker_admin::metrics_cache::MetricsCache::new(),
+        draining: Arc::new(std::sync::atomic::AtomicBool::new(false)),
+    };
+    (state, pool)
+}
+
+async fn post(
+    state: AppState,
+    uri: &str,
+    body: &str,
+    cookie: Option<&str>,
+) -> (StatusCode, String) {
+    let app = router(state);
+    let mut b = Request::builder()
+        .method("POST")
+        .uri(uri)
+        .header("content-type", "application/x-www-form-urlencoded");
+    if let Some(c) = cookie {
+        b = b.header("cookie", c);
+    }
+    let resp = app
+        .oneshot(b.body(Body::from(body.to_string())).unwrap())
+        .await
+        .unwrap();
+    let status = resp.status();
+    let loc = resp
+        .headers()
+        .get("location")
+        .and_then(|v| v.to_str().ok())
+        .unwrap_or("")
+        .to_string();
+    (status, loc)
+}
+
+#[tokio::test]
+async fn token_login_bootstraps_to_setup() {
+    let (state, _pool) = state_with_db().await;
+    // Fresh DB, no admin account ⇒ token login routes to setup.
+    let (status, loc) = post(state, "/admin/login/token", "token=break-glass-tok", None).await;
+    assert_eq!(status, StatusCode::SEE_OTHER);
+    assert_eq!(loc, "/admin/setup");
+}
+
+#[tokio::test]
+async fn wrong_token_is_rejected() {
+    let (state, _pool) = state_with_db().await;
+    let (status, _) = post(state, "/admin/login/token", "token=nope", None).await;
+    assert_eq!(status, StatusCode::UNAUTHORIZED);
+}
+
+#[tokio::test]
+async fn password_login_succeeds_and_wrong_fails() {
+    let (state, pool) = state_with_db().await;
+    ruscker_admin::db::users::create(&pool, "alice", "alicepass1", Role::Editor, false, None)
+        .await
+        .unwrap();
+
+    let (ok_status, ok_loc) = post(
+        state.clone(),
+        "/admin/login",
+        "username=alice&password=alicepass1",
+        None,
+    )
+    .await;
+    assert_eq!(ok_status, StatusCode::SEE_OTHER);
+    assert_eq!(ok_loc, "/admin/dashboard");
+
+    let (bad_status, _) = post(state, "/admin/login", "username=alice&password=WRONG", None).await;
+    assert_eq!(bad_status, StatusCode::UNAUTHORIZED);
+}
+
+#[tokio::test]
+async fn first_login_with_must_change_redirects_to_password() {
+    let (state, pool) = state_with_db().await;
+    // must_change = true ⇒ first login lands on the change-password page.
+    ruscker_admin::db::users::create(&pool, "bob", "bobpass12", Role::Viewer, true, None)
+        .await
+        .unwrap();
+    let (status, loc) = post(
+        state,
+        "/admin/login",
+        "username=bob&password=bobpass12",
+        None,
+    )
+    .await;
+    assert_eq!(status, StatusCode::SEE_OTHER);
+    assert_eq!(loc, "/admin/account/password");
+}
+
+#[tokio::test]
+async fn last_admin_cannot_be_deleted() {
+    let (state, pool) = state_with_db().await;
+    ruscker_admin::db::users::create(&pool, "root", "rootpass1", Role::Admin, false, None)
+        .await
+        .unwrap();
+    // Mint an admin session directly (the shared store the router reads).
+    let sid = state
+        .admin_sessions
+        .create(Role::Admin, Some("root".into()));
+    let cookie = format!("{COOKIE_NAME}={sid}");
+
+    let (status, loc) = post(state, "/admin/users/root/delete", "", Some(&cookie)).await;
+    assert_eq!(status, StatusCode::SEE_OTHER);
+    assert!(loc.contains("flash=last-admin"), "got {loc}");
+    // The sole admin survives.
+    assert_eq!(
+        ruscker_admin::db::users::count_admins(&pool).await.unwrap(),
+        1
+    );
+}

--- a/docs/SECURITY.md
+++ b/docs/SECURITY.md
@@ -18,9 +18,8 @@ Status: living document. Tracks the Phase 5 security audit
 
 | Asset | Why it matters |
 |-------|----------------|
-| `RUSCKER_ADMIN_TOKEN` | full admin access — create/edit specs, read audit log, stop containers |
-| `RUSCKER_EDITOR_TOKEN` | (optional) Editor role — apps + media + dashboard actions |
-| `RUSCKER_VIEWER_TOKEN` | (optional) Viewer role — dashboard read-only |
+| `RUSCKER_ADMIN_TOKEN` | break-glass Admin login + first-account bootstrap — full access |
+| User passwords (DB) | per-user login; stored as argon2id hashes |
 | `RUSCKER_MASTER_KEY` | decrypts the registry-credential store |
 | `RUSCKER_COOKIE_KEY` | forges sticky-session cookies |
 | Registry credentials (DB) | pull access to private images |
@@ -52,11 +51,20 @@ Status: living document. Tracks the Phase 5 security audit
 
 ## 2. Authentication & authorization
 
-- **[implemented]** Constant-time token compare —
-  `auth::AdminAuth::role_for` → `ct_eq` (XOR-fold, length-checked).
-  Time depends only on the public length, not the bytes. The
-  candidate is compared against each configured role token
-  (most-privileged first) and resolves to the matched [`Role`].
+- **[implemented]** User accounts (#107) — per-user login
+  (`username` + `password`) backed by the `users` table; passwords
+  stored only as **argon2id** PHC hashes (`db::users`, never
+  plaintext). `verify_login` runs a decoy hash on unknown usernames
+  so timing doesn't reveal whether an account exists. Roles
+  (`viewer`/`editor`/`admin`) are per-user.
+- **[implemented]** Break-glass admin token —
+  `auth::AdminAuth::matches_token` → `ct_eq` (XOR-fold, length-
+  checked; time depends only on the public length). `RUSCKER_ADMIN_TOKEN`
+  always grants an Admin session and **bootstraps the first account**
+  (token login on a fresh install → forced setup). It's the recovery
+  path so an operator can never be locked out; treat it as a
+  break-glass secret. The old `RUSCKER_EDITOR_TOKEN`/`RUSCKER_VIEWER_TOKEN`
+  (the #101 MVP) are **removed** — Editor/Viewer are DB accounts now.
 - **[implemented]** Login rate limiting —
   `auth::LoginRateLimiter` (global sliding window, default 10
   failures / 60 s). Saturated → `429` + `Retry-After`. Wired in
@@ -70,19 +78,19 @@ Status: living document. Tracks the Phase 5 security audit
   carries a random 244-bit session id (`auth::AdminSessions`), never
   the token. Logout and server restart revoke it; a stolen cookie
   never exposes the token.
-- **[implemented]** Role-based access control (#101) — three roles
-  with separate env tokens: `RUSCKER_ADMIN_TOKEN` (required ⇒
-  **Admin**, full access), and optional `RUSCKER_EDITOR_TOKEN`
-  (**Editor**: apps + media + dashboard incl. stop/restart) and
-  `RUSCKER_VIEWER_TOKEN` (**Viewer**: dashboard read-only). The
-  matched role rides in the session. Enforcement is **server-side**
-  via the `AdminSession` / `RequireEditor` / `RequireAdmin`
-  extractors on each route group — the permission matrix lives in
-  `Role::can_access_section` / `can_manage`, and the nav only *hides*
-  links it can't reach (UX, not the boundary). Denied → `403`. With
-  only the admin token set, behaviour is identical to the previous
-  single-token model (backward-compatible). Per-app ACLs and external
-  IdPs (OIDC/SAML/LDAP) remain Phase 8.
+- **[implemented]** Role-based access control (#101/#107) — three
+  roles (**Viewer** = dashboard read-only; **Editor** = apps + media +
+  dashboard incl. stop/restart; **Admin** = everything, incl. user
+  management). Enforcement is **server-side** via the `AdminSession` /
+  `RequireEditor` / `RequireAdmin` extractors on each route group —
+  the permission matrix lives in `Role::can_access_section` /
+  `can_manage`, and the nav only *hides* links it can't reach (UX, not
+  the boundary). Denied → `403`. Admins manage accounts at
+  `/admin/users` (create/role/reset-password/delete) with a
+  **last-admin guard** that refuses to delete or demote the only
+  remaining admin. Audit entries record the acting username (or
+  `token` for a break-glass session). Per-app ACLs and external IdPs
+  (OIDC/SAML/LDAP) remain Phase 8.
 - **[accepted limitation]** Login lockout can be triggered by a
   flood of bad attempts (the global limiter's trade-off). Self-
   heals within the 60 s window.
@@ -257,16 +265,16 @@ ruscker serve --bind 127.0.0.1:8080 ...
 ### Secrets (env vars — never in YAML)
 
 ```bash
-export RUSCKER_ADMIN_TOKEN=$(openssl rand -hex 32)   # 256-bit — Admin
+export RUSCKER_ADMIN_TOKEN=$(openssl rand -hex 32)   # 256-bit — break-glass admin
 export RUSCKER_MASTER_KEY=$(openssl rand -hex 32)    # AES-256 key
 export RUSCKER_COOKIE_KEY=$(openssl rand -hex 32)    # sticky HMAC key
-# Optional extra roles (RBAC, §2) — omit for the single-admin model:
-export RUSCKER_EDITOR_TOKEN=$(openssl rand -hex 32)  # Editor: apps + media
-export RUSCKER_VIEWER_TOKEN=$(openssl rand -hex 32)  # Viewer: dashboard only
 ```
 
-Use **distinct** tokens per role; sharing one across roles resolves
-to the highest privilege.
+On first run, log in with `RUSCKER_ADMIN_TOKEN` and you'll be prompted
+to create the first admin **account** (username + password). After
+that, everyone signs in with their account; the token stays as a
+break-glass / recovery path. Manage further accounts (Viewer / Editor /
+Admin) at `/admin/users`.
 
 - Set `RUSCKER_COOKIE_KEY` explicitly in prod — without it the
   sticky key is randomized per process, invalidating all sessions

--- a/packaging/ruscker.env.example
+++ b/packaging/ruscker.env.example
@@ -4,21 +4,16 @@
 #
 # Uncomment and fill the values you need, then `systemctl restart ruscker`.
 
-# Admin panel token (Admin role — full access). On first .deb install
-# a strong random value is generated here automatically and printed
-# once (no default password). Until a token is set, /admin/* returns
-# 503 and only the public landing + proxy are served. To set/rotate
-# manually:  openssl rand -hex 32
-#RUSCKER_ADMIN_TOKEN=
-
-# Optional extra access levels (RBAC). Set distinct tokens to hand out
-# limited logins without sharing the admin token:
-#   Editor — create/edit apps, upload media, dashboard + stop/restart
-#   Viewer — read-only dashboard, nothing else
-# Omit both for the single-admin model. Generate each with:
+# Break-glass admin token. On first .deb install a strong random value
+# is generated here automatically and printed once (no default
+# password). Log in with it at /admin/login the first time; you'll be
+# asked to create the first admin ACCOUNT (username + password). After
+# that everyone signs in with their account, and you manage further
+# users (Viewer / Editor / Admin) under /admin/users. The token remains
+# a break-glass / recovery login so you can never be locked out. Until
+# it's set, /admin/* returns 503. To set/rotate manually:
 #   openssl rand -hex 32
-#RUSCKER_EDITOR_TOKEN=
-#RUSCKER_VIEWER_TOKEN=
+#RUSCKER_ADMIN_TOKEN=
 
 # Master key for the encrypted credentials store (AES-256-GCM).
 # Required only if you use the admin credentials store. Hex (64 chars)


### PR DESCRIPTION
Closes #107. Follow-up to #101 — replaces the env-token RBAC with real **per-user accounts** (option B).

## Flow (as requested)
1. **Bootstrap** — fresh install: `/admin/login` shows the **token** form; `RUSCKER_ADMIN_TOKEN` login routes to **/admin/setup**, where the admin creates the first account (username + password).
2. **Admin creates users** — `/admin/users` (Admin-only): username + role + **initial password**.
3. **First access** — a user with an admin-assigned password is **asked once** whether to change it (optional skip; doesn't repeat).

Confirmed decisions: the admin token is a **permanent break-glass** (never locked out); `RUSCKER_EDITOR_TOKEN`/`RUSCKER_VIEWER_TOKEN` are **removed** (Editor/Viewer are DB accounts now).

## What's in it
- **`0006_users`** + **`db::users`** — argon2id hashes (never plaintext); `verify_login` uses a decoy hash on unknown usernames for uniform timing.
- **Auth** — `AdminAuth` = break-glass token only; sessions carry `(Role, actor)`; guards expose the actor.
- **Routes/UI** — `/admin/login` (user/pass) + `/admin/login/token` (break-glass) + `/admin/setup` + `/admin/account/password` + `/admin/users` (CRUD with a **last-admin guard**). New "Users" nav (Admin-only).
- **Audit** now records the real acting username (or `token`) instead of a hardcoded `"admin"`.

## Tests + smoke
- `db::users` unit tests + `tests/user_accounts.rs` (token bootstrap → setup; password login pass/fail; first-login redirect; last-admin guard). **295 tests green**, clippy clean.
- **Live HTTP smoke**: fresh db → token → setup (`root`) → dashboard; login page flips to user/pass; root login; root creates editor `jane` (`flash=created`); jane first login → `/admin/account/password`; jane gating (`/admin/users`=403, `/admin/specs`=200); jane skip → clears must-change; **audit** shows `token` created root and `root` created jane; last-admin guard blocks deleting the sole admin, then **releases** after a 2nd admin is added.
- fmt-drift: new files 0-drift; no edited file increased its hunk count vs `main`.

## Docs
SECURITY.md §1/§2/§9, `book/src/admin.md`, packaging env template (drop editor/viewer, document break-glass + accounts), i18n ×4 locales.

## Out of scope (Phase 8)
External IdPs (OIDC/SAML/LDAP), per-app ACLs, self-registration, email password-reset, 2FA.

🤖 Generated with [Claude Code](https://claude.com/claude-code)