### PR TITLE
Phase 6a: proxy.hosts schema + validation (multi-host foundation) (#127)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -509,14 +509,20 @@ dependencies = [
  "futures-core",
  "futures-util",
  "hex",
+ "home",
  "http",
  "http-body-util",
  "hyper",
  "hyper-named-pipe",
+ "hyper-rustls",
  "hyper-util",
  "hyperlocal",
  "log",
+ "openssh",
  "pin-project-lite",
+ "rustls",
+ "rustls-native-certs",
+ "rustls-pki-types",
  "serde",
  "serde_derive",
  "serde_json",
@@ -731,6 +737,16 @@ dependencies = [
  "percent-encoding",
  "time",
  "version_check",
+]
+
+[[package]]
+name = "core-foundation"
+version = "0.10.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b2a6cd9ae233e7f62ba4e9353e81a88df7fc8a5987b8d445b4d90c879bd156f6"
+dependencies = [
+ "core-foundation-sys",
+ "libc",
 ]
 
 [[package]]
@@ -1480,6 +1496,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "home"
+version = "0.5.12"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cc627f471c528ff0c4a49e1d5e60450c8f6461dd6d10ba9dcd3a61d3dff7728d"
+dependencies = [
+ "windows-sys 0.61.2",
+]
+
+[[package]]
 name = "http"
 version = "1.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1573,6 +1598,21 @@ dependencies = [
  "tokio",
  "tower-service",
  "winapi",
+]
+
+[[package]]
+name = "hyper-rustls"
+version = "0.27.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "33ca68d021ef39cf6463ab54c1d0f5daf03377b70561305bb89a8f83aab66e0f"
+dependencies = [
+ "http",
+ "hyper",
+ "hyper-util",
+ "rustls",
+ "tokio",
+ "tokio-rustls",
+ "tower-service",
 ]
 
 [[package]]
@@ -2248,6 +2288,26 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c08d65885ee38876c4f86fa503fb49d7b507c2b62552df7c70b2fce627e06381"
 
 [[package]]
+name = "openssh"
+version = "0.11.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d534c4bfecb0ed71dea4db444a5922a294d15cf40e700548f27295e1feb0ef18"
+dependencies = [
+ "libc",
+ "once_cell",
+ "shell-escape",
+ "tempfile",
+ "thiserror",
+ "tokio",
+]
+
+[[package]]
+name = "openssl-probe"
+version = "0.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7c87def4c32ab89d880effc9e097653c8da5d6ef28e6b539d313baaacfbafcbe"
+
+[[package]]
 name = "ordered-float"
 version = "5.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2881,6 +2941,52 @@ dependencies = [
 ]
 
 [[package]]
+name = "rustls"
+version = "0.23.40"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ef86cd5876211988985292b91c96a8f2d298df24e75989a43a3c73f2d4d8168b"
+dependencies = [
+ "once_cell",
+ "ring",
+ "rustls-pki-types",
+ "rustls-webpki",
+ "subtle",
+ "zeroize",
+]
+
+[[package]]
+name = "rustls-native-certs"
+version = "0.8.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "612460d5f7bea540c490b2b6395d8e34a953e52b491accd6c86c8164c5932a63"
+dependencies = [
+ "openssl-probe",
+ "rustls-pki-types",
+ "schannel",
+ "security-framework",
+]
+
+[[package]]
+name = "rustls-pki-types"
+version = "1.14.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "30a7197ae7eb376e574fe940d068c30fe0462554a3ddbe4eca7838e049c937a9"
+dependencies = [
+ "zeroize",
+]
+
+[[package]]
+name = "rustls-webpki"
+version = "0.103.13"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "61c429a8649f110dddef65e2a5ad240f747e85f7758a6bccc7e5777bd33f756e"
+dependencies = [
+ "ring",
+ "rustls-pki-types",
+ "untrusted",
+]
+
+[[package]]
 name = "rustversion"
 version = "1.0.22"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2902,10 +3008,42 @@ dependencies = [
 ]
 
 [[package]]
+name = "schannel"
+version = "0.1.29"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "91c1b7e4904c873ef0710c1f407dde2e6287de2bebc1bbbf7d430bb7cbffd939"
+dependencies = [
+ "windows-sys 0.61.2",
+]
+
+[[package]]
 name = "scopeguard"
 version = "1.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "94143f37725109f92c262ed2cf5e59bce7498c01bcc1502d7b9afe439a4e9f49"
