### PR TITLE
Phase 7c-5: port credentials + images to dual-dialect (#128)

### DIFF
--- a/crates/ruscker-admin/src/db/credentials.rs
+++ b/crates/ruscker-admin/src/db/credentials.rs
@@ -9,10 +9,10 @@
 
 use anyhow::{Context, Result};
 use chrono::{DateTime, Utc};
-use sqlx::SqlitePool;
 use zeroize::Zeroizing;
 
 use crate::crypto::MasterKey;
+use crate::db::ConfigDb;
 
 /// Public-facing summary — no secrets. What the gallery sees.
 #[derive(Debug, Clone)]
@@ -27,7 +27,7 @@ pub struct CredentialMeta {
 /// the master key with a fresh nonce. Audit entry tagged with
 /// `actor`. Returns `true` if a prior row was replaced.
 pub async fn upsert(
-    pool: &SqlitePool,
+    db: &ConfigDb,
     key: &MasterKey,
     name: &str,
     registry: &str,
@@ -37,66 +37,123 @@ pub async fn upsert(
 ) -> Result<bool> {
     let now = Utc::now();
     let (ciphertext, nonce) = key.encrypt(password.as_bytes())?;
-
-    let mut tx = pool.begin().await.context("begin credential tx")?;
-
-    let existing: Option<(i64,)> =
-        sqlx::query_as("SELECT 1 FROM credentials WHERE name = ?")
-            .bind(name)
-            .fetch_optional(&mut *tx)
-            .await
-            .with_context(|| format!("lookup credential {name}"))?;
-    let replaced = existing.is_some();
-
-    sqlx::query(
-        "INSERT INTO credentials
-           (name, registry, username, password_enc, nonce, created_at)
-         VALUES (?, ?, ?, ?, ?, ?)
-         ON CONFLICT(name) DO UPDATE SET
-           registry = excluded.registry,
-           username = excluded.username,
-           password_enc = excluded.password_enc,
-           nonce = excluded.nonce",
-    )
-    .bind(name)
-    .bind(registry)
-    .bind(username)
-    .bind(&ciphertext)
-    .bind(&nonce)
-    .bind(now)
-    .execute(&mut *tx)
-    .await
-    .with_context(|| format!("insert credential {name}"))?;
-
-    sqlx::query(
-        "INSERT INTO audit_log (actor, action, target, diff_json, occurred_at)
-         VALUES (?, ?, ?, ?, ?)",
-    )
-    .bind(actor)
-    .bind(if replaced { "credential.update" } else { "credential.create" })
-    .bind(format!("credential:{name}"))
-    .bind(serde_json::to_string(&serde_json::json!({
+    // Metadata-only audit diff — never the password (see the
+    // `audit_log_never_records_the_password` test).
+    let diff = serde_json::to_string(&serde_json::json!({
         "registry": registry,
         "username": username,
-    }))?)
-    .bind(now)
-    .execute(&mut *tx)
-    .await
-    .context("audit credential upsert")?;
+    }))?;
+    let target = format!("credential:{name}");
 
-    tx.commit().await.context("commit credential tx")?;
-    Ok(replaced)
+    // `ON CONFLICT(name) DO UPDATE SET col = excluded.col` is the same
+    // on both backends — only the placeholders differ.
+    match db {
+        ConfigDb::Sqlite(pool) => {
+            let mut tx = pool.begin().await.context("begin credential tx")?;
+            let existing: Option<(String,)> =
+                sqlx::query_as("SELECT name FROM credentials WHERE name = ?")
+                    .bind(name)
+                    .fetch_optional(&mut *tx)
+                    .await
+                    .with_context(|| format!("lookup credential {name}"))?;
+            let replaced = existing.is_some();
+            sqlx::query(
+                "INSERT INTO credentials
+                   (name, registry, username, password_enc, nonce, created_at)
+                 VALUES (?, ?, ?, ?, ?, ?)
+                 ON CONFLICT(name) DO UPDATE SET
+                   registry = excluded.registry,
+                   username = excluded.username,
+                   password_enc = excluded.password_enc,
+                   nonce = excluded.nonce",
+            )
+            .bind(name)
+            .bind(registry)
+            .bind(username)
+            .bind(&ciphertext)
+            .bind(&nonce)
+            .bind(now)
+            .execute(&mut *tx)
+            .await
+            .with_context(|| format!("insert credential {name}"))?;
+            sqlx::query(
+                "INSERT INTO audit_log (actor, action, target, diff_json, occurred_at)
+                 VALUES (?, ?, ?, ?, ?)",
+            )
+            .bind(actor)
+            .bind(if replaced {
+                "credential.update"
+            } else {
+                "credential.create"
+            })
+            .bind(&target)
+            .bind(&diff)
+            .bind(now)
+            .execute(&mut *tx)
+            .await
+            .context("audit credential upsert")?;
+            tx.commit().await.context("commit credential tx")?;
+            Ok(replaced)
+        }
+        ConfigDb::Postgres(pool) => {
+            let mut tx = pool.begin().await.context("begin credential tx")?;
+            let existing: Option<(String,)> =
+                sqlx::query_as("SELECT name FROM credentials WHERE name = $1")
+                    .bind(name)
+                    .fetch_optional(&mut *tx)
+                    .await
+                    .with_context(|| format!("lookup credential {name}"))?;
+            let replaced = existing.is_some();
+            sqlx::query(
+                "INSERT INTO credentials
+                   (name, registry, username, password_enc, nonce, created_at)
+                 VALUES ($1, $2, $3, $4, $5, $6)
+                 ON CONFLICT(name) DO UPDATE SET
+                   registry = excluded.registry,
+                   username = excluded.username,
+                   password_enc = excluded.password_enc,
+                   nonce = excluded.nonce",
+            )
+            .bind(name)
+            .bind(registry)
+            .bind(username)
+            .bind(&ciphertext)
+            .bind(&nonce)
+            .bind(now)
+            .execute(&mut *tx)
+            .await
+            .with_context(|| format!("insert credential {name}"))?;
+            sqlx::query(
+                "INSERT INTO audit_log (actor, action, target, diff_json, occurred_at)
+                 VALUES ($1, $2, $3, $4, $5)",
+            )
+            .bind(actor)
+            .bind(if replaced {
+                "credential.update"
+            } else {
+                "credential.create"
+            })
+            .bind(&target)
+            .bind(&diff)
+            .bind(now)
+            .execute(&mut *tx)
+            .await
+            .context("audit credential upsert")?;
+            tx.commit().await.context("commit credential tx")?;
+            Ok(replaced)
+        }
+    }
 }
 
 /// List every credential — names, usernames, registries only.
-pub async fn list_all(pool: &SqlitePool) -> Result<Vec<CredentialMeta>> {
-    let rows: Vec<(String, String, String, DateTime<Utc>)> = sqlx::query_as(
-        "SELECT name, registry, username, created_at
+pub async fn list_all(db: &ConfigDb) -> Result<Vec<CredentialMeta>> {
+    let sql = "SELECT name, registry, username, created_at
            FROM credentials
-          ORDER BY name ASC",
-    )
-    .fetch_all(pool)
-    .await
+          ORDER BY name ASC";
+    let rows: Vec<(String, String, String, DateTime<Utc>)> = match db {
+        ConfigDb::Sqlite(pool) => sqlx::query_as(sql).fetch_all(pool).await,
+        ConfigDb::Postgres(pool) => sqlx::query_as(sql).fetch_all(pool).await,
+    }
     .context("list credentials")?;
     Ok(rows
         .into_iter()
@@ -119,16 +176,24 @@ pub async fn list_all(pool: &SqlitePool) -> Result<Vec<CredentialMeta>> {
 /// encrypt/decrypt path; it's called from the spawn path, never
 /// from a UI handler.
 pub async fn resolve(
-    pool: &SqlitePool,
+    db: &ConfigDb,
     key: &MasterKey,
     name: &str,
 ) -> Result<Option<ruscker_core::RegistryCredentials>> {
-    let row: Option<(String, String, Vec<u8>, Vec<u8>)> = sqlx::query_as(
-        "SELECT registry, username, password_enc, nonce FROM credentials WHERE name = ?",
-    )
-    .bind(name)
-    .fetch_optional(pool)
-    .await
+    let row: Option<(String, String, Vec<u8>, Vec<u8>)> = match db {
+        ConfigDb::Sqlite(pool) => sqlx::query_as(
+            "SELECT registry, username, password_enc, nonce FROM credentials WHERE name = ?",
+        )
+        .bind(name)
+        .fetch_optional(pool)
+        .await,
+        ConfigDb::Postgres(pool) => sqlx::query_as(
+            "SELECT registry, username, password_enc, nonce FROM credentials WHERE name = $1",
+        )
+        .bind(name)
+        .fetch_optional(pool)
+        .await,
+    }
     .with_context(|| format!("resolve credential {name}"))?;
     match row {
         None => Ok(None),
@@ -157,16 +222,25 @@ pub async fn resolve(
 /// runtime when pulling an image; **not** exposed in the UI.
 /// Returns `None` if the name doesn't exist.
 pub async fn fetch_password(
-    pool: &SqlitePool,
+    db: &ConfigDb,
     key: &MasterKey,
     name: &str,
 ) -> Result<Option<Zeroizing<String>>> {
-    let row: Option<(Vec<u8>, Vec<u8>)> =
-        sqlx::query_as("SELECT password_enc, nonce FROM credentials WHERE name = ?")
-            .bind(name)
-            .fetch_optional(pool)
-            .await
-            .with_context(|| format!("fetch credential {name}"))?;
+    let row: Option<(Vec<u8>, Vec<u8>)> = match db {
+        ConfigDb::Sqlite(pool) => {
+            sqlx::query_as("SELECT password_enc, nonce FROM credentials WHERE name = ?")
+                .bind(name)
+                .fetch_optional(pool)
+                .await
+        }
+        ConfigDb::Postgres(pool) => {
+            sqlx::query_as("SELECT password_enc, nonce FROM credentials WHERE name = $1")
+                .bind(name)
+                .fetch_optional(pool)
+                .await
+        }
+    }
+    .with_context(|| format!("fetch credential {name}"))?;
     match row {
         None => Ok(None),
         Some((enc, nonce)) => {
@@ -178,29 +252,57 @@ pub async fn fetch_password(
     }
 }
 
-pub async fn delete_one(pool: &SqlitePool, name: &str, actor: Option<&str>) -> Result<bool> {
+pub async fn delete_one(db: &ConfigDb, name: &str, actor: Option<&str>) -> Result<bool> {
     let now = Utc::now();
-    let mut tx = pool.begin().await.context("begin credential delete tx")?;
-    let rows = sqlx::query("DELETE FROM credentials WHERE name = ?")
-        .bind(name)
-        .execute(&mut *tx)
-        .await
-        .with_context(|| format!("delete credential {name}"))?;
-    let removed = rows.rows_affected() > 0;
-    if removed {
-        sqlx::query(
-            "INSERT INTO audit_log (actor, action, target, diff_json, occurred_at)
-             VALUES (?, 'credential.delete', ?, '{}', ?)",
-        )
-        .bind(actor)
-        .bind(format!("credential:{name}"))
-        .bind(now)
-        .execute(&mut *tx)
-        .await
-        .context("audit credential.delete")?;
+    let target = format!("credential:{name}");
+    match db {
+        ConfigDb::Sqlite(pool) => {
+            let mut tx = pool.begin().await.context("begin credential delete tx")?;
+            let rows = sqlx::query("DELETE FROM credentials WHERE name = ?")
+                .bind(name)
+                .execute(&mut *tx)
+                .await
+                .with_context(|| format!("delete credential {name}"))?;
+            let removed = rows.rows_affected() > 0;
+            if removed {
+                sqlx::query(
+                    "INSERT INTO audit_log (actor, action, target, diff_json, occurred_at)
+                     VALUES (?, 'credential.delete', ?, '{}', ?)",
+                )
+                .bind(actor)
+                .bind(&target)
+                .bind(now)
+                .execute(&mut *tx)
+                .await
+                .context("audit credential.delete")?;
+            }
+            tx.commit().await.context("commit credential delete")?;
+            Ok(removed)
+        }
+        ConfigDb::Postgres(pool) => {
+            let mut tx = pool.begin().await.context("begin credential delete tx")?;
+            let rows = sqlx::query("DELETE FROM credentials WHERE name = $1")
+                .bind(name)
+                .execute(&mut *tx)
+                .await
+                .with_context(|| format!("delete credential {name}"))?;
+            let removed = rows.rows_affected() > 0;
+            if removed {
+                sqlx::query(
+                    "INSERT INTO audit_log (actor, action, target, diff_json, occurred_at)
+                     VALUES ($1, 'credential.delete', $2, '{}', $3)",
+                )
+                .bind(actor)
+                .bind(&target)
+                .bind(now)
+                .execute(&mut *tx)
+                .await
+                .context("audit credential.delete")?;
+            }
+            tx.commit().await.context("commit credential delete")?;
+            Ok(removed)
+        }
     }
-    tx.commit().await.context("commit credential delete")?;
-    Ok(removed)
 }
 
 #[cfg(test)]
@@ -215,22 +317,24 @@ mod tests {
     #[tokio::test]
     async fn upsert_then_fetch_round_trip() {
         let pool = open_memory().await.unwrap();
+        let db = ConfigDb::Sqlite(pool.clone());
         let key = fixed_key();
-        upsert(&pool, &key, "docker-hub", "docker.io", "acme", "hunter2", Some("admin"))
+        upsert(&db, &key, "docker-hub", "docker.io", "acme", "hunter2", Some("admin"))
             .await
             .unwrap();
-        let pw = fetch_password(&pool, &key, "docker-hub").await.unwrap();
+        let pw = fetch_password(&db, &key, "docker-hub").await.unwrap();
         assert_eq!(pw.unwrap().as_str(), "hunter2");
     }
 
     #[tokio::test]
     async fn list_does_not_contain_passwords() {
         let pool = open_memory().await.unwrap();
+        let db = ConfigDb::Sqlite(pool.clone());
         let key = fixed_key();
-        upsert(&pool, &key, "dh", "docker.io", "acme", "topsecret", None)
+        upsert(&db, &key, "dh", "docker.io", "acme", "topsecret", None)
             .await
             .unwrap();
-        let metas = list_all(&pool).await.unwrap();
+        let metas = list_all(&db).await.unwrap();
         assert_eq!(metas.len(), 1);
         assert_eq!(metas[0].name, "dh");
         assert_eq!(metas[0].username, "acme");
@@ -241,9 +345,10 @@ mod tests {
     #[tokio::test]
     async fn audit_log_never_records_the_password() {
         let pool = open_memory().await.unwrap();
+        let db = ConfigDb::Sqlite(pool.clone());
         let key = fixed_key();
         upsert(
-            &pool,
+            &db,
             &key,
             "dh",
             "docker.io",
@@ -271,31 +376,34 @@ mod tests {
     #[tokio::test]
     async fn upsert_replaces_password() {
         let pool = open_memory().await.unwrap();
+        let db = ConfigDb::Sqlite(pool.clone());
         let key = fixed_key();
-        upsert(&pool, &key, "dh", "docker.io", "acme", "old", None).await.unwrap();
-        let replaced = upsert(&pool, &key, "dh", "docker.io", "acme", "new", None).await.unwrap();
+        upsert(&db, &key, "dh", "docker.io", "acme", "old", None).await.unwrap();
+        let replaced = upsert(&db, &key, "dh", "docker.io", "acme", "new", None).await.unwrap();
         assert!(replaced);
-        let pw = fetch_password(&pool, &key, "dh").await.unwrap().unwrap();
+        let pw = fetch_password(&db, &key, "dh").await.unwrap().unwrap();
         assert_eq!(pw.as_str(), "new");
     }
 
     #[tokio::test]
     async fn delete_then_fetch_returns_none() {
         let pool = open_memory().await.unwrap();
+        let db = ConfigDb::Sqlite(pool.clone());
         let key = fixed_key();
-        upsert(&pool, &key, "dh", "docker.io", "acme", "x", None).await.unwrap();
-        assert!(delete_one(&pool, "dh", None).await.unwrap());
-        assert!(fetch_password(&pool, &key, "dh").await.unwrap().is_none());
+        upsert(&db, &key, "dh", "docker.io", "acme", "x", None).await.unwrap();
+        assert!(delete_one(&db, "dh", None).await.unwrap());
+        assert!(fetch_password(&db, &key, "dh").await.unwrap().is_none());
     }
 
     #[tokio::test]
     async fn resolve_returns_full_credential() {
         let pool = open_memory().await.unwrap();
+        let db = ConfigDb::Sqlite(pool.clone());
         let key = fixed_key();
-        upsert(&pool, &key, "priv", "registry.example.com", "bot", "hunter2", None)
+        upsert(&db, &key, "priv", "registry.example.com", "bot", "hunter2", None)
             .await
             .unwrap();
-        let c = resolve(&pool, &key, "priv").await.unwrap().expect("resolved");
+        let c = resolve(&db, &key, "priv").await.unwrap().expect("resolved");
         assert_eq!(c.username, "bot");
         assert_eq!(c.password, "hunter2");
         assert_eq!(c.server_address.as_deref(), Some("registry.example.com"));
@@ -304,16 +412,58 @@ mod tests {
     #[tokio::test]
     async fn resolve_empty_registry_means_docker_hub() {
         let pool = open_memory().await.unwrap();
+        let db = ConfigDb::Sqlite(pool.clone());
         let key = fixed_key();
-        upsert(&pool, &key, "hub", "", "bot", "pw", None).await.unwrap();
-        let c = resolve(&pool, &key, "hub").await.unwrap().unwrap();
+        upsert(&db, &key, "hub", "", "bot", "pw", None).await.unwrap();
+        let c = resolve(&db, &key, "hub").await.unwrap().unwrap();
         assert!(c.server_address.is_none(), "empty registry -> Docker Hub default");
     }
 
     #[tokio::test]
     async fn resolve_unknown_name_is_none() {
         let pool = open_memory().await.unwrap();
+        let db = ConfigDb::Sqlite(pool.clone());
         let key = fixed_key();
-        assert!(resolve(&pool, &key, "nope").await.unwrap().is_none());
+        assert!(resolve(&db, &key, "nope").await.unwrap().is_none());
+    }
+
+    // Encrypt/replace/decrypt/resolve/delete through the
+    // `ConfigDb::Postgres` arm against a real daemon (BYTEA round-trip +
+    // `ON CONFLICT`). Gated on `postgres-it`.
+    #[cfg(feature = "postgres-it")]
+    #[tokio::test]
+    async fn credentials_against_real_postgres() {
+        let url = std::env::var("RUSCKER_TEST_PG_URL")
+            .expect("set RUSCKER_TEST_PG_URL to a reachable postgres:// DSN");
+        let pool = crate::db::open_pg(&url).await.unwrap();
+        sqlx::query("DELETE FROM credentials")
+            .execute(&pool)
+            .await
+            .unwrap();
+        let db = ConfigDb::Postgres(pool);
+        let key = fixed_key();
+
+        assert!(
+            !upsert(&db, &key, "dh", "docker.io", "acme", "s3cret", Some("admin"))
+                .await
+                .unwrap(),
+            "first upsert inserts"
+        );
+        assert!(
+            upsert(&db, &key, "dh", "docker.io", "acme2", "s3cret2", Some("admin"))
+                .await
+                .unwrap(),
+            "second upsert replaces"
+        );
+        assert_eq!(
+            fetch_password(&db, &key, "dh").await.unwrap().unwrap().as_str(),
+            "s3cret2"
+        );
+        let c = resolve(&db, &key, "dh").await.unwrap().unwrap();
+        assert_eq!(c.username, "acme2");
+        assert_eq!(c.server_address.as_deref(), Some("docker.io"));
+        assert_eq!(list_all(&db).await.unwrap().len(), 1);
+        assert!(delete_one(&db, "dh", Some("admin")).await.unwrap());
+        assert!(fetch_password(&db, &key, "dh").await.unwrap().is_none());
     }
 }

--- a/crates/ruscker-admin/src/db/images.rs
+++ b/crates/ruscker-admin/src/db/images.rs
@@ -12,9 +12,9 @@
 
 use anyhow::{Context, Result};
 use chrono::{DateTime, Utc};
-use sqlx::SqlitePool;
 use uuid::Uuid;
 
+use crate::db::ConfigDb;
 use crate::images::Processed;
 
 /// Soft limit warned about (not enforced) on encoded image size.
@@ -38,82 +38,132 @@ pub struct ImageMeta {
 /// Idempotent on filename: re-uploading the same filename
 /// **replaces** the existing row (and the prior bytes are gone —
 /// we don't keep image history, only spec history).
-pub async fn insert(pool: &SqlitePool, processed: Processed, actor: Option<&str>) -> Result<String> {
+pub async fn insert(db: &ConfigDb, processed: Processed, actor: Option<&str>) -> Result<String> {
     let now = Utc::now();
-    let mut tx = pool.begin().await.context("begin image insert tx")?;
-
-    // Remove any prior row with the same filename so the new
-    // upload wins. We could UPSERT with the same id but reusing
-    // ids across content is worse for cache headers downstream.
-    sqlx::query("DELETE FROM images WHERE filename = ?")
-        .bind(&processed.filename)
-        .execute(&mut *tx)
-        .await
-        .with_context(|| format!("delete prior image {}", processed.filename))?;
-
     let id = Uuid::new_v4().to_string();
-    sqlx::query(
-        "INSERT INTO images
-           (id, filename, mime_type, size_bytes, blob, width, height, uploaded_at)
-         VALUES (?, ?, ?, ?, ?, ?, ?, ?)",
-    )
-    .bind(&id)
-    .bind(&processed.filename)
-    .bind(&processed.mime_type)
-    .bind(processed.bytes.len() as i64)
-    .bind(&processed.bytes)
-    .bind(processed.width.map(|n| n as i64))
-    .bind(processed.height.map(|n| n as i64))
-    .bind(now)
-    .execute(&mut *tx)
-    .await
-    .with_context(|| format!("insert image {}", processed.filename))?;
-
-    sqlx::query(
-        "INSERT INTO audit_log (actor, action, target, diff_json, occurred_at)
-         VALUES (?, 'image.upload', ?, ?, ?)",
-    )
-    .bind(actor)
-    .bind(format!("image:{id}"))
-    .bind(serde_json::to_string(&serde_json::json!({
+    let target = format!("image:{id}");
+    let diff = serde_json::to_string(&serde_json::json!({
         "filename": processed.filename,
         "mime": processed.mime_type,
         "size": processed.bytes.len(),
-    }))?)
-    .bind(now)
-    .execute(&mut *tx)
-    .await
-    .context("audit image.upload")?;
+    }))?;
+    let size = processed.bytes.len() as i64;
+    let width = processed.width.map(|n| n as i64);
+    let height = processed.height.map(|n| n as i64);
 
-    tx.commit().await.context("commit image insert")?;
+    // Replace any prior row with the same filename so the new upload
+    // wins (we don't keep image history, only spec history).
+    match db {
+        ConfigDb::Sqlite(pool) => {
+            let mut tx = pool.begin().await.context("begin image insert tx")?;
+            sqlx::query("DELETE FROM images WHERE filename = ?")
+                .bind(&processed.filename)
+                .execute(&mut *tx)
+                .await
+                .with_context(|| format!("delete prior image {}", processed.filename))?;
+            sqlx::query(
+                "INSERT INTO images
+                   (id, filename, mime_type, size_bytes, blob, width, height, uploaded_at)
+                 VALUES (?, ?, ?, ?, ?, ?, ?, ?)",
+            )
+            .bind(&id)
+            .bind(&processed.filename)
+            .bind(&processed.mime_type)
+            .bind(size)
+            .bind(&processed.bytes)
+            .bind(width)
+            .bind(height)
+            .bind(now)
+            .execute(&mut *tx)
+            .await
+            .with_context(|| format!("insert image {}", processed.filename))?;
+            sqlx::query(
+                "INSERT INTO audit_log (actor, action, target, diff_json, occurred_at)
+                 VALUES (?, 'image.upload', ?, ?, ?)",
+            )
+            .bind(actor)
+            .bind(&target)
+            .bind(&diff)
+            .bind(now)
+            .execute(&mut *tx)
+            .await
+            .context("audit image.upload")?;
+            tx.commit().await.context("commit image insert")?;
+        }
+        ConfigDb::Postgres(pool) => {
+            let mut tx = pool.begin().await.context("begin image insert tx")?;
+            sqlx::query("DELETE FROM images WHERE filename = $1")
+                .bind(&processed.filename)
+                .execute(&mut *tx)
+                .await
+                .with_context(|| format!("delete prior image {}", processed.filename))?;
+            sqlx::query(
+                "INSERT INTO images
+                   (id, filename, mime_type, size_bytes, blob, width, height, uploaded_at)
+                 VALUES ($1, $2, $3, $4, $5, $6, $7, $8)",
+            )
+            .bind(&id)
+            .bind(&processed.filename)
+            .bind(&processed.mime_type)
+            .bind(size)
+            .bind(&processed.bytes)
+            .bind(width)
+            .bind(height)
+            .bind(now)
+            .execute(&mut *tx)
+            .await
+            .with_context(|| format!("insert image {}", processed.filename))?;
+            sqlx::query(
+                "INSERT INTO audit_log (actor, action, target, diff_json, occurred_at)
+                 VALUES ($1, 'image.upload', $2, $3, $4)",
+            )
+            .bind(actor)
+            .bind(&target)
+            .bind(&diff)
+            .bind(now)
+            .execute(&mut *tx)
+            .await
+            .context("audit image.upload")?;
+            tx.commit().await.context("commit image insert")?;
+        }
+    }
     Ok(id)
 }
 
 /// Fetch the bytes + MIME of an image by **filename**. This is the
 /// public lookup hit by `GET /assets/img/<filename>`.
 pub async fn fetch_by_filename(
-    pool: &SqlitePool,
+    db: &ConfigDb,
     filename: &str,
 ) -> Result<Option<(String, Vec<u8>)>> {
-    let row: Option<(String, Vec<u8>)> =
-        sqlx::query_as("SELECT mime_type, blob FROM images WHERE filename = ?")
-            .bind(filename)
-            .fetch_optional(pool)
-            .await
-            .with_context(|| format!("fetch image {filename}"))?;
+    let row: Option<(String, Vec<u8>)> = match db {
+        ConfigDb::Sqlite(pool) => {
+            sqlx::query_as("SELECT mime_type, blob FROM images WHERE filename = ?")
+                .bind(filename)
+                .fetch_optional(pool)
+                .await
+        }
+        ConfigDb::Postgres(pool) => {
+            sqlx::query_as("SELECT mime_type, blob FROM images WHERE filename = $1")
+                .bind(filename)
+                .fetch_optional(pool)
+                .await
+        }
+    }
+    .with_context(|| format!("fetch image {filename}"))?;
     Ok(row)
 }
 
 /// Gallery listing — every uploaded image, newest first.
-pub async fn list_all(pool: &SqlitePool) -> Result<Vec<ImageMeta>> {
-    let rows: Vec<(String, String, String, i64, Option<i64>, Option<i64>, DateTime<Utc>)> =
-        sqlx::query_as(
-            "SELECT id, filename, mime_type, size_bytes, width, height, uploaded_at
+pub async fn list_all(db: &ConfigDb) -> Result<Vec<ImageMeta>> {
+    let sql = "SELECT id, filename, mime_type, size_bytes, width, height, uploaded_at
                FROM images
-              ORDER BY uploaded_at DESC, filename ASC",
-        )
-        .fetch_all(pool)
-        .await
+              ORDER BY uploaded_at DESC, filename ASC";
+    let rows: Vec<(String, String, String, i64, Option<i64>, Option<i64>, DateTime<Utc>)> =
+        match db {
+            ConfigDb::Sqlite(pool) => sqlx::query_as(sql).fetch_all(pool).await,
+            ConfigDb::Postgres(pool) => sqlx::query_as(sql).fetch_all(pool).await,
+        }
         .context("list images")?;
     Ok(rows
         .into_iter()
@@ -133,41 +183,121 @@ pub async fn list_all(pool: &SqlitePool) -> Result<Vec<ImageMeta>> {
 
 /// Delete by id. Returns true if a row was removed. Audit row is
 /// written on either branch (an attempted delete is an event).
-pub async fn delete_one(pool: &SqlitePool, id: &str, actor: Option<&str>) -> Result<bool> {
+pub async fn delete_one(db: &ConfigDb, id: &str, actor: Option<&str>) -> Result<bool> {
     let now = Utc::now();
-    let mut tx = pool.begin().await.context("begin image delete tx")?;
-
-    // Capture filename for the audit diff before deletion.
-    let filename: Option<(String,)> = sqlx::query_as("SELECT filename FROM images WHERE id = ?")
-        .bind(id)
-        .fetch_optional(&mut *tx)
-        .await
-        .context("lookup image for delete")?;
-
-    let rows = sqlx::query("DELETE FROM images WHERE id = ?")
-        .bind(id)
-        .execute(&mut *tx)
-        .await
-        .with_context(|| format!("delete image {id}"))?;
-    let removed = rows.rows_affected() > 0;
-
-    if removed {
-        let diff = filename
-            .as_ref()
-            .map(|(f,)| serde_json::json!({ "filename": f }))
-            .unwrap_or_else(|| serde_json::json!({}));
-        sqlx::query(
-            "INSERT INTO audit_log (actor, action, target, diff_json, occurred_at)
-             VALUES (?, 'image.delete', ?, ?, ?)",
-        )
-        .bind(actor)
-        .bind(format!("image:{id}"))
-        .bind(serde_json::to_string(&diff)?)
-        .bind(now)
-        .execute(&mut *tx)
-        .await
-        .context("audit image.delete")?;
+    let target = format!("image:{id}");
+    match db {
+        ConfigDb::Sqlite(pool) => {
+            let mut tx = pool.begin().await.context("begin image delete tx")?;
+            // Capture filename for the audit diff before deletion.
+            let filename: Option<(String,)> =
+                sqlx::query_as("SELECT filename FROM images WHERE id = ?")
+                    .bind(id)
+                    .fetch_optional(&mut *tx)
+                    .await
+                    .context("lookup image for delete")?;
+            let rows = sqlx::query("DELETE FROM images WHERE id = ?")
+                .bind(id)
+                .execute(&mut *tx)
+                .await
+                .with_context(|| format!("delete image {id}"))?;
+            let removed = rows.rows_affected() > 0;
+            if removed {
+                sqlx::query(
+                    "INSERT INTO audit_log (actor, action, target, diff_json, occurred_at)
+                     VALUES (?, 'image.delete', ?, ?, ?)",
+                )
+                .bind(actor)
+                .bind(&target)
+                .bind(serde_json::to_string(&delete_diff(filename.as_ref()))?)
+                .bind(now)
+                .execute(&mut *tx)
+                .await
+                .context("audit image.delete")?;
+            }
+            tx.commit().await.context("commit image delete")?;
+            Ok(removed)
+        }
+        ConfigDb::Postgres(pool) => {
+            let mut tx = pool.begin().await.context("begin image delete tx")?;
+            let filename: Option<(String,)> =
+                sqlx::query_as("SELECT filename FROM images WHERE id = $1")
+                    .bind(id)
+                    .fetch_optional(&mut *tx)
+                    .await
+                    .context("lookup image for delete")?;
+            let rows = sqlx::query("DELETE FROM images WHERE id = $1")
+                .bind(id)
+                .execute(&mut *tx)
+                .await
+                .with_context(|| format!("delete image {id}"))?;
+            let removed = rows.rows_affected() > 0;
+            if removed {
+                sqlx::query(
+                    "INSERT INTO audit_log (actor, action, target, diff_json, occurred_at)
+                     VALUES ($1, 'image.delete', $2, $3, $4)",
+                )
+                .bind(actor)
+                .bind(&target)
+                .bind(serde_json::to_string(&delete_diff(filename.as_ref()))?)
+                .bind(now)
+                .execute(&mut *tx)
+                .await
+                .context("audit image.delete")?;
+            }
+            tx.commit().await.context("commit image delete")?;
+            Ok(removed)
+        }
     }
-    tx.commit().await.context("commit image delete")?;
-    Ok(removed)
+}
+
+/// Audit diff for a delete — the filename if we captured one, else
+/// an empty object.
+fn delete_diff(filename: Option<&(String,)>) -> serde_json::Value {
+    match filename {
+        Some((f,)) => serde_json::json!({ "filename": f }),
+        None => serde_json::json!({}),
+    }
+}
+
+#[cfg(all(test, feature = "postgres-it"))]
+mod pg_tests {
+    use super::*;
+
+    // insert (BYTEA blob) → fetch_by_filename → list_all → delete,
+    // through the `ConfigDb::Postgres` arm against a real daemon.
+    #[tokio::test]
+    async fn images_against_real_postgres() {
+        let url = std::env::var("RUSCKER_TEST_PG_URL")
+            .expect("set RUSCKER_TEST_PG_URL to a reachable postgres:// DSN");
+        let pool = crate::db::open_pg(&url).await.unwrap();
+        sqlx::query("DELETE FROM images")
+            .execute(&pool)
+            .await
+            .unwrap();
+        let db = ConfigDb::Postgres(pool);
+
+        let processed = Processed {
+            filename: "logo.webp".into(),
+            mime_type: "image/webp".into(),
+            bytes: vec![0xDE, 0xAD, 0xBE, 0xEF],
+            width: Some(48),
+            height: Some(48),
+        };
+        let id = insert(&db, processed, Some("admin")).await.unwrap();
+        assert!(!id.is_empty());
+
+        let (mime, bytes) = fetch_by_filename(&db, "logo.webp").await.unwrap().unwrap();
+        assert_eq!(mime, "image/webp");
+        assert_eq!(bytes, vec![0xDE, 0xAD, 0xBE, 0xEF]);
+
+        let metas = list_all(&db).await.unwrap();
+        assert_eq!(metas.len(), 1);
+        assert_eq!(metas[0].filename, "logo.webp");
+        assert_eq!(metas[0].size_bytes, 4);
+        assert_eq!(metas[0].width, Some(48));
+
+        assert!(delete_one(&db, &id, Some("admin")).await.unwrap());
+        assert!(fetch_by_filename(&db, "logo.webp").await.unwrap().is_none());
+    }
 }

--- a/crates/ruscker-admin/src/routes/admin/credentials.rs
+++ b/crates/ruscker-admin/src/routes/admin/credentials.rs
@@ -67,7 +67,7 @@ async fn render_index(
     flash_saved: Option<String>,
     flash_error: Option<String>,
 ) -> Response {
-    let Some(pool) = state.sqlite() else {
+    let Some(pool) = state.db.as_ref() else {
         return (StatusCode::SERVICE_UNAVAILABLE, "no db").into_response();
     };
     let credentials = match db::credentials::list_all(pool).await {
@@ -107,7 +107,7 @@ async fn create_or_update(
     theme: Theme,
     Form(form): Form<CredentialForm>,
 ) -> Response {
-    let Some(pool) = state.sqlite() else {
+    let Some(pool) = state.db.as_ref() else {
         return (StatusCode::SERVICE_UNAVAILABLE, "no db").into_response();
     };
     if !state.master_key.is_configured() {
@@ -165,7 +165,7 @@ async fn delete(
     State(state): State<AppState>,
     Path(name): Path<String>,
 ) -> Response {
-    let Some(pool) = state.sqlite() else {
+    let Some(pool) = state.db.as_ref() else {
         return (StatusCode::SERVICE_UNAVAILABLE, "no db").into_response();
     };
     match db::credentials::delete_one(pool, &name, Some(admin.actor())).await {

--- a/crates/ruscker-admin/src/routes/admin/images.rs
+++ b/crates/ruscker-admin/src/routes/admin/images.rs
@@ -99,7 +99,7 @@ async fn render_index(
     flash_uploaded: Option<String>,
     flash_error: Option<String>,
 ) -> Response {
-    let Some(pool) = state.sqlite() else {
+    let Some(pool) = state.db.as_ref() else {
         return (
             StatusCode::SERVICE_UNAVAILABLE,
             "database not attached — start with --db <path>",
@@ -134,7 +134,7 @@ async fn upload(
     theme: Theme,
     mut multipart: Multipart,
 ) -> Response {
-    let Some(pool) = state.sqlite() else {
+    let Some(pool) = state.db.as_ref() else {
         return (StatusCode::SERVICE_UNAVAILABLE, "no db").into_response();
     };
 
@@ -205,7 +205,7 @@ async fn delete(
     State(state): State<AppState>,
     Path(id): Path<String>,
 ) -> Response {
-    let Some(pool) = state.sqlite() else {
+    let Some(pool) = state.db.as_ref() else {
         return (StatusCode::SERVICE_UNAVAILABLE, "no db").into_response();
     };
     match db::images::delete_one(pool, &id, Some(editor.actor())).await {

--- a/crates/ruscker-admin/src/routes/admin/spec_form.rs
+++ b/crates/ruscker-admin/src/routes/admin/spec_form.rs
@@ -490,7 +490,7 @@ impl<'a> SpecFormPage<'a> {
 /// Media-library filenames for the logo picker. Empty when no DB is
 /// wired or the query fails — the picker degrades to the text field.
 async fn logo_filenames(state: &AppState) -> Vec<String> {
-    match state.sqlite() {
+    match state.db.as_ref() {
         Some(pool) => db::images::list_all(pool)
             .await
             .map(|imgs| imgs.into_iter().map(|i| i.filename).collect())

--- a/crates/ruscker-admin/src/routes/assets.rs
+++ b/crates/ruscker-admin/src/routes/assets.rs
@@ -109,7 +109,7 @@ async fn serve_card_image(
     }
 
     // 1. DB lookup
-    if let Some(pool) = state.sqlite() {
+    if let Some(pool) = state.db.as_ref() {
         match crate::db::images::fetch_by_filename(pool, &filename).await {
             Ok(Some((mime, bytes))) => return serve_dynamic(bytes, &mime),
             Ok(None) => {}

--- a/crates/ruscker-admin/src/routes/proxy.rs
+++ b/crates/ruscker-admin/src/routes/proxy.rs
@@ -743,7 +743,7 @@ pub(crate) async fn resolve_creds(
         .as_deref()
         .filter(|s| !s.is_empty())
     {
-        match (state.sqlite(), state.master_key.is_configured()) {
+        match (state.db.as_ref(), state.master_key.is_configured()) {
             (Some(pool), true) => {
                 match crate::db::credentials::resolve(pool, &state.master_key, name).await {
                     Ok(Some(c)) => return Some(c),


### PR DESCRIPTION
Two more self-contained repositories through the `ConfigDb` seam. Both store binary blobs and one uses `ON CONFLICT` — exercises BYTEA round-trip and the upsert idiom across backends.

## What's here
- **`credentials`** (`upsert` / `list_all` / `resolve` / `fetch_password` / `delete_one`) take `&ConfigDb`. `ON CONFLICT(name) DO UPDATE SET col = excluded.col` is identical on both backends, so only the placeholders fork; the existence check switched from `SELECT 1` to `SELECT name` (a bare `1` is `INT4` on Postgres and won't decode into the `i64` the SQLite path used). AES-GCM ciphertext + nonce ride as `BYTEA` via `Vec<u8>`.
- **`images`** (`insert` / `fetch_by_filename` / `list_all` / `delete_one`) take `&ConfigDb`; the WebP blob is `BYTEA`. Extracted a tiny `delete_diff` helper shared by both arms.
- Callers updated: admin credentials/images routes, the public `/assets/img` lookup, `spec_form::logo_filenames`, and the spawn-path `credentials::resolve` in proxy.rs.
- **Gated tests** (`--features postgres-it`): credentials insert/replace/decrypt/resolve/delete and image insert/fetch/list/delete against real Postgres.

## Verification
- **317 default tests green**; edited files 0-drift.
- All seven `postgres-it` tests pass against a real `postgres:16-alpine`:
  ```
  test db::credentials::tests::credentials_against_real_postgres ... ok
  test db::images::pg_tests::images_against_real_postgres ... ok
  test db::specs::tests::spec_crud_against_real_postgres ... ok
  test db::landing::tests::fetch_against_real_postgres ... ok
  test db::landing_blocks::tests::list_enabled_against_real_postgres ... ok
  test db::pg_tests::pg_migrations_apply_and_match_sqlite_tables ... ok
  test sessions_pg::tests::end_to_end_against_real_postgres ... ok
  ```

Next: **7c-6** ports the `landing` / `landing_blocks` write paths (which unblocks `import_all`), then `users` and `audit` (`QueryBuilder<Postgres>`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)