### PR TITLE
Phase 6d: multi-host deploy guide + gated integration test (#127)

### DIFF
--- a/book/src/deploying.md
+++ b/book/src/deploying.md
@@ -51,6 +51,62 @@ spec. With many specs that's a lot of idle containers. To match
 ShinyProxy's on-demand behaviour (spawn on first request, reap when
 idle), set `min-replicas: 0` on the specs.
 
+### Multiple Docker hosts (Phase 6)
+
+By default Ruscker drives the **local** Docker daemon. To spread app
+containers across several hosts, list them under `proxy.hosts` — then
+Ruscker schedules, routes, monitors and reaps containers on all of
+them from the one process:
+
+```yaml
+proxy:
+  hosts:
+    - id: gpu-1
+      address: ssh://ops@10.0.0.11        # Docker over SSH — simplest
+    - id: gpu-2
+      address: tcp://10.0.0.12:2376       # Docker over TLS
+      tls: { ca: /etc/ruscker/ca.pem, cert: /etc/ruscker/cert.pem, key: /etc/ruscker/key.pem }
+      max-containers: 40                  # cap; placement won't exceed it
+      weight: 2                           # bigger host ⇒ more of the spread
+  specs:
+    - id: heavy-shiny
+      container-image: org/shiny:latest
+      placement: spread                   # spread (default) | bin-pack
+      anti-affinity: true                 # replicas on distinct hosts
+```
+
+**Transports.** `ssh://user@host[:port]` (reuses your SSH keys — no
+daemon TLS to set up), `tcp://host:port` + `tls` (mutual TLS), or
+`http://host:port` (plain TCP — trusted networks only). SSH is the
+least-effort option. Empty `hosts` keeps the single-local-daemon mode.
+
+**Networking — the catch.** On a remote host Ruscker publishes each
+container's port on the host's `0.0.0.0` and proxies to
+`host:published-port`. So **the Ruscker box must be able to reach the
+app hosts on the ephemeral published ports** (roughly 32768–60999).
+Put Ruscker and the hosts on a private network and open that range
+between them; **do not expose those ports to the public** — they're
+unauthenticated app backends. (For SSH hosts, the SSH connection is
+only the Docker *control* plane; the *data* plane is still this direct
+TCP path.)
+
+**Placement.** `spread` (default) distributes replicas (weighted by
+`weight`) for fault isolation; `bin-pack` fills one host before the
+next. `anti-affinity: true` keeps a spec's replicas on distinct hosts,
+falling back gracefully when every eligible host already runs it.
+`max-containers` caps a host; if all hosts are full a spawn fails and
+the scaler retries. The dashboard's **Host** column shows where each
+replica landed.
+
+**Validating it.** A gated integration test exercises spawn + spread +
+routed stop against two real daemons:
+
+```sh
+RUSCKER_IT_HOST1=ssh://ops@10.0.0.11 \
+RUSCKER_IT_HOST2=ssh://ops@10.0.0.12 \
+cargo test -p ruscker-docker --features multihost-it -- --nocapture
+```
+
 ## 3. nginx
 
 Terminate TLS at your edge / load balancer and forward to nginx with

--- a/crates/ruscker-docker/Cargo.toml
+++ b/crates/ruscker-docker/Cargo.toml
@@ -27,3 +27,10 @@ async-stream = { workspace = true }
 # `cargo test -p ruscker-docker --features docker-it`. Requires the
 # `docker` group / socket access on the host.
 docker-it = []
+
+# Multi-host integration test against TWO real Docker endpoints. Enable
+# with `cargo test -p ruscker-docker --features multihost-it`. Needs
+# RUSCKER_IT_HOST1 / RUSCKER_IT_HOST2 set to reachable daemon addresses
+# (ssh:// / http:// / unix://) whose published ports the test host can
+# reach. See book/src/deploying.md § Multi-host scheduling.
+multihost-it = []