+
+[[package]]
+name = "security-framework"
+version = "3.7.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b7f4bc775c73d9a02cde8bf7b2ec4c9d12743edf609006c7facc23998404cd1d"
+dependencies = [
+ "bitflags",
+ "core-foundation",
+ "core-foundation-sys",
+ "libc",
+ "security-framework-sys",
+]
+
+[[package]]
+name = "security-framework-sys"
+version = "2.17.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6ce2691df843ecc5d231c0b14ece2acc3efb62c0a398c7e1d875f3983ce020e3"
+dependencies = [
+ "core-foundation-sys",
+ "libc",
+]
 
 [[package]]
 name = "selectors"
@@ -3089,6 +3227,12 @@ checksum = "f40ca3c46823713e0d4209592e8d6e826aa57e928f09752619fc696c499637f6"
 dependencies = [
  "lazy_static",
 ]
+
+[[package]]
+name = "shell-escape"
+version = "0.1.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "45bb67a18fa91266cc7807181f62f9178a6873bfad7dc788c42e6430db40184f"
 
 [[package]]
 name = "shlex"
@@ -3528,6 +3672,16 @@ dependencies = [
  "proc-macro2",
  "quote",
  "syn",
+]
+
+[[package]]
+name = "tokio-rustls"
+version = "0.26.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1729aa945f29d91ba541258c8df89027d5792d85a8841fb65e8bf0f4ede4ef61"
+dependencies = [
+ "rustls",
+ "tokio",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -82,8 +82,10 @@ infer = "0.19"
 # Database (SQLite via sqlx)
 sqlx = { version = "0.9", features = ["runtime-tokio", "sqlite", "macros", "chrono", "uuid"] }
 
-# Docker client
-bollard = "0.21"
+# Docker client. `ssh` + `ssl` enable remote daemons over `ssh://` and
+# `tcp://` (mTLS) for multi-host scheduling (Phase 6); the default
+# `http`+`pipe` only cover the local socket.
+bollard = { version = "0.21", features = ["ssh", "ssl"] }
 
 # Cryptography
 ring = "0.17.14"

--- a/crates/ruscker-cli/src/main.rs
+++ b/crates/ruscker-cli/src/main.rs
@@ -627,6 +627,9 @@ fn format_warning(w: &Warning) -> String {
                  (expected `/host:/container` or `/host:/container:ro`) — the mount will be skipped"
             )
         }
+        Warning::InvalidHost { host, reason } => {
+            format!("docker host `{host}`: {reason} — it will fail to connect at startup")
+        }
     }
 }
 

--- a/crates/ruscker-config/src/schema.rs
+++ b/crates/ruscker-config/src/schema.rs
@@ -183,6 +183,53 @@ pub struct Proxy {
     /// extension — not present in ShinyProxy YAML.
     #[serde(rename = "metrics-enabled")]
     pub metrics_enabled: bool,
+
+    /// Docker hosts for multi-host scheduling (Phase 6). **Empty (the
+    /// default) ⇒ the single local Docker daemon** — today's behaviour.
+    /// When set, Ruscker spawns app containers across these hosts.
+    /// Ruscker extension.
+    #[serde(default)]
+    pub hosts: Vec<Host>,
+}
+
+/// A Docker host Ruscker can schedule containers onto (Phase 6).
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct Host {
+    /// Stable identifier — referenced by replicas, placement, and the
+    /// dashboard. Required and unique.
+    pub id: String,
+
+    /// Daemon address. Supported schemes:
+    /// - `ssh://user@host[:port]` — Docker over SSH (simplest to run);
+    /// - `tcp://host:port` — Docker over TLS (set `tls`);
+    /// - `http://host:port` — Docker over plain TCP (no TLS; trusted
+    ///   networks only);
+    /// - `unix:///path/to/docker.sock` — a local socket.
+    pub address: String,
+
+    /// Client TLS material for `tcp://` mutual TLS. Ignored for other
+    /// schemes.
+    #[serde(default)]
+    pub tls: Option<HostTls>,
+
+    /// Optional hard cap on the number of containers this host runs.
+    /// Placement (Phase 6c) won't exceed it.
+    #[serde(rename = "max-containers")]
+    pub max_containers: Option<u32>,
+
+    /// Relative weight for spread placement. Defaults to 1.
+    pub weight: Option<u32>,
+}
+
+/// Client TLS paths for a `tcp://` Docker host (mutual TLS).
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct HostTls {
+    /// CA certificate that signed the daemon's server cert.
+    pub ca: PathBuf,
+    /// Client certificate presented to the daemon.
+    pub cert: PathBuf,
+    /// Client private key.
+    pub key: PathBuf,
 }
 
 impl Default for Proxy {
@@ -204,6 +251,7 @@ impl Default for Proxy {
             specs: Vec::new(),
             landing_customization: LandingCustomization::default(),
             metrics_enabled: false,
+            hosts: Vec::new(),
         }
     }
 }

