### PR TITLE
Phase 7c-2: ConfigDb seam — AppState.db abstracts SQLite vs Postgres (#128)

### DIFF
--- a/crates/ruscker-admin/src/db.rs
+++ b/crates/ruscker-admin/src/db.rs
@@ -37,6 +37,33 @@ pub static MIGRATIONS: sqlx::migrate::Migrator = sqlx::migrate!("./migrations");
 /// opt-in for clustering.
 pub static MIGRATIONS_PG: sqlx::migrate::Migrator = sqlx::migrate!("./migrations-pg");
 
+/// A handle to the admin config database.
+///
+/// SQLite is the zero-config single-node default; Postgres backs the
+/// shared catalog in HA mode (Phase 7). The repository functions are
+/// ported to dual-dialect **one module at a time** — until a function
+/// is ported it runs in SQLite mode only, reached through
+/// [`ConfigDb::as_sqlite`]. In Postgres mode an un-ported path gets
+/// `None` and the caller surfaces a clear "not yet supported" response
+/// rather than silently misbehaving.
+#[derive(Debug, Clone)]
+pub enum ConfigDb {
+    Sqlite(SqlitePool),
+    Postgres(sqlx::PgPool),
+}
+
+impl ConfigDb {
+    /// The SQLite pool when running in SQLite mode, else `None`.
+    /// Un-ported repositories go through this; a ported one matches on
+    /// the enum directly.
+    pub fn as_sqlite(&self) -> Option<&SqlitePool> {
+        match self {
+            ConfigDb::Sqlite(pool) => Some(pool),
+            ConfigDb::Postgres(_) => None,
+        }
+    }
+}
+
 /// Open the SQLite database at `path`, creating the file if
 /// missing, and apply any pending migrations. Returns the pool
 /// ready for use.

--- a/crates/ruscker-admin/src/lib.rs
+++ b/crates/ruscker-admin/src/lib.rs
@@ -59,9 +59,11 @@ pub struct AppState {
     /// `AppState` sees the same sliding windows. Specs without a
     /// configured limit never touch it.
     pub api_limiter: Arc<ratelimit::ApiRateLimiter>,
-    /// Optional SQLite pool. `None` ⇒ admin CRUD routes 503
-    /// because they have no source of truth to read or write.
-    pub db: Option<SqlitePool>,
+    /// Optional admin config database (SQLite by default, Postgres in
+    /// HA mode). `None` ⇒ admin CRUD routes 503 because they have no
+    /// source of truth. Reach the SQLite pool for not-yet-ported
+    /// repositories via [`AppState::sqlite`].
+    pub db: Option<db::ConfigDb>,
     /// On-disk fallback directory for `/assets/img/<file>`. When
     /// the DB lookup misses (or `db` is `None`), the assets route
     /// falls through to this directory before 404'ing. `None`
@@ -123,6 +125,15 @@ pub struct AppState {
     /// closes. Shared (Arc) so the signal handler and every request
     /// handler observe the same flag.
     pub draining: Arc<std::sync::atomic::AtomicBool>,
+}
+
+impl AppState {
+    /// The SQLite pool when the config DB is SQLite, else `None`.
+    /// Repositories not yet ported to Postgres call this; in Postgres
+    /// mode they get `None` and 503. See [`db::ConfigDb`].
+    pub fn sqlite(&self) -> Option<&SqlitePool> {
+        self.db.as_ref().and_then(db::ConfigDb::as_sqlite)
+    }
 }
 
 /// HTTP server hosting the landing and (later) the admin panel.
@@ -242,7 +253,7 @@ impl AdminServer {
     /// across all requests — sqlx handles the connection
     /// multiplexing.
     pub fn with_db(mut self, pool: SqlitePool) -> Self {
-        self.state.db = Some(pool);
+        self.state.db = Some(db::ConfigDb::Sqlite(pool));
         self
     }
 

--- a/crates/ruscker-admin/src/routes/admin.rs
+++ b/crates/ruscker-admin/src/routes/admin.rs
@@ -159,7 +159,7 @@ async fn show_token_form(state: &AppState, force_token: bool) -> bool {
     if force_token {
         return true;
     }
-    match state.db.as_ref() {
+    match state.sqlite() {
         Some(pool) => !db::users::any_user_exists(pool).await.unwrap_or(false),
         None => true,
     }
@@ -242,7 +242,7 @@ async fn login_submit(
 
     // Username/password login needs the user store. Without a DB the
     // only way in is the break-glass token.
-    let Some(pool) = state.db.as_ref() else {
+    let Some(pool) = state.sqlite() else {
         return login_error(&state, loc, theme, "wrong-login", false);
     };
 
@@ -320,7 +320,7 @@ async fn token_login(
     issue_session_cookie(&cookies, &headers, session_id);
 
     // No admin account yet (and a DB to create one in) ⇒ run setup.
-    let need_setup = match state.db.as_ref() {
+    let need_setup = match state.sqlite() {
         Some(pool) => !db::users::any_admin_exists(pool).await.unwrap_or(false),
         None => false,
     };
@@ -344,7 +344,7 @@ async fn setup_form(
 ) -> Response {
     // Setup is admin-gated and only meaningful before the first admin
     // account exists. Once one does, send the operator to the dashboard.
-    if let Some(pool) = state.db.as_ref() {
+    if let Some(pool) = state.sqlite() {
         if db::users::any_admin_exists(pool).await.unwrap_or(false) {
             return Redirect::to("/admin/dashboard").into_response();
         }
@@ -380,7 +380,7 @@ async fn setup_submit(
     headers: HeaderMap,
     Form(form): Form<SetupForm>,
 ) -> Response {
-    let Some(pool) = state.db.as_ref() else {
+    let Some(pool) = state.sqlite() else {
         return (
             StatusCode::SERVICE_UNAVAILABLE,
             "no database — start with --db",
@@ -447,7 +447,7 @@ async fn password_form(
     let Some(actor) = session.actor.clone() else {
         return Redirect::to("/admin/dashboard").into_response();
     };
-    let first = match state.db.as_ref() {
+    let first = match state.sqlite() {
         Some(pool) => db::users::fetch(pool, &actor)
             .await
             .ok()
@@ -488,7 +488,7 @@ async fn password_submit(
     let Some(actor) = session.actor.clone() else {
         return Redirect::to("/admin/dashboard").into_response();
     };
-    let Some(pool) = state.db.as_ref() else {
+    let Some(pool) = state.sqlite() else {
         return (
             StatusCode::SERVICE_UNAVAILABLE,
             "no database — start with --db",

--- a/crates/ruscker-admin/src/routes/admin/audit.rs
+++ b/crates/ruscker-admin/src/routes/admin/audit.rs
@@ -104,7 +104,7 @@ async fn index(
     theme: Theme,
     Query(q): Query<AuditQuery>,
 ) -> Response {
-    let Some(pool) = state.db.as_ref() else {
+    let Some(pool) = state.sqlite() else {
         return (StatusCode::SERVICE_UNAVAILABLE, "no db").into_response();
     };
 

--- a/crates/ruscker-admin/src/routes/admin/blocks.rs
+++ b/crates/ruscker-admin/src/routes/admin/blocks.rs
@@ -66,7 +66,7 @@ async fn index(
     loc: Locale,
     theme: Theme,
 ) -> Response {
-    let Some(pool) = state.db.as_ref() else {
+    let Some(pool) = state.sqlite() else {
         return no_db();
     };
     let blocks = match landing_blocks::list_all(pool).await {
@@ -132,7 +132,7 @@ async fn new_form(
     loc: Locale,
     theme: Theme,
 ) -> Response {
-    if state.db.is_none() {
+    if state.sqlite().is_none() {
         return no_db();
     }
     super::render(&BlockFormPage {
@@ -160,7 +160,7 @@ async fn edit_form(
     theme: Theme,
     Path(id): Path<String>,
 ) -> Response {
-    let Some(pool) = state.db.as_ref() else {
+    let Some(pool) = state.sqlite() else {
         return no_db();
     };
     let block = match landing_blocks::fetch_one(pool, &id).await {
@@ -226,7 +226,7 @@ async fn create(
     State(state): State<AppState>,
     Form(form): Form<BlockForm>,
 ) -> Response {
-    let Some(pool) = state.db.as_ref() else {
+    let Some(pool) = state.sqlite() else {
         return no_db();
     };
     match landing_blocks::insert(pool, &form.into_input(), Some(admin.actor())).await {
@@ -244,7 +244,7 @@ async fn update(
     Path(id): Path<String>,
     Form(form): Form<BlockForm>,
 ) -> Response {
-    let Some(pool) = state.db.as_ref() else {
+    let Some(pool) = state.sqlite() else {
         return no_db();
     };
     match landing_blocks::update(pool, &id, &form.into_input(), Some(admin.actor())).await {
@@ -262,7 +262,7 @@ async fn delete(
     State(state): State<AppState>,
     Path(id): Path<String>,
 ) -> Response {
-    let Some(pool) = state.db.as_ref() else {
+    let Some(pool) = state.sqlite() else {
         return no_db();
     };
     match landing_blocks::delete(pool, &id, Some(admin.actor())).await {
@@ -279,7 +279,7 @@ async fn move_block(
     State(state): State<AppState>,
     Path((id, dir)): Path<(String, String)>,
 ) -> Response {
-    let Some(pool) = state.db.as_ref() else {
+    let Some(pool) = state.sqlite() else {
         return no_db();
     };
     let up = match dir.as_str() {
@@ -311,7 +311,7 @@ async fn reorder(
     State(state): State<AppState>,
     Json(req): Json<ReorderReq>,
 ) -> Response {
-    let Some(pool) = state.db.as_ref() else {
+    let Some(pool) = state.sqlite() else {
         return no_db();
     };
     match landing_blocks::reorder(pool, &req.slot, &req.ids, Some(admin.actor())).await {

--- a/crates/ruscker-admin/src/routes/admin/credentials.rs
+++ b/crates/ruscker-admin/src/routes/admin/credentials.rs
@@ -67,7 +67,7 @@ async fn render_index(
     flash_saved: Option<String>,
     flash_error: Option<String>,
 ) -> Response {
-    let Some(pool) = state.db.as_ref() else {
+    let Some(pool) = state.sqlite() else {
         return (StatusCode::SERVICE_UNAVAILABLE, "no db").into_response();
     };
     let credentials = match db::credentials::list_all(pool).await {
@@ -107,7 +107,7 @@ async fn create_or_update(
     theme: Theme,
     Form(form): Form<CredentialForm>,
 ) -> Response {
-    let Some(pool) = state.db.as_ref() else {
+    let Some(pool) = state.sqlite() else {
         return (StatusCode::SERVICE_UNAVAILABLE, "no db").into_response();
     };
     if !state.master_key.is_configured() {
@@ -165,7 +165,7 @@ async fn delete(
     State(state): State<AppState>,
     Path(name): Path<String>,
 ) -> Response {
-    let Some(pool) = state.db.as_ref() else {
+    let Some(pool) = state.sqlite() else {
         return (StatusCode::SERVICE_UNAVAILABLE, "no db").into_response();
     };
     match db::credentials::delete_one(pool, &name, Some(admin.actor())).await {

--- a/crates/ruscker-admin/src/routes/admin/images.rs
+++ b/crates/ruscker-admin/src/routes/admin/images.rs
@@ -99,7 +99,7 @@ async fn render_index(
     flash_uploaded: Option<String>,
     flash_error: Option<String>,
 ) -> Response {
-    let Some(pool) = state.db.as_ref() else {
+    let Some(pool) = state.sqlite() else {
         return (
             StatusCode::SERVICE_UNAVAILABLE,
             "database not attached — start with --db <path>",
@@ -134,7 +134,7 @@ async fn upload(
     theme: Theme,
     mut multipart: Multipart,
 ) -> Response {
-    let Some(pool) = state.db.as_ref() else {
+    let Some(pool) = state.sqlite() else {
         return (StatusCode::SERVICE_UNAVAILABLE, "no db").into_response();
     };
 
@@ -205,7 +205,7 @@ async fn delete(
     State(state): State<AppState>,
     Path(id): Path<String>,
 ) -> Response {
-    let Some(pool) = state.db.as_ref() else {
+    let Some(pool) = state.sqlite() else {
         return (StatusCode::SERVICE_UNAVAILABLE, "no db").into_response();
     };
     match db::images::delete_one(pool, &id, Some(editor.actor())).await {

--- a/crates/ruscker-admin/src/routes/admin/landing.rs
+++ b/crates/ruscker-admin/src/routes/admin/landing.rs
@@ -155,7 +155,7 @@ async fn save(
     theme: Theme,
     Form(form): Form<LandingForm>,
 ) -> Response {
-    let Some(pool) = state.db.as_ref() else {
+    let Some(pool) = state.sqlite() else {
         return (StatusCode::SERVICE_UNAVAILABLE, "no db").into_response();
     };
     let lc = form.into_customization();
@@ -184,7 +184,7 @@ async fn render(
     flash_saved: bool,
     flash_error: Option<String>,
 ) -> Response {
-    let Some(pool) = state.db.as_ref() else {
+    let Some(pool) = state.sqlite() else {
         return (StatusCode::SERVICE_UNAVAILABLE, "no db").into_response();
     };
     let form = match preset_form {

--- a/crates/ruscker-admin/src/routes/admin/spec_form.rs
+++ b/crates/ruscker-admin/src/routes/admin/spec_form.rs
@@ -490,7 +490,7 @@ impl<'a> SpecFormPage<'a> {
 /// Media-library filenames for the logo picker. Empty when no DB is
 /// wired or the query fails — the picker degrades to the text field.
 async fn logo_filenames(state: &AppState) -> Vec<String> {
-    match state.db.as_ref() {
+    match state.sqlite() {
         Some(pool) => db::images::list_all(pool)
             .await
             .map(|imgs| imgs.into_iter().map(|i| i.filename).collect())
@@ -536,7 +536,7 @@ async fn edit_form(
     theme: Theme,
     Path(id): Path<String>,
 ) -> Response {
-    let Some(pool) = state.db.as_ref() else {
+    let Some(pool) = state.sqlite() else {
         return (StatusCode::SERVICE_UNAVAILABLE, "no db").into_response();
     };
     let spec = match db::specs::fetch_one(pool, &id).await {
@@ -569,7 +569,7 @@ async fn create(
     theme: Theme,
     Form(form): Form<SpecForm>,
 ) -> Response {
-    let Some(pool) = state.db.as_ref() else {
+    let Some(pool) = state.sqlite() else {
         return (StatusCode::SERVICE_UNAVAILABLE, "no db").into_response();
     };
 
@@ -626,7 +626,7 @@ async fn update(
     Path(id): Path<String>,
     Form(mut form): Form<SpecForm>,
 ) -> Response {
-    let Some(pool) = state.db.as_ref() else {
+    let Some(pool) = state.sqlite() else {
         return (StatusCode::SERVICE_UNAVAILABLE, "no db").into_response();
     };
 
@@ -682,7 +682,7 @@ async fn delete(
     State(state): State<AppState>,
     Path(id): Path<String>,
 ) -> Response {
-    let Some(pool) = state.db.as_ref() else {
+    let Some(pool) = state.sqlite() else {
         return (StatusCode::SERVICE_UNAVAILABLE, "no db").into_response();
     };
     match db::specs::delete_one(pool, &id, Some(editor.actor())).await {

--- a/crates/ruscker-admin/src/routes/admin/specs.rs
+++ b/crates/ruscker-admin/src/routes/admin/specs.rs
@@ -136,7 +136,7 @@ async fn index(
     theme: Theme,
     Query(flash): Query<SpecsQuery>,
 ) -> Response {
-    let Some(pool) = state.db.as_ref() else {
+    let Some(pool) = state.sqlite() else {
         return (
             StatusCode::SERVICE_UNAVAILABLE,
             "database not attached — start with --db <path>",
@@ -187,7 +187,7 @@ async fn import(
     State(state): State<AppState>,
     mut multipart: Multipart,
 ) -> Response {
-    let Some(pool) = state.db.as_ref() else {
+    let Some(pool) = state.sqlite() else {
         return (StatusCode::SERVICE_UNAVAILABLE, "no db").into_response();
     };
 

--- a/crates/ruscker-admin/src/routes/admin/users.rs
+++ b/crates/ruscker-admin/src/routes/admin/users.rs
@@ -78,7 +78,7 @@ async fn index(
     theme: Theme,
     Query(q): Query<UsersQuery>,
 ) -> Response {
-    let Some(pool) = state.db.as_ref() else {
+    let Some(pool) = state.sqlite() else {
         return (
             StatusCode::SERVICE_UNAVAILABLE,
             "database not attached — start with --db <path>",
@@ -129,7 +129,7 @@ async fn create(
     State(state): State<AppState>,
     Form(form): Form<CreateForm>,
 ) -> Response {
-    let Some(pool) = state.db.as_ref() else {
+    let Some(pool) = state.sqlite() else {
         return (StatusCode::SERVICE_UNAVAILABLE, "no db").into_response();
     };
     let username = db::users::normalize_username(&form.username);
@@ -167,7 +167,7 @@ async fn set_role(
     Path(username): Path<String>,
     Form(form): Form<RoleForm>,
 ) -> Response {
-    let Some(pool) = state.db.as_ref() else {
+    let Some(pool) = state.sqlite() else {
         return (StatusCode::SERVICE_UNAVAILABLE, "no db").into_response();
     };
     let new_role = Role::parse(&form.role).unwrap_or(Role::Viewer);
@@ -196,7 +196,7 @@ async fn reset_password(
     Path(username): Path<String>,
     Form(form): Form<ResetForm>,
 ) -> Response {
-    let Some(pool) = state.db.as_ref() else {
+    let Some(pool) = state.sqlite() else {
         return (StatusCode::SERVICE_UNAVAILABLE, "no db").into_response();
     };
     if form.password.len() < MIN_PASSWORD_LEN {
@@ -218,7 +218,7 @@ async fn delete(
     State(state): State<AppState>,
     Path(username): Path<String>,
 ) -> Response {
-    let Some(pool) = state.db.as_ref() else {
+    let Some(pool) = state.sqlite() else {
         return (StatusCode::SERVICE_UNAVAILABLE, "no db").into_response();
     };
     // Last-admin guard: deleting the only admin would lock everyone out.

--- a/crates/ruscker-admin/src/routes/assets.rs
+++ b/crates/ruscker-admin/src/routes/assets.rs
@@ -109,7 +109,7 @@ async fn serve_card_image(
     }
 
     // 1. DB lookup
-    if let Some(pool) = state.db.as_ref() {
+    if let Some(pool) = state.sqlite() {
         match crate::db::images::fetch_by_filename(pool, &filename).await {
             Ok(Some((mime, bytes))) => return serve_dynamic(bytes, &mime),
             Ok(None) => {}

--- a/crates/ruscker-admin/src/routes/health.rs
+++ b/crates/ruscker-admin/src/routes/health.rs
@@ -75,8 +75,10 @@ async fn readyz(State(state): State<AppState>) -> Response {
 
     // SQLite: a trivial round-trip confirms the pool can hand out a
     // live connection (catches a deleted/locked DB file or an
-    // exhausted pool).
-    if let Some(pool) = &state.db {
+    // exhausted pool). In Postgres mode `sqlite()` is `None` and this
+    // probe is skipped until readiness learns to probe that pool too
+    // (a later Phase 7c slice, when the CLI can select Postgres).
+    if let Some(pool) = state.sqlite() {
         match sqlx::query("SELECT 1").fetch_one(pool).await {
             Ok(_) => {
                 checks.insert("db".into(), json!("ok"));

--- a/crates/ruscker-admin/src/routes/landing.rs
+++ b/crates/ruscker-admin/src/routes/landing.rs
@@ -99,7 +99,7 @@ async fn index(State(state): State<AppState>, loc: Locale, theme: Theme) -> Resp
     // Landing customization: read from DB when available
     // (admin-editable), fall back to the YAML-derived value
     // otherwise (Phase 1 / no-DB deployments).
-    let lc = match state.db.as_ref() {
+    let lc = match state.sqlite() {
         Some(pool) => crate::db::landing::fetch(pool)
             .await
             .unwrap_or_else(|err| {
@@ -140,7 +140,7 @@ async fn index(State(state): State<AppState>, loc: Locale, theme: Theme) -> Resp
     // content can load.
     let (mut blocks_top, mut blocks_bottom) = (Vec::new(), Vec::new());
     let mut origins = not_blank(&lc.analytics_origins).unwrap_or_default();
-    if let Some(pool) = state.db.as_ref() {
+    if let Some(pool) = state.sqlite() {
         match crate::db::landing_blocks::list_enabled(pool).await {
             Ok(blocks) => {
                 for b in blocks {

--- a/crates/ruscker-admin/src/routes/proxy.rs
+++ b/crates/ruscker-admin/src/routes/proxy.rs
@@ -743,7 +743,7 @@ pub(crate) async fn resolve_creds(
         .as_deref()
         .filter(|s| !s.is_empty())
     {
-        match (state.db.as_ref(), state.master_key.is_configured()) {
+        match (state.sqlite(), state.master_key.is_configured()) {
             (Some(pool), true) => {
                 match crate::db::credentials::resolve(pool, &state.master_key, name).await {
                     Ok(Some(c)) => return Some(c),

--- a/crates/ruscker-admin/tests/user_accounts.rs
+++ b/crates/ruscker-admin/tests/user_accounts.rs
@@ -30,7 +30,7 @@ async fn state_with_db() -> (AppState, sqlx::SqlitePool) {
         log_buffer: None,
         login_limiter: Arc::new(ruscker_admin::auth::LoginRateLimiter::default_policy()),
         api_limiter: Arc::new(ruscker_admin::ratelimit::ApiRateLimiter::new()),
-        db: Some(pool.clone()),
+        db: Some(ruscker_admin::db::ConfigDb::Sqlite(pool.clone())),
         images_dir: None,
         master_key: Default::default(),
         backend: None,


### PR DESCRIPTION
Structural enabler for the per-module query port. Introduces a backend handle so the admin config DB can be SQLite (today) or Postgres (HA), **without yet porting any repository** — behaviour is identical and the full SQLite suite proves it.

## What's here
- **`db::ConfigDb { Sqlite(SqlitePool), Postgres(PgPool) }`** with `as_sqlite() -> Option<&SqlitePool>`.
- **`AppState.db: Option<ConfigDb>`** (was `Option<SqlitePool>`) + `AppState::sqlite()` accessor. `with_db(SqlitePool)` wraps into `ConfigDb::Sqlite`, so every caller and integration test is unchanged.
- **Repositories (`db/*.rs`) are untouched.** Un-ported routes reach the pool via `state.sqlite()` — the ~40 `state.db.as_ref()` call sites became `state.sqlite()`. When a module is ported (7c-3+) it switches its call sites back to the `ConfigDb` and matches on the enum; in Postgres mode an un-ported path simply gets `None` → 503 rather than misbehaving.
- Readiness's SQLite probe is skipped in Postgres mode for now (noted inline); it learns to probe the PG pool when the CLI can select Postgres.

## Why a pure seam
Per the agreed plan: foundation/seam first, then port modules one at a time so ~55 statements (with their dialect-specific transactions, `QueryBuilder<Sqlite>`, `INSERT OR REPLACE`, boolean binds) don't all move in one risky PR.

## Verification
- No new behaviour; no Postgres reachable yet (no CLI flag, no ported module).
- **317 tests green**; edited files 0-drift; no new clippy warnings.

Next: **7c-3** ports the first repository module to dual-dialect with a gated real-Postgres test.

🤖 Generated with [Claude Code](https://claude.com/claude-code)