### PR TITLE
Prometheus /metrics endpoint (opt-in) (#109)

### DIFF
--- a/crates/ruscker-admin/src/lib.rs
+++ b/crates/ruscker-admin/src/lib.rs
@@ -431,6 +431,10 @@ pub fn router_with_images(state: AppState, _images_dir: Option<&Path>) -> Router
     // outer level.
     own.merge(routes::proxy::routes())
         .merge(routes::health::routes())
+        // `/metrics` (opt-in via proxy.metrics-enabled) is likewise
+        // unauthenticated and outside `security_headers` — it serves
+        // Prometheus text for a scraper, not HTML for a browser.
+        .merge(routes::metrics::routes())
         .layer(CookieManagerLayer::new())
         .with_state(state)
 }

--- a/crates/ruscker-admin/src/routes/metrics.rs
+++ b/crates/ruscker-admin/src/routes/metrics.rs
@@ -1,0 +1,256 @@
+//! Prometheus `/metrics` endpoint (#109).
+//!
+//! Opt-in via `proxy.metrics-enabled` — when off (the default) the
+//! route 404s. When on it's served **unauthenticated**, like the
+//! health probes, so it must only be reachable by your scraper
+//! (private network / firewall); see `docs/SECURITY.md`.
+//!
+//! The exposition is built from the same live state the dashboard
+//! reads — the [`ReplicaRegistry`] and the per-replica
+//! [`MetricsCache`] — so there's no separate collection path.
+
+use axum::{
+    extract::State,
+    http::{header, StatusCode},
+    response::{IntoResponse, Response},
+    routing::get,
+    Router,
+};
+use ruscker_core::{Replica, ReplicaState};
+use std::collections::BTreeMap;
+use std::fmt::Write as _;
+
+use crate::metrics_cache::MetricsCache;
+use crate::AppState;
+
+pub fn routes() -> Router<AppState> {
+    Router::new().route("/metrics", get(metrics))
+}
+
+/// Prometheus text exposition format content type (v0.0.4).
+const PROM_CONTENT_TYPE: &str = "text/plain; version=0.0.4; charset=utf-8";
+
+async fn metrics(State(state): State<AppState>) -> Response {
+    if !state.config.proxy.metrics_enabled {
+        // Off by default — don't advertise that the route exists.
+        return (StatusCode::NOT_FOUND, "metrics disabled").into_response();
+    }
+
+    // Snapshot the registry under the read lock, then render lock-free.
+    let replicas: Vec<Replica> = {
+        let reg = state.replicas.read().await;
+        reg.all().cloned().collect()
+    };
+    let body = encode(
+        &replicas,
+        &state.metrics,
+        state.sessions.len(),
+        state.backend.is_some(),
+    );
+
+    (
+        StatusCode::OK,
+        [(header::CONTENT_TYPE, PROM_CONTENT_TYPE)],
+        body,
+    )
+        .into_response()
+}
+
+/// Lowercase label for a replica state (stable metric label values).
+fn state_label(s: ReplicaState) -> &'static str {
+    match s {
+        ReplicaState::Starting => "starting",
+        ReplicaState::Ready => "ready",
+        ReplicaState::Draining => "draining",
+        ReplicaState::Stopped => "stopped",
+        ReplicaState::Failed => "failed",
+    }
+}
+
+/// Escape a Prometheus label *value* per the exposition format:
+/// backslash, double-quote and newline.
+fn esc(v: &str) -> String {
+    let mut out = String::with_capacity(v.len());
+    for c in v.chars() {
+        match c {
+            '\\' => out.push_str("\\\\"),
+            '"' => out.push_str("\\\""),
+            '\n' => out.push_str("\\n"),
+            _ => out.push(c),
+        }
+    }
+    out
+}
+
+/// Render the Prometheus exposition text from a registry snapshot +
+/// the metrics cache. Pure (no I/O), so it's unit-testable.
+fn encode(
+    replicas: &[Replica],
+    metrics: &MetricsCache,
+    tracked_sessions: usize,
+    backend_connected: bool,
+) -> String {
+    let mut out = String::new();
+
+    // backend up/down
+    let _ = writeln!(
+        out,
+        "# HELP ruscker_up Container backend connected (1) or absent (0)."
+    );
+    let _ = writeln!(out, "# TYPE ruscker_up gauge");
+    let _ = writeln!(out, "ruscker_up {}", backend_connected as u8);
+
+    // total replicas
+    let _ = writeln!(
+        out,
+        "# HELP ruscker_replicas_total Running replicas across all specs."
+    );
+    let _ = writeln!(out, "# TYPE ruscker_replicas_total gauge");
+    let _ = writeln!(out, "ruscker_replicas_total {}", replicas.len());
+
+    // tracked sticky sessions
+    let _ = writeln!(
+        out,
+        "# HELP ruscker_sessions_tracked Sticky sessions currently tracked."
+    );
+    let _ = writeln!(out, "# TYPE ruscker_sessions_tracked gauge");
+    let _ = writeln!(out, "ruscker_sessions_tracked {tracked_sessions}");
+
+    // replicas by (spec, state) — BTreeMap keeps the output stable.
+    let mut by_spec_state: BTreeMap<(&str, &str), u32> = BTreeMap::new();
+    let mut sessions_by_spec: BTreeMap<&str, u32> = BTreeMap::new();
+    for r in replicas {
+        *by_spec_state
+            .entry((r.spec_id.as_str(), state_label(r.state)))
+            .or_insert(0) += 1;
+        *sessions_by_spec.entry(r.spec_id.as_str()).or_insert(0) += r.sessions_active;
+    }
+
+    let _ = writeln!(
+        out,
+        "# HELP ruscker_replicas Running replicas by spec and state."
+    );
+    let _ = writeln!(out, "# TYPE ruscker_replicas gauge");
+    for ((spec, st), n) in &by_spec_state {
+        let _ = writeln!(
+            out,
+            "ruscker_replicas{{spec=\"{}\",state=\"{}\"}} {}",
+            esc(spec),
+            st,
+            n
+        );
+    }
+
+    let _ = writeln!(
+        out,
+        "# HELP ruscker_sessions_active Active sessions by spec."
+    );
+    let _ = writeln!(out, "# TYPE ruscker_sessions_active gauge");
+    for (spec, n) in &sessions_by_spec {
+        let _ = writeln!(
+            out,
+            "ruscker_sessions_active{{spec=\"{}\"}} {}",
+            esc(spec),
+            n
+        );
+    }
+
+    // per-replica CPU + memory from the cache (skip replicas with no
+    // reading yet, e.g. just-spawned ones).
+    let _ = writeln!(
+        out,
+        "# HELP ruscker_replica_cpu_percent Per-replica CPU usage (percent)."
+    );
+    let _ = writeln!(out, "# TYPE ruscker_replica_cpu_percent gauge");
+    let mut mem_lines = String::new();
+    for r in replicas {
+        if let Some(c) = metrics.get(&r.id) {
+            let _ = writeln!(
+                out,
+                "ruscker_replica_cpu_percent{{spec=\"{}\",replica=\"{}\"}} {}",
+                esc(&r.spec_id),
+                r.id,
+                c.metrics.cpu_percent
+            );
+            let _ = writeln!(
+                mem_lines,
+                "ruscker_replica_memory_bytes{{spec=\"{}\",replica=\"{}\"}} {}",
+                esc(&r.spec_id),
+                r.id,
+                c.metrics.memory_bytes
+            );
+        }
+    }
+    let _ = writeln!(
+        out,
+        "# HELP ruscker_replica_memory_bytes Per-replica memory usage (bytes)."
+    );
+    let _ = writeln!(out, "# TYPE ruscker_replica_memory_bytes gauge");
+    out.push_str(&mem_lines);
+
+    out
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use ruscker_core::{ReplicaId, ReplicaMetrics};
+    use std::net::SocketAddr;
+
+    fn replica(spec: &str, state: ReplicaState, active: u32) -> Replica {
+        Replica {
+            id: ReplicaId::new(),
+            spec_id: spec.to_string(),
+            container_id: "c".into(),
+            upstream: "127.0.0.1:8000".parse::<SocketAddr>().unwrap(),
+            state,
+            started_at: chrono::Utc::now(),
+            sessions_active: active,
+            sessions_max: 5,
+        }
+    }
+
+    #[test]
+    fn encodes_gauges_and_labels() {
+        let rs = vec![
+            replica("shiny-a", ReplicaState::Ready, 2),
+            replica("shiny-a", ReplicaState::Ready, 1),
+            replica("api-b", ReplicaState::Starting, 0),
+        ];
+        let cache = MetricsCache::new();
+        cache.replace(vec![(
+            rs[0].id.clone(),
+            ReplicaMetrics {
+                cpu_percent: 12.5,
+                memory_bytes: 1024,
+                network_rx_bytes: 0,
+                network_tx_bytes: 0,
+            },
+        )]);
+
+        let out = encode(&rs, &cache, 3, true);
+
+        assert!(out.contains("ruscker_up 1"));
+        assert!(out.contains("ruscker_replicas_total 3"));
+        assert!(out.contains("ruscker_sessions_tracked 3"));
+        // Two ready replicas of shiny-a aggregate.
+        assert!(out.contains("ruscker_replicas{spec=\"shiny-a\",state=\"ready\"} 2"));
+        assert!(out.contains("ruscker_replicas{spec=\"api-b\",state=\"starting\"} 1"));
+        // Sessions summed per spec.
+        assert!(out.contains("ruscker_sessions_active{spec=\"shiny-a\"} 3"));
+        // Per-replica metrics only for the replica with a cached reading.
+        assert!(out.contains("ruscker_replica_cpu_percent{spec=\"shiny-a\""));
+        assert!(out.contains(" 12.5"));
+        assert!(out.contains("ruscker_replica_memory_bytes{spec=\"shiny-a\""));
+        assert!(out.contains(" 1024"));
+        // Each TYPE line appears once.
+        assert_eq!(out.matches("# TYPE ruscker_up gauge").count(), 1);
+    }
+
+    #[test]
+    fn backend_absent_is_zero() {
+        let out = encode(&[], &MetricsCache::new(), 0, false);
+        assert!(out.contains("ruscker_up 0"));
+        assert!(out.contains("ruscker_replicas_total 0"));
+    }
+}

