### PR TITLE
Explicit per-spec container-port (inner port) (#120)

### DIFF
--- a/crates/ruscker-admin/src/routes/admin/spec_form.rs
+++ b/crates/ruscker-admin/src/routes/admin/spec_form.rs
@@ -288,6 +288,7 @@ impl SpecForm {
             },
             // ── Not modelled by the form: preserve from `base` so an
             //    edit never silently drops YAML-imported config. ──────
+            container_port: base.and_then(|b| b.container_port),
             container_lifetime: base.and_then(|b| b.container_lifetime),
             stop_on_logout: base.and_then(|b| b.stop_on_logout),
             docker_registry_username: base.and_then(|b| b.docker_registry_username.clone()),

--- a/crates/ruscker-admin/src/routes/proxy.rs
+++ b/crates/ruscker-admin/src/routes/proxy.rs
@@ -643,11 +643,7 @@ async fn pick_or_spawn(state: &AppState, spec: &Spec) -> anyhow::Result<Replica>
         .as_deref()
         .ok_or_else(|| anyhow::anyhow!("spec {} has no container-image", spec.id))?;
 
-    let inner_port = spec
-        .api
-        .as_ref()
-        .and_then(|a| a.port)
-        .or_else(|| infer_inner_port(spec));
+    let inner_port = spec.effective_inner_port();
 
     let creds = resolve_creds(state, spec).await;
     let limits = limits_from_spec(spec);
@@ -681,13 +677,6 @@ async fn pick_or_spawn(state: &AppState, spec: &Spec) -> anyhow::Result<Replica>
     // — and release before the spec mutex unwinds.
     state.replicas.write().await.add(replica.clone());
     Ok(replica)
-}
-
-fn infer_inner_port(spec: &Spec) -> Option<u16> {
-    match spec.kind() {
-        SpecKind::Api => Some(8080),
-        _ => None,
-    }
 }
 
 /// Build optional registry credentials from a spec. Returns

--- a/crates/ruscker-admin/src/scaler.rs
+++ b/crates/ruscker-admin/src/scaler.rs
@@ -415,11 +415,7 @@ async fn spawn_one(
         .as_deref()
         .ok_or_else(|| anyhow::anyhow!("spec {} has no container-image", spec.id))?;
 
-    let inner_port = spec
-        .api
-        .as_ref()
-        .and_then(|a| a.port)
-        .or_else(|| infer_inner_port(spec));
+    let inner_port = spec.effective_inner_port();
 
     let creds = crate::routes::proxy::resolve_creds(state, spec).await;
     let limits = crate::routes::proxy::limits_from_spec(spec);
@@ -443,20 +439,6 @@ async fn spawn_one(
 
     state.replicas.write().await.add(replica);
     Ok(())
-}
-
-/// Best-guess inner port for a spec. Mirrors the helper in
-/// `routes::proxy` — pulled into a small free function here to
-/// avoid taking a dependency on the routes module from the
-/// scaler. Kept private and minimal; if a third caller appears,
-/// promote to a shared module.
-fn infer_inner_port(spec: &Spec) -> Option<u16> {
-    match spec.kind() {
-        SpecKind::Api => Some(8000),
-        SpecKind::Shiny => Some(3838),
-        SpecKind::InteractiveApp => Some(8080),
-        SpecKind::External => None,
-    }
 }
 
 #[cfg(test)]

--- a/crates/ruscker-cli/tests/e2e.rs
+++ b/crates/ruscker-cli/tests/e2e.rs
@@ -13,8 +13,8 @@
 //!   cargo test -p ruscker-cli --features e2e -- --nocapture
 //!
 //! The spec is `type: streamlit` (an InteractiveApp ⇒ sticky sessions +
-//! WS forwarding) with `api.port: 8080` to point Ruscker at the
-//! echo-server's listen port.
+//! WS forwarding) with `container-port: 8080` to point Ruscker at the
+//! echo-server's listen port (#120).
 #![cfg(feature = "e2e")]
 
 use futures_util::StreamExt;
@@ -84,7 +84,7 @@ async fn e2e_proxy_and_websocket_through_subpath() {
         format!(
             "proxy:\n  title: E2E\n  specs:\n    - id: {SPEC}\n      display-name: Echo\n      \
              container-image: jmalloc/echo-server:latest\n      type: streamlit\n      \
-             api:\n        port: 8080\n"
+             container-port: 8080\n"
         ),
     )
     .unwrap();

--- a/crates/ruscker-config/src/schema.rs
+++ b/crates/ruscker-config/src/schema.rs
@@ -356,6 +356,16 @@ pub struct Spec {
     #[serde(rename = "container-image")]
     pub container_image: Option<String>,
 
+    /// Port the app listens on **inside** the container. Needed for
+    /// frameworks that don't use Shiny's 3838 default — Streamlit
+    /// (8501), Dash (8050), Bokeh/Panel (5006), Voilà (8866), … .
+    /// Accepts ShinyProxy's `port:` as an alias for friction-free
+    /// migration. Resolved via [`Spec::effective_inner_port`]; when
+    /// unset the runtime falls back to `api.port`, then a kind default
+    /// (8080 for APIs), then the backend's 3838.
+    #[serde(rename = "container-port", alias = "port")]
+    pub container_port: Option<u16>,
+
     /// Maximum number of concurrent sessions on a single container.
     /// When all containers in a spec's pool reach this limit, the
     /// auto-scaler spawns a new replica (if `max_replicas` allows).
@@ -681,6 +691,22 @@ impl Spec {
     /// `X-Forwarded-Prefix`.
     pub fn effective_inject_base_href(&self) -> bool {
         self.inject_base_href.unwrap_or(true)
+    }
+
+    /// The port to forward to **inside** the container, or `None` to
+    /// let the backend use its default (3838, the Shiny Server port).
+    ///
+    /// Precedence: explicit `container-port` (or ShinyProxy `port`) →
+    /// `api.port` → a per-kind default (8080 for APIs) → `None`
+    /// (backend default). Centralises what the proxy + scaler used to
+    /// resolve by hand.
+    pub fn effective_inner_port(&self) -> Option<u16> {
+        self.container_port
+            .or_else(|| self.api.as_ref().and_then(|a| a.port))
+            .or_else(|| match self.kind() {
+                SpecKind::Api => Some(8080),
+                _ => None,
+            })
     }
 }
 
@@ -1085,6 +1111,7 @@ proxy:
             drain_timeout: None,
             routing_strategy: None,
             inject_base_href: None,
+            container_port: None,
             concurrent_requests_per_replica: None,
         };
         assert_eq!(spec.kind(), SpecKind::External);
@@ -1124,6 +1151,7 @@ proxy:
             drain_timeout: None,
             routing_strategy: None,
             inject_base_href: None,
+            container_port: None,
             concurrent_requests_per_replica: None,
         };
         assert_eq!(spec.kind(), SpecKind::Shiny);
