### PR TITLE
Phase 7c-1: Postgres schema foundation for the shared admin catalog (#128)

### DIFF
--- a/crates/ruscker-admin/migrations-pg/0001_initial.sql
+++ b/crates/ruscker-admin/migrations-pg/0001_initial.sql
@@ -1,0 +1,93 @@
+-- Initial schema for the Ruscker admin DB — **Postgres dialect**.
+--
+-- Mirrors `migrations/0001_initial.sql` (SQLite) one-for-one; this
+-- directory is the HA / multi-instance store (Phase 7). Keep the two
+-- in lockstep: every SQLite migration gets a Postgres twin with the
+-- same number so the shared admin catalog stays identical whichever
+-- backend an install runs.
+--
+-- Dialect mapping vs. the SQLite original:
+--   * INTEGER counters / sizes (read as i64 in Rust) -> BIGINT
+--   * INTEGER 0/1 booleans                            -> BOOLEAN
+--   * BLOB                                            -> BYTEA
+--   * TIMESTAMP / TEXT timestamps (DateTime<Utc>)     -> TIMESTAMPTZ
+--   * INTEGER PRIMARY KEY AUTOINCREMENT               -> BIGINT GENERATED
+--                                                        ALWAYS AS IDENTITY
+-- The application remains the single source of "now()": no DB-level
+-- DEFAULTs on write-path timestamps (the singleton seed below is the
+-- one exception, and it's overwritten on first save).
+
+CREATE TABLE specs (
+    id              TEXT        PRIMARY KEY,
+    display_name    TEXT,
+    description     TEXT,
+    -- 'shiny' | 'interactive' | 'api' | 'external' (DisplayType / SpecKind)
+    kind            TEXT        NOT NULL,
+    container_image TEXT,
+    -- Full Spec serialized as JSON for round-trip fidelity.
+    config_json     TEXT        NOT NULL,
+    -- 'active' | 'inactive'.
+    state           TEXT        NOT NULL DEFAULT 'active',
+    created_at      TIMESTAMPTZ NOT NULL,
+    updated_at      TIMESTAMPTZ NOT NULL,
+    -- Monotonic counter bumped on every UPDATE.
+    version         BIGINT      NOT NULL DEFAULT 1
+);
+
+CREATE INDEX specs_state_idx ON specs (state);
+CREATE INDEX specs_kind_idx ON specs (kind);
+
+CREATE TABLE spec_versions (
+    spec_id     TEXT        NOT NULL REFERENCES specs(id) ON DELETE CASCADE,
+    version     BIGINT      NOT NULL,
+    config_json TEXT        NOT NULL,
+    changed_at  TIMESTAMPTZ NOT NULL,
+    changed_by  TEXT,
+    PRIMARY KEY (spec_id, version)
+);
+
+CREATE TABLE images (
+    id           TEXT        PRIMARY KEY,
+    filename     TEXT        NOT NULL,
+    mime_type    TEXT        NOT NULL,
+    size_bytes   BIGINT      NOT NULL,
+    blob         BYTEA       NOT NULL,
+    width        BIGINT,
+    height       BIGINT,
+    uploaded_at  TIMESTAMPTZ NOT NULL
+);
+
+CREATE INDEX images_filename_idx ON images (filename);
+
+CREATE TABLE credentials (
+    name         TEXT        PRIMARY KEY,
+    registry     TEXT        NOT NULL,
+    username     TEXT        NOT NULL,
+    password_enc BYTEA       NOT NULL,
+    nonce        BYTEA       NOT NULL,
+    created_at   TIMESTAMPTZ NOT NULL
+);
+
+CREATE TABLE landing_customization (
+    id           INTEGER     PRIMARY KEY CHECK (id = 1), -- singleton row
+    header_bg    TEXT,
+    header_fg    TEXT,
+    intro        TEXT,
+    intro_locales_json TEXT  NOT NULL DEFAULT '{}',
+    updated_at   TIMESTAMPTZ NOT NULL
+);
+
+INSERT INTO landing_customization (id, intro_locales_json, updated_at)
+VALUES (1, '{}', CURRENT_TIMESTAMP);
+
+CREATE TABLE audit_log (
+    id          BIGINT      GENERATED ALWAYS AS IDENTITY PRIMARY KEY,
+    actor       TEXT,
+    action      TEXT        NOT NULL,
+    target      TEXT,
+    diff_json   TEXT,
+    occurred_at TIMESTAMPTZ NOT NULL
+);
+
+CREATE INDEX audit_log_target_idx ON audit_log (target);
+CREATE INDEX audit_log_action_idx ON audit_log (action);

--- a/crates/ruscker-admin/migrations-pg/0002_config_meta.sql
+++ b/crates/ruscker-admin/migrations-pg/0002_config_meta.sql
@@ -1,0 +1,9 @@
+-- Catch-all for YAML sections without dedicated tables (top-level
+-- `server`, `logging`, and the rest of `proxy` minus `specs` and
+-- `landing-customization`). Postgres twin of migrations/0002.
+CREATE TABLE config_meta (
+    -- 'proxy' | 'server' | 'logging'
+    key         TEXT        PRIMARY KEY,
+    value_json  TEXT        NOT NULL,
+    updated_at  TIMESTAMPTZ NOT NULL
+);

--- a/crates/ruscker-admin/migrations-pg/0003_landing_seo.sql
+++ b/crates/ruscker-admin/migrations-pg/0003_landing_seo.sql
@@ -1,0 +1,5 @@
+-- SEO / social-share meta tags on the landing_customization singleton.
+-- Postgres twin of migrations/0003. All optional; NULL means fall back.
+ALTER TABLE landing_customization ADD COLUMN seo_title       TEXT;
+ALTER TABLE landing_customization ADD COLUMN seo_description TEXT;
+ALTER TABLE landing_customization ADD COLUMN og_image        TEXT;

--- a/crates/ruscker-admin/migrations-pg/0004_landing_analytics.sql
+++ b/crates/ruscker-admin/migrations-pg/0004_landing_analytics.sql
@@ -1,0 +1,4 @@
+-- Analytics snippet + its CSP origins on the landing_customization
+-- singleton. Postgres twin of migrations/0004. Both optional/NULL.
+ALTER TABLE landing_customization ADD COLUMN analytics_html    TEXT;
+ALTER TABLE landing_customization ADD COLUMN analytics_origins TEXT;

--- a/crates/ruscker-admin/migrations-pg/0005_landing_blocks.sql
+++ b/crates/ruscker-admin/migrations-pg/0005_landing_blocks.sql
@@ -1,0 +1,20 @@
+-- Custom HTML blocks rendered in fixed landing slots ('top' / 'bottom').
+-- Postgres twin of migrations/0005. `position` orders within a slot;
+-- `csp_origins` widens the landing CSP.
+--
+-- Note the dialect shift from the SQLite original: `enabled` is a real
+-- BOOLEAN here (the SQLite table stores it as INTEGER 0/1). The query
+-- port (Phase 7c-2) binds/reads it as `bool` directly instead of the
+-- SQLite-side `enabled as i64`.
+CREATE TABLE landing_blocks (
+    id          TEXT        PRIMARY KEY,
+    slot        TEXT        NOT NULL,
+    position    BIGINT      NOT NULL DEFAULT 0,
+    enabled     BOOLEAN     NOT NULL DEFAULT TRUE,
+    title       TEXT        NOT NULL DEFAULT '',
+    html        TEXT        NOT NULL DEFAULT '',
+    csp_origins TEXT        NOT NULL DEFAULT '',
+    created_at  TIMESTAMPTZ NOT NULL,
+    updated_at  TIMESTAMPTZ NOT NULL
+);
+CREATE INDEX idx_landing_blocks_slot_pos ON landing_blocks (slot, position);

--- a/crates/ruscker-admin/migrations-pg/0006_users.sql
+++ b/crates/ruscker-admin/migrations-pg/0006_users.sql
@@ -1,0 +1,17 @@
+-- Admin user accounts with per-user password login (real RBAC).
+-- Postgres twin of migrations/0006. Roles mirror `auth::Role`
+-- ('viewer' | 'editor' | 'admin'); passwords are argon2id PHC hashes.
+--
+-- As with landing_blocks, `must_change_password` is a real BOOLEAN
+-- here (INTEGER 0/1 on SQLite); the query port binds/reads it as
+-- `bool`. `username` is stored lowercased and is unique.
+CREATE TABLE users (
+    id                   TEXT        PRIMARY KEY,
+    username             TEXT        NOT NULL UNIQUE,
+    password_hash        TEXT        NOT NULL,
+    role                 TEXT        NOT NULL,
+    must_change_password BOOLEAN     NOT NULL DEFAULT FALSE,
+    created_at           TIMESTAMPTZ NOT NULL,
+    updated_at           TIMESTAMPTZ NOT NULL,
+    created_by           TEXT
+);

--- a/crates/ruscker-admin/src/db.rs
+++ b/crates/ruscker-admin/src/db.rs
@@ -27,6 +27,16 @@ use std::str::FromStr;
 /// no separate deployment needed.
 pub static MIGRATIONS: sqlx::migrate::Migrator = sqlx::migrate!("./migrations");
 
+/// Postgres twin of [`MIGRATIONS`], embedded from `migrations-pg/`.
+///
+/// Phase 7 (HA / active-active) lets the admin catalog live in shared
+/// Postgres instead of per-node SQLite. The two directories are kept
+/// in lockstep — same migration numbers, same intent, different
+/// dialect — so the schema is identical whichever backend an install
+/// runs. SQLite stays the zero-config single-node default; Postgres is
+/// opt-in for clustering.
+pub static MIGRATIONS_PG: sqlx::migrate::Migrator = sqlx::migrate!("./migrations-pg");
+
 /// Open the SQLite database at `path`, creating the file if
 /// missing, and apply any pending migrations. Returns the pool
 /// ready for use.
@@ -59,6 +69,31 @@ pub async fn open(path: impl AsRef<Path>) -> Result<SqlitePool> {
     Ok(pool)
 }
 
+/// Open the shared Postgres admin database at `url` (a `postgres://…`
+/// DSN) and apply any pending [`MIGRATIONS_PG`]. Returns the pool ready
+/// for use.
+///
+/// This is the HA counterpart to [`open`]: several Ruscker instances
+/// point at the same Postgres so they share one editable spec catalog,
+/// landing customization, credential store, user table and audit log.
+/// The per-statement query port that lets the existing repositories
+/// run against this pool lands in the following Phase 7c slices; this
+/// function plus `migrations-pg/` is the foundation it builds on.
+pub async fn open_pg(url: &str) -> Result<sqlx::PgPool> {
+    let pool = sqlx::postgres::PgPoolOptions::new()
+        .max_connections(5)
+        .connect(url)
+        .await
+        .context("open Postgres admin database")?;
+
+    MIGRATIONS_PG
+        .run(&pool)
+        .await
+        .context("apply Postgres migrations")?;
+
+    Ok(pool)
+}
+
 /// Open an in-memory database for tests. Migrations applied.
 #[cfg(test)]
 pub async fn open_memory() -> Result<SqlitePool> {
@@ -81,3 +116,77 @@ pub mod landing;
 pub mod landing_blocks;
 pub mod specs;
 pub mod users;
+
+#[cfg(all(test, feature = "postgres-it"))]
+mod pg_tests {
+    use super::*;
+    use sqlx::Row;
+
+    // Proves the Postgres migrations apply cleanly to a real daemon
+    // and produce the same table set as the SQLite schema. Gated:
+    //   docker run --rm -e POSTGRES_PASSWORD=pg -p 5433:5432 postgres:16-alpine
+    //   RUSCKER_TEST_PG_URL=postgres://postgres:pg@127.0.0.1:5433/postgres \
+    //     cargo test -p ruscker-admin --features postgres-it -- --nocapture
+    #[tokio::test]
+    async fn pg_migrations_apply_and_match_sqlite_tables() {
+        let url = std::env::var("RUSCKER_TEST_PG_URL")
+            .expect("set RUSCKER_TEST_PG_URL to a reachable postgres:// DSN");
+
+        // open_pg runs every migration. A second open_pg must be a
+        // no-op (the migrator tracks applied rows) — exercise
+        // idempotency. Non-destructive throughout so this can share a
+        // database with the 7b session-store test without racing it.
+        let pool = open_pg(&url).await.unwrap();
+        let pool = {
+            drop(pool);
+            open_pg(&url).await.unwrap()
+        };
+
+        // Every admin table the SQLite schema defines must be present
+        // (subset check — a sibling test's `proxy_sessions` may also
+        // exist; we don't require an exact match).
+        let present: std::collections::HashSet<String> = sqlx::query(
+            "SELECT table_name FROM information_schema.tables
+             WHERE table_schema = 'public' AND table_type = 'BASE TABLE'",
+        )
+        .fetch_all(&pool)
+        .await
+        .unwrap()
+        .into_iter()
+        .map(|r| r.get::<String, _>("table_name"))
+        .collect();
+        for expected in [
+            "audit_log",
+            "config_meta",
+            "credentials",
+            "images",
+            "landing_blocks",
+            "landing_customization",
+            "spec_versions",
+            "specs",
+            "users",
+        ] {
+            assert!(present.contains(expected), "missing table: {expected}");
+        }
+
+        // The singleton landing row was seeded by 0001.
+        let n: i64 = sqlx::query("SELECT count(*) AS n FROM landing_customization")
+            .fetch_one(&pool)
+            .await
+            .unwrap()
+            .get("n");
+        assert_eq!(n, 1);
+
+        // The 0003/0004 ALTERs landed (seo + analytics columns).
+        let cols: i64 = sqlx::query(
+            "SELECT count(*) AS n FROM information_schema.columns
+             WHERE table_name = 'landing_customization'
+               AND column_name IN ('seo_title', 'analytics_html', 'og_image')",
+        )
+        .fetch_one(&pool)
+        .await
+        .unwrap()
+        .get("n");
+        assert_eq!(cols, 3);
+    }
+}


### PR DESCRIPTION
First slice of **"config in Postgres"** (HA / active-active). At runtime the proxy and landing already read specs from the YAML-loaded `Config`; the SQLite DB is purely the **admin CRUD** store (specs, landing, blocks, credentials, users, audit, images). Making that store optionally Postgres lets several instances share one editable catalog.

This slice lands the **foundation** the query port builds on — schema + connection + a real-Postgres smoke — **without** yet rewiring `AppState` or the repositories. Per the agreed plan, the per-module query port (so all ~55 statements don't move at once) comes in 7c-2+.

## What's here
- **`migrations-pg/`** — Postgres twins of all six SQLite migrations, same numbers / same intent, kept in lockstep. Dialect mapping: i64 counters/sizes → `BIGINT`, INTEGER 0/1 booleans → `BOOLEAN`, `BLOB` → `BYTEA`, timestamps (`DateTime<Utc>`) → `TIMESTAMPTZ`, `AUTOINCREMENT` → `GENERATED ALWAYS AS IDENTITY`. The two BOOLEAN columns (`landing_blocks.enabled`, `users.must_change_password`) are flagged inline for the port to bind/read as `bool` instead of the SQLite `as i64`.
- **`db::MIGRATIONS_PG` + `db::open_pg(url)`** — HA counterpart to `open()`: connect to a `postgres://` DSN and apply the PG migrations.
- **Gated test** (`--features postgres-it`, `RUSCKER_TEST_PG_URL`): applies the migrations to a real `postgres:16-alpine`, re-runs `open_pg` to prove idempotency, asserts all nine admin tables exist, the landing singleton was seeded, and the 0003/0004 ALTERs landed. Non-destructive, so it shares a DB with the 7b session test without racing.

## Decisions (confirmed)
- **Dual, SQLite default**: SQLite stays the zero-config single-node path; Postgres is opt-in for clustering.

## Verification
- **317 default tests green**; db.rs 0-drift; new files are `.sql`.
- Both `postgres-it` tests pass together against a real daemon:
  ```
  test db::pg_tests::pg_migrations_apply_and_match_sqlite_tables ... ok
  test sessions_pg::tests::end_to_end_against_real_postgres ... ok
  ```

Next: **7c-2** introduces the sqlite/postgres dispatch on `AppState.db` and ports the first repository module.

🤖 Generated with [Claude Code](https://claude.com/claude-code)