--- a/crates/ruscker-admin/src/routes/mod.rs
+++ b/crates/ruscker-admin/src/routes/mod.rs
@@ -4,6 +4,7 @@ pub mod admin;
 pub mod assets;
 pub mod health;
 pub mod landing;
+pub mod metrics;
 pub mod prefs;
 pub mod proxy;
 pub mod rewrite;

--- a/crates/ruscker-admin/tests/metrics.rs
+++ b/crates/ruscker-admin/tests/metrics.rs
@@ -1,0 +1,71 @@
+//! Integration tests for the opt-in Prometheus `/metrics` route (#109).
+
+use axum::body::Body;
+use axum::http::{Request, StatusCode};
+use ruscker_admin::{router, AppState};
+use ruscker_config::Config;
+use std::sync::Arc;
+use tower::ServiceExt;
+
+fn state(yaml: &str) -> AppState {
+    std::env::set_var("DOCKER_REGISTRY_PASSWORD", "test");
+    let config = Config::from_yaml(yaml).expect("parse config");
+    let locales = ruscker_admin::i18n::Locales::load().expect("load locales");
+    AppState {
+        config: Arc::new(config),
+        locales: Arc::new(locales),
+        admin_auth: Default::default(),
+        admin_sessions: Default::default(),
+        log_buffer: None,
+        login_limiter: Arc::new(ruscker_admin::auth::LoginRateLimiter::default_policy()),
+        api_limiter: Arc::new(ruscker_admin::ratelimit::ApiRateLimiter::new()),
+        db: None,
+        images_dir: None,
+        master_key: Default::default(),
+        backend: None,
+        replicas: Arc::new(tokio::sync::RwLock::new(Default::default())),
+        cookie_key: ruscker_proxy::sticky::CookieKey::random(),
+        spawn_locks: Arc::new(dashmap::DashMap::new()),
+        sessions: Arc::new(ruscker_admin::sessions::SessionTracker::new()),
+        metrics: ruscker_admin::metrics_cache::MetricsCache::new(),
+        draining: Arc::new(std::sync::atomic::AtomicBool::new(false)),
+    }
+}
+
+async fn get_metrics(state: AppState) -> axum::http::Response<Body> {
+    let req = Request::builder()
+        .uri("/metrics")
+        .body(Body::empty())
+        .unwrap();
+    router(state).oneshot(req).await.unwrap()
+}
+
+#[tokio::test]
+async fn metrics_disabled_by_default_returns_404() {
+    let resp = get_metrics(state("proxy:\n  title: T\n  specs: []\n")).await;
+    assert_eq!(resp.status(), StatusCode::NOT_FOUND);
+}
+
+#[tokio::test]
+async fn metrics_enabled_serves_prometheus_text() {
+    let resp = get_metrics(state(
+        "proxy:\n  title: T\n  metrics-enabled: true\n  specs: []\n",
+    ))
+    .await;
+    assert_eq!(resp.status(), StatusCode::OK);
+    let ct = resp
+        .headers()
+        .get("content-type")
+        .and_then(|v| v.to_str().ok())
+        .unwrap_or("");
+    assert!(ct.starts_with("text/plain"), "content-type was {ct}");
+
+    let bytes = axum::body::to_bytes(resp.into_body(), 1 << 20)
+        .await
+        .unwrap();
+    let body = String::from_utf8(bytes.to_vec()).unwrap();
+    // No backend wired in this test ⇒ up=0, no replicas.
+    assert!(body.contains("ruscker_up 0"), "body:\n{body}");
+    assert!(body.contains("ruscker_replicas_total 0"));
+    assert!(body.contains("# TYPE ruscker_sessions_tracked gauge"));
+}

