### PR TITLE
docs: SVG diagrams, Roadmap chapter, v0.1.0 refresh

### DIFF
--- a/README.md
+++ b/README.md
@@ -73,9 +73,12 @@ tool" cases) is in
 
 ## Status
 
-**Production-ready and running in production.** Where the JVM-based
+**v0.1.0 — production-ready and running in production.** Releases are
+multi-arch (amd64 + arm64) and [cosign-signed]. Where the JVM-based
 stack it replaced idled at hundreds of megabytes, Ruscker idles in the
 low tens:
+
+[cosign-signed]: https://strategicprojects.github.io/ruscker/installation.html#verifying-release-artifacts
 
 > **~540 MB → ~16 MB idle** — roughly a 30× cut, on the same machine
 > serving the same apps. A real 31-spec config migrated with **no
@@ -92,16 +95,20 @@ What's in the box:
   form, including API/scaling/resource/lifecycle settings, with inline
   help), image/media library, encrypted credentials store, a
   landing-page editor (colors, intros, SEO, social meta, analytics,
-  custom HTML blocks), an audit log, and a live SSE dashboard
-  (CPU/memory, logs, stop/restart).
+  custom HTML blocks), an audit log, **user accounts with Viewer /
+  Editor / Admin roles**, and a live SSE dashboard (CPU/memory
+  sparklines, live-follow logs, stop/restart).
 - **Operations** — `/healthz` + `/readyz` probes, graceful shutdown,
   structured (JSON) logging, per-API rate limiting + CORS, request
-  body-size limits, `validate --strict-compat` migration pre-flight.
+  body-size limits, an opt-in Prometheus `/metrics` endpoint, and
+  `validate --strict-compat` migration pre-flight.
 - **Distribution** — a multi-arch Docker image, a Debian package with a
-  hardened `systemd` unit, and static musl tarballs.
+  hardened `systemd` unit, static musl tarballs, a Homebrew tap, and
+  cosign-signed release artifacts.
 
-200+ unit + integration tests run green on `cargo test` (no Docker
-required); an extra suite exercises a real Docker daemon.
+300+ unit + integration tests run green on `cargo test` (no Docker
+required); extra feature-gated suites exercise a real Docker daemon
+(`docker-it`) and a full proxy + WebSocket end-to-end run (`e2e`).
 
 ## Install
 
@@ -118,6 +125,14 @@ Picks the right artifact from the latest release: the `.deb` (with the
 `systemd` unit + an auto-generated admin token) on Debian/Ubuntu, or the
 static binary into `/usr/local/bin` elsewhere. Pin a version or target
 dir with `./install.sh v0.1.0` or `PREFIX=~/.local/bin ./install.sh`.
+
+### Homebrew (macOS / Linux)
+
+```bash
+brew install strategicprojects/tap/ruscker
+```
+
+Linux pulls the prebuilt musl binary; macOS builds from source.
 
 ### Docker
 
@@ -235,8 +250,9 @@ how to extend it.
 
 ```bash
 cargo build
-cargo test                                   # ~200 tests, no Docker needed
+cargo test                                   # 300+ tests, no Docker needed
 cargo test -p ruscker-docker --features docker-it   # + real Docker daemon
+cargo test -p ruscker-cli --features e2e            # + full proxy/WS e2e
 cargo fmt && cargo clippy --all-targets
 ./scripts/i18n-check.sh                      # enforce locale key parity
 ```

--- a/book/src/SUMMARY.md
+++ b/book/src/SUMMARY.md
@@ -15,4 +15,5 @@
 # Reference
 
 - [Architecture](./architecture.md)
+- [Roadmap](./roadmap.md)
 - [Security](./security.md)

