### PR TITLE
Phase 6c: placement (spread/bin-pack) + anti-affinity + caps (#127)

### DIFF
--- a/crates/ruscker-admin/src/routes/admin/spec_form.rs
+++ b/crates/ruscker-admin/src/routes/admin/spec_form.rs
@@ -289,6 +289,8 @@ impl SpecForm {
             // ── Not modelled by the form: preserve from `base` so an
             //    edit never silently drops YAML-imported config. ──────
             container_port: base.and_then(|b| b.container_port),
+            placement: base.and_then(|b| b.placement),
+            anti_affinity: base.and_then(|b| b.anti_affinity),
             container_lifetime: base.and_then(|b| b.container_lifetime),
             stop_on_logout: base.and_then(|b| b.stop_on_logout),
             docker_registry_username: base.and_then(|b| b.docker_registry_username.clone()),

--- a/crates/ruscker-admin/src/routes/proxy.rs
+++ b/crates/ruscker-admin/src/routes/proxy.rs
@@ -657,7 +657,9 @@ async fn pick_or_spawn(state: &AppState, spec: &Spec) -> anyhow::Result<Replica>
     );
     let mut req = ruscker_core::SpawnRequest::new(&spec.id, image)
         .with_limits(limits)
-        .with_volumes(spec.volumes.clone().unwrap_or_default());
+        .with_volumes(spec.volumes.clone().unwrap_or_default())
+        .with_placement(spec.effective_placement())
+        .with_anti_affinity(spec.effective_anti_affinity());
     if let Some(port) = inner_port {
         req = req.with_port(port);
     }

--- a/crates/ruscker-admin/src/scaler.rs
+++ b/crates/ruscker-admin/src/scaler.rs
@@ -421,7 +421,9 @@ async fn spawn_one(
     let limits = crate::routes::proxy::limits_from_spec(spec);
     let mut req = ruscker_core::SpawnRequest::new(&spec.id, image)
         .with_limits(limits)
-        .with_volumes(spec.volumes.clone().unwrap_or_default());
+        .with_volumes(spec.volumes.clone().unwrap_or_default())
+        .with_placement(spec.effective_placement())
+        .with_anti_affinity(spec.effective_anti_affinity());
     if let Some(port) = inner_port {
         req = req.with_port(port);
     }

--- a/crates/ruscker-config/src/lib.rs
+++ b/crates/ruscker-config/src/lib.rs
@@ -43,8 +43,8 @@ pub mod validate;
 pub use error::{Error, Result};
 pub use schema::{
     is_valid_memory_size, ApiSpec, Config, Host, HostTls, LandingBlock, LandingCustomization,
-    Logging, Proxy, RatePolicy, RoutingStrategy, Server, Spec, SpecKind, SpecKindOverride,
-    TemplateProperties,
+    Logging, Placement, Proxy, RatePolicy, RoutingStrategy, Server, Spec, SpecKind,
+    SpecKindOverride, TemplateProperties,
 };
 pub use validate::{is_valid_volume_bind, CompatWarning, ValidationReport, Warning};
 

--- a/crates/ruscker-config/src/schema.rs
+++ b/crates/ruscker-config/src/schema.rs
@@ -562,6 +562,20 @@ pub struct Spec {
     #[serde(rename = "concurrent-requests-per-replica")]
     pub concurrent_requests_per_replica: Option<u32>,
 
+    // -- Ruscker extensions: multi-host placement (Phase 6) --
+    /// How to place this spec's replicas across `proxy.hosts`:
+    /// `spread` (default — distribute for fault isolation) or
+    /// `bin-pack` (fill a host before using the next). Only matters
+    /// with multiple hosts configured.
+    pub placement: Option<Placement>,
+
+    /// Keep replicas of this spec on **distinct** hosts when possible
+    /// (anti-affinity). Defaults to `false`. Best-effort: if every
+    /// eligible host already runs the spec, placement falls back to the
+    /// strategy above rather than refusing to scale.
+    #[serde(rename = "anti-affinity")]
+    pub anti_affinity: Option<bool>,
+
     // -- Ruscker extensions: smart routing --
     /// Whether to inject `<base href>` and rewrite root-relative URLs
     /// in HTML responses on the `/app/{spec}` route — the transform
@@ -681,6 +695,16 @@ impl Spec {
     /// auto-scaling unless the operator opts in).
     pub fn effective_max_replicas(&self) -> u32 {
         self.max_replicas.unwrap_or_else(|| self.effective_min_replicas())
+    }
+
+    /// Multi-host placement strategy (default [`Placement::Spread`]).
+    pub fn effective_placement(&self) -> Placement {
+        self.placement.unwrap_or_default()
+    }
+
+    /// Whether replicas should prefer distinct hosts (default false).
+    pub fn effective_anti_affinity(&self) -> bool {
+        self.anti_affinity.unwrap_or(false)
     }
 
     /// Effective routing strategy.
@@ -1079,6 +1103,19 @@ pub enum RoutingStrategy {
     ResourceAware,
 }
 
+/// How to place a spec's replicas across multiple Docker hosts
+/// (Phase 6). Default [`Placement::Spread`].
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Default, Serialize, Deserialize)]
+#[serde(rename_all = "kebab-case")]
+pub enum Placement {
+    /// Distribute replicas across hosts (weighted by `host.weight`) for
+    /// fault isolation. The default.
+    #[default]
+    Spread,
+    /// Fill one host before using the next (better density / cost).
+    BinPack,
+}
+
 #[derive(Debug, Clone, Default, Serialize, Deserialize)]
 #[serde(default)]
 pub struct Logging {
@@ -1160,6 +1197,8 @@ proxy:
             routing_strategy: None,
             inject_base_href: None,
             container_port: None,
+            placement: None,
+            anti_affinity: None,
             concurrent_requests_per_replica: None,
         };
         assert_eq!(spec.kind(), SpecKind::External);
@@ -1200,6 +1239,8 @@ proxy:
             routing_strategy: None,
             inject_base_href: None,
             container_port: None,
+            placement: None,
+            anti_affinity: None,
             concurrent_requests_per_replica: None,
         };
         assert_eq!(spec.kind(), SpecKind::Shiny);
@@ -1240,6 +1281,8 @@ proxy:
             routing_strategy: None,
             inject_base_href: None,
             container_port: None,
+            placement: None,
+            anti_affinity: None,
             concurrent_requests_per_replica: None,
         };
         spec.kind_override = Some(SpecKindOverride::Api);

