### PR TITLE
ci: bump GitHub Actions to latest majors (Node 24)

### DIFF
--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -34,7 +34,7 @@ jobs:
     env:
       MDBOOK_VERSION: "0.4.40"
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
 
       - name: Install mdBook
         run: |
@@ -46,11 +46,11 @@ jobs:
       - name: Build the book
         run: mdbook build book
 
-      - uses: actions/configure-pages@v5
+      - uses: actions/configure-pages@v6
 
-      - uses: actions/upload-pages-artifact@v3
+      - uses: actions/upload-pages-artifact@v5
         with:
           path: book/book
 
       - id: deployment
-        uses: actions/deploy-pages@v4
+        uses: actions/deploy-pages@v5

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -65,7 +65,7 @@ jobs:
             target: aarch64-unknown-linux-musl
     runs-on: ${{ matrix.runner }}
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
 
       - name: Install build deps
         run: |
@@ -147,7 +147,7 @@ jobs:
           for f in *.tar.gz *.deb; do sha256sum "$f" > "$f.sha256"; done
           ls -la
 
-      - uses: actions/upload-artifact@v4
+      - uses: actions/upload-artifact@v7
         with:
           name: artifacts-${{ matrix.arch }}
           path: dist/*
@@ -171,12 +171,12 @@ jobs:
             platform: linux/arm64
     runs-on: ${{ matrix.runner }}
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
 
-      - uses: docker/setup-buildx-action@v3
+      - uses: docker/setup-buildx-action@v4
 
       - name: Log in to ghcr.io
-        uses: docker/login-action@v3
+        uses: docker/login-action@v4
         with:
           registry: ghcr.io
           username: ${{ github.actor }}
@@ -184,7 +184,7 @@ jobs:
 
       - name: Build and push by digest
         id: build
-        uses: docker/build-push-action@v6
+        uses: docker/build-push-action@v7
         with:
           context: .
           platforms: ${{ matrix.platform }}
@@ -200,7 +200,7 @@ jobs:
         env:
           digest: ${{ steps.build.outputs.digest }}
 
-      - uses: actions/upload-artifact@v4
+      - uses: actions/upload-artifact@v7
         with:
           name: digest-${{ matrix.arch }}
           path: /tmp/digests/*
@@ -215,16 +215,16 @@ jobs:
     needs: [meta, docker-build]
     runs-on: ubuntu-24.04
     steps:
-      - uses: actions/download-artifact@v4
+      - uses: actions/download-artifact@v8
         with:
           path: /tmp/digests
           pattern: digest-*
           merge-multiple: true
 
-      - uses: docker/setup-buildx-action@v3
+      - uses: docker/setup-buildx-action@v4
 
       - name: Log in to ghcr.io
-        uses: docker/login-action@v3
+        uses: docker/login-action@v4
         with:
           registry: ghcr.io
           username: ${{ github.actor }}
@@ -251,7 +251,7 @@ jobs:
           echo "digest=${digest}" >> "$GITHUB_OUTPUT"
 
       - name: Install cosign
-        uses: sigstore/cosign-installer@v3
+        uses: sigstore/cosign-installer@v4
 
       - name: Sign the image (keyless)
         env:
@@ -268,7 +268,7 @@ jobs:
     runs-on: ubuntu-24.04
     steps:
       - name: Download artifacts
-        uses: actions/download-artifact@v4
+        uses: actions/download-artifact@v8
         with:
           path: dist
           pattern: artifacts-*
@@ -278,7 +278,7 @@ jobs:
         run: ls -la dist
 
       - name: Install cosign
-        uses: sigstore/cosign-installer@v3
+        uses: sigstore/cosign-installer@v4
 
       - name: Sign release blobs (keyless)
         working-directory: dist

--- a/.github/workflows/security.yml
+++ b/.github/workflows/security.yml
@@ -26,7 +26,7 @@ jobs:
   cargo-audit:
     runs-on: ubuntu-24.04
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
       - name: Install cargo-audit
         run: cargo install cargo-audit --locked
       - name: Audit dependencies


### PR DESCRIPTION
Clears the **Node.js 20 deprecation** warning on the workflow runs. Pinned to the current latest majors (verified live via the GitHub API), keeping the repo's major-only pin style.

| Action | from → to |
|---|---|
| actions/checkout | v4 → **v6** |
| actions/upload-artifact | v4 → **v7** |
| actions/download-artifact | v4 → **v8** |
| actions/configure-pages | v5 → **v6** |
| actions/deploy-pages | v4 → **v5** |
| actions/upload-pages-artifact | v3 → **v5** |
| docker/setup-buildx-action | v3 → **v4** |
| docker/login-action | v3 → **v4** |
| docker/build-push-action | v6 → **v7** |
| sigstore/cosign-installer | v3 → **v4** |
| Swatinem/rust-cache | v2 (latest major; not Node-20-flagged) |

The artifact actions keep the same inputs in use (`name`/`path`/`pattern`/`merge-multiple` — stable since v4; the major jumps are runtime + backend per the release notes). All three workflow YAMLs validate. The **docs (Pages) deploy** exercises the checkout + pages-action bumps on merge; `release.yml` runs on the next tag.

🤖 Generated with [Claude Code](https://claude.com/claude-code)