--- a/crates/ruscker-config/src/validate.rs
+++ b/crates/ruscker-config/src/validate.rs
@@ -132,6 +132,14 @@ pub enum Warning {
         spec_id: String,
         value: String,
     },
+    /// A `proxy.hosts` entry is malformed: empty/duplicate `id`, an
+    /// `address` with an unsupported scheme, or `tls` set on a non-`tcp`
+    /// address (or missing on a `tcp://` one). The host would fail to
+    /// connect at startup. `host` is the id (or index when blank).
+    InvalidHost {
+        host: String,
+        reason: String,
+    },
 }
 
 const KNOWN_TYPES: &[&str] = &["app", "package", "talk", "report", "api"];
@@ -332,9 +340,72 @@ pub fn run(config: &Config) -> ValidationReport {
         });
     }
 
+    check_hosts(&config.proxy.hosts, &mut warnings);
+
     let stats = collect_stats(config);
 
     ValidationReport { warnings, stats }
+}
+
+/// Validate `proxy.hosts` (Phase 6): non-empty unique ids, a supported
+/// address scheme, and `tls` paired correctly with `tcp://`. Pure
+/// string-level checks — the actual daemon connection happens in
+/// `ruscker-docker` at startup.
+fn check_hosts(hosts: &[crate::schema::Host], warnings: &mut Vec<Warning>) {
+    let mut seen: HashMap<&str, usize> = HashMap::new();
+    for (i, host) in hosts.iter().enumerate() {
+        let label = if host.id.trim().is_empty() {
+            format!("#{i}")
+        } else {
+            host.id.clone()
+        };
+
+        if host.id.trim().is_empty() {
+            warnings.push(Warning::InvalidHost {
+                host: label.clone(),
+                reason: "empty `id`".to_string(),
+            });
+        } else {
+            *seen.entry(host.id.as_str()).or_insert(0) += 1;
+        }
+
+        let addr = host.address.trim();
+        let scheme = addr.split("://").next().filter(|s| *s != addr);
+        match scheme {
+            Some("ssh") | Some("http") | Some("unix") => {
+                if host.tls.is_some() {
+                    warnings.push(Warning::InvalidHost {
+                        host: label.clone(),
+                        reason: format!("`tls` is only used with `tcp://` (address is {addr})"),
+                    });
+                }
+            }
+            Some("tcp") => {
+                if host.tls.is_none() {
+                    warnings.push(Warning::InvalidHost {
+                        host: label.clone(),
+                        reason: "`tcp://` host needs `tls` (ca/cert/key) for mutual TLS"
+                            .to_string(),
+                    });
+                }
+            }
+            _ => warnings.push(Warning::InvalidHost {
+                host: label.clone(),
+                reason: format!(
+                    "address `{addr}` must start with ssh:// , tcp:// , http:// or unix://"
+                ),
+            }),
+        }
+    }
+
+    for (id, count) in seen {
+        if count > 1 {
+            warnings.push(Warning::InvalidHost {
+                host: id.to_string(),
+                reason: "duplicate host id".to_string(),
+            });
+        }
+    }
 }
 
 fn check_spec(spec: &Spec, warnings: &mut Vec<Warning>) {
@@ -897,5 +968,68 @@ proxy:
             &issues[0],
             CompatWarning::UnsupportedProxyField { field, .. } if field == "docker"
         ));
+    }
+
+    // ── proxy.hosts validation (Phase 6) ────────────────────────────
+
+    fn host_warnings(yaml: &str) -> Vec<String> {
+        let config = Config::from_yaml(yaml).expect("parse");
+        run(&config)
+            .warnings
+            .iter()
+            .filter_map(|w| match w {
+                Warning::InvalidHost { host, reason } => Some(format!("{host}: {reason}")),
+                _ => None,
+            })
+            .collect()
+    }
+
+    #[test]
+    fn valid_hosts_produce_no_warnings() {
+        let yaml = "\
+proxy:
+  hosts:
+    - id: ssh-1
+      address: ssh://ops@10.0.0.11
+    - id: tcp-1
+      address: tcp://10.0.0.12:2376
+      tls: { ca: /c/ca.pem, cert: /c/cert.pem, key: /c/key.pem }
+    - id: local
+      address: unix:///var/run/docker.sock
+  specs: []
+";
+        assert!(host_warnings(yaml).is_empty(), "{:?}", host_warnings(yaml));
+    }
+
+    #[test]
+    fn host_flags_bad_scheme_dup_and_tls_mismatch() {
+        let yaml = "\
+proxy:
+  hosts:
+    - id: weird
+      address: rdp://nope
+    - id: tcp-notls
+      address: tcp://h:2376
+    - id: ssh-withtls
+      address: ssh://ops@h
+      tls: { ca: /a, cert: /b, key: /c }
+    - id: dup
+      address: ssh://a
+    - id: dup
+      address: ssh://b
+  specs: []
+";
+        let w = host_warnings(yaml);
+        let has = |id: &str, frag: &str| w.iter().any(|s| s.starts_with(id) && s.contains(frag));
+        assert!(has("weird:", "ssh://"));
+        assert!(has("tcp-notls:", "needs `tls`"));
+        assert!(has("ssh-withtls:", "only used with"));
+        assert!(has("dup:", "duplicate"));
+    }
+
+    #[test]
+    fn no_hosts_is_clean() {
+        // Absent `hosts` is the default single-local-daemon mode.
+        assert!(host_warnings("proxy:\n  specs: []\n").is_empty());
     }
 }

