### PR TITLE
Phase 6b: Replica.host + dashboard host column (#127)

### DIFF
--- a/crates/ruscker-admin/assets/i18n/en/landing.ftl
+++ b/crates/ruscker-admin/assets/i18n/en/landing.ftl
@@ -134,6 +134,7 @@ admin-dashboard-col-spec = App
 admin-dashboard-col-state = State
 admin-dashboard-col-uptime = Uptime
 admin-dashboard-col-sessions = Sessions
+admin-dashboard-col-host = Host
 admin-dashboard-col-container = Container
 admin-dashboard-col-cpu = CPU
 admin-dashboard-col-memory = Memory

--- a/crates/ruscker-admin/assets/i18n/es/landing.ftl
+++ b/crates/ruscker-admin/assets/i18n/es/landing.ftl
@@ -134,6 +134,7 @@ admin-dashboard-col-spec = Aplicación
 admin-dashboard-col-state = Estado
 admin-dashboard-col-uptime = Uptime
 admin-dashboard-col-sessions = Sesiones
+admin-dashboard-col-host = Host
 admin-dashboard-col-container = Contenedor
 admin-dashboard-col-cpu = CPU
 admin-dashboard-col-memory = Memoria

--- a/crates/ruscker-admin/assets/i18n/fr/landing.ftl
+++ b/crates/ruscker-admin/assets/i18n/fr/landing.ftl
@@ -134,6 +134,7 @@ admin-dashboard-col-spec = Application
 admin-dashboard-col-state = État
 admin-dashboard-col-uptime = Uptime
 admin-dashboard-col-sessions = Sessions
+admin-dashboard-col-host = Hôte
 admin-dashboard-col-container = Conteneur
 admin-dashboard-col-cpu = CPU
 admin-dashboard-col-memory = Mémoire

--- a/crates/ruscker-admin/assets/i18n/pt/landing.ftl
+++ b/crates/ruscker-admin/assets/i18n/pt/landing.ftl
@@ -138,6 +138,7 @@ admin-dashboard-col-spec = Aplicação
 admin-dashboard-col-state = Estado
 admin-dashboard-col-uptime = Uptime
 admin-dashboard-col-sessions = Sessões
+admin-dashboard-col-host = Host
 admin-dashboard-col-container = Container
 admin-dashboard-col-cpu = CPU
 admin-dashboard-col-memory = Memória

--- a/crates/ruscker-admin/src/metrics_cache.rs
+++ b/crates/ruscker-admin/src/metrics_cache.rs
@@ -198,6 +198,7 @@ mod tests {
             started_at: chrono::Utc::now(),
             sessions_active: 0,
             sessions_max: 1,
+            host: None,
         }
     }
 

--- a/crates/ruscker-admin/src/routes/admin/dashboard.rs
+++ b/crates/ruscker-admin/src/routes/admin/dashboard.rs
@@ -115,6 +115,9 @@ struct ReplicaRow {
     /// sparklines. Empty until the metrics cache has ≥1 reading.
     cpu_history: Vec<f64>,
     mem_history: Vec<u64>,
+    /// Docker host the replica runs on (multi-host, Phase 6). Empty for
+    /// the single local daemon — rendered as "local".
+    host: String,
 }
 
 /// What both the HTML render and the SSE stream consume.
@@ -322,6 +325,7 @@ async fn build_snapshot(state: &AppState, locale: Locale) -> DashboardSnapshot {
                 memory_display,
                 cpu_history,
                 mem_history,
+                host: r.host.unwrap_or_default(),
             }
         })
         .collect();
@@ -723,6 +727,7 @@ mod tests {
             memory_display: None,
             cpu_history: Vec::new(),
             mem_history: Vec::new(),
+            host: String::new(),
         }
     }
 