--- a/crates/ruscker-docker/src/multihost.rs
+++ b/crates/ruscker-docker/src/multihost.rs
@@ -448,4 +448,47 @@ mod tests {
         // only asserting we reached the tcp branch (not the scheme error).
         assert!(!err_of(connect_host(&h)).contains("must start with"));
     }
+
+    /// Live test against TWO real Docker endpoints. Skipped unless built
+    /// with `--features multihost-it` and `RUSCKER_IT_HOST1` /
+    /// `RUSCKER_IT_HOST2` point at reachable daemons (`ssh://` /
+    /// `http://` / `unix://`) whose published ports this host can reach.
+    /// See `book/src/deploying.md` § Multi-host scheduling.
+    ///
+    ///   RUSCKER_IT_HOST1=ssh://ops@10.0.0.11 \
+    ///   RUSCKER_IT_HOST2=ssh://ops@10.0.0.12 \
+    ///   cargo test -p ruscker-docker --features multihost-it -- --nocapture
+    #[cfg(feature = "multihost-it")]
+    #[tokio::test]
+    async fn spreads_two_replicas_across_real_hosts() {
+        use ruscker_core::ContainerBackend;
+
+        let addr1 = std::env::var("RUSCKER_IT_HOST1").expect("set RUSCKER_IT_HOST1");
+        let addr2 = std::env::var("RUSCKER_IT_HOST2").expect("set RUSCKER_IT_HOST2");
+        let image =
+            std::env::var("RUSCKER_IT_IMAGE").unwrap_or_else(|_| "nginx:1.29-alpine".into());
+
+        let backend = MultiHostDockerBackend::connect(&[host("h1", &addr1), host("h2", &addr2)])
+            .expect("connect both hosts");
+
+        // Two spread replicas of the same spec should land on different
+        // hosts (anti-affinity off; spread = least-loaded).
+        let req = SpawnRequest::new("it-spec", &image).with_port(80);
+        let r1 = backend.spawn_request(&req).await.expect("spawn 1");
+        let r2 = backend.spawn_request(&req).await.expect("spawn 2");
+        assert!(
+            r1.host.is_some() && r2.host.is_some(),
+            "replicas carry a host"
+        );
+        assert_ne!(r1.host, r2.host, "spread placed both on the same host");
+
+        // list() fans out over both hosts and tags each replica.
+        let listed = backend.list().await.expect("list");
+        assert!(listed.iter().any(|r| r.id == r1.id && r.host == r1.host));
+        assert!(listed.iter().any(|r| r.id == r2.id && r.host == r2.host));
+
+        // Routed stop reaches the owning host.
+        backend.stop(&r1.id).await.expect("stop 1");
+        backend.stop(&r2.id).await.expect("stop 2");
+    }
 }


### PR DESCRIPTION
Closes the **Phase 6 multi-host** work.

- **Deploy guide** (`book/src/deploying.md` § *Multiple Docker hosts*): the `proxy.hosts` config, the three transports (`ssh` / `tcp`+TLS / `http`), the **networking catch** — the Ruscker box must reach the hosts' published ephemeral ports, so keep them on a private network and **never expose them publicly** (they're unauthenticated app backends) — plus placement / anti-affinity / `max-containers` / `weight` and the dashboard Host column.
- **Gated integration test** (`--features multihost-it`): spawns two spread replicas across two real daemons (`RUSCKER_IT_HOST1` / `RUSCKER_IT_HOST2`), asserts they land on **different hosts** and carry `Replica.host`, `list()` tags both, and a routed `stop` reaches the owning host. Off by default (needs real multi-host infra); documented inline + in the guide.

## Verification
Compiles under `--features multihost-it`; **317 default tests green**; book builds; fmt-drift unchanged (new test 0-drift).

**Phase 6 (multi-host scheduling) is complete** (6a–6d). The remaining real-infra validation is the operator's `multihost-it` run on their own dev hosts — not the SEPE production box.

🤖 Generated with [Claude Code](https://claude.com/claude-code)