### PR TITLE
Phase 7c-7: port the users repository to dual-dialect (#128)

### DIFF
--- a/crates/ruscker-admin/src/db/users.rs
+++ b/crates/ruscker-admin/src/db/users.rs
@@ -15,9 +15,9 @@ use argon2::password_hash::rand_core::OsRng;
 use argon2::password_hash::{PasswordHash, PasswordHasher, PasswordVerifier, SaltString};
 use argon2::Argon2;
 use chrono::{DateTime, Utc};
-use sqlx::SqlitePool;
 
 use crate::auth::Role;
+use crate::db::ConfigDb;
 
 /// A user row without the password hash — safe to render.
 #[derive(Debug, Clone)]
@@ -60,28 +60,32 @@ pub fn verify_password(plain: &str, phc: &str) -> bool {
 
 /// Number of users with the Admin role. Used to block removing or
 /// demoting the last admin (lockout protection).
-pub async fn count_admins(pool: &SqlitePool) -> Result<i64> {
-    let (n,): (i64,) = sqlx::query_as("SELECT COUNT(*) FROM users WHERE role = 'admin'")
-        .fetch_one(pool)
-        .await
-        .context("count admins")?;
+pub async fn count_admins(db: &ConfigDb) -> Result<i64> {
+    let sql = "SELECT COUNT(*) FROM users WHERE role = 'admin'";
+    let (n,): (i64,) = match db {
+        ConfigDb::Sqlite(pool) => sqlx::query_as(sql).fetch_one(pool).await,
+        ConfigDb::Postgres(pool) => sqlx::query_as(sql).fetch_one(pool).await,
+    }
+    .context("count admins")?;
     Ok(n)
 }
 
 /// Whether any admin account exists yet. Drives the bootstrap flow:
 /// with no admin user, login falls back to the break-glass token and
 /// the setup wizard.
-pub async fn any_admin_exists(pool: &SqlitePool) -> Result<bool> {
-    Ok(count_admins(pool).await? > 0)
+pub async fn any_admin_exists(db: &ConfigDb) -> Result<bool> {
+    Ok(count_admins(db).await? > 0)
 }
 
 /// Whether any user at all exists (used by the login page to decide
 /// between the bootstrap and the normal form).
-pub async fn any_user_exists(pool: &SqlitePool) -> Result<bool> {
-    let (n,): (i64,) = sqlx::query_as("SELECT COUNT(*) FROM users")
-        .fetch_one(pool)
-        .await
-        .context("count users")?;
+pub async fn any_user_exists(db: &ConfigDb) -> Result<bool> {
+    let sql = "SELECT COUNT(*) FROM users";
+    let (n,): (i64,) = match db {
+        ConfigDb::Sqlite(pool) => sqlx::query_as(sql).fetch_one(pool).await,
+        ConfigDb::Postgres(pool) => sqlx::query_as(sql).fetch_one(pool).await,
+    }
+    .context("count users")?;
     Ok(n > 0)
 }
 
@@ -92,7 +96,7 @@ fn row_from(
     id: String,
     username: String,
     role: String,
-    must_change: i64,
+    must_change: bool,
     created_at: DateTime<Utc>,
     created_by: Option<String>,
 ) -> UserRow {
@@ -100,21 +104,24 @@ fn row_from(
         id,
         username,
         role: Role::parse(&role).unwrap_or(Role::Viewer),
-        must_change_password: must_change != 0,
+        // `must_change_password` reads as `bool` on both backends: sqlx
+        // decodes SQLite's INTEGER 0/1 and Postgres' native BOOLEAN.
+        must_change_password: must_change,
         created_at,
         created_by,
     }
 }
 
 /// List all users (no hashes), most-recent first.
-pub async fn list_all(pool: &SqlitePool) -> Result<Vec<UserRow>> {
-    let rows: Vec<(String, String, String, i64, DateTime<Utc>, Option<String>)> = sqlx::query_as(
-        "SELECT id, username, role, must_change_password, created_at, created_by
+pub async fn list_all(db: &ConfigDb) -> Result<Vec<UserRow>> {
+    type Row = (String, String, String, bool, DateTime<Utc>, Option<String>);
+    let sql = "SELECT id, username, role, must_change_password, created_at, created_by
            FROM users
-          ORDER BY created_at DESC, username ASC",
-    )
-    .fetch_all(pool)
-    .await
+          ORDER BY created_at DESC, username ASC";
+    let rows: Vec<Row> = match db {
+        ConfigDb::Sqlite(pool) => sqlx::query_as(sql).fetch_all(pool).await,
+        ConfigDb::Postgres(pool) => sqlx::query_as(sql).fetch_all(pool).await,
+    }
     .context("list users")?;
     Ok(rows
         .into_iter()
@@ -123,15 +130,25 @@ pub async fn list_all(pool: &SqlitePool) -> Result<Vec<UserRow>> {
 }
 
 /// Fetch one user by (normalized) username, without the hash.
-pub async fn fetch(pool: &SqlitePool, username: &str) -> Result<Option<UserRow>> {
+pub async fn fetch(db: &ConfigDb, username: &str) -> Result<Option<UserRow>> {
+    type Row = (String, String, String, bool, DateTime<Utc>, Option<String>);
     let username = normalize_username(username);
-    let row: Option<(String, String, String, i64, DateTime<Utc>, Option<String>)> = sqlx::query_as(
-        "SELECT id, username, role, must_change_password, created_at, created_by
+    let row: Option<Row> = match db {
+        ConfigDb::Sqlite(pool) => sqlx::query_as(
+            "SELECT id, username, role, must_change_password, created_at, created_by
                FROM users WHERE username = ?",
-    )
-    .bind(&username)
-    .fetch_optional(pool)
-    .await
+        )
+        .bind(&username)
+        .fetch_optional(pool)
+        .await,
+        ConfigDb::Postgres(pool) => sqlx::query_as(
+            "SELECT id, username, role, must_change_password, created_at, created_by
+               FROM users WHERE username = $1",
+        )
+        .bind(&username)
+        .fetch_optional(pool)
+        .await,
+    }
     .with_context(|| format!("fetch user {username}"))?;
     Ok(row.map(|(id, u, r, m, c, by)| row_from(id, u, r, m, c, by)))
 }
@@ -142,26 +159,36 @@ pub async fn fetch(pool: &SqlitePool, username: &str) -> Result<Option<UserRow>>
 /// user, against a dummy hash — so response time doesn't reveal
 /// whether the username exists.
 pub async fn verify_login(
-    pool: &SqlitePool,
+    db: &ConfigDb,
     username: &str,
     password: &str,
 ) -> Result<Option<UserRow>> {
-    let username = normalize_username(username);
-    let row: Option<(
+    type Row = (
         String,
         String,
         String,
-        i64,
+        bool,
         DateTime<Utc>,
         Option<String>,
         String,
-    )> = sqlx::query_as(
-        "SELECT id, username, role, must_change_password, created_at, created_by, password_hash
+    );
+    let username = normalize_username(username);
+    let row: Option<Row> = match db {
+        ConfigDb::Sqlite(pool) => sqlx::query_as(
+            "SELECT id, username, role, must_change_password, created_at, created_by, password_hash
                FROM users WHERE username = ?",
-    )
-    .bind(&username)
-    .fetch_optional(pool)
-    .await
+        )
+        .bind(&username)
+        .fetch_optional(pool)
+        .await,
+        ConfigDb::Postgres(pool) => sqlx::query_as(
+            "SELECT id, username, role, must_change_password, created_at, created_by, password_hash
+               FROM users WHERE username = $1",
+        )
+        .bind(&username)
+        .fetch_optional(pool)
+        .await,
+    }
     .with_context(|| format!("login lookup {username}"))?;
 
     match row {
@@ -189,7 +216,7 @@ fn dummy_hash() -> &'static str {
 /// Create a new user. `must_change` marks the optional first-login
 /// password-change prompt. Errors if the username already exists.
 pub async fn create(
-    pool: &SqlitePool,
+    db: &ConfigDb,
     username: &str,
     password: &str,
     role: Role,
@@ -201,33 +228,58 @@ pub async fn create(
     let now = Utc::now();
     let id = uuid::Uuid::new_v4().to_string();
 
-    let mut tx = pool.begin().await.context("begin user tx")?;
-    sqlx::query(
-        "INSERT INTO users
-           (id, username, password_hash, role, must_change_password,
-            created_at, updated_at, created_by)
-         VALUES (?, ?, ?, ?, ?, ?, ?, ?)",
-    )
-    .bind(&id)
-    .bind(&username)
-    .bind(&hash)
-    .bind(role.as_str())
-    .bind(must_change as i64)
-    .bind(now)
-    .bind(now)
-    .bind(actor)
-    .execute(&mut *tx)
-    .await
-    .with_context(|| format!("insert user {username}"))?;
-
-    audit(&mut tx, actor, "user.create", &username, &role, now).await?;
-    tx.commit().await.context("commit user create")?;
+    match db {
+        ConfigDb::Sqlite(pool) => {
+            let mut tx = pool.begin().await.context("begin user tx")?;
+            sqlx::query(
+                "INSERT INTO users
+                   (id, username, password_hash, role, must_change_password,
+                    created_at, updated_at, created_by)
+                 VALUES (?, ?, ?, ?, ?, ?, ?, ?)",
+            )
+            .bind(&id)
+            .bind(&username)
+            .bind(&hash)
+            .bind(role.as_str())
+            .bind(must_change as i64)
+            .bind(now)
+            .bind(now)
+            .bind(actor)
+            .execute(&mut *tx)
+            .await
+            .with_context(|| format!("insert user {username}"))?;
+            audit(&mut tx, actor, "user.create", &username, &role, now).await?;
+            tx.commit().await.context("commit user create")?;
+        }
+        ConfigDb::Postgres(pool) => {
+            let mut tx = pool.begin().await.context("begin user tx")?;
+            sqlx::query(
+                "INSERT INTO users
+                   (id, username, password_hash, role, must_change_password,
+                    created_at, updated_at, created_by)
+                 VALUES ($1, $2, $3, $4, $5, $6, $7, $8)",
+            )
+            .bind(&id)
+            .bind(&username)
+            .bind(&hash)
+            .bind(role.as_str())
+            .bind(must_change)
+            .bind(now)
+            .bind(now)
+            .bind(actor)
+            .execute(&mut *tx)
+            .await
+            .with_context(|| format!("insert user {username}"))?;
+            audit_pg(&mut tx, actor, "user.create", &username, &role, now).await?;
+            tx.commit().await.context("commit user create")?;
+        }
+    }
     Ok(())
 }
 
 /// Replace a user's password and set/clear the must-change prompt.
 pub async fn set_password(
-    pool: &SqlitePool,
+    db: &ConfigDb,
     username: &str,
     new_password: &str,
     must_change: bool,
@@ -236,42 +288,74 @@ pub async fn set_password(
     let username = normalize_username(username);
     let hash = hash_password(new_password)?;
     let now = Utc::now();
+    let target = format!("user:{username}");
 
-    let mut tx = pool.begin().await.context("begin password tx")?;
-    let res = sqlx::query(
-        "UPDATE users
-            SET password_hash = ?, must_change_password = ?, updated_at = ?
-          WHERE username = ?",
-    )
-    .bind(&hash)
-    .bind(must_change as i64)
-    .bind(now)
-    .bind(&username)
-    .execute(&mut *tx)
-    .await
-    .with_context(|| format!("set password for {username}"))?;
-    if res.rows_affected() == 0 {
-        anyhow::bail!("user {username} not found");
+    match db {
+        ConfigDb::Sqlite(pool) => {
+            let mut tx = pool.begin().await.context("begin password tx")?;
+            let res = sqlx::query(
+                "UPDATE users
+                    SET password_hash = ?, must_change_password = ?, updated_at = ?
+                  WHERE username = ?",
+            )
+            .bind(&hash)
+            .bind(must_change as i64)
+            .bind(now)
+            .bind(&username)
+            .execute(&mut *tx)
+            .await
+            .with_context(|| format!("set password for {username}"))?;
+            if res.rows_affected() == 0 {
+                anyhow::bail!("user {username} not found");
+            }
+            sqlx::query(
+                "INSERT INTO audit_log (actor, action, target, diff_json, occurred_at)
+                 VALUES (?, 'user.password', ?, NULL, ?)",
+            )
+            .bind(actor)
+            .bind(&target)
+            .bind(now)
+            .execute(&mut *tx)
+            .await
+            .context("audit password change")?;
+            tx.commit().await.context("commit password change")?;
+        }
+        ConfigDb::Postgres(pool) => {
+            let mut tx = pool.begin().await.context("begin password tx")?;
+            let res = sqlx::query(
+                "UPDATE users
+                    SET password_hash = $1, must_change_password = $2, updated_at = $3
+                  WHERE username = $4",
+            )
+            .bind(&hash)
+            .bind(must_change)
+            .bind(now)
+            .bind(&username)
+            .execute(&mut *tx)
+            .await
+            .with_context(|| format!("set password for {username}"))?;
+            if res.rows_affected() == 0 {
+                anyhow::bail!("user {username} not found");
+            }
+            sqlx::query(
+                "INSERT INTO audit_log (actor, action, target, diff_json, occurred_at)
+                 VALUES ($1, 'user.password', $2, NULL, $3)",
+            )
+            .bind(actor)
+            .bind(&target)
+            .bind(now)
+            .execute(&mut *tx)
+            .await
+            .context("audit password change")?;
+            tx.commit().await.context("commit password change")?;
+        }
     }
-
-    sqlx::query(
-        "INSERT INTO audit_log (actor, action, target, diff_json, occurred_at)
-         VALUES (?, 'user.password', ?, NULL, ?)",
-    )
-    .bind(actor)
-    .bind(format!("user:{username}"))
-    .bind(now)
-    .execute(&mut *tx)
-    .await
-    .context("audit password change")?;
-
-    tx.commit().await.context("commit password change")?;
     Ok(())
 }
 
 /// Change a user's role.
 pub async fn set_role(
-    pool: &SqlitePool,
+    db: &ConfigDb,
     username: &str,
     role: Role,
     actor: Option<&str>,
@@ -279,63 +363,118 @@ pub async fn set_role(
     let username = normalize_username(username);
     let now = Utc::now();
 
-    let mut tx = pool.begin().await.context("begin role tx")?;
-    let res = sqlx::query("UPDATE users SET role = ?, updated_at = ? WHERE username = ?")
-        .bind(role.as_str())
-        .bind(now)
-        .bind(&username)
-        .execute(&mut *tx)
-        .await
-        .with_context(|| format!("set role for {username}"))?;
-    if res.rows_affected() == 0 {
-        anyhow::bail!("user {username} not found");
+    match db {
+        ConfigDb::Sqlite(pool) => {
+            let mut tx = pool.begin().await.context("begin role tx")?;
+            let res = sqlx::query("UPDATE users SET role = ?, updated_at = ? WHERE username = ?")
+                .bind(role.as_str())
+                .bind(now)
+                .bind(&username)
+                .execute(&mut *tx)
+                .await
+                .with_context(|| format!("set role for {username}"))?;
+            if res.rows_affected() == 0 {
+                anyhow::bail!("user {username} not found");
+            }
+            audit(&mut tx, actor, "user.role", &username, &role, now).await?;
+            tx.commit().await.context("commit role change")?;
+        }
+        ConfigDb::Postgres(pool) => {
+            let mut tx = pool.begin().await.context("begin role tx")?;
+            let res = sqlx::query("UPDATE users SET role = $1, updated_at = $2 WHERE username = $3")
+                .bind(role.as_str())
+                .bind(now)
+                .bind(&username)
+                .execute(&mut *tx)
+                .await
+                .with_context(|| format!("set role for {username}"))?;
+            if res.rows_affected() == 0 {
+                anyhow::bail!("user {username} not found");
+            }
+            audit_pg(&mut tx, actor, "user.role", &username, &role, now).await?;
+            tx.commit().await.context("commit role change")?;
+        }
     }
-
-    audit(&mut tx, actor, "user.role", &username, &role, now).await?;
-    tx.commit().await.context("commit role change")?;
     Ok(())
 }
 
 /// Clear the first-login password-change prompt once it's been
 /// answered (whether or not the user actually changed it). No audit —
-/// it's a benign per-user UI flag.
-pub async fn clear_must_change(pool: &SqlitePool, username: &str) -> Result<()> {
+/// it's a benign per-user UI flag. `= FALSE` is valid on both backends.
+pub async fn clear_must_change(db: &ConfigDb, username: &str) -> Result<()> {
     let username = normalize_username(username);
-    sqlx::query("UPDATE users SET must_change_password = 0 WHERE username = ?")
-        .bind(&username)
-        .execute(pool)
-        .await
-        .with_context(|| format!("clear must-change for {username}"))?;
+    let ctx = || format!("clear must-change for {username}");
+    match db {
+        ConfigDb::Sqlite(pool) => {
+            sqlx::query("UPDATE users SET must_change_password = FALSE WHERE username = ?")
+                .bind(&username)
+                .execute(pool)
+                .await
+                .with_context(ctx)?;
+        }
+        ConfigDb::Postgres(pool) => {
+            sqlx::query("UPDATE users SET must_change_password = FALSE WHERE username = $1")
+                .bind(&username)
+                .execute(pool)
+                .await
+                .with_context(ctx)?;
+        }
+    }
     Ok(())
 }
 
 /// Delete a user.
-pub async fn delete(pool: &SqlitePool, username: &str, actor: Option<&str>) -> Result<()> {
+pub async fn delete(db: &ConfigDb, username: &str, actor: Option<&str>) -> Result<()> {
     let username = normalize_username(username);
     let now = Utc::now();
+    let target = format!("user:{username}");
 
-    let mut tx = pool.begin().await.context("begin user delete")?;
-    let res = sqlx::query("DELETE FROM users WHERE username = ?")
-        .bind(&username)
-        .execute(&mut *tx)
-        .await
-        .with_context(|| format!("delete user {username}"))?;
-    if res.rows_affected() == 0 {
-        anyhow::bail!("user {username} not found");
+    match db {
+        ConfigDb::Sqlite(pool) => {
+            let mut tx = pool.begin().await.context("begin user delete")?;
+            let res = sqlx::query("DELETE FROM users WHERE username = ?")
+                .bind(&username)
+                .execute(&mut *tx)
+                .await
+                .with_context(|| format!("delete user {username}"))?;
+            if res.rows_affected() == 0 {
+                anyhow::bail!("user {username} not found");
+            }
+            sqlx::query(
+                "INSERT INTO audit_log (actor, action, target, diff_json, occurred_at)
+                 VALUES (?, 'user.delete', ?, NULL, ?)",
+            )
+            .bind(actor)
+            .bind(&target)
+            .bind(now)
+            .execute(&mut *tx)
+            .await
+            .context("audit user delete")?;
+            tx.commit().await.context("commit user delete")?;
+        }
+        ConfigDb::Postgres(pool) => {
+            let mut tx = pool.begin().await.context("begin user delete")?;
+            let res = sqlx::query("DELETE FROM users WHERE username = $1")
+                .bind(&username)
+                .execute(&mut *tx)
+                .await
+                .with_context(|| format!("delete user {username}"))?;
+            if res.rows_affected() == 0 {
+                anyhow::bail!("user {username} not found");
+            }
+            sqlx::query(
+                "INSERT INTO audit_log (actor, action, target, diff_json, occurred_at)
+                 VALUES ($1, 'user.delete', $2, NULL, $3)",
+            )
+            .bind(actor)
+            .bind(&target)
+            .bind(now)
+            .execute(&mut *tx)
+            .await
+            .context("audit user delete")?;
+            tx.commit().await.context("commit user delete")?;
+        }
     }
-
-    sqlx::query(
-        "INSERT INTO audit_log (actor, action, target, diff_json, occurred_at)
-         VALUES (?, 'user.delete', ?, NULL, ?)",
-    )
-    .bind(actor)
-    .bind(format!("user:{username}"))
-    .bind(now)
-    .execute(&mut *tx)
-    .await
-    .context("audit user delete")?;
-
-    tx.commit().await.context("commit user delete")?;
     Ok(())
 }
 
@@ -364,12 +503,36 @@ async fn audit(
     Ok(())
 }
 
+/// Postgres twin of [`audit`] — `$n` placeholders.
+async fn audit_pg(
+    tx: &mut sqlx::Transaction<'_, sqlx::Postgres>,
+    actor: Option<&str>,
+    action: &str,
+    username: &str,
+    role: &Role,
+    now: DateTime<Utc>,
+) -> Result<()> {
+    sqlx::query(
+        "INSERT INTO audit_log (actor, action, target, diff_json, occurred_at)
+         VALUES ($1, $2, $3, $4, $5)",
+    )
+    .bind(actor)
+    .bind(action)
+    .bind(format!("user:{username}"))
+    .bind(serde_json::json!({ "role": role.as_str() }).to_string())
+    .bind(now)
+    .execute(&mut **tx)
+    .await
+    .context("audit user op")?;
+    Ok(())
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
 
-    async fn pool() -> SqlitePool {
-        crate::db::open_memory().await.expect("memory db")
+    async fn pool() -> ConfigDb {
+        ConfigDb::Sqlite(crate::db::open_memory().await.expect("memory db"))
     }
 
     #[test]
@@ -437,5 +600,59 @@ mod tests {
         let u = verify_login(&p, "bob", "new-pw").await.unwrap().unwrap();
         assert!(!u.must_change_password);
         assert!(verify_login(&p, "bob", "init-pw").await.unwrap().is_none());
+    }
+
+    // Full user lifecycle through the `ConfigDb::Postgres` arm against a
+    // real daemon (BOOLEAN `must_change_password`, argon2 verify, audit,
+    // last-admin count). Gated on `postgres-it`.
+    #[cfg(feature = "postgres-it")]
+    #[tokio::test]
+    async fn users_against_real_postgres() {
+        let _guard = crate::db::pg_test_lock().lock().await;
+        let url = std::env::var("RUSCKER_TEST_PG_URL")
+            .expect("set RUSCKER_TEST_PG_URL to a reachable postgres:// DSN");
+        let pg = crate::db::open_pg(&url).await.unwrap();
+        sqlx::query("DELETE FROM users")
+            .execute(&pg)
+            .await
+            .unwrap();
+        let db = ConfigDb::Postgres(pg);
+
+        assert!(!any_admin_exists(&db).await.unwrap());
+        create(&db, "Root", "rootpw12", Role::Admin, false, None)
+            .await
+            .unwrap();
+        create(&db, "Ed", "edpw1234", Role::Editor, true, Some("root"))
+            .await
+            .unwrap();
+        assert_eq!(count_admins(&db).await.unwrap(), 1);
+        assert!(any_user_exists(&db).await.unwrap());
+        assert_eq!(list_all(&db).await.unwrap().len(), 2);
+
+        // Case-insensitive login + must_change BOOLEAN round-trip.
+        let u = verify_login(&db, "ed", "edpw1234")
+            .await
+            .unwrap()
+            .expect("login ok");
+        assert_eq!(u.role, Role::Editor);
+        assert!(u.must_change_password);
+        assert!(verify_login(&db, "ed", "wrong").await.unwrap().is_none());
+        assert!(verify_login(&db, "ghost", "x").await.unwrap().is_none());
+
+        // Promote, re-set password (clears must_change), then delete.
+        set_role(&db, "ed", Role::Admin, Some("root")).await.unwrap();
+        assert_eq!(count_admins(&db).await.unwrap(), 2);
+        set_password(&db, "ed", "newpw123", false, Some("ed"))
+            .await
+            .unwrap();
+        assert!(!verify_login(&db, "ed", "newpw123")
+            .await
+            .unwrap()
+            .unwrap()
+            .must_change_password);
+        clear_must_change(&db, "root").await.unwrap();
+        delete(&db, "ed", Some("root")).await.unwrap();
+        assert!(fetch(&db, "ed").await.unwrap().is_none());
+        assert_eq!(count_admins(&db).await.unwrap(), 1);
     }
 }

--- a/crates/ruscker-admin/src/routes/admin.rs
+++ b/crates/ruscker-admin/src/routes/admin.rs
@@ -159,7 +159,7 @@ async fn show_token_form(state: &AppState, force_token: bool) -> bool {
     if force_token {
         return true;
     }
-    match state.sqlite() {
+    match state.db.as_ref() {
         Some(pool) => !db::users::any_user_exists(pool).await.unwrap_or(false),
         None => true,
     }
@@ -242,7 +242,7 @@ async fn login_submit(
 
     // Username/password login needs the user store. Without a DB the
     // only way in is the break-glass token.
-    let Some(pool) = state.sqlite() else {
+    let Some(pool) = state.db.as_ref() else {
         return login_error(&state, loc, theme, "wrong-login", false);
     };
 
@@ -320,7 +320,7 @@ async fn token_login(
     issue_session_cookie(&cookies, &headers, session_id);
 
     // No admin account yet (and a DB to create one in) ⇒ run setup.
-    let need_setup = match state.sqlite() {
+    let need_setup = match state.db.as_ref() {
         Some(pool) => !db::users::any_admin_exists(pool).await.unwrap_or(false),
         None => false,
     };
@@ -344,7 +344,7 @@ async fn setup_form(
 ) -> Response {
     // Setup is admin-gated and only meaningful before the first admin
     // account exists. Once one does, send the operator to the dashboard.
-    if let Some(pool) = state.sqlite() {
+    if let Some(pool) = state.db.as_ref() {
         if db::users::any_admin_exists(pool).await.unwrap_or(false) {
             return Redirect::to("/admin/dashboard").into_response();
         }
@@ -380,7 +380,7 @@ async fn setup_submit(
     headers: HeaderMap,
     Form(form): Form<SetupForm>,
 ) -> Response {
-    let Some(pool) = state.sqlite() else {
+    let Some(pool) = state.db.as_ref() else {
         return (
             StatusCode::SERVICE_UNAVAILABLE,
             "no database — start with --db",
@@ -447,7 +447,7 @@ async fn password_form(
     let Some(actor) = session.actor.clone() else {
         return Redirect::to("/admin/dashboard").into_response();
     };
-    let first = match state.sqlite() {
+    let first = match state.db.as_ref() {
         Some(pool) => db::users::fetch(pool, &actor)
             .await
             .ok()
@@ -488,7 +488,7 @@ async fn password_submit(
     let Some(actor) = session.actor.clone() else {
         return Redirect::to("/admin/dashboard").into_response();
     };
-    let Some(pool) = state.sqlite() else {
+    let Some(pool) = state.db.as_ref() else {
         return (
             StatusCode::SERVICE_UNAVAILABLE,
             "no database — start with --db",

--- a/crates/ruscker-admin/src/routes/admin/users.rs
+++ b/crates/ruscker-admin/src/routes/admin/users.rs
@@ -78,7 +78,7 @@ async fn index(
     theme: Theme,
     Query(q): Query<UsersQuery>,
 ) -> Response {
-    let Some(pool) = state.sqlite() else {
+    let Some(pool) = state.db.as_ref() else {
         return (
             StatusCode::SERVICE_UNAVAILABLE,
             "database not attached — start with --db <path>",
@@ -129,7 +129,7 @@ async fn create(
     State(state): State<AppState>,
     Form(form): Form<CreateForm>,
 ) -> Response {
-    let Some(pool) = state.sqlite() else {
+    let Some(pool) = state.db.as_ref() else {
         return (StatusCode::SERVICE_UNAVAILABLE, "no db").into_response();
     };
     let username = db::users::normalize_username(&form.username);
@@ -167,7 +167,7 @@ async fn set_role(
     Path(username): Path<String>,
     Form(form): Form<RoleForm>,
 ) -> Response {
-    let Some(pool) = state.sqlite() else {
+    let Some(pool) = state.db.as_ref() else {
         return (StatusCode::SERVICE_UNAVAILABLE, "no db").into_response();
     };
     let new_role = Role::parse(&form.role).unwrap_or(Role::Viewer);
@@ -196,7 +196,7 @@ async fn reset_password(
     Path(username): Path<String>,
     Form(form): Form<ResetForm>,
 ) -> Response {
-    let Some(pool) = state.sqlite() else {
+    let Some(pool) = state.db.as_ref() else {
         return (StatusCode::SERVICE_UNAVAILABLE, "no db").into_response();
     };
     if form.password.len() < MIN_PASSWORD_LEN {
@@ -218,7 +218,7 @@ async fn delete(
     State(state): State<AppState>,
     Path(username): Path<String>,
 ) -> Response {
-    let Some(pool) = state.sqlite() else {
+    let Some(pool) = state.db.as_ref() else {
         return (StatusCode::SERVICE_UNAVAILABLE, "no db").into_response();
     };
     // Last-admin guard: deleting the only admin would lock everyone out.
@@ -238,7 +238,7 @@ async fn delete(
 /// `new_role` is `None`) leave the portal with zero admins? True ⇒ the
 /// caller must refuse.
 async fn would_strip_last_admin(
-    pool: &sqlx::SqlitePool,
+    pool: &crate::db::ConfigDb,
     username: &str,
     new_role: Option<Role>,
 ) -> bool {

--- a/crates/ruscker-admin/tests/user_accounts.rs
+++ b/crates/ruscker-admin/tests/user_accounts.rs
@@ -91,7 +91,7 @@ async fn wrong_token_is_rejected() {
 #[tokio::test]
 async fn password_login_succeeds_and_wrong_fails() {
     let (state, pool) = state_with_db().await;
-    ruscker_admin::db::users::create(&pool, "alice", "alicepass1", Role::Editor, false, None)
+    ruscker_admin::db::users::create(&ruscker_admin::db::ConfigDb::Sqlite(pool.clone()), "alice", "alicepass1", Role::Editor, false, None)
         .await
         .unwrap();
 
@@ -113,7 +113,7 @@ async fn password_login_succeeds_and_wrong_fails() {
 async fn first_login_with_must_change_redirects_to_password() {
     let (state, pool) = state_with_db().await;
     // must_change = true ⇒ first login lands on the change-password page.
-    ruscker_admin::db::users::create(&pool, "bob", "bobpass12", Role::Viewer, true, None)
+    ruscker_admin::db::users::create(&ruscker_admin::db::ConfigDb::Sqlite(pool.clone()), "bob", "bobpass12", Role::Viewer, true, None)
         .await
         .unwrap();
     let (status, loc) = post(
@@ -130,7 +130,7 @@ async fn first_login_with_must_change_redirects_to_password() {
 #[tokio::test]
 async fn last_admin_cannot_be_deleted() {
     let (state, pool) = state_with_db().await;
-    ruscker_admin::db::users::create(&pool, "root", "rootpass1", Role::Admin, false, None)
+    ruscker_admin::db::users::create(&ruscker_admin::db::ConfigDb::Sqlite(pool.clone()), "root", "rootpass1", Role::Admin, false, None)
         .await
         .unwrap();
     // Mint an admin session directly (the shared store the router reads).
@@ -144,7 +144,7 @@ async fn last_admin_cannot_be_deleted() {
     assert!(loc.contains("flash=last-admin"), "got {loc}");
     // The sole admin survives.
     assert_eq!(
-        ruscker_admin::db::users::count_admins(&pool).await.unwrap(),
+        ruscker_admin::db::users::count_admins(&ruscker_admin::db::ConfigDb::Sqlite(pool.clone())).await.unwrap(),
         1
     );
 }


### PR DESCRIPTION
Admin user accounts (login, RBAC, CRUD) now work against **either** backend — the last admin-write module before `audit` and `import_all`.

## What's here
- All eleven DB fns take `&ConfigDb`: `count_admins` / `any_admin_exists` / `any_user_exists` / `list_all` / `fetch` / `verify_login` (reads); `create` / `set_password` / `set_role` / `delete` (tx + audit); `clear_must_change` (single UPDATE). Pure helpers (`hash_password`, `verify_password`, `normalize_username`, timing decoy) untouched; an `audit_pg` twin mirrors the role-audit insert.
- `must_change_password` reads as `bool` (one Row type both ways — sqlx decodes SQLite INTEGER 0/1 and Postgres BOOLEAN) and binds as `bool` on the Postgres arm; `clear_must_change` uses `= FALSE` (valid on both). `count_admins`/`any_user_exists` read `COUNT(*)` as `i64` (BIGINT on Postgres).
- Callers pass the `ConfigDb`: the users admin routes (incl. the `would_strip_last_admin` last-admin guard) and the auth flows in `admin.rs` (login / setup / account / password). The `user_accounts` integration test wraps its pool in `ConfigDb::Sqlite`.
- **Gated test** (`--features postgres-it`): full lifecycle — create, count/last-admin, case-insensitive `verify_login` (right/wrong/unknown), promote, `set_password` clearing must-change, delete — against real Postgres.

## Verification
- **317 default tests green**; edited files 0-drift.
- All ten `postgres-it` tests pass against a real `postgres:16-alpine` (`users_against_real_postgres ... ok`, plus the nine prior).

Next: **7c-8** ports `audit` (`QueryBuilder<Postgres>`) and a dual `import_all`, then the CLI `--config-db-url` flag wires Postgres mode end-to-end.

🤖 Generated with [Claude Code](https://claude.com/claude-code)