--- a/crates/ruscker-core/src/lib.rs
+++ b/crates/ruscker-core/src/lib.rs
@@ -130,6 +130,12 @@ pub struct SpawnRequest {
     /// Empty → no binds. The local backend maps these to
     /// `HostConfig.binds`.
     pub volumes: Vec<String>,
+    /// Multi-host placement strategy for this spec (Phase 6). Ignored
+    /// by the single-host backend; the `MultiHostDockerBackend` uses it
+    /// to choose which host to spawn on.
+    pub placement: ruscker_config::Placement,
+    /// Prefer distinct hosts for this spec's replicas (anti-affinity).
+    pub anti_affinity: bool,
 }
 
 impl SpawnRequest {
@@ -141,7 +147,18 @@ impl SpawnRequest {
             creds: None,
             limits: ResourceLimits::default(),
             volumes: Vec::new(),
+            placement: ruscker_config::Placement::default(),
+            anti_affinity: false,
         }
+    }
+
+    pub fn with_placement(mut self, placement: ruscker_config::Placement) -> Self {
+        self.placement = placement;
+        self
+    }
+    pub fn with_anti_affinity(mut self, anti_affinity: bool) -> Self {
+        self.anti_affinity = anti_affinity;
+        self
     }
 
     pub fn with_port(mut self, port: u16) -> Self {

--- a/crates/ruscker-docker/src/multihost.rs
+++ b/crates/ruscker-docker/src/multihost.rs
@@ -14,7 +14,7 @@
 use async_trait::async_trait;
 use bollard::{Docker, API_DEFAULT_VERSION};
 use dashmap::DashMap;
-use ruscker_config::Host;
+use ruscker_config::{Host, Placement};
 use ruscker_core::{
     ContainerBackend, CoreError, CoreResult, LogStream, Replica, ReplicaId, ReplicaMetrics,
     SpawnRequest,
@@ -93,13 +93,75 @@ fn host_part(authority: &str) -> String {
     no_user.split(':').next().unwrap_or(no_user).to_string()
 }
 
+/// A connected host plus the placement metadata from its config.
+struct HostEntry {
+    id: String,
+    backend: LocalDockerBackend,
+    max_containers: Option<u32>,
+    weight: u32,
+}
+
 /// Backend that schedules containers across several Docker hosts.
 pub struct MultiHostDockerBackend {
-    /// host id → per-host backend, in config order.
-    hosts: Vec<(String, LocalDockerBackend)>,
-    /// replica id → host id, so `stop`/`metrics`/`logs` reach the right
-    /// daemon. Populated on `spawn` and refreshed on `list`.
-    placement: DashMap<ReplicaId, String>,
+    /// Connected hosts, in config order.
+    hosts: Vec<HostEntry>,
+    /// replica id → (host id, spec id). The host id routes
+    /// `stop`/`metrics`/`logs`; the spec id powers anti-affinity (how
+    /// many of a spec already run on each host). Populated on `spawn`
+    /// and refreshed on `list`.
+    placement: DashMap<ReplicaId, (String, String)>,
+}
+
+/// One host's current load — the input to the pure placement decision.
+#[derive(Debug, Clone)]
+struct HostLoad {
+    count: usize,
+    max: Option<u32>,
+    weight: u32,
+    runs_spec: bool,
+}
+
+/// Choose the index of the host to spawn on, or `None` if every host is
+/// at its `max_containers` capacity. Pure (no I/O), so it's unit-tested
+/// directly:
+/// - capacity caps exclude full hosts;
+/// - anti-affinity prefers hosts not already running the spec, falling
+///   back to all eligible hosts rather than refusing to scale;
+/// - `Spread` picks the weighted least-loaded host; `BinPack` fills the
+///   fullest host that still has room. Ties break to the lowest index.
+fn choose_host(loads: &[HostLoad], placement: Placement, anti_affinity: bool) -> Option<usize> {
+    let eligible: Vec<usize> = (0..loads.len())
+        .filter(|&i| loads[i].max.is_none_or(|m| (loads[i].count as u32) < m))
+        .collect();
+    if eligible.is_empty() {
+        return None;
+    }
+    let pool: Vec<usize> = if anti_affinity {
+        let free: Vec<usize> = eligible
+            .iter()
+            .copied()
+            .filter(|&i| !loads[i].runs_spec)
+            .collect();
+        if free.is_empty() {
+            eligible
+        } else {
+            free
+        }
+    } else {
+        eligible
+    };
+    match placement {
+        Placement::Spread => pool.into_iter().min_by(|&a, &b| {
+            let la = loads[a].count as f64 / loads[a].weight.max(1) as f64;
+            let lb = loads[b].count as f64 / loads[b].weight.max(1) as f64;
+            la.partial_cmp(&lb)
+                .unwrap_or(std::cmp::Ordering::Equal)
+                .then(a.cmp(&b))
+        }),
+        Placement::BinPack => pool
+            .into_iter()
+            .max_by(|&a, &b| loads[a].count.cmp(&loads[b].count).then(b.cmp(&a))),
+    }
 }
 
 impl MultiHostDockerBackend {
@@ -111,7 +173,12 @@ impl MultiHostDockerBackend {
         }
         let mut built = Vec::with_capacity(hosts.len());
         for h in hosts {
-            built.push((h.id.clone(), connect_host(h)?));
+            built.push(HostEntry {
+                id: h.id.clone(),
+                backend: connect_host(h)?,
+                max_containers: h.max_containers,
+                weight: h.weight.unwrap_or(1).max(1),
+            });
         }
         Ok(Self {
             hosts: built,
@@ -119,26 +186,49 @@ impl MultiHostDockerBackend {
         })
     }
 
-    /// Pick the least-loaded host (fewest currently-placed replicas).
-    /// Simple spread; richer placement is 6c.
-    fn pick_host(&self) -> &(String, LocalDockerBackend) {
-        let mut counts: std::collections::HashMap<String, usize> = std::collections::HashMap::new();
-        for kv in self.placement.iter() {
-            *counts.entry(kv.value().clone()).or_insert(0) += 1;
-        }
-        self.hosts
+    /// Choose a host for `req` honouring its placement strategy,
+    /// per-host capacity caps, and anti-affinity. Errors only when every
+    /// host is full.
+    fn pick_host(&self, req: &SpawnRequest) -> CoreResult<&HostEntry> {
+        let idx_of: std::collections::HashMap<&str, usize> = self
+            .hosts
             .iter()
-            .min_by_key(|(id, _)| counts.get(id).copied().unwrap_or(0))
-            .expect("connect() guarantees >=1 host")
+            .enumerate()
+            .map(|(i, h)| (h.id.as_str(), i))
+            .collect();
+        let mut counts = vec![0usize; self.hosts.len()];
+        let mut runs = vec![false; self.hosts.len()];
+        for kv in self.placement.iter() {
+            let (host, spec) = kv.value();
+            if let Some(&i) = idx_of.get(host.as_str()) {
+                counts[i] += 1;
+                if *spec == req.spec_id {
+                    runs[i] = true;
+                }
+            }
+        }
+        let loads: Vec<HostLoad> = self
+            .hosts
+            .iter()
+            .enumerate()
+            .map(|(i, h)| HostLoad {
+                count: counts[i],
+                max: h.max_containers,
+                weight: h.weight,
+                runs_spec: runs[i],
+            })
+            .collect();
+        match choose_host(&loads, req.placement, req.anti_affinity) {
+            Some(i) => Ok(&self.hosts[i]),
+            None => Err(CoreError::Backend("all docker hosts at capacity".into())),
+        }
     }
 
     /// The backend a replica lives on, by recorded placement.
     fn placed(&self, id: &ReplicaId) -> Option<&LocalDockerBackend> {
-        let host = self.placement.get(id)?;
-        self.hosts
-            .iter()
-            .find(|(hid, _)| *hid == *host.value())
-            .map(|(_, b)| b)
+        let entry = self.placement.get(id)?;
+        let host = entry.value().0.clone();
+        self.hosts.iter().find(|h| h.id == host).map(|h| &h.backend)
     }
 }
 
@@ -149,11 +239,12 @@ impl ContainerBackend for MultiHostDockerBackend {
     }
 
     async fn spawn_request(&self, req: &SpawnRequest) -> CoreResult<Replica> {
-        let (host_id, backend) = self.pick_host();
-        let mut replica = backend.spawn_request(req).await?;
-        replica.host = Some(host_id.clone());
-        self.placement.insert(replica.id.clone(), host_id.clone());
-        tracing::info!(host = %host_id, replica = %replica.id, spec = %req.spec_id, "spawned on host");
+        let entry = self.pick_host(req)?;
+        let mut replica = entry.backend.spawn_request(req).await?;
+        replica.host = Some(entry.id.clone());
+        self.placement
+            .insert(replica.id.clone(), (entry.id.clone(), req.spec_id.clone()));
+        tracing::info!(host = %entry.id, replica = %replica.id, spec = %req.spec_id, "spawned on host");
         Ok(replica)
     }
 
@@ -164,8 +255,8 @@ impl ContainerBackend for MultiHostDockerBackend {
             return r;
         }
         // Placement miss (e.g. never listed): best-effort across hosts.
-        for (_, backend) in &self.hosts {
-            if backend.stop(replica_id).await.is_ok() {
+        for h in &self.hosts {
+            if h.backend.stop(replica_id).await.is_ok() {
                 self.placement.remove(replica_id);
                 return Ok(());
             }
@@ -180,17 +271,18 @@ impl ContainerBackend for MultiHostDockerBackend {
         // later stop/metrics/logs route correctly. A host that fails to
         // answer is logged and skipped (degraded, not fatal).
         let mut all = Vec::new();
-        for (host_id, backend) in &self.hosts {
-            match backend.list().await {
+        for h in &self.hosts {
+            match h.backend.list().await {
                 Ok(mut replicas) => {
                     for r in &mut replicas {
-                        self.placement.insert(r.id.clone(), host_id.clone());
-                        r.host = Some(host_id.clone());
+                        self.placement
+                            .insert(r.id.clone(), (h.id.clone(), r.spec_id.clone()));
+                        r.host = Some(h.id.clone());
                     }
                     all.extend(replicas);
                 }
                 Err(e) => {
-                    tracing::warn!(host = %host_id, error = %e, "list on host failed; skipping");
+                    tracing::warn!(host = %h.id, error = %e, "list on host failed; skipping");
                 }
             }
         }
@@ -201,8 +293,8 @@ impl ContainerBackend for MultiHostDockerBackend {
         if let Some(backend) = self.placed(replica_id) {
             return backend.metrics(replica_id).await;
         }
-        for (_, backend) in &self.hosts {
-            if let Ok(m) = backend.metrics(replica_id).await {
+        for h in &self.hosts {
+            if let Ok(m) = h.backend.metrics(replica_id).await {
                 return Ok(m);
             }
         }
@@ -252,6 +344,64 @@ mod tests {
         assert_eq!(host_part("10.0.0.12:2376"), "10.0.0.12");
         assert_eq!(host_part("ops@host.example:2376"), "host.example");
         assert_eq!(host_part("plainhost"), "plainhost");
+    }
+
+    fn load(count: usize, max: Option<u32>, weight: u32, runs_spec: bool) -> HostLoad {
+        HostLoad {
+            count,
+            max,
+            weight,
+            runs_spec,
+        }
+    }
+
+    #[test]
+    fn spread_picks_weighted_least_loaded() {
+        // host0: 3 containers, host1: 1 → spread picks host1.
+        let loads = [load(3, None, 1, false), load(1, None, 1, false)];
+        assert_eq!(choose_host(&loads, Placement::Spread, false), Some(1));
+        // Weight: host0 has 4 but weight 4 (eff 1.0); host1 has 2 weight 1
+        // (eff 2.0) → host0 wins.
+        let loads = [load(4, None, 4, false), load(2, None, 1, false)];
+        assert_eq!(choose_host(&loads, Placement::Spread, false), Some(0));
+        // Tie → lowest index.
+        let loads = [load(2, None, 1, false), load(2, None, 1, false)];
+        assert_eq!(choose_host(&loads, Placement::Spread, false), Some(0));
+    }
+
+    #[test]
+    fn binpack_fills_fullest_with_room() {
+        // host0: 4/5, host1: 1/5 → bin-pack tops up host0.
+        let loads = [load(4, Some(5), 1, false), load(1, Some(5), 1, false)];
+        assert_eq!(choose_host(&loads, Placement::BinPack, false), Some(0));
+    }
+
+    #[test]
+    fn capacity_caps_exclude_full_hosts() {
+        // host0 full (5/5) ⇒ spread must pick host1 even though host1 is
+        // more loaded than an (ineligible) full host.
+        let loads = [load(5, Some(5), 1, false), load(2, Some(5), 1, false)];
+        assert_eq!(choose_host(&loads, Placement::Spread, false), Some(1));
+        // Every host full ⇒ None.
+        let loads = [load(5, Some(5), 1, false), load(3, Some(3), 1, false)];
+        assert_eq!(choose_host(&loads, Placement::Spread, false), None);
+    }
+
+    #[test]
+    fn anti_affinity_prefers_hosts_without_the_spec() {
+        // host0 (less loaded) already runs the spec; host1 doesn't →
+        // anti-affinity picks host1 despite being more loaded.
+        let loads = [load(0, None, 1, true), load(2, None, 1, false)];
+        assert_eq!(choose_host(&loads, Placement::Spread, true), Some(1));
+        // Soft fallback: every eligible host runs the spec ⇒ behave like
+        // plain spread (least-loaded).
+        let loads = [load(2, None, 1, true), load(1, None, 1, true)];
+        assert_eq!(choose_host(&loads, Placement::Spread, true), Some(1));
+    }
+
+    #[test]
+    fn empty_loads_is_none() {
+        assert_eq!(choose_host(&[], Placement::Spread, false), None);
     }
 
     // `LocalDockerBackend` isn't `Debug`, so extract the error message

--- a/docs/YAML_SCHEMA.md
+++ b/docs/YAML_SCHEMA.md
@@ -75,8 +75,25 @@ proxy:
 Address schemes: `ssh://user@host[:port]`, `tcp://host:port` (needs
 `tls`), `http://host:port` (plain TCP — trusted networks only),
 `unix:///path`. `validate` flags empty/duplicate ids, unknown schemes,
-and `tls` mismatched with the scheme. Placement controls
-(spread/bin-pack, anti-affinity) land in a later slice.
+and `tls` mismatched with the scheme.
+
+**Per-host:** `max-containers` caps how many containers a host runs;
+`weight` (default 1) biases spread placement toward bigger hosts.
+
+**Per-spec placement** controls how a spec's replicas land across hosts:
+
+```yaml
+- id: heavy-shiny
+  placement: spread          # spread (default) | bin-pack
+  anti-affinity: true        # keep replicas on distinct hosts (best-effort)
+```
+
+- `spread` distributes replicas (weighted least-loaded) for fault
+  isolation; `bin-pack` fills one host before using the next.
+- `anti-affinity: true` prefers hosts not already running the spec,
+  falling back to the strategy above if every eligible host does
+  (so scaling never stalls). Hosts at `max-containers` are skipped; if
+  all are full, the spawn fails (the scaler retries).
 | `container-log-path` | path | none | Directory for per-container logs |
 | `port` | u16 | `8080` | HTTP listener port |
 | `bind-address` | string | `"0.0.0.0"` | Listener interface |


### PR DESCRIPTION
Replaces the multi-host backend's naive least-loaded spawn with a **real placement decision**.

## What changed
- **`Placement` enum** (`spread` / `bin-pack`, default spread) + per-spec **`placement`** and **`anti-affinity`** in the schema, with `effective_placement` / `effective_anti_affinity`. `SpawnRequest` carries them (`with_placement` / `with_anti_affinity`); proxy + scaler pass them from the spec.
- Per-host **`max-containers`** (capacity cap) and **`weight`** (bias spread toward bigger hosts) now drive scheduling. `MultiHostDockerBackend` tracks `replica → (host, spec)` so it knows per-host load and which hosts already run a spec.
- Pure **`choose_host(loads, placement, anti_affinity)`**: caps exclude full hosts; anti-affinity prefers hosts not running the spec (**soft fallback** so scaling never stalls); `spread` = weighted least-loaded, `bin-pack` = fullest-with-room; ties → lowest index. All hosts full ⇒ spawn errors (scaler retries).
- `YAML_SCHEMA` documents placement / anti-affinity / max-containers / weight.

## Tests
`choose_host` unit-tested for spread (incl. weight + ties), bin-pack, capacity caps (incl. all-full → None), and anti-affinity (incl. soft fallback). **317 tests green**, fmt-drift unchanged, new code 0-drift.

This completes the **multi-host core (6a–6c)**. Remaining: **6d** — the deploy-guide section (networking, SSH/TLS setup) + a multi-endpoint integration test, which needs real multi-host infra (not the prod box).

🤖 Generated with [Claude Code](https://claude.com/claude-code)