--- a/crates/ruscker-config/src/schema.rs
+++ b/crates/ruscker-config/src/schema.rs
@@ -175,6 +175,14 @@ pub struct Proxy {
     /// through a UI (see `docs/mockups/admin-landing-editor.html`).
     #[serde(default, rename = "landing-customization")]
     pub landing_customization: LandingCustomization,
+
+    /// Expose a Prometheus `/metrics` endpoint. **Off by default.**
+    /// When enabled, `/metrics` is served *unauthenticated* (like
+    /// `/healthz`), so only turn it on where the endpoint is reachable
+    /// only by your scraper (private network / firewall). Ruscker
+    /// extension — not present in ShinyProxy YAML.
+    #[serde(rename = "metrics-enabled")]
+    pub metrics_enabled: bool,
 }
 
 impl Default for Proxy {
@@ -195,6 +203,7 @@ impl Default for Proxy {
             authentication: AuthScheme::None,
             specs: Vec::new(),
             landing_customization: LandingCustomization::default(),
+            metrics_enabled: false,
         }
     }
 }

--- a/docs/SECURITY.md
+++ b/docs/SECURITY.md
@@ -216,6 +216,13 @@ Status: living document. Tracks the Phase 5 security audit
   PII.
 - **[accepted limitation]** No PII is collected today; revisit if
   auth/user features land.