--- a/book/src/images/crate-map.svg
+++ b/book/src/images/crate-map.svg
@@ -1,0 +1,58 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 720 470" width="720" height="470" font-family="Jost, Inter, system-ui, -apple-system, sans-serif" role="img" aria-label="Crate dependency map: ruscker-cli (binary) builds on the I/O crates (docker, proxy, admin), which build on ruscker-core, which builds on ruscker-config. Config and core are pure-domain with no I/O.">
+  <title>Ruscker — crate map</title>
+
+  <defs>
+    <marker id="up" viewBox="0 0 10 10" refX="5" refY="2" markerWidth="7" markerHeight="7" orient="auto">
+      <path d="M0,10 L5,0 L10,10 z" fill="#1D9E75"/>
+    </marker>
+  </defs>
+
+  <!-- layer bands -->
+  <rect x="24" y="120" width="672" height="92" rx="12" fill="#F4F8F7" stroke="#D7E5E0" stroke-width="1.5"/>
+  <text x="40" y="142" font-size="12" font-weight="600" fill="#5B6B66">I/O layer · async + tokio</text>
+  <rect x="24" y="250" width="672" height="178" rx="12" fill="#E8F3EE" stroke="#D7E5E0" stroke-width="1.5"/>
+  <text x="40" y="272" font-size="12" font-weight="600" fill="#5B6B66">pure domain · no I/O, no async (trait defs aside)</text>
+
+  <!-- ruscker-cli (binary) -->
+  <rect x="270" y="28" width="180" height="58" rx="10" fill="#0F6E56" stroke="#0F6E56" stroke-width="2"/>
+  <text x="360" y="53" text-anchor="middle" font-size="14" font-weight="700" fill="#FFFFFF">ruscker-cli</text>
+  <text x="360" y="71" text-anchor="middle" font-size="11" fill="#CDECE0">the `ruscker` binary</text>
+
+  <!-- I/O crates -->
+  <rect x="56" y="150" width="180" height="50" rx="10" fill="#FFFFFF" stroke="#1D9E75" stroke-width="1.8"/>
+  <text x="146" y="172" text-anchor="middle" font-size="13" font-weight="600" fill="#085041">ruscker-docker</text>
+  <text x="146" y="190" text-anchor="middle" font-size="10.5" fill="#5B6B66">ContainerBackend (bollard)</text>
+
+  <rect x="270" y="150" width="180" height="50" rx="10" fill="#FFFFFF" stroke="#1D9E75" stroke-width="1.8"/>
+  <text x="360" y="172" text-anchor="middle" font-size="13" font-weight="600" fill="#085041">ruscker-proxy</text>
+  <text x="360" y="190" text-anchor="middle" font-size="10.5" fill="#5B6B66">sticky cookie · WS pump</text>
+
+  <rect x="484" y="150" width="180" height="50" rx="10" fill="#FFFFFF" stroke="#1D9E75" stroke-width="1.8"/>
+  <text x="574" y="172" text-anchor="middle" font-size="13" font-weight="600" fill="#085041">ruscker-admin</text>
+  <text x="574" y="190" text-anchor="middle" font-size="10.5" fill="#5B6B66">landing · admin · proxy routes</text>
+
+  <!-- ruscker-core -->
+  <rect x="210" y="296" width="300" height="52" rx="10" fill="#FFFFFF" stroke="#0F6E56" stroke-width="1.8"/>
+  <text x="360" y="319" text-anchor="middle" font-size="13" font-weight="700" fill="#085041">ruscker-core</text>
+  <text x="360" y="337" text-anchor="middle" font-size="10.5" fill="#5B6B66">traits · types · routing · ReplicaRegistry</text>
+
+  <!-- ruscker-config -->
+  <rect x="210" y="364" width="300" height="50" rx="10" fill="#FFFFFF" stroke="#0F6E56" stroke-width="1.8"/>
+  <text x="360" y="386" text-anchor="middle" font-size="13" font-weight="700" fill="#085041">ruscker-config</text>
+  <text x="360" y="404" text-anchor="middle" font-size="10.5" fill="#5B6B66">YAML schema · parsing · validation</text>
+
+  <!-- edges: arrows point up, toward the consumer ("built on") -->
+  <!-- cli ← the three I/O crates -->
+  <line x1="146" y1="150" x2="300" y2="88" stroke="#1D9E75" stroke-width="2" marker-end="url(#up)"/>
+  <line x1="360" y1="150" x2="360" y2="88" stroke="#1D9E75" stroke-width="2" marker-end="url(#up)"/>
+  <line x1="574" y1="150" x2="420" y2="88" stroke="#1D9E75" stroke-width="2" marker-end="url(#up)"/>
+  <!-- core ← I/O crates (fan out from core's top edge) -->
+  <line x1="300" y1="296" x2="146" y2="202" stroke="#1D9E75" stroke-width="2" marker-end="url(#up)"/>
+  <line x1="360" y1="296" x2="360" y2="202" stroke="#1D9E75" stroke-width="2" marker-end="url(#up)"/>
+  <line x1="420" y1="296" x2="574" y2="202" stroke="#1D9E75" stroke-width="2" marker-end="url(#up)"/>
+  <!-- config ← core -->
+  <line x1="360" y1="364" x2="360" y2="350" stroke="#1D9E75" stroke-width="2" marker-end="url(#up)"/>
+
+  <text x="360" y="450" text-anchor="middle" font-size="11" fill="#5B6B66">arrows point to the crate that depends on it · swap a backend by swapping a `ContainerBackend` impl</text>
+</svg>

--- a/book/src/images/deployment.svg
+++ b/book/src/images/deployment.svg
@@ -1,0 +1,62 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 720 430" width="720" height="430" font-family="Jost, Inter, system-ui, -apple-system, sans-serif" role="img" aria-label="Two deployment shapes. Single-node (today): reverse proxy to one Ruscker to the local Docker daemon to app containers. Multi-node HA (planned, phase 7): an L4 load balancer fans to two Ruscker instances that share session state in Postgres and schedule onto Docker Swarm or Kubernetes.">
+  <title>Ruscker — deployment shapes</title>
+
+  <defs>
+    <marker id="dn" viewBox="0 0 10 10" refX="5" refY="8" markerWidth="7" markerHeight="7" orient="auto">
+      <path d="M0,0 L5,10 L10,0 z" fill="#1D9E75"/>
+    </marker>
+  </defs>
+
+  <!-- divider -->
+  <line x1="360" y1="20" x2="360" y2="410" stroke="#D7E5E0" stroke-width="1.5" stroke-dasharray="4 5"/>
+
+  <!-- ───────────── Single-node (left) ───────────── -->
+  <text x="185" y="34" text-anchor="middle" font-size="14" font-weight="700" fill="#085041">Single-node · today</text>
+
+  <rect x="55" y="50" width="260" height="44" rx="9" fill="#FFFFFF" stroke="#5DCAA5" stroke-width="1.6"/>
+  <text x="185" y="77" text-anchor="middle" font-size="12.5" fill="#085041">Reverse proxy · terminates TLS</text>
+  <line x1="185" y1="94" x2="185" y2="120" stroke="#1D9E75" stroke-width="2.2" marker-end="url(#dn)"/>
+
+  <rect x="55" y="124" width="260" height="58" rx="9" fill="#FFFFFF" stroke="#0F6E56" stroke-width="2"/>
+  <text x="185" y="148" text-anchor="middle" font-size="13" font-weight="700" fill="#085041">Ruscker</text>
+  <text x="185" y="167" text-anchor="middle" font-size="10.5" fill="#5B6B66">proxy · admin · Docker control</text>
+  <line x1="185" y1="182" x2="185" y2="208" stroke="#1D9E75" stroke-width="2.2" marker-end="url(#dn)"/>
+  <text x="195" y="200" font-size="10.5" fill="#5B6B66">Docker API · local socket</text>
+
+  <rect x="55" y="212" width="260" height="44" rx="9" fill="#F4F8F7" stroke="#5DCAA5" stroke-width="1.6"/>
+  <text x="185" y="239" text-anchor="middle" font-size="12.5" fill="#085041">Docker daemon</text>
+  <line x1="185" y1="256" x2="185" y2="282" stroke="#1D9E75" stroke-width="2.2" marker-end="url(#dn)"/>
+
+  <rect x="55" y="286" width="260" height="56" rx="9" fill="#F4F8F7" stroke="#5DCAA5" stroke-width="1.6"/>
+  <text x="185" y="310" text-anchor="middle" font-size="12.5" font-weight="600" fill="#085041">App containers ×N</text>
+  <text x="185" y="328" text-anchor="middle" font-size="10.5" fill="#5B6B66">spawned on demand · reaped when idle</text>
+
+  <text x="185" y="372" text-anchor="middle" font-size="11" fill="#5B6B66">what 99% of installs run — simple and fast</text>
+
+  <!-- ───────────── Multi-node HA (right) ───────────── -->
+  <text x="535" y="34" text-anchor="middle" font-size="14" font-weight="700" fill="#085041">Multi-node HA · planned (Phase 7)</text>
+
+  <rect x="405" y="50" width="260" height="44" rx="9" fill="#FFFFFF" stroke="#5DCAA5" stroke-width="1.6"/>
+  <text x="535" y="77" text-anchor="middle" font-size="12.5" fill="#085041">L4 load balancer</text>
+  <line x1="475" y1="94" x2="475" y2="120" stroke="#1D9E75" stroke-width="2.2" marker-end="url(#dn)"/>
+  <line x1="595" y1="94" x2="595" y2="120" stroke="#1D9E75" stroke-width="2.2" marker-end="url(#dn)"/>
+
+  <rect x="405" y="124" width="120" height="50" rx="9" fill="#FFFFFF" stroke="#0F6E56" stroke-width="2"/>
+  <text x="465" y="153" text-anchor="middle" font-size="12" font-weight="700" fill="#085041">Ruscker 1</text>
+  <rect x="545" y="124" width="120" height="50" rx="9" fill="#FFFFFF" stroke="#0F6E56" stroke-width="2"/>
+  <text x="605" y="153" text-anchor="middle" font-size="12" font-weight="700" fill="#085041">Ruscker 2</text>
+  <line x1="465" y1="174" x2="500" y2="208" stroke="#1D9E75" stroke-width="2.2" marker-end="url(#dn)"/>
+  <line x1="605" y1="174" x2="570" y2="208" stroke="#1D9E75" stroke-width="2.2" marker-end="url(#dn)"/>
+
+  <rect x="405" y="212" width="260" height="44" rx="9" fill="#E8F3EE" stroke="#1D9E75" stroke-width="1.6"/>
+  <text x="535" y="231" text-anchor="middle" font-size="12.5" font-weight="600" fill="#085041">Postgres — shared session state</text>
+  <text x="535" y="248" text-anchor="middle" font-size="10" fill="#5B6B66">either instance can serve any session</text>
+  <line x1="535" y1="256" x2="535" y2="282" stroke="#1D9E75" stroke-width="2.2" marker-end="url(#dn)"/>
+
+  <rect x="405" y="286" width="260" height="56" rx="9" fill="#F4F8F7" stroke="#5DCAA5" stroke-width="1.6"/>
+  <text x="535" y="310" text-anchor="middle" font-size="12.5" font-weight="600" fill="#085041">Docker Swarm / Kubernetes</text>
+  <text x="535" y="328" text-anchor="middle" font-size="10.5" fill="#5B6B66">multi-host scheduling (Phase 6)</text>
+
+  <text x="535" y="372" text-anchor="middle" font-size="11" fill="#5B6B66">for teams needing failover + horizontal scale</text>
+</svg>

--- a/book/src/images/roadmap.svg
+++ b/book/src/images/roadmap.svg
@@ -1,0 +1,69 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 720 520" width="720" height="520" font-family="Jost, Inter, system-ui, -apple-system, sans-serif" role="img" aria-label="Roadmap timeline. Phases 0 through 5 are shipped (scaffolding, landing page, persistence and admin CRUD, proxy and Docker backend, monitoring dashboard, production polish — v0.1.0). Phases 6 to 8 are planned and optional: multi-host scheduling, high availability, and external auth.">
+  <title>Ruscker — roadmap</title>
+
+  <!-- rail: solid teal through the shipped phases, dashed grey after -->
+  <line x1="60" y1="52" x2="60" y2="312" stroke="#1D9E75" stroke-width="3"/>
+  <line x1="60" y1="312" x2="60" y2="476" stroke="#B9CDC6" stroke-width="3" stroke-dasharray="3 6"/>
+
+  <!-- done phases -->
+  <g font-size="13">
+    <!-- 0 -->
+    <circle cx="60" cy="52" r="9" fill="#0F6E56"/>
+    <path d="M55.5,52 l3,3 l6,-6.5" fill="none" stroke="#FFFFFF" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"/>
+    <text x="86" y="49" font-weight="700" fill="#085041">Phase 0 · Scaffolding</text>
+    <text x="86" y="65" font-size="11" fill="#5B6B66">workspace · YAML schema · validation · CLI</text>
+
+    <!-- 1 -->
+    <circle cx="60" cy="104" r="9" fill="#0F6E56"/>
+    <path d="M55.5,104 l3,3 l6,-6.5" fill="none" stroke="#FFFFFF" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"/>
+    <text x="86" y="101" font-weight="700" fill="#085041">Phase 1 · Landing page</text>
+    <text x="86" y="117" font-size="11" fill="#5B6B66">Askama · Tailwind 4 · i18n (pt/en/es/fr)</text>
+
+    <!-- 2 -->
+    <circle cx="60" cy="156" r="9" fill="#0F6E56"/>
+    <path d="M55.5,156 l3,3 l6,-6.5" fill="none" stroke="#FFFFFF" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"/>
+    <text x="86" y="153" font-weight="700" fill="#085041">Phase 2 · Persistence + admin CRUD</text>
+    <text x="86" y="169" font-size="11" fill="#5B6B66">SQLite · import/export · forms · credentials</text>
+
+    <!-- 3 -->
+    <circle cx="60" cy="208" r="9" fill="#0F6E56"/>
+    <path d="M55.5,208 l3,3 l6,-6.5" fill="none" stroke="#FFFFFF" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"/>
+    <text x="86" y="205" font-weight="700" fill="#085041">Phase 3 · Proxy + Docker backend</text>
+    <text x="86" y="221" font-size="11" fill="#5B6B66">sticky · WebSocket · auto-scaler · URL rewrite</text>
+
+    <!-- 4 -->
+    <circle cx="60" cy="260" r="9" fill="#0F6E56"/>
+    <path d="M55.5,260 l3,3 l6,-6.5" fill="none" stroke="#FFFFFF" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"/>
+    <text x="86" y="257" font-weight="700" fill="#085041">Phase 4 · Monitoring dashboard</text>
+    <text x="86" y="273" font-size="11" fill="#5B6B66">live SSE · per-replica CPU/mem · logs · actions</text>
+
+    <!-- 5 -->
+    <circle cx="60" cy="312" r="9" fill="#0F6E56"/>
+    <path d="M55.5,312 l3,3 l6,-6.5" fill="none" stroke="#FFFFFF" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"/>
+    <text x="86" y="309" font-weight="700" fill="#085041">Phase 5 · Production polish</text>
+    <text x="86" y="325" font-size="11" fill="#5B6B66">probes · graceful shutdown · RBAC · signed releases</text>
+    <rect x="520" y="298" width="120" height="22" rx="11" fill="#0F6E56"/>
+    <text x="580" y="313" text-anchor="middle" font-size="11" font-weight="700" fill="#FFFFFF">shipped · v0.1.0</text>
+  </g>
+
+  <!-- planned phases -->
+  <g font-size="13">
+    <!-- 6 -->
+    <circle cx="60" cy="368" r="8.5" fill="#FFFFFF" stroke="#B9CDC6" stroke-width="2.5"/>
+    <text x="86" y="365" font-weight="700" fill="#5B6B66">Phase 6 · Multi-host scheduling</text>
+    <text x="86" y="381" font-size="11" fill="#90A39C">multiple Docker hosts · bin-pack / spread · anti-affinity</text>
+
+    <!-- 7 -->
+    <circle cx="60" cy="420" r="8.5" fill="#FFFFFF" stroke="#B9CDC6" stroke-width="2.5"/>
+    <text x="86" y="417" font-weight="700" fill="#5B6B66">Phase 7 · HA / multi-instance</text>
+    <text x="86" y="433" font-size="11" fill="#90A39C">Postgres session store · advisory locks · failover</text>
+
+    <!-- 8 -->
+    <circle cx="60" cy="472" r="8.5" fill="#FFFFFF" stroke="#B9CDC6" stroke-width="2.5"/>
+    <text x="86" y="469" font-weight="700" fill="#5B6B66">Phase 8 · External auth</text>
+    <text x="86" y="485" font-size="11" fill="#90A39C">OIDC · SAML · LDAP · per-app ACLs (RBAC already shipped)</text>
+    <rect x="520" y="458" width="120" height="22" rx="11" fill="#FFFFFF" stroke="#B9CDC6" stroke-width="1.5"/>
+    <text x="580" y="473" text-anchor="middle" font-size="11" font-weight="600" fill="#5B6B66">planned · optional</text>
+  </g>
+</svg>

--- a/book/src/introduction.md
+++ b/book/src/introduction.md
@@ -37,39 +37,45 @@ proper admin panel, a monitoring dashboard, and load balancing.
 
 ## In production
 
-Ruscker runs in production today. Where the JVM-based stack it replaced
-idled at hundreds of megabytes, Ruscker idles in the low tens:
+Ruscker shipped **v0.1.0** and runs in production today. Where the
+JVM-based stack it replaced idled at hundreds of megabytes, Ruscker
+idles in the low tens:
 
 > **~540 MB → ~16 MB idle** — roughly a 30× cut, on the same machine
 > serving the same apps.
 
 A real 31-spec config migrated with **no unsupported features**, and
-apps spawn on demand.
+apps spawn on demand. Releases are multi-arch and **cosign-signed**;
+the [Roadmap](./roadmap.md) tracks what's shipped and what's next.
 
 ## What's in the box
 
 - **Reverse proxy + load balancer** with sticky sessions, WebSocket
-  forwarding, per-spec replica pools and an auto-scaler.
-- **Container backend** (Docker) that spawns app containers on demand
-  and reaps idle ones.
+  forwarding, per-spec replica pools, an auto-scaler, and absolute-URL
+  rewriting so unmodified Shiny/Streamlit apps work behind a sub-path.
+- **Container backend** (Docker) that spawns app containers on demand,
+  applies per-container CPU/memory limits, and reaps idle ones.
 - **Admin panel** — apps CRUD, image/media library, encrypted
   credentials store, landing-page editor (colors, intros, SEO, social
-  meta, analytics, custom HTML blocks), audit log, and a live
-  monitoring dashboard.
+  meta, analytics, custom HTML blocks), audit log, **user accounts with
+  Viewer / Editor / Admin roles**, and a live monitoring dashboard
+  (CPU/memory sparklines, live-follow logs, stop/restart).
 - **Operations**: `/healthz` + `/readyz` probes, graceful shutdown,
   structured (JSON) logging, per-API rate limiting + CORS, request