--- a/docs/YAML_SCHEMA.md
+++ b/docs/YAML_SCHEMA.md
@@ -51,6 +51,32 @@ ignored by Ruscker.
 | `shutdown-grace-ms` | ms | `30000` | Drain window on SIGTERM/Ctrl-C before forced exit; `/readyz` reports `draining` during it. Ruscker extension |
 | `max-body-size` | size | none | Global cap on proxied request bodies (`"10m"`, `"1g"`, bytes); over → `413`. Per-spec `max-body-size` overrides. Ruscker extension |
 | `metrics-enabled` | bool | `false` | Expose a Prometheus `/metrics` endpoint (**unauthenticated** when on — firewall it). Ruscker extension |
+| `hosts` | list | `[]` | Docker hosts for multi-host scheduling (Phase 6). Empty ⇒ the local daemon. Ruscker extension |
+
+### `proxy.hosts` — multi-host scheduling (Phase 6)
+
+Empty (the default) means the single local Docker daemon — today's
+behaviour. List hosts to spawn app containers across several daemons:
+
+```yaml
+proxy:
+  hosts:
+    - id: ssh-1
+      address: ssh://ops@10.0.0.11      # Docker over SSH (simplest)
+    - id: tcp-1
+      address: tcp://10.0.0.12:2376     # Docker over TLS
+      tls: { ca: /etc/ruscker/ca.pem, cert: /etc/ruscker/cert.pem, key: /etc/ruscker/key.pem }
+      max-containers: 40                # optional cap
+      weight: 2                         # optional, for spread placement
+    - id: local
+      address: unix:///var/run/docker.sock
+```
+
+Address schemes: `ssh://user@host[:port]`, `tcp://host:port` (needs
+`tls`), `http://host:port` (plain TCP — trusted networks only),
+`unix:///path`. `validate` flags empty/duplicate ids, unknown schemes,
+and `tls` mismatched with the scheme. Placement controls
+(spread/bin-pack, anti-affinity) land in a later slice.
 | `container-log-path` | path | none | Directory for per-container logs |
 | `port` | u16 | `8080` | HTTP listener port |
 | `bind-address` | string | `"0.0.0.0"` | Listener interface |


### PR DESCRIPTION
First slice of multi-host scheduling (#127) — the **config surface + validation**, fully testable with no Docker. Empty `hosts` (the default) keeps today's single-local-daemon behaviour, so this is non-breaking.

## What changed
- **`proxy.hosts: Vec<Host>`** in the schema. Each `Host`: `id`, `address` (`ssh://user@host` / `tcp://host:port` / `http://host:port` / `unix:///path`), optional `tls` (ca/cert/key for tcp mTLS), `max-containers`, `weight`.
- **`validate`** flags malformed hosts (`Warning::InvalidHost`): empty/duplicate id, unknown address scheme, and `tls` mismatched with the scheme (set on a non-tcp host, or missing on a `tcp://` one). CLI formatter case + unit tests.
- **bollard** gains the `ssh` + `ssl` features (its `default` is only `http`+`pipe`) so the remote transports are available to the backend in the next slice.
- `YAML_SCHEMA.md` documents `proxy.hosts`.

## Scope / sequencing
This is deliberately the **foundation half of 6a** — config + validation, which is fully unit-testable here. The `MultiHostDockerBackend` connection-builder (address → bollard client), spawn/list/stop routing, the **bind-IP / upstream-host addressing refactor**, and `Replica.host` are the immediate next slice: that part needs a real remote daemon to smoke (the local `unix://` path validates the backend code; the ssh/tcp remote smoke needs a multi-endpoint CI harness, as noted in #127). Splitting keeps each PR green and reviewable.

## Tests
`valid_hosts_produce_no_warnings`, `host_flags_bad_scheme_dup_and_tls_mismatch`, `no_hosts_is_clean`. **307 tests green**, fmt-drift unchanged.

🤖 Generated with [Claude Code](https://claude.com/claude-code)