### PR TITLE
Per-replica metric history + dashboard sparklines (#113)

### DIFF
--- a/crates/ruscker-admin/src/metrics_cache.rs
+++ b/crates/ruscker-admin/src/metrics_cache.rs
@@ -34,11 +34,20 @@ use tracing::{info, warn};
 /// CPU delta windows large enough to read sanely.
 pub const REFRESH_INTERVAL: Duration = Duration::from_secs(5);
 
-/// What we keep per replica.
+/// How many recent samples to keep per replica for the dashboard
+/// sparklines. 30 × [`REFRESH_INTERVAL`] (5 s) ≈ 2.5 min of history —
+/// enough to show a trend without unbounded growth.
+pub const HISTORY_LEN: usize = 30;
+
+/// What we keep per replica: the latest reading plus a short rolling
+/// history of CPU% and memory for the dashboard sparklines (oldest
+/// first, most recent last).
 #[derive(Debug, Clone)]
 pub struct CachedMetrics {
     pub metrics: ReplicaMetrics,
     pub observed_at: Instant,
+    pub cpu_history: Vec<f64>,
+    pub mem_history: Vec<u64>,
 }
 
 /// The cache itself. Cheap to clone (it's all `Arc`s underneath)
@@ -68,18 +77,38 @@ impl MetricsCache {
 
     /// Replace the cache contents with the given (id, metrics)
     /// pairs and drop any entries for ids that didn't appear.
-    /// Called by the refresher each tick.
+    /// Called by the refresher each tick. Each replica's rolling
+    /// CPU/memory history is **carried forward** and appended to (capped
+    /// at [`HISTORY_LEN`]), so the dashboard sparklines accumulate a
+    /// trend instead of resetting every tick. A replica that
+    /// disappears and comes back starts its history fresh.
     pub fn replace(&self, fresh: Vec<(ReplicaId, ReplicaMetrics)>) {
         use std::collections::HashSet;
         let now = Instant::now();
         let kept: HashSet<ReplicaId> = fresh.iter().map(|(id, _)| id.clone()).collect();
         self.inner.retain(|id, _| kept.contains(id));
         for (id, m) in fresh {
+            // Carry the prior history forward, then append this sample.
+            let (mut cpu_history, mut mem_history) = self
+                .inner
+                .get(&id)
+                .map(|e| (e.cpu_history.clone(), e.mem_history.clone()))
+                .unwrap_or_default();
+            cpu_history.push(m.cpu_percent);
+            mem_history.push(m.memory_bytes);
+            // Keep only the most recent HISTORY_LEN samples.
+            if cpu_history.len() > HISTORY_LEN {
+                let drop = cpu_history.len() - HISTORY_LEN;
+                cpu_history.drain(0..drop);
+                mem_history.drain(0..drop);
+            }
             self.inner.insert(
                 id,
                 CachedMetrics {
                     metrics: m,
                     observed_at: now,
+                    cpu_history,
+                    mem_history,
                 },
             );
         }
@@ -236,6 +265,39 @@ mod tests {
         reg.write().await.remove(&id1);
         refresh_once(&cache, backend.as_ref(), &reg).await;
         assert!(cache.is_empty(), "stale entry must be evicted");
+    }
+
+    #[test]
+    fn history_accumulates_and_caps() {
+        let cache = MetricsCache::new();
+        let id = ReplicaId(uuid::Uuid::new_v4());
+        let sample = |cpu: f64, mem: u64| {
+            vec![(
+                id.clone(),
+                ReplicaMetrics {
+                    cpu_percent: cpu,
+                    memory_bytes: mem,
+                    network_rx_bytes: 0,
+                    network_tx_bytes: 0,
+                },
+            )]
+        };
+        // Two ticks ⇒ two samples, oldest first.
+        cache.replace(sample(1.0, 10));
+        cache.replace(sample(2.0, 20));
+        let c = cache.get(&id).unwrap();
+        assert_eq!(c.cpu_history, vec![1.0, 2.0]);
+        assert_eq!(c.mem_history, vec![10, 20]);
+        assert_eq!(c.metrics.cpu_percent, 2.0); // latest
+
+        // Push well past the cap; only the most recent HISTORY_LEN survive.
+        for i in 0..HISTORY_LEN + 10 {
+            cache.replace(sample(i as f64, i as u64));
+        }
+        let c = cache.get(&id).unwrap();
+        assert_eq!(c.cpu_history.len(), HISTORY_LEN);
+        // Last sample is the most recent push.
+        assert_eq!(*c.cpu_history.last().unwrap(), (HISTORY_LEN + 9) as f64);
     }
 
     #[tokio::test]

--- a/crates/ruscker-admin/src/routes/admin/dashboard.rs
+++ b/crates/ruscker-admin/src/routes/admin/dashboard.rs
@@ -111,6 +111,10 @@ struct ReplicaRow {
     cpu_display: Option<String>,
     /// Pre-formatted "412 MB" / "n/a" for the memory column.
     memory_display: Option<String>,
+    /// Recent CPU% / memory samples (oldest first) for the inline
+    /// sparklines. Empty until the metrics cache has ≥1 reading.
+    cpu_history: Vec<f64>,
+    mem_history: Vec<u64>,
 }
 
 /// What both the HTML render and the SSE stream consume.
@@ -296,6 +300,8 @@ async fn build_snapshot(state: &AppState, locale: Locale) -> DashboardSnapshot {
             let cached = state.metrics.get(&r.id);
             let cpu_display = cached.as_ref().map(|c| format!("{:.0}%", c.metrics.cpu_percent));
             let memory_display = cached.as_ref().map(|c| format_bytes(c.metrics.memory_bytes));
+            let cpu_history = cached.as_ref().map(|c| c.cpu_history.clone()).unwrap_or_default();
+            let mem_history = cached.as_ref().map(|c| c.mem_history.clone()).unwrap_or_default();
             if let Some(c) = cached.as_ref() {
                 total_memory_bytes = total_memory_bytes.saturating_add(c.metrics.memory_bytes);
             }
@@ -314,6 +320,8 @@ async fn build_snapshot(state: &AppState, locale: Locale) -> DashboardSnapshot {
                 container_short,
                 cpu_display,
                 memory_display,
+                cpu_history,
+                mem_history,
             }
         })
         .collect();
@@ -713,6 +721,8 @@ mod tests {
             container_short: "abc123def456".into(),
             cpu_display: None,
             memory_display: None,
+            cpu_history: Vec::new(),
+            mem_history: Vec::new(),
         }
     }
 

--- a/crates/ruscker-admin/templates/admin/dashboard.html
+++ b/crates/ruscker-admin/templates/admin/dashboard.html
@@ -102,6 +102,9 @@
   }
   .dash-action:hover { background: var(--color-background-secondary, rgba(120,120,120,0.12)); }
   .dash-action--danger:hover { color: #ef4444; }
+  /* Inline CPU/memory trend sparkline next to the numeric value. */
+  .dash-metric-val { display: inline-block; min-width: 3.2em; }
+  .dash-spark { vertical-align: middle; margin-left: 6px; opacity: 0.75; }
 </style>
 
 <div class="flex items-end justify-between mb-5">
@@ -237,6 +240,27 @@
     });
   }
 