-  body-size limits.
-- **Distribution**: a multi-stage Docker image and a Debian package
-  with a hardened `systemd` unit.
+  body-size limits, and an opt-in Prometheus `/metrics` endpoint.
+- **Distribution**: a multi-arch Docker image, a Debian package with a
+  hardened `systemd` unit, static musl tarballs, a Homebrew tap, and
+  cosign-signed artifacts.
 
 ## Where to next
 
 - [What Ruscker can serve](./use-cases.md) — Shiny, Streamlit, Dash,
   FastAPI, JupyterLab, LLM UIs, BI tools, and more.
-- [Installation](./installation.md) — Docker or the `.deb`.
+- [Installation](./installation.md) — Docker, the `.deb`, or `brew`.
 - [Migrating from ShinyProxy](./migrating.md) — point Ruscker at your
   existing `application.yml`.
 - [Configuration](./configuration.md) — the full YAML reference.
 - [The admin panel](./admin.md) — what each screen does.
 - [Deploying in production](./deploying.md) — systemd + nginx,
   side-by-side with ShinyProxy.
+- [Roadmap](./roadmap.md) — shipped phases and what's planned.

--- a/book/src/roadmap.md
+++ b/book/src/roadmap.md
@@ -1,0 +1,98 @@
+# Roadmap
+
+Ruscker shipped **v0.1.0** — Phases 0 through 5 are done and the proxy
+is production-ready. Phases 6–8 are optional and demand-driven.
+
+![Roadmap timeline: phases 0–5 are shipped (scaffolding, landing page, persistence + admin CRUD, proxy + Docker backend, monitoring dashboard, production polish — v0.1.0). Phases 6–8 are planned and optional: multi-host scheduling, high availability, and external auth.](images/roadmap.svg)
+
+## Shipped
+
+### Phase 0 — Scaffolding
+The Cargo workspace, the ShinyProxy-compatible YAML schema, env-var
+interpolation, two-phase validation, and the `ruscker validate` /
+`show` / `inspect` CLI.
+
+### Phase 1 — Landing page
+The public portal rendered from config with Askama + Tailwind 4 (no
+Node toolchain), full i18n in **pt-BR / en-US / es-ES / fr-FR**, theme
+and locale cookies, and the kind-tinted card grid with filters.
+
+### Phase 2 — Persistence + admin CRUD
+SQLite as the source of truth (sqlx, embedded migrations),
+`ruscker import` / `export` to round-trip YAML, and the admin panel:
+apps list + spec form, image/media library (WebP conversion), an
+AES-256-GCM credentials store, the landing-page editor, and an audit
+log.
+
+### Phase 3 — Proxy + Docker backend
+HTTP forwarding, **sticky sessions** (HMAC-signed cookie), **WebSocket
+proxying**, the Docker backend (spawn / stop / stats / logs via
+bollard), per-spec replica pools, the **auto-scaler** (scale-to-min,
+scale-up on saturation, scale-down on idle with hysteresis), the
+session tracker + heartbeat sweeper, absolute-URL rewriting so
+unmodified Shiny/Streamlit apps work behind a sub-path, and
+per-container CPU/memory limits.
+
+### Phase 4 — Monitoring dashboard
+A live dashboard over **Server-Sent Events**: aggregate cards,
+per-replica state / uptime / sessions / **CPU + memory** (with
+sparklines), one-shot and **live-follow logs**, per-replica
+**stop / restart**, and a Prometheus `/metrics` endpoint.
+
+### Phase 5 — Production polish → **v0.1.0**
+`/healthz` + `/readyz` probes, graceful shutdown (session drain),
+structured JSON logging, per-API rate limiting + CORS, request
+body-size limits, `validate --strict-compat` migration pre-flight,
+**role-based access control** (Viewer / Editor / Admin with per-user
+password accounts), smart-routing headers (`X-Forwarded-Prefix` …),
+and distribution: a **multi-arch Docker image**, a **Debian package**
+with a hardened systemd unit, static **musl tarballs**, a `curl | sh`
+installer, a **Homebrew tap**, and **cosign-signed** release artifacts.
+
+> **Production milestone.** Ruscker replaced a JVM-based stack on the
+> same machine serving the same apps, cutting idle memory from
+> **~540 MB to ~16 MB** (~30×). A real 31-spec config migrated with no
+> unsupported features.
+
+## Planned (optional)
+
+These are demand-driven — Ruscker is complete and useful without them.
+
+### Phase 6 — Multi-host scheduling
+A `MultiHostDockerBackend` that talks to several Docker hosts, with
+bin-pack vs spread placement and per-spec anti-affinity ("replicas on
+different hosts"). Slots in behind the existing `ContainerBackend`
+trait — no proxy changes.
+
+### Phase 7 — HA / multi-instance
+A Postgres `SessionStore` so two Ruscker instances behind an L4 load
+balancer can share session state and either can serve any session;
+coordination via Postgres advisory locks; failover testing. See
+[Deployment shapes](./architecture.md#deployment-shapes).
+
+### Phase 8 — External auth
+OIDC (Keycloak / Auth0 / Google), SAML, and LDAP, plus per-app access
+lists ("only group X can use this app"). The coarse Viewer / Editor /
+Admin RBAC already shipped in Phase 5; this is the federated-identity
+and fine-grained-ACL layer on top.
+
+## Explicitly out of scope
+
+- **Kubernetes backend** — possible as a future `ContainerBackend`
+  impl, but not a committed phase until there's demand.
+- **App-ecosystem features** (pause/resume, snapshots) — these are
+  ShinyProxy Pro territory.
+- **Multi-tenancy / billing** and a **public app marketplace**.
+
+## What "done" means
+
+After Phase 5, Ruscker can drop in where ShinyProxy runs today:
+
+1. `ruscker import application.yml --db /var/ruscker/ruscker.db`
+2. Stop ShinyProxy.
+3. Start Ruscker on the same port.
+4. Verify with the same browser URL.
+
+Phases 6+ are for organisations with more demanding scale or
+identity needs. Progress is tracked in the GitHub issues and
+`docs/ROADMAP.md`.

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -6,67 +6,29 @@ how the pieces fit together.
 
 ## High-level diagram
 
-```
-                    ┌────────────────────┐
-                    │  Visitors (browsers)│
-                    └──────────┬──────────┘
-                               │ HTTPS
-                               ▼
-                    ┌─────────────────────┐
-                    │   Ruscker process   │
-                    │  ┌───────────────┐  │
-                    │  │ Landing page  │  │ ◄── Askama templates
-                    │  │ (Tailwind 4)  │  │
-                    │  └───────────────┘  │
-                    │  ┌───────────────┐  │
-                    │  │ HTTP+WS proxy │  │ ◄── ruscker-proxy
-                    │  │  - sticky     │  │
-                    │  │  - rewrite    │  │
-                    │  │  - WS upgrade │  │
-                    │  └───────────────┘  │
-                    │  ┌───────────────┐  │
-                    │  │  Admin panel  │  │ ◄── ruscker-admin
-                    │  │ (HTMX+Tailw.) │  │
-                    │  └───────────────┘  │
-                    │  ┌───────────────┐  │
-                    │  │  Router /     │  │ ◄── ruscker-core
-                    │  │  Auto-scaler  │  │
-                    │  └───────┬───────┘  │
-                    └──────────┼──────────┘
-                               │ Docker API
-                               ▼
-                    ┌─────────────────────┐
-                    │   Docker daemon     │
-                    │  ┌─────┐ ┌─────┐    │
-                    │  │ App │ │ App │    │
-                    │  │  1  │ │  2  │ …  │
-                    │  └─────┘ └─────┘    │
-                    └─────────────────────┘
-```
+![How Ruscker works: browsers and API clients hit a single Ruscker binary, which serves the landing page + admin and reverse-proxies to app containers it spawns on demand via the Docker daemon.](images/architecture.svg)
 
-All of this is a single Rust process (single binary, ~20MB).
+All of this is a single Rust process — one static binary, ~14 MB idle,
+no JVM. Visitors and API clients reach it on one port; it serves the
+landing page and admin UI, reverse-proxies `/app/{spec}` and
+`/api/{spec}` to the right replica (keeping Shiny sessions sticky and
+upgrading WebSockets), and drives the Docker daemon to spawn and reap
+containers. SQLite is the source of truth for configuration; the live
+replica registry and session store live in memory.
 
 ## Crate map
 
-```
-ruscker-config  (schema, parsing, validation)
-       ▲
-       │
-ruscker-core  (traits, types, routing algorithms)
-       ▲
-       ├──── ruscker-docker  (ContainerBackend impl)
-       │
-       ├──── ruscker-proxy   (HTTP+WS reverse proxy)
-       │
-       └──── ruscker-admin   (Web UI for management)
-                  ▲
-                  │
-            ruscker-cli   (binary entry point)
-```
+The workspace is six crates. `ruscker-config` and `ruscker-core` are
+**pure-domain** — no I/O, no async (bar the async trait *definitions*
+in core). Everything that touches the network or Docker layers on top,
+and the `ruscker-cli` binary stitches them together.
 
-`ruscker-config` and `ruscker-core` are pure-domain crates. They do no
-I/O and contain no async code (except for trait definitions in core
-which need to be async-capable for impls).
+![Crate dependency map: ruscker-cli builds on the I/O crates (docker, proxy, admin), which build on ruscker-core, which builds on ruscker-config.](images/crate-map.svg)
+
+Keeping the backend behind the `ContainerBackend` trait in
+`ruscker-core` means a future Kubernetes or multi-host backend is a new
+impl, not a rewrite — see [Deployment shapes](#deployment-shapes) and
+`docs/adr/`.
 
 ## Request flow
 
@@ -167,9 +129,12 @@ for git versioning, but the running config lives in SQLite.
 ### Trust levels
 
 - **Untrusted**: visitors. They can hit `/app/*` and `/api/*` only.
-  Admin paths require auth (when implemented).
-- **Privileged**: admin users. Can mutate specs, view logs, restart
-  containers.
+  Admin paths require an authenticated session.
+- **Privileged**: admin users. `/admin/*` is gated by per-user
+  password login with three roles — **Viewer** (read-only dashboard),
+  **Editor** (apps + media), **Admin** (everything, incl. user
+  management) — enforced server-side. A break-glass `RUSCKER_ADMIN_TOKEN`
+  bootstraps the first account. See `docs/SECURITY.md` §2.
 - **Operator**: filesystem access (the person running Ruscker). Can
   edit YAML, restart the process.
 
@@ -185,38 +150,21 @@ for git versioning, but the running config lives in SQLite.
 
 ## Deployment shapes
 
-### Single-node (default, MVP)
+![Two deployment shapes. Single-node (today): a reverse proxy in front of one Ruscker driving the local Docker daemon and its app containers. Multi-node HA (planned, Phase 7): an L4 load balancer fans to two Ruscker instances sharing session state in Postgres, scheduling onto Docker Swarm or Kubernetes.](images/deployment.svg)
 
-```
-[load balancer]
-      │
-      ▼
-[Ruscker (proxy + admin + Docker control)]
-      │
-      ▼
-[Docker daemon, local socket]
-      │
-      ▼
-[App containers]
-```
+### Single-node (default)
 
-This is what 99% of users will deploy. Simple, fast, easy to operate.
+A reverse proxy terminates TLS in front of a single Ruscker, which
+talks to the local Docker daemon over its socket. This is what 99% of
+installs run — simple, fast, easy to operate.
 
-### Multi-node HA (future)
+### Multi-node HA (planned — Phase 7)
 
-```
-[L4 load balancer]
-      │
-      ├──► [Ruscker 1] ──┐
-      │                  ├──► [Postgres]  ◄── shared state
-      └──► [Ruscker 2] ──┘
-                         │
-                         ▼
-                  [Docker Swarm / K8s]
-```
-
-Two Ruscker instances behind a real LB share session state via
-Postgres. Either can serve any session.
+Two Ruscker instances behind an L4 load balancer share session state in
+Postgres, so either can serve any session, and schedule onto a
+multi-host backend (Phase 6). Tracked on the Roadmap (Phases 6–7); the
+`ContainerBackend` / `SessionStore` traits already leave room for it
+without touching proxy code.
 
 ## What's not covered here
 

--- a/docs/ROADMAP.md
+++ b/docs/ROADMAP.md
@@ -1,7 +1,15 @@
 # Roadmap
 
-Phased plan from "config parsing only" (today) to "production-ready
-ShinyProxy replacement" (~8-10 weeks of focused work).
+> **Status: Phases 0–5 shipped — `v0.1.0` is out and production-ready.**
+> Phases 6–8 below are optional and demand-driven. For the narrative,
+> up-to-date version with a timeline diagram, see the
+> [Roadmap chapter](https://strategicprojects.github.io/ruscker/roadmap.html)
+> on the docs site. The phase checklists below are the original
+> planning detail (they predate v0.1.0; treat the per-item boxes as
+> historical scope, not live status).
+
+Phased plan from "config parsing only" to "production-ready ShinyProxy
+replacement".
 
 Each phase has a clear deliverable. Skip ahead if a phase doesn't
 apply to your use case (e.g. skip phase 4 if you don't need a

--- a/docs/images/architecture.svg
+++ b/docs/images/architecture.svg
@@ -1,0 +1,91 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 720 600" width="720" height="600" font-family="Jost, Inter, system-ui, -apple-system, sans-serif" role="img" aria-label="How Ruscker works: browsers and API clients hit a single Ruscker binary, which proxies to app containers it spawns on demand via the Docker daemon.">
+  <title>Ruscker — how it works</title>
+
+  <defs>
+    <marker id="arrow" viewBox="0 0 10 10" refX="8" refY="5" markerWidth="7" markerHeight="7" orient="auto-start-reverse">
+      <path d="M0,0 L10,5 L0,10 z" fill="#1D9E75"/>
+    </marker>
+  </defs>
+
+  <!-- ── Clients ───────────────────────────────────────────── -->
+  <rect x="200" y="22" width="320" height="46" rx="23" fill="#FFFFFF" stroke="#1D9E75" stroke-width="2"/>
+  <text x="360" y="51" text-anchor="middle" font-size="15" font-weight="600" fill="#1A1A1A">Browsers · API clients</text>
+
+  <!-- arrow 1 -->
+  <line x1="360" y1="68" x2="360" y2="100" stroke="#1D9E75" stroke-width="2.5" marker-end="url(#arrow)"/>
+  <text x="372" y="89" font-size="12" fill="#5B6B66">HTTPS · /app/{spec} · /api/{spec}</text>
+
+  <!-- ── Ruscker process ───────────────────────────────────── -->
+  <rect x="40" y="104" width="640" height="300" rx="14" fill="#FFFFFF" stroke="#0F6E56" stroke-width="2"/>
+  <!-- title bar (top corners rounded) -->
+  <path d="M40,146 L40,118 Q40,104 54,104 L666,104 Q680,104 680,118 L680,146 Z" fill="#0F6E56"/>
+  <!-- brand mark, white knockout -->
+  <g transform="translate(54.4,110) scale(0.34)">
+    <polygon points="14,52 40,40 66,52 40,64" fill="#FFFFFF" opacity="0.45"/>
+    <polygon points="14,40 40,28 66,40 40,52" fill="#FFFFFF" opacity="0.72"/>
+    <polygon points="14,28 40,16 66,28 40,40" fill="#FFFFFF"/>
+  </g>
+  <text x="92" y="131" font-size="15" font-weight="600" fill="#FFFFFF">Ruscker — single static binary · ~14 MB · no JVM</text>
+
+  <!-- component boxes -->
+  <!-- (1) Landing -->
+  <rect x="60" y="158" width="290" height="64" rx="10" fill="#F4F8F7" stroke="#5DCAA5" stroke-width="1.5"/>
+  <text x="205" y="186" text-anchor="middle" font-size="14" font-weight="600" fill="#085041">Landing page</text>
+  <text x="205" y="205" text-anchor="middle" font-size="11" fill="#5B6B66">Askama · Tailwind 4 · i18n (pt/en/es/fr)</text>
+  <!-- (2) Admin -->
+  <rect x="370" y="158" width="290" height="64" rx="10" fill="#F4F8F7" stroke="#5DCAA5" stroke-width="1.5"/>
+  <text x="515" y="186" text-anchor="middle" font-size="14" font-weight="600" fill="#085041">Admin · live dashboard</text>
+  <text x="515" y="205" text-anchor="middle" font-size="11" fill="#5B6B66">HTMX · SSE · image library · audit log</text>
+  <!-- (3) Proxy -->
+  <rect x="60" y="232" width="290" height="64" rx="10" fill="#F4F8F7" stroke="#5DCAA5" stroke-width="1.5"/>
+  <text x="205" y="260" text-anchor="middle" font-size="14" font-weight="600" fill="#085041">Reverse proxy</text>
+  <text x="205" y="279" text-anchor="middle" font-size="11" fill="#5B6B66">sticky · WebSocket · URL rewrite · rate-limit</text>
+  <!-- (4) Router -->
+  <rect x="370" y="232" width="290" height="64" rx="10" fill="#F4F8F7" stroke="#5DCAA5" stroke-width="1.5"/>
+  <text x="515" y="260" text-anchor="middle" font-size="14" font-weight="600" fill="#085041">Router · auto-scaler</text>
+  <text x="515" y="279" text-anchor="middle" font-size="11" fill="#5B6B66">least-conn / round-robin · min–max replicas</text>
+  <!-- state -->
+  <rect x="60" y="312" width="600" height="56" rx="10" fill="#E8F3EE" stroke="#1D9E75" stroke-width="1.5"/>
+  <text x="360" y="338" text-anchor="middle" font-size="14" font-weight="600" fill="#085041">SQLite — source of truth</text>
+  <text x="360" y="356" text-anchor="middle" font-size="11" fill="#5B6B66">specs · images · encrypted credentials · audit log</text>
+
+  <!-- arrow 2 -->
+  <line x1="360" y1="404" x2="360" y2="436" stroke="#1D9E75" stroke-width="2.5" marker-end="url(#arrow)"/>
+  <text x="372" y="425" font-size="12" fill="#5B6B66">Docker API · spawn / stop / stats / logs</text>
+
+  <!-- ── Docker daemon ─────────────────────────────────────── -->
+  <rect x="40" y="440" width="640" height="148" rx="14" fill="#FFFFFF" stroke="#D7E5E0" stroke-width="2"/>
+  <text x="60" y="464" font-size="13" font-weight="600" fill="#5B6B66">Docker daemon</text>
+
+  <!-- replicas -->
+  <g>
+    <rect x="64" y="474" width="180" height="74" rx="10" fill="#F4F8F7" stroke="#5DCAA5" stroke-width="1.5"/>
+    <g transform="translate(154,486) scale(0.42)">
+      <polygon points="14,52 40,40 66,52 40,64" fill="#0F6E56"/>
+      <polygon points="14,40 40,28 66,40 40,52" fill="#1D9E75"/>
+      <polygon points="14,28 40,16 66,28 40,40" fill="#5DCAA5"/>
+    </g>
+    <text x="154" y="538" text-anchor="middle" font-size="12" font-weight="600" fill="#085041">App replica · R1</text>
+  </g>
+  <g>
+    <rect x="270" y="474" width="180" height="74" rx="10" fill="#F4F8F7" stroke="#5DCAA5" stroke-width="1.5"/>
+    <g transform="translate(360,486) scale(0.42)">
+      <polygon points="14,52 40,40 66,52 40,64" fill="#0F6E56"/>
+      <polygon points="14,40 40,28 66,40 40,52" fill="#1D9E75"/>
+      <polygon points="14,28 40,16 66,28 40,40" fill="#5DCAA5"/>
+    </g>
+    <text x="360" y="538" text-anchor="middle" font-size="12" font-weight="600" fill="#085041">App replica · R2</text>
+  </g>
+  <g>
+    <rect x="476" y="474" width="180" height="74" rx="10" fill="#F4F8F7" stroke="#5DCAA5" stroke-width="1.5"/>
+    <g transform="translate(566,486) scale(0.42)">
+      <polygon points="14,52 40,40 66,52 40,64" fill="#0F6E56"/>
+      <polygon points="14,40 40,28 66,40 40,52" fill="#1D9E75"/>
+      <polygon points="14,28 40,16 66,28 40,40" fill="#5DCAA5"/>
+    </g>
+    <text x="566" y="538" text-anchor="middle" font-size="12" font-weight="600" fill="#085041">App replica · R3</text>
+  </g>
+
+  <text x="360" y="574" text-anchor="middle" font-size="11" fill="#5B6B66">spawned on demand · reaped when idle · per-container CPU and memory limits</text>
+</svg>

--- a/docs/images/crate-map.svg
+++ b/docs/images/crate-map.svg
@@ -1,0 +1,58 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 720 470" width="720" height="470" font-family="Jost, Inter, system-ui, -apple-system, sans-serif" role="img" aria-label="Crate dependency map: ruscker-cli (binary) builds on the I/O crates (docker, proxy, admin), which build on ruscker-core, which builds on ruscker-config. Config and core are pure-domain with no I/O.">
+  <title>Ruscker — crate map</title>
+
+  <defs>
+    <marker id="up" viewBox="0 0 10 10" refX="5" refY="2" markerWidth="7" markerHeight="7" orient="auto">
+      <path d="M0,10 L5,0 L10,10 z" fill="#1D9E75"/>
+    </marker>
+  </defs>
+
+  <!-- layer bands -->
+  <rect x="24" y="120" width="672" height="92" rx="12" fill="#F4F8F7" stroke="#D7E5E0" stroke-width="1.5"/>
+  <text x="40" y="142" font-size="12" font-weight="600" fill="#5B6B66">I/O layer · async + tokio</text>
+  <rect x="24" y="250" width="672" height="178" rx="12" fill="#E8F3EE" stroke="#D7E5E0" stroke-width="1.5"/>
+  <text x="40" y="272" font-size="12" font-weight="600" fill="#5B6B66">pure domain · no I/O, no async (trait defs aside)</text>
+
+  <!-- ruscker-cli (binary) -->
+  <rect x="270" y="28" width="180" height="58" rx="10" fill="#0F6E56" stroke="#0F6E56" stroke-width="2"/>
+  <text x="360" y="53" text-anchor="middle" font-size="14" font-weight="700" fill="#FFFFFF">ruscker-cli</text>
+  <text x="360" y="71" text-anchor="middle" font-size="11" fill="#CDECE0">the `ruscker` binary</text>
+
+  <!-- I/O crates -->
+  <rect x="56" y="150" width="180" height="50" rx="10" fill="#FFFFFF" stroke="#1D9E75" stroke-width="1.8"/>
+  <text x="146" y="172" text-anchor="middle" font-size="13" font-weight="600" fill="#085041">ruscker-docker</text>
+  <text x="146" y="190" text-anchor="middle" font-size="10.5" fill="#5B6B66">ContainerBackend (bollard)</text>
+
+  <rect x="270" y="150" width="180" height="50" rx="10" fill="#FFFFFF" stroke="#1D9E75" stroke-width="1.8"/>
+  <text x="360" y="172" text-anchor="middle" font-size="13" font-weight="600" fill="#085041">ruscker-proxy</text>
+  <text x="360" y="190" text-anchor="middle" font-size="10.5" fill="#5B6B66">sticky cookie · WS pump</text>
+
+  <rect x="484" y="150" width="180" height="50" rx="10" fill="#FFFFFF" stroke="#1D9E75" stroke-width="1.8"/>
+  <text x="574" y="172" text-anchor="middle" font-size="13" font-weight="600" fill="#085041">ruscker-admin</text>
+  <text x="574" y="190" text-anchor="middle" font-size="10.5" fill="#5B6B66">landing · admin · proxy routes</text>
+
+  <!-- ruscker-core -->
+  <rect x="210" y="296" width="300" height="52" rx="10" fill="#FFFFFF" stroke="#0F6E56" stroke-width="1.8"/>
+  <text x="360" y="319" text-anchor="middle" font-size="13" font-weight="700" fill="#085041">ruscker-core</text>
+  <text x="360" y="337" text-anchor="middle" font-size="10.5" fill="#5B6B66">traits · types · routing · ReplicaRegistry</text>
+
+  <!-- ruscker-config -->
+  <rect x="210" y="364" width="300" height="50" rx="10" fill="#FFFFFF" stroke="#0F6E56" stroke-width="1.8"/>
+  <text x="360" y="386" text-anchor="middle" font-size="13" font-weight="700" fill="#085041">ruscker-config</text>
+  <text x="360" y="404" text-anchor="middle" font-size="10.5" fill="#5B6B66">YAML schema · parsing · validation</text>
+
+  <!-- edges: arrows point up, toward the consumer ("built on") -->
+  <!-- cli ← the three I/O crates -->
+  <line x1="146" y1="150" x2="300" y2="88" stroke="#1D9E75" stroke-width="2" marker-end="url(#up)"/>
+  <line x1="360" y1="150" x2="360" y2="88" stroke="#1D9E75" stroke-width="2" marker-end="url(#up)"/>
+  <line x1="574" y1="150" x2="420" y2="88" stroke="#1D9E75" stroke-width="2" marker-end="url(#up)"/>
+  <!-- core ← I/O crates (fan out from core's top edge) -->
+  <line x1="300" y1="296" x2="146" y2="202" stroke="#1D9E75" stroke-width="2" marker-end="url(#up)"/>
+  <line x1="360" y1="296" x2="360" y2="202" stroke="#1D9E75" stroke-width="2" marker-end="url(#up)"/>
+  <line x1="420" y1="296" x2="574" y2="202" stroke="#1D9E75" stroke-width="2" marker-end="url(#up)"/>
+  <!-- config ← core -->
+  <line x1="360" y1="364" x2="360" y2="350" stroke="#1D9E75" stroke-width="2" marker-end="url(#up)"/>
+
+  <text x="360" y="450" text-anchor="middle" font-size="11" fill="#5B6B66">arrows point to the crate that depends on it · swap a backend by swapping a `ContainerBackend` impl</text>
+</svg>

--- a/docs/images/deployment.svg
+++ b/docs/images/deployment.svg
@@ -1,0 +1,62 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 720 430" width="720" height="430" font-family="Jost, Inter, system-ui, -apple-system, sans-serif" role="img" aria-label="Two deployment shapes. Single-node (today): reverse proxy to one Ruscker to the local Docker daemon to app containers. Multi-node HA (planned, phase 7): an L4 load balancer fans to two Ruscker instances that share session state in Postgres and schedule onto Docker Swarm or Kubernetes.">
+  <title>Ruscker — deployment shapes</title>
+
+  <defs>
+    <marker id="dn" viewBox="0 0 10 10" refX="5" refY="8" markerWidth="7" markerHeight="7" orient="auto">
+      <path d="M0,0 L5,10 L10,0 z" fill="#1D9E75"/>
+    </marker>
+  </defs>
+
+  <!-- divider -->
+  <line x1="360" y1="20" x2="360" y2="410" stroke="#D7E5E0" stroke-width="1.5" stroke-dasharray="4 5"/>
+
+  <!-- ───────────── Single-node (left) ───────────── -->
+  <text x="185" y="34" text-anchor="middle" font-size="14" font-weight="700" fill="#085041">Single-node · today</text>
+
+  <rect x="55" y="50" width="260" height="44" rx="9" fill="#FFFFFF" stroke="#5DCAA5" stroke-width="1.6"/>
+  <text x="185" y="77" text-anchor="middle" font-size="12.5" fill="#085041">Reverse proxy · terminates TLS</text>
+  <line x1="185" y1="94" x2="185" y2="120" stroke="#1D9E75" stroke-width="2.2" marker-end="url(#dn)"/>
+
+  <rect x="55" y="124" width="260" height="58" rx="9" fill="#FFFFFF" stroke="#0F6E56" stroke-width="2"/>
+  <text x="185" y="148" text-anchor="middle" font-size="13" font-weight="700" fill="#085041">Ruscker</text>
+  <text x="185" y="167" text-anchor="middle" font-size="10.5" fill="#5B6B66">proxy · admin · Docker control</text>
+  <line x1="185" y1="182" x2="185" y2="208" stroke="#1D9E75" stroke-width="2.2" marker-end="url(#dn)"/>
+  <text x="195" y="200" font-size="10.5" fill="#5B6B66">Docker API · local socket</text>
+
+  <rect x="55" y="212" width="260" height="44" rx="9" fill="#F4F8F7" stroke="#5DCAA5" stroke-width="1.6"/>
+  <text x="185" y="239" text-anchor="middle" font-size="12.5" fill="#085041">Docker daemon</text>
+  <line x1="185" y1="256" x2="185" y2="282" stroke="#1D9E75" stroke-width="2.2" marker-end="url(#dn)"/>
+
+  <rect x="55" y="286" width="260" height="56" rx="9" fill="#F4F8F7" stroke="#5DCAA5" stroke-width="1.6"/>
+  <text x="185" y="310" text-anchor="middle" font-size="12.5" font-weight="600" fill="#085041">App containers ×N</text>
+  <text x="185" y="328" text-anchor="middle" font-size="10.5" fill="#5B6B66">spawned on demand · reaped when idle</text>
+
+  <text x="185" y="372" text-anchor="middle" font-size="11" fill="#5B6B66">what 99% of installs run — simple and fast</text>
+
+  <!-- ───────────── Multi-node HA (right) ───────────── -->
+  <text x="535" y="34" text-anchor="middle" font-size="14" font-weight="700" fill="#085041">Multi-node HA · planned (Phase 7)</text>
+
+  <rect x="405" y="50" width="260" height="44" rx="9" fill="#FFFFFF" stroke="#5DCAA5" stroke-width="1.6"/>
+  <text x="535" y="77" text-anchor="middle" font-size="12.5" fill="#085041">L4 load balancer</text>
+  <line x1="475" y1="94" x2="475" y2="120" stroke="#1D9E75" stroke-width="2.2" marker-end="url(#dn)"/>
+  <line x1="595" y1="94" x2="595" y2="120" stroke="#1D9E75" stroke-width="2.2" marker-end="url(#dn)"/>
+
+  <rect x="405" y="124" width="120" height="50" rx="9" fill="#FFFFFF" stroke="#0F6E56" stroke-width="2"/>
+  <text x="465" y="153" text-anchor="middle" font-size="12" font-weight="700" fill="#085041">Ruscker 1</text>
+  <rect x="545" y="124" width="120" height="50" rx="9" fill="#FFFFFF" stroke="#0F6E56" stroke-width="2"/>
+  <text x="605" y="153" text-anchor="middle" font-size="12" font-weight="700" fill="#085041">Ruscker 2</text>
+  <line x1="465" y1="174" x2="500" y2="208" stroke="#1D9E75" stroke-width="2.2" marker-end="url(#dn)"/>
+  <line x1="605" y1="174" x2="570" y2="208" stroke="#1D9E75" stroke-width="2.2" marker-end="url(#dn)"/>
+
+  <rect x="405" y="212" width="260" height="44" rx="9" fill="#E8F3EE" stroke="#1D9E75" stroke-width="1.6"/>
+  <text x="535" y="231" text-anchor="middle" font-size="12.5" font-weight="600" fill="#085041">Postgres — shared session state</text>
+  <text x="535" y="248" text-anchor="middle" font-size="10" fill="#5B6B66">either instance can serve any session</text>
+  <line x1="535" y1="256" x2="535" y2="282" stroke="#1D9E75" stroke-width="2.2" marker-end="url(#dn)"/>
+
+  <rect x="405" y="286" width="260" height="56" rx="9" fill="#F4F8F7" stroke="#5DCAA5" stroke-width="1.6"/>
+  <text x="535" y="310" text-anchor="middle" font-size="12.5" font-weight="600" fill="#085041">Docker Swarm / Kubernetes</text>
+  <text x="535" y="328" text-anchor="middle" font-size="10.5" fill="#5B6B66">multi-host scheduling (Phase 6)</text>
+
+  <text x="535" y="372" text-anchor="middle" font-size="11" fill="#5B6B66">for teams needing failover + horizontal scale</text>
+</svg>

--- a/docs/images/roadmap.svg
+++ b/docs/images/roadmap.svg
@@ -1,0 +1,69 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 720 520" width="720" height="520" font-family="Jost, Inter, system-ui, -apple-system, sans-serif" role="img" aria-label="Roadmap timeline. Phases 0 through 5 are shipped (scaffolding, landing page, persistence and admin CRUD, proxy and Docker backend, monitoring dashboard, production polish — v0.1.0). Phases 6 to 8 are planned and optional: multi-host scheduling, high availability, and external auth.">
+  <title>Ruscker — roadmap</title>
+
+  <!-- rail: solid teal through the shipped phases, dashed grey after -->
+  <line x1="60" y1="52" x2="60" y2="312" stroke="#1D9E75" stroke-width="3"/>
+  <line x1="60" y1="312" x2="60" y2="476" stroke="#B9CDC6" stroke-width="3" stroke-dasharray="3 6"/>
+
+  <!-- done phases -->
+  <g font-size="13">
+    <!-- 0 -->
+    <circle cx="60" cy="52" r="9" fill="#0F6E56"/>
+    <path d="M55.5,52 l3,3 l6,-6.5" fill="none" stroke="#FFFFFF" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"/>
+    <text x="86" y="49" font-weight="700" fill="#085041">Phase 0 · Scaffolding</text>
+    <text x="86" y="65" font-size="11" fill="#5B6B66">workspace · YAML schema · validation · CLI</text>
+
+    <!-- 1 -->
+    <circle cx="60" cy="104" r="9" fill="#0F6E56"/>
+    <path d="M55.5,104 l3,3 l6,-6.5" fill="none" stroke="#FFFFFF" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"/>
+    <text x="86" y="101" font-weight="700" fill="#085041">Phase 1 · Landing page</text>
+    <text x="86" y="117" font-size="11" fill="#5B6B66">Askama · Tailwind 4 · i18n (pt/en/es/fr)</text>
+
+    <!-- 2 -->
+    <circle cx="60" cy="156" r="9" fill="#0F6E56"/>
+    <path d="M55.5,156 l3,3 l6,-6.5" fill="none" stroke="#FFFFFF" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"/>
+    <text x="86" y="153" font-weight="700" fill="#085041">Phase 2 · Persistence + admin CRUD</text>
+    <text x="86" y="169" font-size="11" fill="#5B6B66">SQLite · import/export · forms · credentials</text>
+
+    <!-- 3 -->
+    <circle cx="60" cy="208" r="9" fill="#0F6E56"/>
+    <path d="M55.5,208 l3,3 l6,-6.5" fill="none" stroke="#FFFFFF" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"/>
+    <text x="86" y="205" font-weight="700" fill="#085041">Phase 3 · Proxy + Docker backend</text>
+    <text x="86" y="221" font-size="11" fill="#5B6B66">sticky · WebSocket · auto-scaler · URL rewrite</text>
+
+    <!-- 4 -->
+    <circle cx="60" cy="260" r="9" fill="#0F6E56"/>
+    <path d="M55.5,260 l3,3 l6,-6.5" fill="none" stroke="#FFFFFF" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"/>
+    <text x="86" y="257" font-weight="700" fill="#085041">Phase 4 · Monitoring dashboard</text>
+    <text x="86" y="273" font-size="11" fill="#5B6B66">live SSE · per-replica CPU/mem · logs · actions</text>
+
+    <!-- 5 -->
+    <circle cx="60" cy="312" r="9" fill="#0F6E56"/>
+    <path d="M55.5,312 l3,3 l6,-6.5" fill="none" stroke="#FFFFFF" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"/>
+    <text x="86" y="309" font-weight="700" fill="#085041">Phase 5 · Production polish</text>
+    <text x="86" y="325" font-size="11" fill="#5B6B66">probes · graceful shutdown · RBAC · signed releases</text>
+    <rect x="520" y="298" width="120" height="22" rx="11" fill="#0F6E56"/>
+    <text x="580" y="313" text-anchor="middle" font-size="11" font-weight="700" fill="#FFFFFF">shipped · v0.1.0</text>
+  </g>
+
+  <!-- planned phases -->
+  <g font-size="13">
+    <!-- 6 -->
+    <circle cx="60" cy="368" r="8.5" fill="#FFFFFF" stroke="#B9CDC6" stroke-width="2.5"/>
+    <text x="86" y="365" font-weight="700" fill="#5B6B66">Phase 6 · Multi-host scheduling</text>
+    <text x="86" y="381" font-size="11" fill="#90A39C">multiple Docker hosts · bin-pack / spread · anti-affinity</text>
+
+    <!-- 7 -->
+    <circle cx="60" cy="420" r="8.5" fill="#FFFFFF" stroke="#B9CDC6" stroke-width="2.5"/>
+    <text x="86" y="417" font-weight="700" fill="#5B6B66">Phase 7 · HA / multi-instance</text>
+    <text x="86" y="433" font-size="11" fill="#90A39C">Postgres session store · advisory locks · failover</text>
+
+    <!-- 8 -->
+    <circle cx="60" cy="472" r="8.5" fill="#FFFFFF" stroke="#B9CDC6" stroke-width="2.5"/>
+    <text x="86" y="469" font-weight="700" fill="#5B6B66">Phase 8 · External auth</text>
+    <text x="86" y="485" font-size="11" fill="#90A39C">OIDC · SAML · LDAP · per-app ACLs (RBAC already shipped)</text>
+    <rect x="520" y="458" width="120" height="22" rx="11" fill="#FFFFFF" stroke="#B9CDC6" stroke-width="1.5"/>
+    <text x="580" y="473" text-anchor="middle" font-size="11" font-weight="600" fill="#5B6B66">planned · optional</text>
+  </g>
+</svg>


### PR DESCRIPTION
Documentation overhaul for the v0.1.0 release.

## Diagrams: ASCII → SVG
The box-drawing diagrams in `docs/ARCHITECTURE.md` are replaced with brand-styled SVGs (teal palette, Jost, the Ruscker mark):
- **high-level** architecture (reused the existing `architecture.svg`),
- **crate map** (dependency graph, pure-domain vs I/O layers),
- **deployment shapes** (single-node today + HA planned, side by side).

SVGs live in **both** `docs/images/` and `book/src/images/`, so the same `images/x.svg` path resolves in the GitHub repo view **and** on the mdBook site — including through `{{#include ../../docs/ARCHITECTURE.md}}`. The numbered request-flow steps stay as text (they're not box-drawing art).

## New Roadmap chapter
`book/src/roadmap.md` (+ SUMMARY entry) with a **phases 0–8 timeline SVG**, honest shipped/planned status, and the v0.1.0 milestone. `docs/ROADMAP.md` gets a status banner pointing at it (its per-item checkboxes predate v0.1.0 and are flagged historical).

## README + intro refresh
v0.1.0, **cosign-signed** multi-arch releases, **Homebrew** install, user roles + Prometheus `/metrics` in the feature list, 300+ tests + the `e2e` suite. `introduction.md` mirrors it and links the Roadmap.

## Verified
- `mdbook build` clean (new SVGs copied to `book/book/images/`; `architecture.html` and `roadmap.html` reference them correctly).
- All SVGs validate as XML and were **rasterized + eyeballed** (no overlap/clipping).

🤖 Generated with [Claude Code](https://claude.com/claude-code)