@@ -1163,11 +1191,49 @@ proxy:
             drain_timeout: None,
             routing_strategy: None,
             inject_base_href: None,
+            container_port: None,
             concurrent_requests_per_replica: None,
         };
         spec.kind_override = Some(SpecKindOverride::Api);
         assert_eq!(spec.kind(), SpecKind::Api);
         assert_eq!(spec.effective_routing(), RoutingStrategy::RoundRobin);
         assert!(!spec.needs_sticky_sessions());
+    }
+
+    fn parse_spec(yaml: &str) -> Spec {
+        serde_yaml_ng::from_str(yaml).expect("parse spec")
+    }
+
+    #[test]
+    fn container_port_explicit_wins() {
+        let s = parse_spec("id: st\ncontainer-image: x:1\ntype: streamlit\ncontainer-port: 8501\n");
+        assert_eq!(s.container_port, Some(8501));
+        assert_eq!(s.effective_inner_port(), Some(8501));
+    }
+
+    #[test]
+    fn shinyproxy_port_aliases_to_container_port() {
+        // ShinyProxy's spec-level `port:` migrates cleanly.
+        let s = parse_spec("id: legacy\ncontainer-image: rocker/shiny\nport: 3838\n");
+        assert_eq!(s.container_port, Some(3838));
+        assert_eq!(s.effective_inner_port(), Some(3838));
+    }
+
+    #[test]
+    fn effective_inner_port_precedence_and_defaults() {
+        // container-port beats api.port.
+        let s = parse_spec(
+            "id: a\ncontainer-image: x:1\ntype: api\ncontainer-port: 9000\napi:\n  port: 8000\n",
+        );
+        assert_eq!(s.effective_inner_port(), Some(9000));
+        // api.port when no container-port.
+        let s = parse_spec("id: a\ncontainer-image: x:1\ntype: api\napi:\n  port: 8000\n");
+        assert_eq!(s.effective_inner_port(), Some(8000));
+        // API kind with nothing set → 8080 default.
+        let s = parse_spec("id: a\ncontainer-image: x:1\ntype: api\n");
+        assert_eq!(s.effective_inner_port(), Some(8080));
+        // A Shiny-ish app with nothing set → None (backend default 3838).
+        let s = parse_spec("id: a\ncontainer-image: x:1\ntype: shiny\n");
+        assert_eq!(s.effective_inner_port(), None);
     }
 }