+  // Tiny inline sparkline (relative min..max of its own series). No
+  // chart lib — a single SVG polyline. Returns '' for <2 points so
+  // a just-spawned replica shows nothing rather than a flat dot.
+  function spark(values, stroke) {
+    if (!values || values.length < 2) return '';
+    var w = 56, h = 16, pad = 1.5;
+    var min = Math.min.apply(null, values);
+    var max = Math.max.apply(null, values);
+    var range = (max - min) || 1;
+    var n = values.length;
+    var pts = values.map(function (v, i) {
+      var x = pad + (w - 2 * pad) * (i / (n - 1));
+      var y = pad + (h - 2 * pad) * (1 - (v - min) / range);
+      return x.toFixed(1) + ',' + y.toFixed(1);
+    }).join(' ');
+    return '<svg class="dash-spark" width="' + w + '" height="' + h
+      + '" viewBox="0 0 ' + w + ' ' + h + '" preserveAspectRatio="none" aria-hidden="true">'
+      + '<polyline fill="none" stroke="' + stroke + '" stroke-width="1.2" points="'
+      + pts + '"/></svg>';
+  }
+
   function metric(name, value) {
     var el = document.querySelector('[data-metric="' + name + '"]');
     if (el && el.textContent !== String(value)) el.textContent = value;
@@ -267,8 +291,10 @@
       + '<td>' + escapeHtml(row.state_label) + '</td>'
       + '<td class="dash-mono">' + escapeHtml(row.uptime) + '</td>'
       + '<td>' + row.sessions_active + '<span style="color: var(--text-muted)">/' + row.sessions_max + '</span></td>'
-      + '<td>' + cpu + '</td>'
-      + '<td>' + mem + '</td>'
+      + '<td><span class="dash-metric-val">' + cpu + '</span>'
+        + spark(row.cpu_history, 'var(--accent, #1d9e75)') + '</td>'
+      + '<td><span class="dash-metric-val">' + mem + '</span>'
+        + spark(row.mem_history, 'var(--accent-2, #5dcaa5)') + '</td>'
       + '<td class="dash-mono">' + escapeHtml(row.container_short) + '</td>'
       + '<td style="white-space: nowrap;">'
         + '<a href="/admin/dashboard/logs/' + encodeURIComponent(row.replica_id)


### PR DESCRIPTION
Closes #113.

The dashboard showed only point-in-time CPU/memory; this adds a short **rolling history** and renders an inline **sparkline** next to each value.

- **`MetricsCache`**: `CachedMetrics` keeps `cpu_history` / `mem_history` (oldest first), carried forward across refresher ticks and capped at `HISTORY_LEN` (30 samples ≈ 2.5 min at the 5 s refresh). A replica that disappears and returns starts fresh.
- **Dashboard**: `ReplicaRow` gains the two history vecs, populated in `build_snapshot` and serialized into the snapshot JSON (initial embed + SSE frames).
- **Template**: a tiny vanilla-JS `spark()` — one SVG polyline, relative min..max, no chart lib — drawn in `rowHtml` for CPU and memory, on the initial `apply()` and every SSE frame. `<2` points renders nothing.

## Tests + smoke
- `history_accumulates_and_caps` (accumulation + cap to `HISTORY_LEN`). **300 tests green**, no fmt-drift increase, new code rustfmt-clean.
- **Live smoke** (`traefik/whoami`, `--docker`): after a few ticks the embedded dashboard snapshot carries real series, e.g. `mem_history:[9138176,8990720]`.

Pairs with the Prometheus `/metrics` work (#109).

🤖 Generated with [Claude Code](https://claude.com/claude-code)