### PR TITLE
Homebrew formula (canonical copy) for the tap (#114)

### DIFF
--- a/packaging/homebrew/README.md
+++ b/packaging/homebrew/README.md
@@ -1,0 +1,46 @@
+# Homebrew tap
+
+`ruscker.rb` here is the **canonical** Homebrew formula. The published
+formula lives in a separate tap repo so users can
+`brew install strategicprojects/tap/ruscker`.
+
+## One-time setup (maintainer)
+
+1. Create a public repo **`StrategicProjects/homebrew-tap`** (the
+   `homebrew-` prefix is what lets `brew tap strategicprojects/tap`
+   resolve it).
+2. Copy this formula into it as `Formula/ruscker.rb`:
+   ```sh
+   mkdir -p Formula
+   cp /path/to/ruscker/packaging/homebrew/ruscker.rb Formula/ruscker.rb
+   git add Formula/ruscker.rb && git commit -m "ruscker 0.1.0" && git push
+   ```
+
+## Installing (users)
+
+```sh
+brew install strategicprojects/tap/ruscker
+# or:
+brew tap strategicprojects/tap && brew install ruscker
+```
+
+- **Linux** (Linuxbrew): downloads the prebuilt static musl tarball
+  that `release.yml` attaches to the release (amd64 / arm64).
+- **macOS**: builds from source (`depends_on "rust" => :build`) — there
+  is no prebuilt macOS binary yet. (Follow-up: add a macOS build job to
+  `release.yml` and switch the formula to a prebuilt `url` + `bottle`.)
+
+## Bumping on each release
+
+Update in `ruscker.rb` (then copy to the tap, or let an automated PR do
+it):
+
+- `version "X.Y.Z"`
+- the two **Linux** `sha256` values — from the release's
+  `ruscker-X.Y.Z-linux-{amd64,arm64}.tar.gz.sha256` assets.
+- the **macOS** source `sha256` — of
+  `https://github.com/StrategicProjects/ruscker/archive/refs/tags/vX.Y.Z.tar.gz`
+  (`curl -L … | shasum -a 256`).
+
+Automating the bump (a `release.yml` step that opens a PR to the tap on
+each `v*` tag) is a possible follow-up; manual for now.

--- a/packaging/homebrew/ruscker.rb
+++ b/packaging/homebrew/ruscker.rb
@@ -1,0 +1,53 @@
+# Homebrew formula for Ruscker.
+#
+# This is the canonical copy, version-controlled here. It is published
+# by copying it into the tap repo `StrategicProjects/homebrew-tap` as
+# `Formula/ruscker.rb` (see packaging/homebrew/README.md), after which
+#   brew install strategicprojects/tap/ruscker
+# works.
+#
+# On macOS there is no prebuilt binary yet, so the formula builds from
+# source (needs Rust). On Linux it pulls the static musl tarball that
+# `release.yml` attaches to the GitHub Release.
+#
+# When cutting a release, update `version` and the three `sha256`
+# values (the Linux tarball checksums are in the release's
+# `*.sha256` assets; the macOS source checksum is the GitHub
+# auto-generated source tarball's sha256).
+class Ruscker < Formula
+  desc "Lightweight Rust proxy for containerized apps (Shiny/Streamlit/Dash) and APIs"
+  homepage "https://strategicprojects.github.io/ruscker/"
+  license "Apache-2.0"
+  version "0.1.0"
+
+  on_macos do
+    url "https://github.com/StrategicProjects/ruscker/archive/refs/tags/v#{version}.tar.gz"
+    sha256 "REPLACE_WITH_SOURCE_TARBALL_SHA256"
+    depends_on "rust" => :build
+
+    def install
+      system "cargo", "install", *std_cargo_args(path: "crates/ruscker-cli")
+    end
+  end
+
+  on_linux do
+    on_arm do
+      url "https://github.com/StrategicProjects/ruscker/releases/download/v#{version}/ruscker-#{version}-linux-arm64.tar.gz"
+      sha256 "REPLACE_WITH_LINUX_ARM64_SHA256"
+    end
+    on_intel do
+      url "https://github.com/StrategicProjects/ruscker/releases/download/v#{version}/ruscker-#{version}-linux-amd64.tar.gz"
+      sha256 "REPLACE_WITH_LINUX_AMD64_SHA256"
+    end
+
+    def install
+      # The tarball contains a single top-level dir; Homebrew has
+      # already descended into it, so the binary is in the cwd.
+      bin.install "ruscker"
+    end
+  end
+
+  test do
+    assert_match "ruscker", shell_output("#{bin}/ruscker --help")
+  end
+end


### PR DESCRIPTION
Part of #114.

Adds the **canonical** `packaging/homebrew/ruscker.rb` + a setup README. The formula gets published by copying it into the `StrategicProjects/homebrew-tap` repo as `Formula/ruscker.rb`.

- **macOS**: builds from source (`depends_on "rust" => :build`; `cargo install` the cli) — no prebuilt macOS binary yet.
- **Linux** (Linuxbrew): downloads the static musl tarball `release.yml` attaches (`ruscker-<ver>-linux-{amd64,arm64}.tar.gz`), per arch.
- `version` / `sha256` are placeholders filled at v0.1.0; the README documents the bump (Linux sha from the release `.sha256` assets; macOS sha from the GitHub source tarball). Ruby syntax verified (`ruby -c`).

**Maintainer step remaining** (keeps #114 open): create the public `StrategicProjects/homebrew-tap` repo and copy the formula in — then `brew install strategicprojects/tap/ruscker` works.

🤖 Generated with [Claude Code](https://claude.com/claude-code)