### PR TITLE
Bump version to 0.1.0 (stable release)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2719,7 +2719,7 @@ dependencies = [
 
 [[package]]
 name = "ruscker-admin"
-version = "0.1.0-rc2"
+version = "0.1.0"
 dependencies = [
  "aes-gcm",
  "anyhow",
@@ -2766,7 +2766,7 @@ dependencies = [
 
 [[package]]
 name = "ruscker-cli"
-version = "0.1.0-rc2"
+version = "0.1.0"
 dependencies = [
  "anyhow",
  "clap",
@@ -2786,7 +2786,7 @@ dependencies = [
 
 [[package]]
 name = "ruscker-config"
-version = "0.1.0-rc2"
+version = "0.1.0"
 dependencies = [
  "chrono",
  "ordered-float",
@@ -2801,7 +2801,7 @@ dependencies = [
 
 [[package]]
 name = "ruscker-core"
-version = "0.1.0-rc2"
+version = "0.1.0"
 dependencies = [
  "async-trait",
  "chrono",
@@ -2814,7 +2814,7 @@ dependencies = [
 
 [[package]]
 name = "ruscker-docker"
-version = "0.1.0-rc2"
+version = "0.1.0"
 dependencies = [
  "anyhow",
  "async-stream",
@@ -2833,7 +2833,7 @@ dependencies = [
 
 [[package]]
 name = "ruscker-proxy"
-version = "0.1.0-rc2"
+version = "0.1.0"
 dependencies = [
  "anyhow",
  "axum",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -10,7 +10,7 @@ members = [
 ]
 
 [workspace.package]
-version = "0.1.0-rc2"
+version = "0.1.0"
 edition = "2021"
 rust-version = "1.85"
 license = "Apache-2.0"


### PR DESCRIPTION
Drops the `-rc2` suffix → `0.1.0`. Merging this, then tagging **`v0.1.0`** (no hyphen) triggers `release.yml` to:
- build + attach the musl tarballs (amd64/arm64) + `.deb`s + `.sha256`,
- **cosign-sign** the blobs + the multi-arch ghcr image (#115),
- publish the GitHub Release as **Latest** and move the Docker `:latest` tag.

303 tests green; Cargo.lock refreshed (no `-rc2` left). Closes the path for #5; the v0.1.0 release `.sha256` assets then let me finish the Homebrew formula (#114).

🤖 Generated with [Claude Code](https://claude.com/claude-code)