--- a/crates/ruscker-admin/src/routes/metrics.rs
+++ b/crates/ruscker-admin/src/routes/metrics.rs
@@ -207,6 +207,7 @@ mod tests {
             started_at: chrono::Utc::now(),
             sessions_active: active,
             sessions_max: 5,
+            host: None,
         }
     }
 

--- a/crates/ruscker-admin/src/routes/proxy.rs
+++ b/crates/ruscker-admin/src/routes/proxy.rs
@@ -980,6 +980,7 @@ mod tests {
             started_at: chrono::Utc::now(),
             sessions_active: active,
             sessions_max: max,
+            host: None,
         }
     }
 
@@ -1107,6 +1108,7 @@ mod tests {
                 started_at: chrono::Utc::now(),
                 sessions_active: 0,
                 sessions_max: 1,
+                host: None,
             })
         }
         async fn spawn_with_port(

--- a/crates/ruscker-admin/src/scaler.rs
+++ b/crates/ruscker-admin/src/scaler.rs
@@ -470,6 +470,7 @@ mod tests {
                 started_at: chrono::Utc::now(),
                 sessions_active: 0,
                 sessions_max: 1,
+                host: None,
             })
         }
         async fn spawn_with_port(
@@ -617,6 +618,7 @@ proxy:
             started_at: chrono::Utc::now(),
             sessions_active: 0,
             sessions_max: 1,
+            host: None,
         };
         let pre2 = Replica {
             id: ReplicaId(uuid::Uuid::new_v4()),
@@ -649,6 +651,7 @@ proxy:
             started_at: chrono::Utc::now(),
             sessions_active: active,
             sessions_max: max,
+            host: None,
         }
     }
 

--- a/crates/ruscker-admin/src/sessions.rs
+++ b/crates/ruscker-admin/src/sessions.rs
@@ -296,6 +296,7 @@ mod tests {
             started_at: chrono::Utc::now(),
             sessions_active: 0,
             sessions_max: 5,
+            host: None,
         }
     }
 

--- a/crates/ruscker-admin/templates/admin/dashboard.html
+++ b/crates/ruscker-admin/templates/admin/dashboard.html
@@ -158,6 +158,7 @@
         <th>{{ self.t("admin-dashboard-col-sessions") }}</th>
         <th>{{ self.t("admin-dashboard-col-cpu") }}</th>
         <th>{{ self.t("admin-dashboard-col-memory") }}</th>
+        <th>{{ self.t("admin-dashboard-col-host") }}</th>
         <th>{{ self.t("admin-dashboard-col-container") }}</th>
         <th style="width: 84px;"></th>
       </tr>
@@ -192,6 +193,7 @@
               {% when None %}<span style="color: var(--text-faint)" title="{{ self.t("admin-dashboard-metrics-pending") }}">—</span>
             {% endmatch %}
           </td>
+          <td>{% if row.host.is_empty() %}<span style="color:var(--text-faint)">local</span>{% else %}{{ row.host }}{% endif %}</td>
           <td class="dash-mono">{{ row.container_short }}</td>
           <td style="white-space: nowrap;">
             <a href="/admin/dashboard/logs/{{ row.replica_id }}" title="{{ self.t("admin-logs-title") }}"
@@ -295,6 +297,7 @@
         + spark(row.cpu_history, 'var(--accent, #1d9e75)') + '</td>'
       + '<td><span class="dash-metric-val">' + mem + '</span>'
         + spark(row.mem_history, 'var(--accent-2, #5dcaa5)') + '</td>'
+      + '<td>' + (row.host ? escapeHtml(row.host) : '<span style="color:var(--text-faint)">local</span>') + '</td>'
       + '<td class="dash-mono">' + escapeHtml(row.container_short) + '</td>'
       + '<td style="white-space: nowrap;">'
         + '<a href="/admin/dashboard/logs/' + encodeURIComponent(row.replica_id)

