### PR TITLE
Phase 6a (cont.): MultiHostDockerBackend + remote addressing (#127)

### DIFF
--- a/crates/ruscker-cli/src/main.rs
+++ b/crates/ruscker-cli/src/main.rs
@@ -291,6 +291,10 @@ fn cmd_serve(
         found
     });
 
+    // Captured before `config` is moved into the server — picks the
+    // multi-host backend when `proxy.hosts` is set (Phase 6).
+    let hosts = config.proxy.hosts.clone();
+
     let rt = tokio::runtime::Builder::new_multi_thread()
         .enable_all()
         .build()?;
@@ -307,9 +311,19 @@ fn cmd_serve(
             server = server.with_master_key(k).context("invalid --master-key")?;
         }
         if docker {
-            let backend = ruscker_docker::LocalDockerBackend::local()
-                .context("connect to Docker daemon")?;
-            server = server.with_backend(std::sync::Arc::new(backend));
+            let backend: std::sync::Arc<dyn ruscker_core::ContainerBackend> = if hosts.is_empty() {
+                std::sync::Arc::new(
+                    ruscker_docker::LocalDockerBackend::local()
+                        .context("connect to Docker daemon")?,
+                )
+            } else {
+                tracing::info!(count = hosts.len(), "multi-host backend");
+                std::sync::Arc::new(
+                    ruscker_docker::MultiHostDockerBackend::connect(&hosts)
+                        .context("connect to Docker hosts")?,
+                )
+            };
+            server = server.with_backend(backend);
         }
         if let Some(path) = db_path {
             let pool = ruscker_admin::db::open(&path).await?;

--- a/crates/ruscker-config/src/lib.rs
+++ b/crates/ruscker-config/src/lib.rs
@@ -42,8 +42,9 @@ pub mod validate;
 
 pub use error::{Error, Result};
 pub use schema::{
-    is_valid_memory_size, ApiSpec, Config, LandingBlock, LandingCustomization, Logging, Proxy,
-    RatePolicy, RoutingStrategy, Server, Spec, SpecKind, SpecKindOverride, TemplateProperties,
+    is_valid_memory_size, ApiSpec, Config, Host, HostTls, LandingBlock, LandingCustomization,
+    Logging, Proxy, RatePolicy, RoutingStrategy, Server, Spec, SpecKind, SpecKindOverride,
+    TemplateProperties,
 };
 pub use validate::{is_valid_volume_bind, CompatWarning, ValidationReport, Warning};
 

--- a/crates/ruscker-docker/src/lib.rs
+++ b/crates/ruscker-docker/src/lib.rs
@@ -22,6 +22,9 @@ use bollard::query_parameters::{
     CreateContainerOptions, CreateImageOptions, ListContainersOptions, LogsOptionsBuilder,
     RemoveContainerOptions, StartContainerOptions, StatsOptionsBuilder, StopContainerOptions,
 };
+pub mod multihost;
+pub use multihost::MultiHostDockerBackend;
+
 use bollard::Docker;
 use chrono::Utc;
 use dashmap::DashMap;
@@ -30,7 +33,7 @@ use ruscker_core::{
     ContainerBackend, CoreError, CoreResult, Replica, ReplicaId, ReplicaMetrics, ReplicaState,
 };
 use std::collections::HashMap;
-use std::net::SocketAddr;
+use std::net::{SocketAddr, ToSocketAddrs};
 use std::time::Duration;
 use tokio::net::TcpStream;
 use tokio::time::sleep;
@@ -58,6 +61,15 @@ pub const STOP_TIMEOUT_SECS: i32 = 10;
 
 pub struct LocalDockerBackend {
     docker: Docker,
+    /// Interface the container's port is published on, in the
+    /// daemon's `HostConfig` port binding. `127.0.0.1` for a local
+    /// daemon (keep it off the network); `0.0.0.0` for a remote
+    /// daemon so the proxy can reach it across hosts.
+    publish_ip: String,
+    /// Host the proxy connects to for the upstream — `127.0.0.1` for
+    /// local, or the remote host's reachable IP/name for a remote
+    /// daemon. Combined with the bound port to form `Replica.upstream`.
+    upstream_host: String,
     /// Previous-reading cache for CPU delta calculation. Docker
     /// reports CPU as a cumulative counter; converting to a
     /// percentage requires comparing two readings against each
@@ -88,17 +100,30 @@ impl LocalDockerBackend {
     pub fn local() -> CoreResult<Self> {
         let docker = Docker::connect_with_local_defaults()
             .map_err(|e| CoreError::Backend(format!("connect to docker socket: {e}")))?;
-        Ok(Self {
-            docker,
-            prev_stats: DashMap::new(),
-        })
+        Ok(Self::from_docker(docker))
     }
 
-    /// Build over an existing bollard connection — used by tests
-    /// to inject a stub via testcontainers-rs.
+    /// Build over an existing bollard connection bound to the **local**
+    /// daemon — publishes on `127.0.0.1` and proxies to `127.0.0.1`.
+    /// Used by `local()` and tests.
     pub fn from_docker(docker: Docker) -> Self {
+        Self::from_docker_addressed(docker, "127.0.0.1", "127.0.0.1")
+    }
+
+    /// Build over an existing bollard connection with explicit
+    /// addressing — for a remote daemon (multi-host, Phase 6):
+    /// `publish_ip` is the interface the container port binds to on the
+    /// daemon's host (use `0.0.0.0` so the proxy can reach it), and
+    /// `upstream_host` is the reachable host the proxy connects to.
+    pub fn from_docker_addressed(
+        docker: Docker,
+        publish_ip: impl Into<String>,
+        upstream_host: impl Into<String>,
+    ) -> Self {
         Self {
             docker,
+            publish_ip: publish_ip.into(),
+            upstream_host: upstream_host.into(),
             prev_stats: DashMap::new(),
         }
     }
@@ -154,7 +179,9 @@ impl LocalDockerBackend {
         port_bindings.insert(
             port_key.clone(),
             Some(vec![PortBinding {
-                host_ip: Some("127.0.0.1".to_string()),
+                // Local daemon ⇒ 127.0.0.1 (off the network); remote
+                // daemon ⇒ 0.0.0.0 so the proxy can reach it.
+                host_ip: Some(self.publish_ip.clone()),
                 host_port: Some(String::new()), // "" => ephemeral
             }]),
         );
@@ -207,9 +234,19 @@ impl LocalDockerBackend {
 
         // 4. Inspect to learn the host port Docker assigned.
         let bound = self.bound_host_port(&container_id, &port_key).await?;
-        let upstream: SocketAddr = format!("127.0.0.1:{bound}")
-            .parse()
-            .map_err(|e| CoreError::Backend(format!("parse upstream addr: {e}")))?;
+        // Proxy connects to the daemon's host (127.0.0.1 local, or the
+        // remote host's reachable address) on the published port.
+        // `to_socket_addrs` resolves an IP literal instantly and a
+        // hostname via DNS, so a remote `ssh://user@host` works too.
+        let upstream: SocketAddr = format!("{}:{bound}", self.upstream_host)
+            .to_socket_addrs()
+            .map_err(|e| {
+                CoreError::Backend(format!("resolve upstream {}: {e}", self.upstream_host))
+            })?
+            .next()
+            .ok_or_else(|| {
+                CoreError::Backend(format!("no address for upstream {}", self.upstream_host))
+            })?;
 
         // 5. Wait for the container's process to bind that port.
         wait_for_ready(upstream).await?;
@@ -425,7 +462,16 @@ impl ContainerBackend for LocalDockerBackend {
                     .and_then(|p| p.public_port.map(|n| n))
             });
             let upstream: SocketAddr = match host_port {
-                Some(p) => format!("127.0.0.1:{p}").parse().unwrap(),
+                Some(p) => match format!("{}:{p}", self.upstream_host).to_socket_addrs() {
+                    Ok(mut addrs) => match addrs.next() {
+                        Some(a) => a,
+                        None => continue,
+                    },
+                    Err(e) => {
+                        tracing::warn!(error = %e, host = %self.upstream_host, "resolve upstream on list; skipping");
+                        continue;
+                    }
+                },
                 None => {
                     tracing::warn!(
                         container_id = ?c.id,

--- a/crates/ruscker-docker/src/multihost.rs
+++ b/crates/ruscker-docker/src/multihost.rs
@@ -1,0 +1,299 @@
+//! Multi-host Docker backend (Phase 6).
+//!
+//! Holds one [`LocalDockerBackend`] per configured host — each wrapping
+//! a bollard connection to that daemon (`ssh://`, `tcp://`+TLS,
+//! `http://`, or `unix://`) and configured with the right addressing so
+//! the proxy reaches containers on the remote host. Implements the same
+//! [`ContainerBackend`] trait, so it drops in wherever the single-host
+//! backend went.
+//!
+//! 6a covers connection + spawn/list/stop/metrics/logs routing with a
+//! simple least-loaded placement. Richer placement (spread/bin-pack,
+//! anti-affinity, capacity caps) is 6c.
+
+use async_trait::async_trait;
+use bollard::{Docker, API_DEFAULT_VERSION};
+use dashmap::DashMap;
+use ruscker_config::Host;
+use ruscker_core::{
+    ContainerBackend, CoreError, CoreResult, LogStream, Replica, ReplicaId, ReplicaMetrics,
+    SpawnRequest,
+};
+
+use crate::LocalDockerBackend;
+
+/// Connection timeout for remote daemons, seconds (bollard default).
+const CONNECT_TIMEOUT: u64 = 120;
+
+/// Connect to a configured [`Host`], returning a [`LocalDockerBackend`]
+/// wired with the right addressing:
+/// - `unix://` → local daemon, publish + proxy on `127.0.0.1`;
+/// - `ssh://` / `tcp://` / `http://` → remote daemon, publish on
+///   `0.0.0.0` (so the proxy can reach it) and proxy to the host's
+///   reachable address.
+pub fn connect_host(host: &Host) -> CoreResult<LocalDockerBackend> {
+    let addr = host.address.trim();
+    let map_err = |e: bollard::errors::Error| {
+        CoreError::Backend(format!("connect host `{}` ({addr}): {e}", host.id))
+    };
+
+    if addr.starts_with("unix://") {
+        let docker = Docker::connect_with_unix(addr, CONNECT_TIMEOUT, API_DEFAULT_VERSION)
+            .map_err(map_err)?;
+        Ok(LocalDockerBackend::from_docker(docker))
+    } else if let Some(rest) = addr.strip_prefix("ssh://") {
+        let docker = Docker::connect_with_ssh(addr, CONNECT_TIMEOUT, API_DEFAULT_VERSION, None)
+            .map_err(map_err)?;
+        Ok(LocalDockerBackend::from_docker_addressed(
+            docker,
+            "0.0.0.0",
+            host_part(rest),
+        ))
+    } else if let Some(rest) = addr.strip_prefix("tcp://") {
+        let tls = host.tls.as_ref().ok_or_else(|| {
+            CoreError::Backend(format!(
+                "host `{}`: tcp:// needs `tls` (ca/cert/key)",
+                host.id
+            ))
+        })?;
+        let docker = Docker::connect_with_ssl(
+            addr,
+            &tls.key,
+            &tls.cert,
+            &tls.ca,
+            CONNECT_TIMEOUT,
+            API_DEFAULT_VERSION,
+        )
+        .map_err(map_err)?;
+        Ok(LocalDockerBackend::from_docker_addressed(
+            docker,
+            "0.0.0.0",
+            host_part(rest),
+        ))
+    } else if let Some(rest) = addr.strip_prefix("http://") {
+        let docker = Docker::connect_with_http(addr, CONNECT_TIMEOUT, API_DEFAULT_VERSION)
+            .map_err(map_err)?;
+        Ok(LocalDockerBackend::from_docker_addressed(
+            docker,
+            "0.0.0.0",
+            host_part(rest),
+        ))
+    } else {
+        Err(CoreError::Backend(format!(
+            "host `{}`: address `{addr}` must start with ssh:// , tcp:// , http:// or unix://",
+            host.id
+        )))
+    }
+}
+
+/// Reachable host from an `[user@]host[:port]` authority — drops the
+/// `user@` and the `:port`. (IPv6 literals aren't handled yet.)
+fn host_part(authority: &str) -> String {
+    let no_user = authority.rsplit('@').next().unwrap_or(authority);
+    no_user.split(':').next().unwrap_or(no_user).to_string()
+}
+
+/// Backend that schedules containers across several Docker hosts.
+pub struct MultiHostDockerBackend {
+    /// host id → per-host backend, in config order.
+    hosts: Vec<(String, LocalDockerBackend)>,
+    /// replica id → host id, so `stop`/`metrics`/`logs` reach the right
+    /// daemon. Populated on `spawn` and refreshed on `list`.
+    placement: DashMap<ReplicaId, String>,
+}
+
+impl MultiHostDockerBackend {
+    /// Connect to every configured host. Fails if the list is empty or
+    /// any host can't be built (bad address / TLS).
+    pub fn connect(hosts: &[Host]) -> CoreResult<Self> {
+        if hosts.is_empty() {
+            return Err(CoreError::Backend("no docker hosts configured".into()));
+        }
+        let mut built = Vec::with_capacity(hosts.len());
+        for h in hosts {
+            built.push((h.id.clone(), connect_host(h)?));
+        }
+        Ok(Self {
+            hosts: built,
+            placement: DashMap::new(),
+        })
+    }
+
+    /// Pick the least-loaded host (fewest currently-placed replicas).
+    /// Simple spread; richer placement is 6c.
+    fn pick_host(&self) -> &(String, LocalDockerBackend) {
+        let mut counts: std::collections::HashMap<String, usize> = std::collections::HashMap::new();
+        for kv in self.placement.iter() {
+            *counts.entry(kv.value().clone()).or_insert(0) += 1;
+        }
+        self.hosts
+            .iter()
+            .min_by_key(|(id, _)| counts.get(id).copied().unwrap_or(0))
+            .expect("connect() guarantees >=1 host")
+    }
+
+    /// The backend a replica lives on, by recorded placement.
+    fn placed(&self, id: &ReplicaId) -> Option<&LocalDockerBackend> {
+        let host = self.placement.get(id)?;
+        self.hosts
+            .iter()
+            .find(|(hid, _)| *hid == *host.value())
+            .map(|(_, b)| b)
+    }
+}
+
+#[async_trait]
+impl ContainerBackend for MultiHostDockerBackend {
+    async fn spawn(&self, spec_id: &str, image: &str) -> CoreResult<Replica> {
+        self.spawn_request(&SpawnRequest::new(spec_id, image)).await
+    }
+
+    async fn spawn_request(&self, req: &SpawnRequest) -> CoreResult<Replica> {
+        let (host_id, backend) = self.pick_host();
+        let replica = backend.spawn_request(req).await?;
+        self.placement.insert(replica.id.clone(), host_id.clone());
+        tracing::info!(host = %host_id, replica = %replica.id, spec = %req.spec_id, "spawned on host");
+        Ok(replica)
+    }
+
+    async fn stop(&self, replica_id: &ReplicaId) -> CoreResult<()> {
+        if let Some(backend) = self.placed(replica_id) {
+            let r = backend.stop(replica_id).await;
+            self.placement.remove(replica_id);
+            return r;
+        }
+        // Placement miss (e.g. never listed): best-effort across hosts.
+        for (_, backend) in &self.hosts {
+            if backend.stop(replica_id).await.is_ok() {
+                self.placement.remove(replica_id);
+                return Ok(());
+            }
+        }
+        Err(CoreError::Backend(format!(
+            "replica {replica_id} not found on any host"
+        )))
+    }
+
+    async fn list(&self) -> CoreResult<Vec<Replica>> {
+        // Fan out over every host; tag each replica's placement so
+        // later stop/metrics/logs route correctly. A host that fails to
+        // answer is logged and skipped (degraded, not fatal).
+        let mut all = Vec::new();
+        for (host_id, backend) in &self.hosts {
+            match backend.list().await {
+                Ok(replicas) => {
+                    for r in &replicas {
+                        self.placement.insert(r.id.clone(), host_id.clone());
+                    }
+                    all.extend(replicas);
+                }
+                Err(e) => {
+                    tracing::warn!(host = %host_id, error = %e, "list on host failed; skipping");
+                }
+            }
+        }
+        Ok(all)
+    }
+
+    async fn metrics(&self, replica_id: &ReplicaId) -> CoreResult<ReplicaMetrics> {
+        if let Some(backend) = self.placed(replica_id) {
+            return backend.metrics(replica_id).await;
+        }
+        for (_, backend) in &self.hosts {
+            if let Ok(m) = backend.metrics(replica_id).await {
+                return Ok(m);
+            }
+        }
+        Err(CoreError::Backend(format!(
+            "replica {replica_id} not found on any host"
+        )))
+    }
+
+    async fn logs(&self, replica_id: &ReplicaId, tail: usize) -> CoreResult<Vec<String>> {
+        if let Some(backend) = self.placed(replica_id) {
+            return backend.logs(replica_id, tail).await;
+        }
+        Err(CoreError::Backend(format!(
+            "replica {replica_id} not found on any host"
+        )))
+    }
+
+    async fn logs_follow(&self, replica_id: &ReplicaId, tail: usize) -> CoreResult<LogStream> {
+        if let Some(backend) = self.placed(replica_id) {
+            return backend.logs_follow(replica_id, tail).await;
+        }
+        Err(CoreError::Backend(format!(
+            "replica {replica_id} not found on any host"
+        )))
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use ruscker_config::{Host, HostTls};
+    use std::path::PathBuf;
+
+    fn host(id: &str, address: &str) -> Host {
+        Host {
+            id: id.into(),
+            address: address.into(),
+            tls: None,
+            max_containers: None,
+            weight: None,
+        }
+    }
+
+    #[test]
+    fn host_part_strips_user_and_port() {
+        assert_eq!(host_part("ops@10.0.0.11"), "10.0.0.11");
+        assert_eq!(host_part("10.0.0.12:2376"), "10.0.0.12");
+        assert_eq!(host_part("ops@host.example:2376"), "host.example");
+        assert_eq!(host_part("plainhost"), "plainhost");
+    }
+
+    // `LocalDockerBackend` isn't `Debug`, so extract the error message
+    // by hand rather than `unwrap_err()`.
+    fn err_of(r: CoreResult<LocalDockerBackend>) -> String {
+        match r {
+            Ok(_) => panic!("expected an error"),
+            Err(e) => format!("{e}"),
+        }
+    }
+
+    #[test]
+    fn connect_rejects_unknown_scheme() {
+        assert!(err_of(connect_host(&host("x", "rdp://nope"))).contains("must start with"));
+    }
+
+    #[test]
+    fn connect_tcp_without_tls_errors() {
+        assert!(err_of(connect_host(&host("x", "tcp://h:2376"))).contains("needs `tls`"));
+    }
+
+    #[test]
+    fn connect_empty_hosts_errors() {
+        assert!(MultiHostDockerBackend::connect(&[]).is_err());
+    }
+
+    #[test]
+    fn tls_struct_builds() {
+        // Sanity: a tcp host with tls parses far enough to attempt a
+        // connection (which we don't exercise here — no daemon).
+        let h = Host {
+            id: "tcp".into(),
+            address: "tcp://10.0.0.1:2376".into(),
+            tls: Some(HostTls {
+                ca: PathBuf::from("/ca"),
+                cert: PathBuf::from("/cert"),
+                key: PathBuf::from("/key"),
+            }),
+            max_containers: None,
+            weight: None,
+        };
+        // connect_with_ssl is lazy about the socket but reads the cert
+        // files eagerly; with bogus paths it errors — that's fine, we're
+        // only asserting we reached the tcp branch (not the scheme error).
+        assert!(!err_of(connect_host(&h)).contains("must start with"));
+    }
+}


### PR DESCRIPTION
The **backend half of 6a** — Ruscker can now spawn and route across several Docker daemons. Empty `proxy.hosts` (the default) still uses the local backend, so this is **non-breaking**.

## What changed
- **`LocalDockerBackend` addressing refactor**: `publish_ip` + `upstream_host` fields (was hardcoded `127.0.0.1`). `local()`/`from_docker()` keep `127.0.0.1`; `from_docker_addressed()` lets a remote daemon publish on `0.0.0.0` and the proxy reach it at the host's address. `upstream` resolves via `to_socket_addrs` so a hostname (from `ssh://user@host`) works, not just an IP — applied on **spawn and list**.
- **`multihost::connect_host(&Host)`** — dispatches the address scheme to bollard: `unix://`, `ssh://`, `tcp://`+TLS, `http://`.
- **`MultiHostDockerBackend`** — one `LocalDockerBackend` per host + a `replica → host` placement map. `spawn_request` picks the **least-loaded host** (simple spread; richer placement is 6c) and records placement; `list` fans out + tags placement; `stop`/`metrics`/`logs` route to the owning host (best-effort fallback across hosts on a placement miss). An unreachable host is logged + skipped (degraded, not fatal).
- **CLI `serve`** selects `MultiHostDockerBackend` when `proxy.hosts` is set.
- `Host`/`HostTls` re-exported from ruscker-config; bollard `ssh`+`ssl` (from 6a-foundation) supply the transports.

## Tests + smoke
- Unit: address-scheme dispatch, `host_part` (strips `user@`/`:port`), empty-hosts, tcp-without-tls.
- **Live local smoke**: a `unix://` host through `MultiHostDockerBackend` **spawned + proxied `traefik/whoami` (200)**, container confirmed running — exercising the whole multi-host code path against a real daemon. **312 tests green**, fmt-drift unchanged, new file 0-drift.

## Scope / safety note
The remote (ssh/tcp) **data-plane** smoke needs a real multi-host Linux network (the proxy must reach `host_ip:published_port`) — validate on real dev infra, **not** the SEPE production box. Next: **6b** (dashboard host column + `Replica.host`), **6c** (placement / anti-affinity / capacity caps).

🤖 Generated with [Claude Code](https://claude.com/claude-code)