### PR TITLE
Phase 7c-6: port landing + landing_blocks writes to dual-dialect (#128)

### DIFF
--- a/crates/ruscker-admin/src/db.rs
+++ b/crates/ruscker-admin/src/db.rs
@@ -121,6 +121,18 @@ pub async fn open_pg(url: &str) -> Result<sqlx::PgPool> {
     Ok(pool)
 }
 
+/// Serializes the `postgres-it` integration tests. They all run against
+/// one shared database, so cargo's default parallel test execution would
+/// let them clobber each other's rows (e.g. two tests that
+/// `DELETE FROM landing_blocks`, or a default-singleton read racing a
+/// singleton write). Every gated test takes this lock first, so they run
+/// one at a time regardless of `--test-threads`.
+#[cfg(all(test, feature = "postgres-it"))]
+pub(crate) fn pg_test_lock() -> &'static tokio::sync::Mutex<()> {
+    static LOCK: std::sync::OnceLock<tokio::sync::Mutex<()>> = std::sync::OnceLock::new();
+    LOCK.get_or_init(|| tokio::sync::Mutex::new(()))
+}
+
 /// Open an in-memory database for tests. Migrations applied.
 #[cfg(test)]
 pub async fn open_memory() -> Result<SqlitePool> {
@@ -156,6 +168,7 @@ mod pg_tests {
     //     cargo test -p ruscker-admin --features postgres-it -- --nocapture
     #[tokio::test]
     async fn pg_migrations_apply_and_match_sqlite_tables() {
+        let _guard = crate::db::pg_test_lock().lock().await;
         let url = std::env::var("RUSCKER_TEST_PG_URL")
             .expect("set RUSCKER_TEST_PG_URL to a reachable postgres:// DSN");
 

--- a/crates/ruscker-admin/src/db/credentials.rs
+++ b/crates/ruscker-admin/src/db/credentials.rs
@@ -433,6 +433,7 @@ mod tests {
     #[cfg(feature = "postgres-it")]
     #[tokio::test]
     async fn credentials_against_real_postgres() {
+        let _guard = crate::db::pg_test_lock().lock().await;
         let url = std::env::var("RUSCKER_TEST_PG_URL")
             .expect("set RUSCKER_TEST_PG_URL to a reachable postgres:// DSN");
         let pool = crate::db::open_pg(&url).await.unwrap();

--- a/crates/ruscker-admin/src/db/export.rs
+++ b/crates/ruscker-admin/src/db/export.rs
@@ -37,9 +37,9 @@ pub async fn reconstruct_config(pool: &SqlitePool) -> Result<Config> {
     // `fetch` is dual-dialect now; the export path is SQLite-only, so
     // wrap this pool in a `ConfigDb` to call it. (Cheap — the pool is
     // an `Arc` clone.)
-    let mut landing_customization =
-        super::landing::fetch(&super::ConfigDb::Sqlite(pool.clone())).await?;
-    landing_customization.blocks = super::landing_blocks::list_all(pool)
+    let cfgdb = super::ConfigDb::Sqlite(pool.clone());
+    let mut landing_customization = super::landing::fetch(&cfgdb).await?;
+    landing_customization.blocks = super::landing_blocks::list_all(&cfgdb)
         .await?
         .iter()
         .map(|b| b.to_config())

--- a/crates/ruscker-admin/src/db/images.rs
+++ b/crates/ruscker-admin/src/db/images.rs
@@ -268,6 +268,7 @@ mod pg_tests {
     // through the `ConfigDb::Postgres` arm against a real daemon.
     #[tokio::test]
     async fn images_against_real_postgres() {
+        let _guard = crate::db::pg_test_lock().lock().await;
         let url = std::env::var("RUSCKER_TEST_PG_URL")
             .expect("set RUSCKER_TEST_PG_URL to a reachable postgres:// DSN");
         let pool = crate::db::open_pg(&url).await.unwrap();

--- a/crates/ruscker-admin/src/db/landing.rs
+++ b/crates/ruscker-admin/src/db/landing.rs
@@ -9,7 +9,6 @@ use crate::db::ConfigDb;
 use anyhow::{Context, Result};
 use chrono::Utc;
 use ruscker_config::LandingCustomization;
-use sqlx::SqlitePool;
 
 /// Read the singleton row. Returns the default
 /// [`LandingCustomization`] when the row hasn't been initialized
@@ -78,25 +77,41 @@ pub async fn fetch(db: &ConfigDb) -> Result<LandingCustomization> {
 /// collapses them to `None` so empty values disappear from the
 /// exported YAML rather than serializing as `""`.
 pub async fn update(
-    pool: &SqlitePool,
+    db: &ConfigDb,
     lc: &LandingCustomization,
     actor: Option<&str>,
 ) -> Result<()> {
     let now = Utc::now();
-    let mut tx = pool.begin().await.context("begin landing update tx")?;
-    update_in_tx(&mut tx, lc, now).await?;
-
-    sqlx::query(
-        "INSERT INTO audit_log (actor, action, target, diff_json, occurred_at)
-         VALUES (?, 'landing.update', 'landing:customization', NULL, ?)",
-    )
-    .bind(actor)
-    .bind(now)
-    .execute(&mut *tx)
-    .await
-    .context("audit landing.update")?;
-
-    tx.commit().await.context("commit landing update")?;
+    match db {
+        ConfigDb::Sqlite(pool) => {
+            let mut tx = pool.begin().await.context("begin landing update tx")?;
+            update_in_tx(&mut tx, lc, now).await?;
+            sqlx::query(
+                "INSERT INTO audit_log (actor, action, target, diff_json, occurred_at)
+                 VALUES (?, 'landing.update', 'landing:customization', NULL, ?)",
+            )
+            .bind(actor)
+            .bind(now)
+            .execute(&mut *tx)
+            .await
+            .context("audit landing.update")?;
+            tx.commit().await.context("commit landing update")?;
+        }
+        ConfigDb::Postgres(pool) => {
+            let mut tx = pool.begin().await.context("begin landing update tx")?;
+            update_in_tx_pg(&mut tx, lc, now).await?;
+            sqlx::query(
+                "INSERT INTO audit_log (actor, action, target, diff_json, occurred_at)
+                 VALUES ($1, 'landing.update', 'landing:customization', NULL, $2)",
+            )
+            .bind(actor)
+            .bind(now)
+            .execute(&mut *tx)
+            .await
+            .context("audit landing.update")?;
+            tx.commit().await.context("commit landing update")?;
+        }
+    }
     Ok(())
 }
 
@@ -117,6 +132,40 @@ pub(crate) async fn update_in_tx(
                 intro_locales_json = ?, seo_title = ?, seo_description = ?,
                 og_image = ?, analytics_html = ?, analytics_origins = ?,
                 updated_at = ?
+          WHERE id = 1",
+    )
+    .bind(none_if_empty(&lc.header_bg))
+    .bind(none_if_empty(&lc.header_fg))
+    .bind(none_if_empty(&lc.intro))
+    .bind(&intro_locales_json)
+    .bind(none_if_empty(&lc.seo_title))
+    .bind(none_if_empty(&lc.seo_description))
+    .bind(none_if_empty(&lc.og_image))
+    .bind(none_if_empty(&lc.analytics_html))
+    .bind(none_if_empty(&lc.analytics_origins))
+    .bind(now)
+    .execute(&mut **tx)
+    .await
+    .context("update landing_customization")?;
+    Ok(())
+}
+
+/// Postgres twin of [`update_in_tx`] — `$n` placeholders. Used by the
+/// Postgres arm of [`update`]. (`import_all` stays SQLite-only and
+/// keeps `update_in_tx`.)
+pub(crate) async fn update_in_tx_pg(
+    tx: &mut sqlx::Transaction<'_, sqlx::Postgres>,
+    lc: &LandingCustomization,
+    now: chrono::DateTime<Utc>,
+) -> Result<()> {
+    let intro_locales_json =
+        serde_json::to_string(&lc.intro_locales).context("serialize intro_locales")?;
+    sqlx::query(
+        "UPDATE landing_customization
+            SET header_bg = $1, header_fg = $2, intro = $3,
+                intro_locales_json = $4, seo_title = $5, seo_description = $6,
+                og_image = $7, analytics_html = $8, analytics_origins = $9,
+                updated_at = $10
           WHERE id = 1",
     )
     .bind(none_if_empty(&lc.header_bg))
@@ -166,7 +215,7 @@ mod tests {
         lc.intro_locales.insert("pt".into(), "Bem-vindo".into());
         lc.intro_locales.insert("en".into(), "Welcome".into());
 
-        update(&pool, &lc, Some("admin")).await.unwrap();
+        update(&ConfigDb::Sqlite(pool.clone()), &lc, Some("admin")).await.unwrap();
         let got = fetch(&ConfigDb::Sqlite(pool.clone())).await.unwrap();
         assert_eq!(got.header_bg.as_deref(), Some("#0f6e56"));
         assert_eq!(got.header_fg.as_deref(), Some("#ffffff"));
@@ -190,7 +239,7 @@ mod tests {
         lc.seo_title = Some("Demo Portal".into());
         lc.seo_description = Some("Demo portal description".into());
         lc.og_image = Some("/assets/img/og.png".into());
-        update(&pool, &lc, Some("admin")).await.unwrap();
+        update(&ConfigDb::Sqlite(pool.clone()), &lc, Some("admin")).await.unwrap();
         let got = fetch(&ConfigDb::Sqlite(pool.clone())).await.unwrap();
         assert_eq!(got.seo_title.as_deref(), Some("Demo Portal"));
         assert_eq!(
@@ -208,7 +257,7 @@ mod tests {
         let mut lc = LandingCustomization::default();
         lc.analytics_html = Some(snippet.into());
         lc.analytics_origins = Some(origins.into());
-        update(&pool, &lc, Some("admin")).await.unwrap();
+        update(&ConfigDb::Sqlite(pool.clone()), &lc, Some("admin")).await.unwrap();
         let got = fetch(&ConfigDb::Sqlite(pool.clone())).await.unwrap();
         assert_eq!(got.analytics_html.as_deref(), Some(snippet));
         assert_eq!(got.analytics_origins.as_deref(), Some(origins));
@@ -220,7 +269,7 @@ mod tests {
         let mut lc = LandingCustomization::default();
         lc.header_bg = Some("   ".into()); // whitespace only
         lc.intro = Some("".into());
-        update(&pool, &lc, None).await.unwrap();
+        update(&ConfigDb::Sqlite(pool.clone()), &lc, None).await.unwrap();
         let got = fetch(&ConfigDb::Sqlite(pool.clone())).await.unwrap();
         assert!(got.header_bg.is_none(), "whitespace-only becomes None");
         assert!(got.intro.is_none());
@@ -233,6 +282,7 @@ mod tests {
     #[cfg(feature = "postgres-it")]
     #[tokio::test]
     async fn fetch_against_real_postgres() {
+        let _guard = crate::db::pg_test_lock().lock().await;
         let url = std::env::var("RUSCKER_TEST_PG_URL")
             .expect("set RUSCKER_TEST_PG_URL to a reachable postgres:// DSN");
         let pool = crate::db::open_pg(&url).await.unwrap();
@@ -241,5 +291,35 @@ mod tests {
         assert!(lc.header_bg.is_none());
         assert!(lc.intro.is_none());
         assert!(lc.intro_locales.is_empty());
+    }
+
+    // Writes the singleton through the Postgres arm, then reads it
+    // back (and confirms empty-string collapse). Gated on `postgres-it`.
+    #[cfg(feature = "postgres-it")]
+    #[tokio::test]
+    async fn update_then_fetch_against_real_postgres() {
+        let _guard = crate::db::pg_test_lock().lock().await;
+        let url = std::env::var("RUSCKER_TEST_PG_URL")
+            .expect("set RUSCKER_TEST_PG_URL to a reachable postgres:// DSN");
+        let db = ConfigDb::Postgres(crate::db::open_pg(&url).await.unwrap());
+
+        let mut lc = LandingCustomization::default();
+        lc.header_bg = Some("#0f6e56".into());
+        lc.intro = Some("Bem-vindo".into());
+        lc.seo_title = Some("Portal".into());
+        lc.intro_locales.insert("pt".into(), "Olá".into());
+        update(&db, &lc, Some("admin")).await.unwrap();
+
+        let got = fetch(&db).await.unwrap();
+        assert_eq!(got.header_bg.as_deref(), Some("#0f6e56"));
+        assert_eq!(got.intro.as_deref(), Some("Bem-vindo"));
+        assert_eq!(got.seo_title.as_deref(), Some("Portal"));
+        assert_eq!(got.intro_locales.get("pt").map(String::as_str), Some("Olá"));
+
+        // Whitespace-only collapses to NULL on write.
+        let mut empty = LandingCustomization::default();
+        empty.header_bg = Some("   ".into());
+        update(&db, &empty, None).await.unwrap();
+        assert!(fetch(&db).await.unwrap().header_bg.is_none());
     }
 }

--- a/crates/ruscker-admin/src/db/landing_blocks.rs
+++ b/crates/ruscker-admin/src/db/landing_blocks.rs
@@ -10,7 +10,6 @@
 use crate::db::ConfigDb;
 use anyhow::{Context, Result};
 use chrono::Utc;
-use sqlx::SqlitePool;
 
 /// The two slots a block can live in. Stored as the lowercase string.
 pub const SLOTS: &[&str] = &["top", "bottom"];
@@ -57,13 +56,13 @@ fn row_to_block((id, slot, position, enabled, title, html, csp_origins): Row) ->
 }
 
 /// All blocks, ordered by slot then position — for the admin list.
-pub async fn list_all(pool: &SqlitePool) -> Result<Vec<LandingBlock>> {
-    let rows: Vec<Row> = sqlx::query_as(
-        "SELECT id, slot, position, enabled, title, html, csp_origins
-           FROM landing_blocks ORDER BY slot, position, created_at",
-    )
-    .fetch_all(pool)
-    .await
+pub async fn list_all(db: &ConfigDb) -> Result<Vec<LandingBlock>> {
+    let sql = "SELECT id, slot, position, enabled, title, html, csp_origins
+           FROM landing_blocks ORDER BY slot, position, created_at";
+    let rows: Vec<Row> = match db {
+        ConfigDb::Sqlite(pool) => sqlx::query_as(sql).fetch_all(pool).await,
+        ConfigDb::Postgres(pool) => sqlx::query_as(sql).fetch_all(pool).await,
+    }
     .context("list landing_blocks")?;
     Ok(rows.into_iter().map(row_to_block).collect())
 }
@@ -86,52 +85,94 @@ pub async fn list_enabled(db: &ConfigDb) -> Result<Vec<LandingBlock>> {
 }
 
 /// One block by id, or `None`.
-pub async fn fetch_one(pool: &SqlitePool, id: &str) -> Result<Option<LandingBlock>> {
-    let row: Option<Row> = sqlx::query_as(
-        "SELECT id, slot, position, enabled, title, html, csp_origins
-           FROM landing_blocks WHERE id = ?",
-    )
-    .bind(id)
-    .fetch_optional(pool)
-    .await
+pub async fn fetch_one(db: &ConfigDb, id: &str) -> Result<Option<LandingBlock>> {
+    let row: Option<Row> = match db {
+        ConfigDb::Sqlite(pool) => sqlx::query_as(
+            "SELECT id, slot, position, enabled, title, html, csp_origins
+               FROM landing_blocks WHERE id = ?",
+        )
+        .bind(id)
+        .fetch_optional(pool)
+        .await,
+        ConfigDb::Postgres(pool) => sqlx::query_as(
+            "SELECT id, slot, position, enabled, title, html, csp_origins
+               FROM landing_blocks WHERE id = $1",
+        )
+        .bind(id)
+        .fetch_optional(pool)
+        .await,
+    }
     .context("fetch landing_block")?;
     Ok(row.map(row_to_block))
 }
 
 /// Create a block, appended at the end of its slot. Returns the new id.
-pub async fn insert(pool: &SqlitePool, input: &BlockInput, actor: Option<&str>) -> Result<String> {
+///
+/// `enabled` binds as `bool` on Postgres (native BOOLEAN) but `i64` on
+/// SQLite (INTEGER 0/1) — see the migration note in `migrations-pg`.
+pub async fn insert(db: &ConfigDb, input: &BlockInput, actor: Option<&str>) -> Result<String> {
     let id = uuid::Uuid::new_v4().to_string();
     let now = Utc::now();
-    let mut tx = pool.begin().await.context("begin block insert tx")?;
-
-    // Append: one past the current max position in the slot.
-    let (next_pos,): (i64,) =
-        sqlx::query_as("SELECT COALESCE(MAX(position) + 1, 0) FROM landing_blocks WHERE slot = ?")
+    match db {
+        ConfigDb::Sqlite(pool) => {
+            let mut tx = pool.begin().await.context("begin block insert tx")?;
+            let (next_pos,): (i64,) = sqlx::query_as(
+                "SELECT COALESCE(MAX(position) + 1, 0) FROM landing_blocks WHERE slot = ?",
+            )
             .bind(&input.slot)
             .fetch_one(&mut *tx)
             .await
             .context("compute block position")?;
-
-    sqlx::query(
-        "INSERT INTO landing_blocks
-           (id, slot, position, enabled, title, html, csp_origins, created_at, updated_at)
-         VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?)",
-    )
-    .bind(&id)
-    .bind(&input.slot)
-    .bind(next_pos)
-    .bind(input.enabled as i64)
-    .bind(&input.title)
-    .bind(&input.html)
-    .bind(&input.csp_origins)
-    .bind(now)
-    .bind(now)
-    .execute(&mut *tx)
-    .await
-    .context("insert landing_block")?;
-
-    audit(&mut tx, actor, "landing_block.create", &id, now).await?;
-    tx.commit().await.context("commit block insert")?;
+            sqlx::query(
+                "INSERT INTO landing_blocks
+                   (id, slot, position, enabled, title, html, csp_origins, created_at, updated_at)
+                 VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?)",
+            )
+            .bind(&id)
+            .bind(&input.slot)
+            .bind(next_pos)
+            .bind(input.enabled as i64)
+            .bind(&input.title)
+            .bind(&input.html)
+            .bind(&input.csp_origins)
+            .bind(now)
+            .bind(now)
+            .execute(&mut *tx)
+            .await
+            .context("insert landing_block")?;
+            audit(&mut tx, actor, "landing_block.create", &id, now).await?;
+            tx.commit().await.context("commit block insert")?;
+        }
+        ConfigDb::Postgres(pool) => {
+            let mut tx = pool.begin().await.context("begin block insert tx")?;
+            let (next_pos,): (i64,) = sqlx::query_as(
+                "SELECT COALESCE(MAX(position) + 1, 0) FROM landing_blocks WHERE slot = $1",
+            )
+            .bind(&input.slot)
+            .fetch_one(&mut *tx)
+            .await
+            .context("compute block position")?;
+            sqlx::query(
+                "INSERT INTO landing_blocks
+                   (id, slot, position, enabled, title, html, csp_origins, created_at, updated_at)
+                 VALUES ($1, $2, $3, $4, $5, $6, $7, $8, $9)",
+            )
+            .bind(&id)
+            .bind(&input.slot)
+            .bind(next_pos)
+            .bind(input.enabled)
+            .bind(&input.title)
+            .bind(&input.html)
+            .bind(&input.csp_origins)
+            .bind(now)
+            .bind(now)
+            .execute(&mut *tx)
+            .await
+            .context("insert landing_block")?;
+            audit_pg(&mut tx, actor, "landing_block.create", &id, now).await?;
+            tx.commit().await.context("commit block insert")?;
+        }
+    }
     Ok(id)
 }
 
@@ -139,45 +180,44 @@ pub async fn insert(pool: &SqlitePool, input: &BlockInput, actor: Option<&str>) 
 /// its position unless the slot changed, in which case it's appended
 /// to the new slot.
 pub async fn update(
-    pool: &SqlitePool,
+    db: &ConfigDb,
     id: &str,
     input: &BlockInput,
     actor: Option<&str>,
 ) -> Result<bool> {
     let now = Utc::now();
-    let mut tx = pool.begin().await.context("begin block update tx")?;
-
-    let current: Option<(String,)> = sqlx::query_as("SELECT slot FROM landing_blocks WHERE id = ?")
-        .bind(id)
-        .fetch_optional(&mut *tx)
-        .await
-        .context("lookup block slot")?;
-    let Some((current_slot,)) = current else {
-        return Ok(false);
-    };
-
-    // Moving slots re-appends at the end of the destination slot.
-    let position_sql = if current_slot == input.slot {
-        None
-    } else {
-        let (next_pos,): (i64,) = sqlx::query_as(
-            "SELECT COALESCE(MAX(position) + 1, 0) FROM landing_blocks WHERE slot = ?",
-        )
-        .bind(&input.slot)
-        .fetch_one(&mut *tx)
-        .await
-        .context("compute new-slot position")?;
-        Some(next_pos)
-    };
-
-    match position_sql {
-        Some(pos) => {
+    match db {
+        ConfigDb::Sqlite(pool) => {
+            let mut tx = pool.begin().await.context("begin block update tx")?;
+            let current: Option<(String, i64)> =
+                sqlx::query_as("SELECT slot, position FROM landing_blocks WHERE id = ?")
+                    .bind(id)
+                    .fetch_optional(&mut *tx)
+                    .await
+                    .context("lookup block")?;
+            let Some((current_slot, current_pos)) = current else {
+                return Ok(false);
+            };
+            // Keep the position when the slot is unchanged; re-append at
+            // the end of the destination slot when it moves.
+            let new_pos = if current_slot == input.slot {
+                current_pos
+            } else {
+                let (next_pos,): (i64,) = sqlx::query_as(
+                    "SELECT COALESCE(MAX(position) + 1, 0) FROM landing_blocks WHERE slot = ?",
+                )
+                .bind(&input.slot)
+                .fetch_one(&mut *tx)
+                .await
+                .context("compute new-slot position")?;
+                next_pos
+            };
             sqlx::query(
                 "UPDATE landing_blocks SET slot = ?, position = ?, enabled = ?, title = ?,
                     html = ?, csp_origins = ?, updated_at = ? WHERE id = ?",
             )
             .bind(&input.slot)
-            .bind(pos)
+            .bind(new_pos)
             .bind(input.enabled as i64)
             .bind(&input.title)
             .bind(&input.html)
@@ -186,13 +226,41 @@ pub async fn update(
             .bind(id)
             .execute(&mut *tx)
             .await
+            .context("update landing_block")?;
+            audit(&mut tx, actor, "landing_block.update", id, now).await?;
+            tx.commit().await.context("commit block update")?;
+            Ok(true)
         }
-        None => {
+        ConfigDb::Postgres(pool) => {
+            let mut tx = pool.begin().await.context("begin block update tx")?;
+            let current: Option<(String, i64)> =
+                sqlx::query_as("SELECT slot, position FROM landing_blocks WHERE id = $1")
+                    .bind(id)
+                    .fetch_optional(&mut *tx)
+                    .await
+                    .context("lookup block")?;
+            let Some((current_slot, current_pos)) = current else {
+                return Ok(false);
+            };
+            let new_pos = if current_slot == input.slot {
+                current_pos
+            } else {
+                let (next_pos,): (i64,) = sqlx::query_as(
+                    "SELECT COALESCE(MAX(position) + 1, 0) FROM landing_blocks WHERE slot = $1",
+                )
+                .bind(&input.slot)
+                .fetch_one(&mut *tx)
+                .await
+                .context("compute new-slot position")?;
+                next_pos
+            };
             sqlx::query(
-                "UPDATE landing_blocks SET enabled = ?, title = ?, html = ?,
-                    csp_origins = ?, updated_at = ? WHERE id = ?",
+                "UPDATE landing_blocks SET slot = $1, position = $2, enabled = $3, title = $4,
+                    html = $5, csp_origins = $6, updated_at = $7 WHERE id = $8",
             )
-            .bind(input.enabled as i64)
+            .bind(&input.slot)
+            .bind(new_pos)
+            .bind(input.enabled)
             .bind(&input.title)
             .bind(&input.html)
             .bind(&input.csp_origins)
@@ -200,30 +268,47 @@ pub async fn update(
             .bind(id)
             .execute(&mut *tx)
             .await
+            .context("update landing_block")?;
+            audit_pg(&mut tx, actor, "landing_block.update", id, now).await?;
+            tx.commit().await.context("commit block update")?;
+            Ok(true)
         }
     }
-    .context("update landing_block")?;
-
-    audit(&mut tx, actor, "landing_block.update", id, now).await?;
-    tx.commit().await.context("commit block update")?;
-    Ok(true)
 }
 
 /// Delete a block. Returns whether a row was removed.
-pub async fn delete(pool: &SqlitePool, id: &str, actor: Option<&str>) -> Result<bool> {
+pub async fn delete(db: &ConfigDb, id: &str, actor: Option<&str>) -> Result<bool> {
     let now = Utc::now();
-    let mut tx = pool.begin().await.context("begin block delete tx")?;
-    let rows = sqlx::query("DELETE FROM landing_blocks WHERE id = ?")
-        .bind(id)
-        .execute(&mut *tx)
-        .await
-        .context("delete landing_block")?;
-    let removed = rows.rows_affected() > 0;
-    if removed {
-        audit(&mut tx, actor, "landing_block.delete", id, now).await?;
+    match db {
+        ConfigDb::Sqlite(pool) => {
+            let mut tx = pool.begin().await.context("begin block delete tx")?;
+            let rows = sqlx::query("DELETE FROM landing_blocks WHERE id = ?")
+                .bind(id)
+                .execute(&mut *tx)
+                .await
+                .context("delete landing_block")?;
+            let removed = rows.rows_affected() > 0;
+            if removed {
+                audit(&mut tx, actor, "landing_block.delete", id, now).await?;
+            }
+            tx.commit().await.context("commit block delete")?;
+            Ok(removed)
+        }
+        ConfigDb::Postgres(pool) => {
+            let mut tx = pool.begin().await.context("begin block delete tx")?;
+            let rows = sqlx::query("DELETE FROM landing_blocks WHERE id = $1")
+                .bind(id)
+                .execute(&mut *tx)
+                .await
+                .context("delete landing_block")?;
+            let removed = rows.rows_affected() > 0;
+            if removed {
+                audit_pg(&mut tx, actor, "landing_block.delete", id, now).await?;
+            }
+            tx.commit().await.context("commit block delete")?;
+            Ok(removed)
+        }
     }
-    tx.commit().await.context("commit block delete")?;
-    Ok(removed)
 }
 
 impl LandingBlock {
@@ -289,58 +374,96 @@ pub(crate) async fn replace_all_in_tx(
 /// `false`) when the block doesn't exist or is already at the slot
 /// edge. Gap-safe: it picks the nearest neighbour by position, not by
 /// `position ± 1`.
-pub async fn move_block(
-    pool: &SqlitePool,
-    id: &str,
-    up: bool,
-    actor: Option<&str>,
-) -> Result<bool> {
+pub async fn move_block(db: &ConfigDb, id: &str, up: bool, actor: Option<&str>) -> Result<bool> {
     let now = Utc::now();
-    let mut tx = pool.begin().await.context("begin block move tx")?;
-
-    let me: Option<(String, i64)> =
-        sqlx::query_as("SELECT slot, position FROM landing_blocks WHERE id = ?")
-            .bind(id)
+    match db {
+        ConfigDb::Sqlite(pool) => {
+            let mut tx = pool.begin().await.context("begin block move tx")?;
+            let me: Option<(String, i64)> =
+                sqlx::query_as("SELECT slot, position FROM landing_blocks WHERE id = ?")
+                    .bind(id)
+                    .fetch_optional(&mut *tx)
+                    .await
+                    .context("lookup block for move")?;
+            let Some((slot, pos)) = me else {
+                return Ok(false);
+            };
+            let neighbour: Option<(String, i64)> = if up {
+                sqlx::query_as(
+                    "SELECT id, position FROM landing_blocks
+                       WHERE slot = ? AND position < ? ORDER BY position DESC LIMIT 1",
+                )
+            } else {
+                sqlx::query_as(
+                    "SELECT id, position FROM landing_blocks
+                       WHERE slot = ? AND position > ? ORDER BY position ASC LIMIT 1",
+                )
+            }
+            .bind(&slot)
+            .bind(pos)
             .fetch_optional(&mut *tx)
             .await
-            .context("lookup block for move")?;
-    let Some((slot, pos)) = me else {
-        return Ok(false);
-    };
-
-    let neighbour: Option<(String, i64)> = if up {
-        sqlx::query_as(
-            "SELECT id, position FROM landing_blocks
-               WHERE slot = ? AND position < ? ORDER BY position DESC LIMIT 1",
-        )
-    } else {
-        sqlx::query_as(
-            "SELECT id, position FROM landing_blocks
-               WHERE slot = ? AND position > ? ORDER BY position ASC LIMIT 1",
-        )
-    }
-    .bind(&slot)
-    .bind(pos)
-    .fetch_optional(&mut *tx)
-    .await
-    .context("find move neighbour")?;
-    let Some((nid, npos)) = neighbour else {
-        return Ok(false); // already at the slot edge
-    };
-
-    for (bid, p) in [(id, npos), (nid.as_str(), pos)] {
-        sqlx::query("UPDATE landing_blocks SET position = ?, updated_at = ? WHERE id = ?")
-            .bind(p)
-            .bind(now)
-            .bind(bid)
-            .execute(&mut *tx)
+            .context("find move neighbour")?;
+            let Some((nid, npos)) = neighbour else {
+                return Ok(false); // already at the slot edge
+            };
+            for (bid, p) in [(id, npos), (nid.as_str(), pos)] {
+                sqlx::query("UPDATE landing_blocks SET position = ?, updated_at = ? WHERE id = ?")
+                    .bind(p)
+                    .bind(now)
+                    .bind(bid)
+                    .execute(&mut *tx)
+                    .await
+                    .context("swap block position")?;
+            }
+            audit(&mut tx, actor, "landing_block.move", id, now).await?;
+            tx.commit().await.context("commit block move")?;
+            Ok(true)
+        }
+        ConfigDb::Postgres(pool) => {
+            let mut tx = pool.begin().await.context("begin block move tx")?;
+            let me: Option<(String, i64)> =
+                sqlx::query_as("SELECT slot, position FROM landing_blocks WHERE id = $1")
+                    .bind(id)
+                    .fetch_optional(&mut *tx)
+                    .await
+                    .context("lookup block for move")?;
+            let Some((slot, pos)) = me else {
+                return Ok(false);
+            };
+            let neighbour: Option<(String, i64)> = if up {
+                sqlx::query_as(
+                    "SELECT id, position FROM landing_blocks
+                       WHERE slot = $1 AND position < $2 ORDER BY position DESC LIMIT 1",
+                )
+            } else {
+                sqlx::query_as(
+                    "SELECT id, position FROM landing_blocks
+                       WHERE slot = $1 AND position > $2 ORDER BY position ASC LIMIT 1",
+                )
+            }
+            .bind(&slot)
+            .bind(pos)
+            .fetch_optional(&mut *tx)
             .await
-            .context("swap block position")?;
+            .context("find move neighbour")?;
+            let Some((nid, npos)) = neighbour else {
+                return Ok(false); // already at the slot edge
+            };
+            for (bid, p) in [(id, npos), (nid.as_str(), pos)] {
+                sqlx::query("UPDATE landing_blocks SET position = $1, updated_at = $2 WHERE id = $3")
+                    .bind(p)
+                    .bind(now)
+                    .bind(bid)
+                    .execute(&mut *tx)
+                    .await
+                    .context("swap block position")?;
+            }
+            audit_pg(&mut tx, actor, "landing_block.move", id, now).await?;
+            tx.commit().await.context("commit block move")?;
+            Ok(true)
+        }
     }
-
-    audit(&mut tx, actor, "landing_block.move", id, now).await?;
-    tx.commit().await.context("commit block move")?;
-    Ok(true)
 }
 
 /// Rewrite the `position` of every block in `slot` to match the order
@@ -348,7 +471,7 @@ pub async fn move_block(
 /// are ignored, so a tampered payload can't move blocks across slots.
 /// Returns `false` for an unknown slot.
 pub async fn reorder(
-    pool: &SqlitePool,
+    db: &ConfigDb,
     slot: &str,
     ids: &[String],
     actor: Option<&str>,
@@ -357,31 +480,57 @@ pub async fn reorder(
         return Ok(false);
     }
     let now = Utc::now();
-    let mut tx = pool.begin().await.context("begin block reorder tx")?;
-
-    // Assign 0..N in submitted order; only rows actually in this slot
-    // advance the counter, so positions stay dense and slot-scoped.
-    let mut pos: i64 = 0;
-    for id in ids {
-        let res = sqlx::query(
-            "UPDATE landing_blocks SET position = ?, updated_at = ?
-               WHERE id = ? AND slot = ?",
-        )
-        .bind(pos)
-        .bind(now)
-        .bind(id)
-        .bind(slot)
-        .execute(&mut *tx)
-        .await
-        .context("reorder block")?;
-        if res.rows_affected() > 0 {
-            pos += 1;
+    match db {
+        ConfigDb::Sqlite(pool) => {
+            let mut tx = pool.begin().await.context("begin block reorder tx")?;
+            // Assign 0..N in submitted order; only rows actually in this
+            // slot advance the counter, so positions stay dense and
+            // slot-scoped.
+            let mut pos: i64 = 0;
+            for id in ids {
+                let res = sqlx::query(
+                    "UPDATE landing_blocks SET position = ?, updated_at = ?
+                       WHERE id = ? AND slot = ?",
+                )
+                .bind(pos)
+                .bind(now)
+                .bind(id)
+                .bind(slot)
+                .execute(&mut *tx)
+                .await
+                .context("reorder block")?;
+                if res.rows_affected() > 0 {
+                    pos += 1;
+                }
+            }
+            audit(&mut tx, actor, "landing_block.reorder", slot, now).await?;
+            tx.commit().await.context("commit block reorder")?;
+            Ok(true)
+        }
+        ConfigDb::Postgres(pool) => {
+            let mut tx = pool.begin().await.context("begin block reorder tx")?;
+            let mut pos: i64 = 0;
+            for id in ids {
+                let res = sqlx::query(
+                    "UPDATE landing_blocks SET position = $1, updated_at = $2
+                       WHERE id = $3 AND slot = $4",
+                )
+                .bind(pos)
+                .bind(now)
+                .bind(id)
+                .bind(slot)
+                .execute(&mut *tx)
+                .await
+                .context("reorder block")?;
+                if res.rows_affected() > 0 {
+                    pos += 1;
+                }
+            }
+            audit_pg(&mut tx, actor, "landing_block.reorder", slot, now).await?;
+            tx.commit().await.context("commit block reorder")?;
+            Ok(true)
         }
     }
-
-    audit(&mut tx, actor, "landing_block.reorder", slot, now).await?;
-    tx.commit().await.context("commit block reorder")?;
-    Ok(true)
 }
 
 async fn audit(
@@ -394,6 +543,28 @@ async fn audit(
     sqlx::query(
         "INSERT INTO audit_log (actor, action, target, diff_json, occurred_at)
          VALUES (?, ?, ?, NULL, ?)",
+    )
+    .bind(actor)
+    .bind(action)
+    .bind(format!("landing_block:{id}"))
+    .bind(now)
+    .execute(&mut **tx)
+    .await
+    .context("audit landing_block")?;
+    Ok(())
+}
+
+/// Postgres twin of [`audit`] — `$n` placeholders.
+async fn audit_pg(
+    tx: &mut sqlx::Transaction<'_, sqlx::Postgres>,
+    actor: Option<&str>,
+    action: &str,
+    id: &str,
+    now: chrono::DateTime<Utc>,
+) -> Result<()> {
+    sqlx::query(
+        "INSERT INTO audit_log (actor, action, target, diff_json, occurred_at)
+         VALUES ($1, $2, $3, NULL, $4)",
     )
     .bind(actor)
     .bind(action)
@@ -422,11 +593,11 @@ mod tests {
 
     #[tokio::test]
     async fn insert_appends_position_per_slot() {
-        let pool = open_memory().await.unwrap();
-        insert(&pool, &input("top", "a"), None).await.unwrap();
-        insert(&pool, &input("top", "b"), None).await.unwrap();
-        insert(&pool, &input("bottom", "c"), None).await.unwrap();
-        let all = list_all(&pool).await.unwrap();
+        let db = ConfigDb::Sqlite(open_memory().await.unwrap());
+        insert(&db, &input("top", "a"), None).await.unwrap();
+        insert(&db, &input("top", "b"), None).await.unwrap();
+        insert(&db, &input("bottom", "c"), None).await.unwrap();
+        let all = list_all(&db).await.unwrap();
         // bottom sorts before top alphabetically; within top, a then b.
         let top: Vec<_> = all.iter().filter(|b| b.slot == "top").collect();
         assert_eq!(top.len(), 2);
@@ -437,10 +608,10 @@ mod tests {
 
     #[tokio::test]
     async fn move_block_swaps_within_slot() {
-        let pool = open_memory().await.unwrap();
-        let a = insert(&pool, &input("top", "a"), None).await.unwrap();
-        let _b = insert(&pool, &input("top", "b"), None).await.unwrap();
-        let c = insert(&pool, &input("top", "c"), None).await.unwrap();
+        let db = ConfigDb::Sqlite(open_memory().await.unwrap());
+        let a = insert(&db, &input("top", "a"), None).await.unwrap();
+        let _b = insert(&db, &input("top", "b"), None).await.unwrap();
+        let c = insert(&db, &input("top", "c"), None).await.unwrap();
         let order = |v: &[LandingBlock]| {
             v.iter()
                 .filter(|b| b.slot == "top")
@@ -449,39 +620,39 @@ mod tests {
         };
 
         // Move c (last) up → swaps with b → a, c, b.
-        assert!(move_block(&pool, &c, true, None).await.unwrap());
-        assert_eq!(order(&list_all(&pool).await.unwrap()), ["a", "c", "b"]);
+        assert!(move_block(&db, &c, true, None).await.unwrap());
+        assert_eq!(order(&list_all(&db).await.unwrap()), ["a", "c", "b"]);
 
         // Moving a (first) up is a no-op at the slot edge.
-        assert!(!move_block(&pool, &a, true, None).await.unwrap());
-        assert_eq!(order(&list_all(&pool).await.unwrap()), ["a", "c", "b"]);
+        assert!(!move_block(&db, &a, true, None).await.unwrap());
+        assert_eq!(order(&list_all(&db).await.unwrap()), ["a", "c", "b"]);
 
         // Move a down → swaps with c → c, a, b.
-        assert!(move_block(&pool, &a, false, None).await.unwrap());
-        assert_eq!(order(&list_all(&pool).await.unwrap()), ["c", "a", "b"]);
+        assert!(move_block(&db, &a, false, None).await.unwrap());
+        assert_eq!(order(&list_all(&db).await.unwrap()), ["c", "a", "b"]);
     }
 
     #[tokio::test]
     async fn list_enabled_excludes_disabled() {
-        let pool = open_memory().await.unwrap();
-        let id = insert(&pool, &input("top", "x"), None).await.unwrap();
+        let db = ConfigDb::Sqlite(open_memory().await.unwrap());
+        let id = insert(&db, &input("top", "x"), None).await.unwrap();
         let mut off = input("top", "x");
         off.enabled = false;
-        update(&pool, &id, &off, None).await.unwrap();
-        assert!(list_enabled(&ConfigDb::Sqlite(pool.clone()))
+        update(&db, &id, &off, None).await.unwrap();
+        assert!(list_enabled(&db)
             .await
             .unwrap()
             .is_empty());
-        assert_eq!(list_all(&pool).await.unwrap().len(), 1);
+        assert_eq!(list_all(&db).await.unwrap().len(), 1);
     }
 
     #[tokio::test]
     async fn delete_removes() {
-        let pool = open_memory().await.unwrap();
-        let id = insert(&pool, &input("bottom", "z"), None).await.unwrap();
-        assert!(delete(&pool, &id, None).await.unwrap());
-        assert!(fetch_one(&pool, &id).await.unwrap().is_none());
-        assert!(!delete(&pool, &id, None).await.unwrap());
+        let db = ConfigDb::Sqlite(open_memory().await.unwrap());
+        let id = insert(&db, &input("bottom", "z"), None).await.unwrap();
+        assert!(delete(&db, &id, None).await.unwrap());
+        assert!(fetch_one(&db, &id).await.unwrap().is_none());
+        assert!(!delete(&db, &id, None).await.unwrap());
     }
 
     // Proves the ported `list_enabled` reads the native BOOLEAN column
@@ -490,6 +661,7 @@ mod tests {
     #[cfg(feature = "postgres-it")]
     #[tokio::test]
     async fn list_enabled_against_real_postgres() {
+        let _guard = crate::db::pg_test_lock().lock().await;
         let url = std::env::var("RUSCKER_TEST_PG_URL")
             .expect("set RUSCKER_TEST_PG_URL to a reachable postgres:// DSN");
         let pool = crate::db::open_pg(&url).await.unwrap();
@@ -516,5 +688,55 @@ mod tests {
         let ids: Vec<&str> = enabled.iter().map(|b| b.id.as_str()).collect();
         assert_eq!(ids, ["keep"]);
         assert!(enabled[0].enabled);
+    }
+
+    // insert / update (disable) / move / reorder / delete through the
+    // `ConfigDb::Postgres` arm against a real daemon — the BOOLEAN
+    // `enabled` binds as `bool` here. Gated on `postgres-it`.
+    #[cfg(feature = "postgres-it")]
+    #[tokio::test]
+    async fn blocks_crud_against_real_postgres() {
+        let _guard = crate::db::pg_test_lock().lock().await;
+        let url = std::env::var("RUSCKER_TEST_PG_URL")
+            .expect("set RUSCKER_TEST_PG_URL to a reachable postgres:// DSN");
+        let pool = crate::db::open_pg(&url).await.unwrap();
+        sqlx::query("DELETE FROM landing_blocks")
+            .execute(&pool)
+            .await
+            .unwrap();
+        let db = ConfigDb::Postgres(pool);
+
+        let a = insert(&db, &input("top", "a"), Some("admin")).await.unwrap();
+        let b = insert(&db, &input("top", "b"), Some("admin")).await.unwrap();
+        assert_eq!(list_all(&db).await.unwrap().len(), 2);
+
+        // Disable `a`: it drops out of list_enabled.
+        let mut off = input("top", "a");
+        off.enabled = false;
+        assert!(update(&db, &a, &off, None).await.unwrap());
+        assert!(!fetch_one(&db, &a).await.unwrap().unwrap().enabled);
+        let enabled_ids: Vec<String> = list_enabled(&db)
+            .await
+            .unwrap()
+            .into_iter()
+            .map(|x| x.id)
+            .collect();
+        assert_eq!(enabled_ids, vec![b.clone()]);
+
+        // Reorder top → [b, a].
+        assert!(reorder(&db, "top", &[b.clone(), a.clone()], None)
+            .await
+            .unwrap());
+        let order: Vec<String> = list_all(&db).await.unwrap().into_iter().map(|x| x.id).collect();
+        assert_eq!(order, vec![b.clone(), a.clone()]);
+
+        // move_block b down swaps it back behind a.
+        assert!(move_block(&db, &b, false, None).await.unwrap());
+        let order: Vec<String> = list_all(&db).await.unwrap().into_iter().map(|x| x.id).collect();
+        assert_eq!(order, vec![a.clone(), b.clone()]);
+
+        assert!(delete(&db, &a, None).await.unwrap());
+        assert!(delete(&db, &b, None).await.unwrap());
+        assert!(list_all(&db).await.unwrap().is_empty());
     }
 }

--- a/crates/ruscker-admin/src/db/specs.rs
+++ b/crates/ruscker-admin/src/db/specs.rs
@@ -589,6 +589,7 @@ mod tests {
     #[cfg(feature = "postgres-it")]
     #[tokio::test]
     async fn spec_crud_against_real_postgres() {
+        let _guard = crate::db::pg_test_lock().lock().await;
         let url = std::env::var("RUSCKER_TEST_PG_URL")
             .expect("set RUSCKER_TEST_PG_URL to a reachable postgres:// DSN");
         let pool = crate::db::open_pg(&url).await.unwrap();

--- a/crates/ruscker-admin/src/routes/admin/blocks.rs
+++ b/crates/ruscker-admin/src/routes/admin/blocks.rs
@@ -66,7 +66,7 @@ async fn index(
     loc: Locale,
     theme: Theme,
 ) -> Response {
-    let Some(pool) = state.sqlite() else {
+    let Some(pool) = state.db.as_ref() else {
         return no_db();
     };
     let blocks = match landing_blocks::list_all(pool).await {
@@ -132,7 +132,7 @@ async fn new_form(
     loc: Locale,
     theme: Theme,
 ) -> Response {
-    if state.sqlite().is_none() {
+    if state.db.as_ref().is_none() {
         return no_db();
     }
     super::render(&BlockFormPage {
@@ -160,7 +160,7 @@ async fn edit_form(
     theme: Theme,
     Path(id): Path<String>,
 ) -> Response {
-    let Some(pool) = state.sqlite() else {
+    let Some(pool) = state.db.as_ref() else {
         return no_db();
     };
     let block = match landing_blocks::fetch_one(pool, &id).await {
@@ -226,7 +226,7 @@ async fn create(
     State(state): State<AppState>,
     Form(form): Form<BlockForm>,
 ) -> Response {
-    let Some(pool) = state.sqlite() else {
+    let Some(pool) = state.db.as_ref() else {
         return no_db();
     };
     match landing_blocks::insert(pool, &form.into_input(), Some(admin.actor())).await {
@@ -244,7 +244,7 @@ async fn update(
     Path(id): Path<String>,
     Form(form): Form<BlockForm>,
 ) -> Response {
-    let Some(pool) = state.sqlite() else {
+    let Some(pool) = state.db.as_ref() else {
         return no_db();
     };
     match landing_blocks::update(pool, &id, &form.into_input(), Some(admin.actor())).await {
@@ -262,7 +262,7 @@ async fn delete(
     State(state): State<AppState>,
     Path(id): Path<String>,
 ) -> Response {
-    let Some(pool) = state.sqlite() else {
+    let Some(pool) = state.db.as_ref() else {
         return no_db();
     };
     match landing_blocks::delete(pool, &id, Some(admin.actor())).await {
@@ -279,7 +279,7 @@ async fn move_block(
     State(state): State<AppState>,
     Path((id, dir)): Path<(String, String)>,
 ) -> Response {
-    let Some(pool) = state.sqlite() else {
+    let Some(pool) = state.db.as_ref() else {
         return no_db();
     };
     let up = match dir.as_str() {
@@ -311,7 +311,7 @@ async fn reorder(
     State(state): State<AppState>,
     Json(req): Json<ReorderReq>,
 ) -> Response {
-    let Some(pool) = state.sqlite() else {
+    let Some(pool) = state.db.as_ref() else {
         return no_db();
     };
     match landing_blocks::reorder(pool, &req.slot, &req.ids, Some(admin.actor())).await {

--- a/crates/ruscker-admin/src/routes/admin/landing.rs
+++ b/crates/ruscker-admin/src/routes/admin/landing.rs
@@ -155,7 +155,7 @@ async fn save(
     theme: Theme,
     Form(form): Form<LandingForm>,
 ) -> Response {
-    let Some(pool) = state.sqlite() else {
+    let Some(pool) = state.db.as_ref() else {
         return (StatusCode::SERVICE_UNAVAILABLE, "no db").into_response();
     };
     let lc = form.into_customization();

--- a/crates/ruscker-admin/src/sessions_pg.rs
+++ b/crates/ruscker-admin/src/sessions_pg.rs
@@ -285,7 +285,10 @@ impl SessionStore for PostgresSessionStore {
     }
 }
 
-#[cfg(test)]
+// Only the gated Postgres test lives here; the pure logic is covered
+// by the in-memory store's tests. Gating the whole module on the
+// feature keeps `use super::*` from being unused in the default build.
+#[cfg(all(test, feature = "postgres-it"))]
 mod tests {
     use super::*;
 
@@ -307,6 +310,7 @@ mod tests {
         use std::net::SocketAddr;
         use std::sync::Arc;
 
+        let _guard = crate::db::pg_test_lock().lock().await;
         let url = std::env::var("RUSCKER_TEST_PG_URL")
             .expect("set RUSCKER_TEST_PG_URL to a reachable postgres:// DSN");
         let store = PostgresSessionStore::connect(&url).await.unwrap();


### PR DESCRIPTION
The landing-customization editor and the custom-blocks admin now work against **either** backend. With these, every admin-facing landing path is dual-dialect. `import_all` stays SQLite-only (it drives the `*_in_tx` writers in one transaction and is a SQLite-mode operation — ported in its own slice later).

## What's here
- **`landing::update(&ConfigDb)`** + a `update_in_tx_pg` twin (the SQLite `update_in_tx` stays for `import_all`).
- **`landing_blocks`**: `list_all` / `fetch_one` reads + `insert` / `update` / `delete` / `move_block` / `reorder` writes take `&ConfigDb`, with an `audit_pg` twin. `update` refactored to a **single** UPDATE (compute the final position) so it doesn't fork a second conditional UPDATE per dialect. `enabled` binds as `bool` on Postgres (native BOOLEAN) vs `i64` on SQLite.
- Callers pass the `ConfigDb`: blocks admin routes, the landing editor's `save`, and `export` (SQLite-only) reuses one local `ConfigDb::Sqlite` for both `fetch` and `list_all`.
- **Test isolation:** the `postgres-it` tests share one database, so a new `db::pg_test_lock()` serializes them — two now mutate the same tables (`landing_blocks`, the `landing_customization` singleton) and cargo runs tests in parallel by default. Also gated the `sessions_pg` test module on the feature (drops a stale unused-import warning).
- **Gated tests**: landing `update`+`fetch` round-trip; block insert/update(disable)/reorder/move/delete against real Postgres.

## Verification
- **317 default tests green**; edited files 0-drift; **no build warnings**.
- All nine `postgres-it` tests pass together against a real `postgres:16-alpine`:
  ```
  test db::credentials::tests::credentials_against_real_postgres ... ok
  test db::images::pg_tests::images_against_real_postgres ... ok
  test db::landing::tests::fetch_against_real_postgres ... ok
  test db::landing::tests::update_then_fetch_against_real_postgres ... ok
  test db::landing_blocks::tests::blocks_crud_against_real_postgres ... ok
  test db::landing_blocks::tests::list_enabled_against_real_postgres ... ok
  test db::pg_tests::pg_migrations_apply_and_match_sqlite_tables ... ok
  test db::specs::tests::spec_crud_against_real_postgres ... ok
  test sessions_pg::tests::end_to_end_against_real_postgres ... ok
  ```

Next: **7c-7** `users`, **7c-8** `audit` + `import_all`, then the CLI `--config-db-url` flag wires Postgres mode end-to-end.

🤖 Generated with [Claude Code](https://claude.com/claude-code)