--- a/crates/ruscker-core/src/lib.rs
+++ b/crates/ruscker-core/src/lib.rs
@@ -387,6 +387,7 @@ mod registry_tests {
             started_at: chrono::Utc::now(),
             sessions_active: 0,
             sessions_max: 5,
+            host: None,
         }
     }
 

--- a/crates/ruscker-core/src/replica.rs
+++ b/crates/ruscker-core/src/replica.rs
@@ -52,6 +52,11 @@ pub struct Replica {
     pub started_at: DateTime<Utc>,
     pub sessions_active: u32,
     pub sessions_max: u32,
+    /// Which Docker host this replica runs on (multi-host scheduling,
+    /// Phase 6). `None` for the single local daemon. Set by the
+    /// `MultiHostDockerBackend`; surfaced in the dashboard.
+    #[serde(default)]
+    pub host: Option<String>,
 }
 
 impl Replica {

--- a/crates/ruscker-core/src/routing.rs
+++ b/crates/ruscker-core/src/routing.rs
@@ -87,6 +87,7 @@ mod tests {
             started_at: Utc::now(),
             sessions_active: active,
             sessions_max: max,
+            host: None,
         }
     }
 

--- a/crates/ruscker-docker/src/lib.rs
+++ b/crates/ruscker-docker/src/lib.rs
@@ -260,6 +260,7 @@ impl LocalDockerBackend {
             started_at: Utc::now(),
             sessions_active: 0,
             sessions_max: 0,
+            host: None,
         })
     }
 
@@ -492,6 +493,7 @@ impl ContainerBackend for LocalDockerBackend {
                 started_at: Utc::now(), // exact value would need inspect()
                 sessions_active: 0,
                 sessions_max: 0,
+                host: None,
             });
         }
         Ok(replicas)

--- a/crates/ruscker-docker/src/multihost.rs
+++ b/crates/ruscker-docker/src/multihost.rs
@@ -150,7 +150,8 @@ impl ContainerBackend for MultiHostDockerBackend {
 
     async fn spawn_request(&self, req: &SpawnRequest) -> CoreResult<Replica> {
         let (host_id, backend) = self.pick_host();
-        let replica = backend.spawn_request(req).await?;
+        let mut replica = backend.spawn_request(req).await?;
+        replica.host = Some(host_id.clone());
         self.placement.insert(replica.id.clone(), host_id.clone());
         tracing::info!(host = %host_id, replica = %replica.id, spec = %req.spec_id, "spawned on host");
         Ok(replica)
@@ -181,9 +182,10 @@ impl ContainerBackend for MultiHostDockerBackend {
         let mut all = Vec::new();
         for (host_id, backend) in &self.hosts {
             match backend.list().await {
-                Ok(replicas) => {
-                    for r in &replicas {
+                Ok(mut replicas) => {
+                    for r in &mut replicas {
                         self.placement.insert(r.id.clone(), host_id.clone());
+                        r.host = Some(host_id.clone());
                     }
                     all.extend(replicas);
                 }


### PR DESCRIPTION
Surfaces **which Docker host** each replica runs on, end to end.

- **`Replica.host: Option<String>`** in core (serde default; `None` = local daemon). All construction sites set `None`; the `MultiHostDockerBackend` tags it with the host id **on spawn and on list** (so reconcile-discovered replicas carry it too — the registry then has it).
- **Dashboard**: `ReplicaRow.host`, populated in `build_snapshot`, plus a new **Host** column in both the server render and the SSE JS patcher — shows the host id, or a dimmed *local* for the single local daemon. New i18n header `admin-dashboard-col-host` ×4 locales.

The fan-out `list`, the placement map, and routed `stop`/`metrics`/`logs` already landed in 6a; this makes the host visible in the registry + UI.

**312 tests green**, i18n parity OK, fmt-drift unchanged. Next: **6c** — placement (spread/bin-pack) + anti-affinity + capacity caps.

🤖 Generated with [Claude Code](https://claude.com/claude-code)