### PR TITLE
Phase 7c-3: port the landing reads to dual-dialect (#128)

### DIFF
--- a/crates/ruscker-admin/src/db/export.rs
+++ b/crates/ruscker-admin/src/db/export.rs
@@ -34,7 +34,11 @@ pub async fn reconstruct_config(pool: &SqlitePool) -> Result<Config> {
     //    loader so every field (incl. SEO) round-trips without
     //    duplicating the column list here. Then attach the custom
     //    HTML blocks (ordered by slot, position) so they round-trip too.
-    let mut landing_customization = super::landing::fetch(pool).await?;
+    // `fetch` is dual-dialect now; the export path is SQLite-only, so
+    // wrap this pool in a `ConfigDb` to call it. (Cheap — the pool is
+    // an `Arc` clone.)
+    let mut landing_customization =
+        super::landing::fetch(&super::ConfigDb::Sqlite(pool.clone())).await?;
     landing_customization.blocks = super::landing_blocks::list_all(pool)
         .await?
         .iter()

--- a/crates/ruscker-admin/src/db/landing.rs
+++ b/crates/ruscker-admin/src/db/landing.rs
@@ -5,6 +5,7 @@
 //! The same shape as [`ruscker_config::LandingCustomization`] so
 //! import/export round-trip without translation gymnastics.
 
+use crate::db::ConfigDb;
 use anyhow::{Context, Result};
 use chrono::Utc;
 use ruscker_config::LandingCustomization;
@@ -14,7 +15,11 @@ use sqlx::SqlitePool;
 /// [`LandingCustomization`] when the row hasn't been initialized
 /// yet (which shouldn't normally happen — migration 0001 inserts
 /// it — but defensive code keeps tests with a fresh DB happy).
-pub async fn fetch(pool: &SqlitePool) -> Result<LandingCustomization> {
+///
+/// First repository read ported to dual-dialect (Phase 7c-3): the
+/// SELECT carries no placeholders and reads only TEXT columns, so the
+/// SQL is identical on both backends — only the pool differs.
+pub async fn fetch(db: &ConfigDb) -> Result<LandingCustomization> {
     type Row = (
         Option<String>, // header_bg
         Option<String>, // header_fg
@@ -26,14 +31,14 @@ pub async fn fetch(pool: &SqlitePool) -> Result<LandingCustomization> {
         Option<String>, // analytics_html
         Option<String>, // analytics_origins
     );
-    let row: Option<Row> = sqlx::query_as(
-        "SELECT header_bg, header_fg, intro, intro_locales_json,
+    let sql = "SELECT header_bg, header_fg, intro, intro_locales_json,
                 seo_title, seo_description, og_image,
                 analytics_html, analytics_origins
-           FROM landing_customization WHERE id = 1",
-    )
-    .fetch_optional(pool)
-    .await
+           FROM landing_customization WHERE id = 1";
+    let row: Option<Row> = match db {
+        ConfigDb::Sqlite(pool) => sqlx::query_as(sql).fetch_optional(pool).await,
+        ConfigDb::Postgres(pool) => sqlx::query_as(sql).fetch_optional(pool).await,
+    }
     .context("load landing_customization")?;
     match row {
         None => Ok(LandingCustomization::default()),
@@ -145,7 +150,7 @@ mod tests {
     #[tokio::test]
     async fn defaults_on_fresh_db() {
         let pool = open_memory().await.unwrap();
-        let lc = fetch(&pool).await.unwrap();
+        let lc = fetch(&ConfigDb::Sqlite(pool.clone())).await.unwrap();
         assert!(lc.header_bg.is_none());
         assert!(lc.intro.is_none());
         assert!(lc.intro_locales.is_empty());
@@ -162,7 +167,7 @@ mod tests {
         lc.intro_locales.insert("en".into(), "Welcome".into());
 
         update(&pool, &lc, Some("admin")).await.unwrap();
-        let got = fetch(&pool).await.unwrap();
+        let got = fetch(&ConfigDb::Sqlite(pool.clone())).await.unwrap();
         assert_eq!(got.header_bg.as_deref(), Some("#0f6e56"));
         assert_eq!(got.header_fg.as_deref(), Some("#ffffff"));
         assert_eq!(got.intro.as_deref(), Some("Welcome"));
@@ -186,7 +191,7 @@ mod tests {
         lc.seo_description = Some("Demo portal description".into());
         lc.og_image = Some("/assets/img/og.png".into());
         update(&pool, &lc, Some("admin")).await.unwrap();
-        let got = fetch(&pool).await.unwrap();
+        let got = fetch(&ConfigDb::Sqlite(pool.clone())).await.unwrap();
         assert_eq!(got.seo_title.as_deref(), Some("Demo Portal"));
         assert_eq!(
             got.seo_description.as_deref(),
@@ -204,7 +209,7 @@ mod tests {
         lc.analytics_html = Some(snippet.into());
         lc.analytics_origins = Some(origins.into());
         update(&pool, &lc, Some("admin")).await.unwrap();
-        let got = fetch(&pool).await.unwrap();
+        let got = fetch(&ConfigDb::Sqlite(pool.clone())).await.unwrap();
         assert_eq!(got.analytics_html.as_deref(), Some(snippet));
         assert_eq!(got.analytics_origins.as_deref(), Some(origins));
     }
@@ -216,8 +221,25 @@ mod tests {
         lc.header_bg = Some("   ".into()); // whitespace only
         lc.intro = Some("".into());
         update(&pool, &lc, None).await.unwrap();
-        let got = fetch(&pool).await.unwrap();
+        let got = fetch(&ConfigDb::Sqlite(pool.clone())).await.unwrap();
         assert!(got.header_bg.is_none(), "whitespace-only becomes None");
         assert!(got.intro.is_none());
+    }
+
+    // Proves the ported `fetch` runs against a real Postgres through
+    // the `ConfigDb::Postgres` arm. Gated:
+    //   RUSCKER_TEST_PG_URL=postgres://… \
+    //     cargo test -p ruscker-admin --features postgres-it -- --nocapture
+    #[cfg(feature = "postgres-it")]
+    #[tokio::test]
+    async fn fetch_against_real_postgres() {
+        let url = std::env::var("RUSCKER_TEST_PG_URL")
+            .expect("set RUSCKER_TEST_PG_URL to a reachable postgres:// DSN");
+        let pool = crate::db::open_pg(&url).await.unwrap();
+        // The 0001 migration seeds the singleton with empty fields.
+        let lc = fetch(&ConfigDb::Postgres(pool)).await.unwrap();
+        assert!(lc.header_bg.is_none());
+        assert!(lc.intro.is_none());
+        assert!(lc.intro_locales.is_empty());
     }
 }

--- a/crates/ruscker-admin/src/db/landing_blocks.rs
+++ b/crates/ruscker-admin/src/db/landing_blocks.rs
@@ -7,6 +7,7 @@
 //! separated) widens the landing CSP so embedded third-party content
 //! can load.
 
+use crate::db::ConfigDb;
 use anyhow::{Context, Result};
 use chrono::Utc;
 use sqlx::SqlitePool;
@@ -37,14 +38,18 @@ pub struct BlockInput {
     pub csp_origins: String,
 }
 
-type Row = (String, String, i64, i64, String, String, String);
+// `enabled` is read as `bool`: SQLite decodes its INTEGER 0/1 into a
+// bool, Postgres reads the native BOOLEAN — one Row type serves both
+// dialects (Phase 7c). The write paths still bind `enabled as i64` on
+// the SQLite side; those columns get ported with their modules.
+type Row = (String, String, i64, bool, String, String, String);
 
 fn row_to_block((id, slot, position, enabled, title, html, csp_origins): Row) -> LandingBlock {
     LandingBlock {
         id,
         slot,
         position,
-        enabled: enabled != 0,
+        enabled,
         title,
         html,
         csp_origins,
@@ -64,13 +69,18 @@ pub async fn list_all(pool: &SqlitePool) -> Result<Vec<LandingBlock>> {
 }
 
 /// Enabled blocks only, ordered — for rendering the public landing.
-pub async fn list_enabled(pool: &SqlitePool) -> Result<Vec<LandingBlock>> {
-    let rows: Vec<Row> = sqlx::query_as(
-        "SELECT id, slot, position, enabled, title, html, csp_origins
-           FROM landing_blocks WHERE enabled = 1 ORDER BY slot, position, created_at",
-    )
-    .fetch_all(pool)
-    .await
+///
+/// Ported to dual-dialect (Phase 7c-3): bare `WHERE enabled` (not
+/// `= 1`) is truthy on SQLite and a native BOOLEAN test on Postgres,
+/// and the rest of the SELECT is placeholder-free, so one SQL string
+/// serves both backends.
+pub async fn list_enabled(db: &ConfigDb) -> Result<Vec<LandingBlock>> {
+    let sql = "SELECT id, slot, position, enabled, title, html, csp_origins
+           FROM landing_blocks WHERE enabled ORDER BY slot, position, created_at";
+    let rows: Vec<Row> = match db {
+        ConfigDb::Sqlite(pool) => sqlx::query_as(sql).fetch_all(pool).await,
+        ConfigDb::Postgres(pool) => sqlx::query_as(sql).fetch_all(pool).await,
+    }
     .context("list enabled landing_blocks")?;
     Ok(rows.into_iter().map(row_to_block).collect())
 }
@@ -458,7 +468,10 @@ mod tests {
         let mut off = input("top", "x");
         off.enabled = false;
         update(&pool, &id, &off, None).await.unwrap();
-        assert!(list_enabled(&pool).await.unwrap().is_empty());
+        assert!(list_enabled(&ConfigDb::Sqlite(pool.clone()))
+            .await
+            .unwrap()
+            .is_empty());
         assert_eq!(list_all(&pool).await.unwrap().len(), 1);
     }
 
@@ -469,5 +482,39 @@ mod tests {
         assert!(delete(&pool, &id, None).await.unwrap());
         assert!(fetch_one(&pool, &id).await.unwrap().is_none());
         assert!(!delete(&pool, &id, None).await.unwrap());
+    }
+
+    // Proves the ported `list_enabled` reads the native BOOLEAN column
+    // through the `ConfigDb::Postgres` arm and honours `WHERE enabled`.
+    // Inserts are raw SQL here because the write path isn't ported yet.
+    #[cfg(feature = "postgres-it")]
+    #[tokio::test]
+    async fn list_enabled_against_real_postgres() {
+        let url = std::env::var("RUSCKER_TEST_PG_URL")
+            .expect("set RUSCKER_TEST_PG_URL to a reachable postgres:// DSN");
+        let pool = crate::db::open_pg(&url).await.unwrap();
+        // Isolate from other runs sharing this database.
+        sqlx::query("DELETE FROM landing_blocks")
+            .execute(&pool)
+            .await
+            .unwrap();
+        for (id, enabled) in [("keep", true), ("skip", false)] {
+            sqlx::query(
+                "INSERT INTO landing_blocks
+                   (id, slot, position, enabled, title, html, csp_origins,
+                    created_at, updated_at)
+                 VALUES ($1, 'top', 0, $2, '', '', '', now(), now())",
+            )
+            .bind(id)
+            .bind(enabled)
+            .execute(&pool)
+            .await
+            .unwrap();
+        }
+
+        let enabled = list_enabled(&ConfigDb::Postgres(pool)).await.unwrap();
+        let ids: Vec<&str> = enabled.iter().map(|b| b.id.as_str()).collect();
+        assert_eq!(ids, ["keep"]);
+        assert!(enabled[0].enabled);
     }
 }

--- a/crates/ruscker-admin/src/routes/admin/landing.rs
+++ b/crates/ruscker-admin/src/routes/admin/landing.rs
@@ -184,12 +184,12 @@ async fn render(
     flash_saved: bool,
     flash_error: Option<String>,
 ) -> Response {
-    let Some(pool) = state.sqlite() else {
+    let Some(database) = state.db.as_ref() else {
         return (StatusCode::SERVICE_UNAVAILABLE, "no db").into_response();
     };
     let form = match preset_form {
         Some(f) => f,
-        None => match db::landing::fetch(pool).await {
+        None => match db::landing::fetch(database).await {
             Ok(lc) => LandingForm::from_customization(&lc),
             Err(err) => {
                 tracing::error!(error = ?err, "landing fetch failed");

--- a/crates/ruscker-admin/src/routes/landing.rs
+++ b/crates/ruscker-admin/src/routes/landing.rs
@@ -99,8 +99,8 @@ async fn index(State(state): State<AppState>, loc: Locale, theme: Theme) -> Resp
     // Landing customization: read from DB when available
     // (admin-editable), fall back to the YAML-derived value
     // otherwise (Phase 1 / no-DB deployments).
-    let lc = match state.sqlite() {
-        Some(pool) => crate::db::landing::fetch(pool)
+    let lc = match state.db.as_ref() {
+        Some(db) => crate::db::landing::fetch(db)
             .await
             .unwrap_or_else(|err| {
                 tracing::warn!(error = ?err, "landing customization fetch failed; using YAML");
@@ -140,8 +140,8 @@ async fn index(State(state): State<AppState>, loc: Locale, theme: Theme) -> Resp
     // content can load.
     let (mut blocks_top, mut blocks_bottom) = (Vec::new(), Vec::new());
     let mut origins = not_blank(&lc.analytics_origins).unwrap_or_default();
-    if let Some(pool) = state.sqlite() {
-        match crate::db::landing_blocks::list_enabled(pool).await {
+    if let Some(db) = state.db.as_ref() {
+        match crate::db::landing_blocks::list_enabled(db).await {
             Ok(blocks) => {
                 for b in blocks {
                     if !b.csp_origins.trim().is_empty() {


### PR DESCRIPTION
First repositories ported through the `ConfigDb` seam — the public landing now renders from **either** backend. Both are reads, so no transactions or audit yet; this establishes the dual-dialect **read** pattern the heavier slices reuse.

## What's here
- **`landing::fetch(&ConfigDb)`** — the SELECT is placeholder-free and reads only TEXT columns, so one SQL string serves both backends; the `match` only swaps the pool.
- **`landing_blocks::list_enabled(&ConfigDb)`** — `enabled` is now read as `bool` (sqlx decodes SQLite's INTEGER 0/1 *and* Postgres' native BOOLEAN into one `Row` type), and the filter is a bare `WHERE enabled` (truthy on SQLite, a BOOLEAN test on Postgres) instead of `= 1`. `row_to_block` drops the `!= 0`; the un-ported `list_all`/`fetch_one` keep reading fine through the same `Row`.
- **Callers:** the public landing route passes the `ConfigDb`; the admin editor's `render` reads via it (its `save`/`update` write stays SQLite-only for now); `export::reconstruct_config` (SQLite-only) wraps its pool in `ConfigDb::Sqlite` to call the now-dual `fetch`.
- **Gated tests** (`--features postgres-it`): `fetch` returns the seeded singleton from real Postgres; `list_enabled` honours `WHERE enabled` against the native BOOLEAN column (raw-SQL inserts, since the write path isn't ported).

## Verification
- **317 default tests green**; edited files 0-drift.
- All four `postgres-it` tests pass against a real `postgres:16-alpine`:
  ```
  test db::landing::tests::fetch_against_real_postgres ... ok
  test db::landing_blocks::tests::list_enabled_against_real_postgres ... ok
  test db::pg_tests::pg_migrations_apply_and_match_sqlite_tables ... ok
  test sessions_pg::tests::end_to_end_against_real_postgres ... ok
  ```

Next: **7c-4** ports a transactional/write module (`specs` + `config_meta`, the catalog core) — the first to bring `Transaction<_>` and audit inserts across dialects.

🤖 Generated with [Claude Code](https://claude.com/claude-code)