+- **[opt-in]** Prometheus `/metrics` (`proxy.metrics-enabled`, off by
+  default). When enabled it's served **unauthenticated** — it exposes
+  operational gauges (replica counts/states, per-spec sessions,
+  per-replica CPU/memory), no secrets. Only enable it where the
+  endpoint is reachable solely by your scraper (private network /
+  firewall / bound behind the reverse proxy); don't expose it to the
+  public alongside the landing page.
 
 ---
 

--- a/docs/YAML_SCHEMA.md
+++ b/docs/YAML_SCHEMA.md
@@ -50,6 +50,7 @@ ignored by Ruscker.
 | `container-wait-time` | ms | `60000` | Max wait for container Ready |
 | `shutdown-grace-ms` | ms | `30000` | Drain window on SIGTERM/Ctrl-C before forced exit; `/readyz` reports `draining` during it. Ruscker extension |
 | `max-body-size` | size | none | Global cap on proxied request bodies (`"10m"`, `"1g"`, bytes); over → `413`. Per-spec `max-body-size` overrides. Ruscker extension |
+| `metrics-enabled` | bool | `false` | Expose a Prometheus `/metrics` endpoint (**unauthenticated** when on — firewall it). Ruscker extension |
 | `container-log-path` | path | none | Directory for per-container logs |
 | `port` | u16 | `8080` | HTTP listener port |
 | `bind-address` | string | `"0.0.0.0"` | Listener interface |


### PR DESCRIPTION
Closes #109.

Adds a Prometheus text-format `/metrics` endpoint, built from the **same live state the dashboard reads** (the `ReplicaRegistry` + per-replica `MetricsCache`) — no separate collection path.

## Behaviour
- **Opt-in**: `proxy.metrics-enabled` (bool, default `false`). Off ⇒ `/metrics` **404s** (doesn't advertise itself). On ⇒ served **unauthenticated**, outside `security_headers`, alongside the health probes — must be firewalled / scraper-only (documented in SECURITY §8).
- `routes::metrics::encode()` is a **pure, unit-tested** text builder. Series:
  - `ruscker_up`, `ruscker_replicas_total`, `ruscker_sessions_tracked`
  - `ruscker_replicas{spec,state}`, `ruscker_sessions_active{spec}`
  - `ruscker_replica_cpu_percent{spec,replica}`, `ruscker_replica_memory_bytes{spec,replica}`
  - stable ordering (BTreeMap), label-value escaping, `text/plain; version=0.0.4`.

## Tests + smoke
- Encoder unit tests + integration (`disabled→404`, `enabled→200` + content-type + body). **299 tests green**, clippy clean, new files 0-drift.
- **Live smoke** (`traefik/whoami`, `--docker`): `ruscker_up 1`; `replicas_total` 0→1 after a request spawns the container; `ruscker_replicas{spec="whoami",state="ready"} 1`; real per-replica memory (~9 MB).

## Deferred
`ruscker_proxy_requests_total` / `ruscker_spawn_total` (need new hot-path counters) — noted for follow-up; pairs with the sparkline-history issue (#113).

🤖 Generated with [Claude Code](https://claude.com/claude-code)