--- a/crates/ruscker-config/src/validate.rs
+++ b/crates/ruscker-config/src/validate.rs
@@ -211,10 +211,9 @@ pub enum CompatWarning {
 /// invisible in the parsed model (serde drops unknown keys), so the
 /// scan walks the raw YAML tree.
 const UNSUPPORTED_SPEC_FIELDS: &[(&str, &str)] = &[
-    (
-        "port",
-        "explicit upstream port is ignored — Ruscker auto-detects (use `api.port` for APIs)",
-    ),
+    // NOTE: ShinyProxy's spec-level `port` IS now supported — it maps
+    // to Ruscker's `container-port` (see schema). So it's intentionally
+    // absent here.
     (
         "minimum-seats-available",
         "pre-warm pool not implemented — use `min-replicas`",
@@ -241,7 +240,7 @@ const UNSUPPORTED_PROXY_FIELDS: &[(&str, &str)] = &[(
 /// Two sources, because the unsupported surface splits cleanly:
 /// - `proxy.authentication` is a typed field, so it's read from the
 ///   parsed `config` (post env-interpolation).
-/// - Everything else (`kubernetes-*`, `port`, `volumes`, …) is
+/// - Everything else (`kubernetes-*`, `minimum-seats-available`, …) is
 ///   dropped by serde at parse time, so it's only visible by walking
 ///   the raw YAML tree. Keys survive interpolation untouched, so the
 ///   raw text is parsed as-is (no env vars required).
@@ -831,6 +830,7 @@ proxy:
   - id: legacy
     container-image: rocker/shiny
     port: 3838
+    minimum-seats-available: 2
     volumes:
     - /data:/data
     kubernetes-pod-patches: '[]'
@@ -846,11 +846,20 @@ proxy:
                 _ => None,
             })
             .collect();
-        assert!(fields.contains(&"port"), "fields: {fields:?}");
-        // `volumes` is now a supported field — it must NOT be flagged.
+        // A still-unsupported field is flagged.
+        assert!(
+            fields.contains(&"minimum-seats-available"),
+            "fields: {fields:?}"
+        );
+        // `volumes` (#99) and `port`→`container-port` (#120) are
+        // supported now — they must NOT be flagged.
         assert!(
             !fields.contains(&"volumes"),
-            "volumes is supported now, should not be flagged: {fields:?}"
+            "volumes is supported now: {fields:?}"
+        );
+        assert!(
+            !fields.contains(&"port"),
+            "port maps to container-port now: {fields:?}"
         );
         assert!(
             fields.contains(&"kubernetes-pod-patches"),

--- a/docs/YAML_SCHEMA.md
+++ b/docs/YAML_SCHEMA.md
@@ -93,6 +93,11 @@ A spec describes one app, API, or external link. Every spec has an
 - id: my_app
   container-image: org/repo:tag       # required for containerized
   type: shiny                         # optional, default 'shiny' if image set
+  container-port: 8501                # port the app listens on inside the
+                                      #   container; default 3838 (Shiny).
+                                      #   Set for Streamlit (8501), Dash
+                                      #   (8050), … . ShinyProxy `port:`
+                                      #   is accepted as an alias.
   seats-per-container: 10             # sessions per replica
   max-lifetime: 360                   # minutes — hard cap
   container-lifetime: 360             # minutes — soft cap


### PR DESCRIPTION
Closes #120.

Non-API interactive apps could only use the backend's **3838** default — no clean way to point Ruscker at **Streamlit (8501)**, **Dash (8050)**, Bokeh/Panel (5006), etc. (the `api.port`-on-a-non-api-spec hack aside).

- **`Spec.container_port`** (`container-port`), with `alias = "port"` so ShinyProxy's spec-level `port:` **migrates with no rename**.
- **`Spec::effective_inner_port()`** centralises the precedence: `container-port` → `api.port` → per-kind default (8080 for APIs) → `None` (backend 3838). Proxy + scaler both call it.
- **Fixes a latent proxy↔scaler bug**: the two had *diverging* hand-rolled `infer_inner_port` helpers (Api `8080` vs `8000`; InteractiveApp `None` vs `8080`) — they could spawn and route on **different ports** for the same spec. Both removed for the shared helper.
- `validate --strict-compat` no longer flags spec-level `port` (supported now); compat test updated.
- The #110 e2e switched from the `api.port` hack to `container-port: 8080` — **re-run green** (live smoke for this change: a `type: streamlit` spec routed HTTP + WS to port 8080).

## Tests
Schema tests (explicit `container-port`, ShinyProxy `port` alias, full precedence/defaults) + YAML_SCHEMA doc. **303 tests green**, fmt-drift unchanged.

🤖 Generated with [Claude Code](https://claude.com/claude-code)