### PR TITLE
Phase 7c-8: port audit + import_all to dual-dialect (#128)

### DIFF
--- a/crates/ruscker-admin/src/db/audit.rs
+++ b/crates/ruscker-admin/src/db/audit.rs
@@ -13,7 +13,8 @@
 
 use anyhow::{Context, Result};
 use chrono::{DateTime, Utc};
-use sqlx::SqlitePool;
+
+use crate::db::ConfigDb;
 
 /// One row of `audit_log`, with `diff_json` parsed when valid.
 #[derive(Debug, Clone)]
@@ -81,16 +82,26 @@ impl AuditFilter {
     }
 }
 
-/// List rows matching `filter`, newest first.
-///
-/// Dynamic WHERE built via [`sqlx::QueryBuilder`] (the typed
-/// `query_as` family takes `&'static str` only). All values are
-/// bound through `push_bind`; no string interpolation, no SQL
-/// injection.
-pub async fn list(pool: &SqlitePool, filter: &AuditFilter) -> Result<Vec<AuditEntry>> {
-    let mut qb: sqlx::QueryBuilder<sqlx::Sqlite> = sqlx::QueryBuilder::new(
-        "SELECT id, actor, action, target, diff_json, occurred_at FROM audit_log WHERE 1=1",
-    );
+/// Row tuple shared by both dialect arms of [`list`].
+type ListRow = (
+    i64,
+    Option<String>,
+    String,
+    Option<String>,
+    Option<String>,
+    DateTime<Utc>,
+);
+
+/// Append the dynamic WHERE/ORDER/LIMIT for [`list`] onto a
+/// [`sqlx::QueryBuilder`]. Generic over the database so the SQLite and
+/// Postgres arms share one filter definition — `push_bind` emits the
+/// right placeholder (`?` vs `$n`) for each backend automatically.
+fn push_filters<DB>(qb: &mut sqlx::QueryBuilder<DB>, filter: &AuditFilter)
+where
+    DB: sqlx::Database,
+    String: sqlx::Type<DB> + for<'q> sqlx::Encode<'q, DB>,
+    i64: sqlx::Type<DB> + for<'q> sqlx::Encode<'q, DB>,
+{
     if let Some(family) = filter.family {
         qb.push(" AND action LIKE ");
         qb.push_bind(format!("{}%", family.as_prefix()));
@@ -105,12 +116,31 @@ pub async fn list(pool: &SqlitePool, filter: &AuditFilter) -> Result<Vec<AuditEn
     }
     qb.push(" ORDER BY id DESC LIMIT ");
     qb.push_bind(filter.limit.max(1).min(1000));
+}
 
-    let rows: Vec<(i64, Option<String>, String, Option<String>, Option<String>, DateTime<Utc>)> =
-        qb.build_query_as()
-            .fetch_all(pool)
-            .await
-            .context("list audit_log")?;
+const LIST_SELECT: &str =
+    "SELECT id, actor, action, target, diff_json, occurred_at FROM audit_log WHERE 1=1";
+
+/// List rows matching `filter`, newest first.
+///
+/// Dynamic WHERE built via [`sqlx::QueryBuilder`] (the typed
+/// `query_as` family takes `&'static str` only). All values are
+/// bound through `push_bind`; no string interpolation, no SQL
+/// injection.
+pub async fn list(db: &ConfigDb, filter: &AuditFilter) -> Result<Vec<AuditEntry>> {
+    let rows: Vec<ListRow> = match db {
+        ConfigDb::Sqlite(pool) => {
+            let mut qb: sqlx::QueryBuilder<sqlx::Sqlite> = sqlx::QueryBuilder::new(LIST_SELECT);
+            push_filters(&mut qb, filter);
+            qb.build_query_as().fetch_all(pool).await
+        }
+        ConfigDb::Postgres(pool) => {
+            let mut qb: sqlx::QueryBuilder<sqlx::Postgres> = sqlx::QueryBuilder::new(LIST_SELECT);
+            push_filters(&mut qb, filter);
+            qb.build_query_as().fetch_all(pool).await
+        }
+    }
+    .context("list audit_log")?;
 
     Ok(rows
         .into_iter()
@@ -130,12 +160,25 @@ pub async fn list(pool: &SqlitePool, filter: &AuditFilter) -> Result<Vec<AuditEn
 /// Distinct values of `action` currently in the table — used to
 /// populate the filter dropdown so the UI doesn't enumerate
 /// actions that have never fired in this install.
-pub async fn distinct_actions(pool: &SqlitePool) -> Result<Vec<String>> {
-    let rows: Vec<(String,)> =
-        sqlx::query_as("SELECT DISTINCT action FROM audit_log ORDER BY action ASC")
-            .fetch_all(pool)
-            .await
-            .context("distinct actions")?;
+pub async fn distinct_actions(db: &ConfigDb) -> Result<Vec<String>> {
+    let sql = "SELECT DISTINCT action FROM audit_log ORDER BY action ASC";
+    let rows: Vec<(String,)> = match db {
+        ConfigDb::Sqlite(pool) => sqlx::query_as(sql).fetch_all(pool).await,
+        ConfigDb::Postgres(pool) => sqlx::query_as(sql).fetch_all(pool).await,
+    }
+    .context("distinct actions")?;
+    Ok(rows.into_iter().map(|(a,)| a).collect())
+}
+
+/// Distinct non-null `actor` values — populates the actor filter
+/// dropdown (only worth showing on multi-operator installs).
+pub async fn distinct_actors(db: &ConfigDb) -> Result<Vec<String>> {
+    let sql = "SELECT DISTINCT actor FROM audit_log WHERE actor IS NOT NULL ORDER BY actor ASC";
+    let rows: Vec<(String,)> = match db {
+        ConfigDb::Sqlite(pool) => sqlx::query_as(sql).fetch_all(pool).await,
+        ConfigDb::Postgres(pool) => sqlx::query_as(sql).fetch_all(pool).await,
+    }
+    .context("distinct actors")?;
     Ok(rows.into_iter().map(|(a,)| a).collect())
 }
 
@@ -145,7 +188,8 @@ mod tests {
     use crate::db::open_memory;
     use chrono::Utc;
 
-    async fn seed(pool: &SqlitePool, action: &str, target: Option<&str>, actor: Option<&str>) {
+    async fn seed(db: &ConfigDb, action: &str, target: Option<&str>, actor: Option<&str>) {
+        let pool = db.as_sqlite().unwrap();
         sqlx::query(
             "INSERT INTO audit_log (actor, action, target, diff_json, occurred_at)
              VALUES (?, ?, ?, NULL, ?)",
@@ -161,12 +205,12 @@ mod tests {
 
     #[tokio::test]
     async fn list_returns_newest_first() {
-        let pool = open_memory().await.unwrap();
-        seed(&pool, "spec.create", Some("spec:a"), None).await;
-        seed(&pool, "spec.update", Some("spec:a"), None).await;
-        seed(&pool, "spec.delete", Some("spec:a"), None).await;
+        let db = ConfigDb::Sqlite(open_memory().await.unwrap());
+        seed(&db, "spec.create", Some("spec:a"), None).await;
+        seed(&db, "spec.update", Some("spec:a"), None).await;
+        seed(&db, "spec.delete", Some("spec:a"), None).await;
 
-        let v = list(&pool, &AuditFilter::new()).await.unwrap();
+        let v = list(&db, &AuditFilter::new()).await.unwrap();
         assert_eq!(v.len(), 3);
         assert_eq!(v[0].action, "spec.delete");
         assert_eq!(v[2].action, "spec.create");
@@ -174,46 +218,98 @@ mod tests {
 
     #[tokio::test]
     async fn family_filter_narrows_by_prefix() {
-        let pool = open_memory().await.unwrap();
-        seed(&pool, "spec.create", Some("spec:a"), None).await;
-        seed(&pool, "image.upload", Some("image:1"), None).await;
-        seed(&pool, "credential.create", Some("credential:dh"), None).await;
+        let db = ConfigDb::Sqlite(open_memory().await.unwrap());
+        seed(&db, "spec.create", Some("spec:a"), None).await;
+        seed(&db, "image.upload", Some("image:1"), None).await;
+        seed(&db, "credential.create", Some("credential:dh"), None).await;
 
         let f = AuditFilter {
             family: Some(ActionFamily::Image),
             ..AuditFilter::new()
         };
-        let v = list(&pool, &f).await.unwrap();
+        let v = list(&db, &f).await.unwrap();
         assert_eq!(v.len(), 1);
         assert_eq!(v[0].action, "image.upload");
     }
 
     #[tokio::test]
     async fn target_substring_filter() {
-        let pool = open_memory().await.unwrap();
-        seed(&pool, "spec.update", Some("spec:sales-dashboard"), None).await;
-        seed(&pool, "spec.update", Some("spec:ops-report"), None).await;
+        let db = ConfigDb::Sqlite(open_memory().await.unwrap());
+        seed(&db, "spec.update", Some("spec:sales-dashboard"), None).await;
+        seed(&db, "spec.update", Some("spec:ops-report"), None).await;
 
         let f = AuditFilter {
             target_contains: Some("sales".into()),
             ..AuditFilter::new()
         };
-        let v = list(&pool, &f).await.unwrap();
+        let v = list(&db, &f).await.unwrap();
         assert_eq!(v.len(), 1);
         assert_eq!(v[0].target.as_deref(), Some("spec:sales-dashboard"));
     }
 
     #[tokio::test]
     async fn limit_caps_returned_rows() {
-        let pool = open_memory().await.unwrap();
+        let db = ConfigDb::Sqlite(open_memory().await.unwrap());
         for i in 0..10 {
-            seed(&pool, "spec.create", Some(&format!("spec:{i}")), None).await;
+            seed(&db, "spec.create", Some(&format!("spec:{i}")), None).await;
         }
         let f = AuditFilter {
             limit: 3,
             ..AuditFilter::new()
         };
-        let v = list(&pool, &f).await.unwrap();
+        let v = list(&db, &f).await.unwrap();
         assert_eq!(v.len(), 3);
+    }
+
+    // list (newest-first + family filter via QueryBuilder<Postgres>) +
+    // distinct_actions / distinct_actors against a real daemon. Gated
+    // on `postgres-it`.
+    #[cfg(feature = "postgres-it")]
+    #[tokio::test]
+    async fn audit_against_real_postgres() {
+        let _guard = crate::db::pg_test_lock().lock().await;
+        let url = std::env::var("RUSCKER_TEST_PG_URL")
+            .expect("set RUSCKER_TEST_PG_URL to a reachable postgres:// DSN");
+        let pg = crate::db::open_pg(&url).await.unwrap();
+        sqlx::query("DELETE FROM audit_log")
+            .execute(&pg)
+            .await
+            .unwrap();
+        for (action, target, actor) in [
+            ("spec.create", "spec:a", Some("root")),
+            ("image.upload", "image:1", None),
+            ("spec.update", "spec:a", Some("ed")),
+        ] {
+            sqlx::query(
+                "INSERT INTO audit_log (actor, action, target, diff_json, occurred_at)
+                 VALUES ($1, $2, $3, NULL, now())",
+            )
+            .bind(actor)
+            .bind(action)
+            .bind(target)
+            .execute(&pg)
+            .await
+            .unwrap();
+        }
+        let db = ConfigDb::Postgres(pg);
+
+        let all = list(&db, &AuditFilter::new()).await.unwrap();
+        assert_eq!(all.len(), 3);
+        assert_eq!(all[0].action, "spec.update", "newest first");
+
+        let f = AuditFilter {
+            family: Some(ActionFamily::Image),
+            ..AuditFilter::new()
+        };
+        assert_eq!(list(&db, &f).await.unwrap().len(), 1);
+
+        assert!(distinct_actions(&db)
+            .await
+            .unwrap()
+            .contains(&"spec.create".to_string()));
+        assert_eq!(
+            distinct_actors(&db).await.unwrap(),
+            vec!["ed".to_string(), "root".to_string()]
+        );
     }
 }

--- a/crates/ruscker-admin/src/db/export.rs
+++ b/crates/ruscker-admin/src/db/export.rs
@@ -105,7 +105,7 @@ mod tests {
     async fn round_trip_preserves_specs_count() {
         let pool = open_memory().await.unwrap();
         let cfg_in = Config::from_yaml(&fixture_yaml()).unwrap();
-        import_all(&pool, &cfg_in).await.unwrap();
+        import_all(&crate::db::ConfigDb::Sqlite(pool.clone()), &cfg_in).await.unwrap();
 
         let cfg_out = reconstruct_config(&pool).await.unwrap();
         assert_eq!(cfg_out.proxy.specs.len(), cfg_in.proxy.specs.len());
@@ -115,19 +115,19 @@ mod tests {
     async fn round_trip_then_reimport_is_unchanged() {
         let pool = open_memory().await.unwrap();
         let cfg_in = Config::from_yaml(&fixture_yaml()).unwrap();
-        import_all(&pool, &cfg_in).await.unwrap();
+        import_all(&crate::db::ConfigDb::Sqlite(pool.clone()), &cfg_in).await.unwrap();
 
         let cfg_out = reconstruct_config(&pool).await.unwrap();
 
         // Re-import the exported Config into a fresh DB — every
         // spec should land as Created.
         let pool2 = open_memory().await.unwrap();
-        let r = import_all(&pool2, &cfg_out).await.unwrap();
+        let r = import_all(&crate::db::ConfigDb::Sqlite(pool2.clone()), &cfg_out).await.unwrap();
         assert_eq!(r.created, cfg_in.proxy.specs.len());
 
         // And re-import the same Config into the SAME DB — every
         // spec unchanged.
-        let r2 = import_all(&pool2, &cfg_out).await.unwrap();
+        let r2 = import_all(&crate::db::ConfigDb::Sqlite(pool2.clone()), &cfg_out).await.unwrap();
         assert_eq!(r2.unchanged, cfg_in.proxy.specs.len());
         assert_eq!(r2.updated, 0);
     }
@@ -136,7 +136,7 @@ mod tests {
     async fn round_trip_preserves_landing_customization() {
         let pool = open_memory().await.unwrap();
         let cfg_in = Config::from_yaml(&fixture_yaml()).unwrap();
-        import_all(&pool, &cfg_in).await.unwrap();
+        import_all(&crate::db::ConfigDb::Sqlite(pool.clone()), &cfg_in).await.unwrap();
         let cfg_out = reconstruct_config(&pool).await.unwrap();
 
         assert_eq!(
@@ -166,7 +166,7 @@ proxy:
         // `enabled` defaults to true when the key is omitted.
         assert!(cfg_in.proxy.landing_customization.blocks[1].enabled);
 
-        import_all(&pool, &cfg_in).await.unwrap();
+        import_all(&crate::db::ConfigDb::Sqlite(pool.clone()), &cfg_in).await.unwrap();
         let cfg_out = reconstruct_config(&pool).await.unwrap();
         let out = &cfg_out.proxy.landing_customization.blocks;
 
@@ -189,7 +189,7 @@ proxy:
     async fn round_trip_preserves_proxy_settings() {
         let pool = open_memory().await.unwrap();
         let cfg_in = Config::from_yaml(&fixture_yaml()).unwrap();
-        import_all(&pool, &cfg_in).await.unwrap();
+        import_all(&crate::db::ConfigDb::Sqlite(pool.clone()), &cfg_in).await.unwrap();
         let cfg_out = reconstruct_config(&pool).await.unwrap();
 
         assert_eq!(cfg_out.proxy.title, cfg_in.proxy.title);

--- a/crates/ruscker-admin/src/db/landing_blocks.rs
+++ b/crates/ruscker-admin/src/db/landing_blocks.rs
@@ -369,6 +369,49 @@ pub(crate) async fn replace_all_in_tx(
     Ok(())
 }
 
+/// Postgres twin of [`replace_all_in_tx`] — `$n` placeholders, and
+/// `enabled` binds as the native `bool`. Used by the Postgres arm of
+/// `specs::import_all`.
+pub(crate) async fn replace_all_in_tx_pg(
+    tx: &mut sqlx::Transaction<'_, sqlx::Postgres>,
+    blocks: &[ruscker_config::LandingBlock],
+    now: chrono::DateTime<Utc>,
+) -> Result<()> {
+    sqlx::query("DELETE FROM landing_blocks")
+        .execute(&mut **tx)
+        .await
+        .context("clear landing_blocks")?;
+
+    let mut next: std::collections::HashMap<String, i64> = std::collections::HashMap::new();
+    for b in blocks {
+        let slot = if SLOTS.contains(&b.slot.as_str()) {
+            b.slot.as_str()
+        } else {
+            "top"
+        };
+        let pos = next.entry(slot.to_owned()).or_insert(0);
+        sqlx::query(
+            "INSERT INTO landing_blocks
+               (id, slot, position, enabled, title, html, csp_origins, created_at, updated_at)
+             VALUES ($1, $2, $3, $4, $5, $6, $7, $8, $9)",
+        )
+        .bind(uuid::Uuid::new_v4().to_string())
+        .bind(slot)
+        .bind(*pos)
+        .bind(b.enabled)
+        .bind(&b.title)
+        .bind(&b.html)
+        .bind(&b.csp_origins)
+        .bind(now)
+        .bind(now)
+        .execute(&mut **tx)
+        .await
+        .context("insert imported block")?;
+        *pos += 1;
+    }
+    Ok(())
+}
+
 /// Move a block one step within its slot by swapping `position` with
 /// the adjacent block (`up` = toward the front). No-op (returns
 /// `false`) when the block doesn't exist or is already at the slot

--- a/crates/ruscker-admin/src/db/specs.rs
+++ b/crates/ruscker-admin/src/db/specs.rs
@@ -8,7 +8,6 @@ use crate::db::ConfigDb;
 use anyhow::{Context, Result};
 use chrono::{DateTime, Utc};
 use ruscker_config::{Config, Spec};
-use sqlx::SqlitePool;
 
 /// What happened during [`import_all`].
 #[derive(Debug, Default, Clone)]
@@ -30,56 +29,68 @@ pub struct ImportReport {
 /// incoming config are NOT deleted — that's a separate operator
 /// action (no surprise destruction).
 ///
-/// The whole import runs in a single transaction.
-pub async fn import_all(pool: &SqlitePool, config: &Config) -> Result<ImportReport> {
+/// The whole import runs in a single transaction. Dual-dialect: each
+/// arm uses its backend's `*_in_tx` writers (SQLite vs Postgres twins)
+/// and placeholders, but the spec-iteration + report bookkeeping is the
+/// same shape.
+pub async fn import_all(db: &ConfigDb, config: &Config) -> Result<ImportReport> {
     let now = Utc::now();
-    let mut tx = pool.begin().await.context("begin import tx")?;
+    let lc = &config.proxy.landing_customization;
+    // The rest of `proxy` (minus specs + landing-customization) and the
+    // top-level server / logging blocks round-trip as JSON in
+    // config_meta — computed once, written inside the chosen arm.
+    let proxy_meta = proxy_meta_value(&config.proxy)?;
+    let server_meta = serde_json::to_value(&config.server)?;
+    let logging_meta = serde_json::to_value(&config.logging)?;
 
-    let mut report = ImportReport::default();
-
-    for spec in &config.proxy.specs {
-        let outcome = upsert_in_tx(&mut tx, spec, now).await?;
-        match outcome {
-            UpsertOutcome::Created => report.created += 1,
-            UpsertOutcome::Updated => report.updated += 1,
-            UpsertOutcome::Unchanged => report.unchanged += 1,
+    match db {
+        ConfigDb::Sqlite(pool) => {
+            let mut tx = pool.begin().await.context("begin import tx")?;
+            let mut report = ImportReport::default();
+            for spec in &config.proxy.specs {
+                tally(&mut report, upsert_in_tx(&mut tx, spec, now).await?);
+            }
+            super::landing::update_in_tx(&mut tx, lc, now).await?;
+            super::landing_blocks::replace_all_in_tx(&mut tx, &lc.blocks, now).await?;
+            upsert_meta(&mut tx, "proxy", &proxy_meta, now).await?;
+            upsert_meta(&mut tx, "server", &server_meta, now).await?;
+            upsert_meta(&mut tx, "logging", &logging_meta, now).await?;
+            sqlx::query(
+                "INSERT INTO audit_log (actor, action, target, diff_json, occurred_at)
+                 VALUES (NULL, 'spec.import', NULL, ?, ?)",
+            )
+            .bind(import_diff(&report)?)
+            .bind(now)
+            .execute(&mut *tx)
+            .await
+            .context("audit import")?;
+            tx.commit().await.context("commit import tx")?;
+            Ok(report)
+        }
+        ConfigDb::Postgres(pool) => {
+            let mut tx = pool.begin().await.context("begin import tx")?;
+            let mut report = ImportReport::default();
+            for spec in &config.proxy.specs {
+                tally(&mut report, upsert_in_tx_pg(&mut tx, spec, now).await?);
+            }
+            super::landing::update_in_tx_pg(&mut tx, lc, now).await?;
+            super::landing_blocks::replace_all_in_tx_pg(&mut tx, &lc.blocks, now).await?;
+            upsert_meta_pg(&mut tx, "proxy", &proxy_meta, now).await?;
+            upsert_meta_pg(&mut tx, "server", &server_meta, now).await?;
+            upsert_meta_pg(&mut tx, "logging", &logging_meta, now).await?;
+            sqlx::query(
+                "INSERT INTO audit_log (actor, action, target, diff_json, occurred_at)
+                 VALUES (NULL, 'spec.import', NULL, $1, $2)",
+            )
+            .bind(import_diff(&report)?)
+            .bind(now)
+            .execute(&mut *tx)
+            .await
+            .context("audit import")?;
+            tx.commit().await.context("commit import tx")?;
+            Ok(report)
         }
     }
-
-    // Landing customization is a singleton — replace it whole, incl.
-    // SEO/analytics columns (via the shared writer) and the custom
-    // HTML blocks, so the full landing config round-trips.
-    let lc = &config.proxy.landing_customization;
-    super::landing::update_in_tx(&mut tx, lc, now).await?;
-    super::landing_blocks::replace_all_in_tx(&mut tx, &lc.blocks, now).await?;
-
-    // Persist the rest of `proxy` (everything except specs and
-    // landing-customization) + the top-level server / logging
-    // blocks as JSON blobs in config_meta. Lets export reconstruct
-    // a byte-equivalent (mod whitespace) YAML without inventing
-    // schema for every field the admin UI doesn't expose yet.
-    let proxy_meta = proxy_meta_value(&config.proxy)?;
-    upsert_meta(&mut tx, "proxy", &proxy_meta, now).await?;
-    upsert_meta(&mut tx, "server", &serde_json::to_value(&config.server)?, now).await?;
-    upsert_meta(&mut tx, "logging", &serde_json::to_value(&config.logging)?, now).await?;
-
-    // System-level audit entry for the import.
-    sqlx::query(
-        "INSERT INTO audit_log (actor, action, target, diff_json, occurred_at)
-         VALUES (NULL, 'spec.import', NULL, ?, ?)",
-    )
-    .bind(serde_json::to_string(&serde_json::json!({
-        "created": report.created,
-        "updated": report.updated,
-        "unchanged": report.unchanged,
-    }))?)
-    .bind(now)
-    .execute(&mut *tx)
-    .await
-    .context("audit import")?;
-
-    tx.commit().await.context("commit import tx")?;
-    Ok(report)
 }
 
 #[derive(Debug, PartialEq, Eq)]
@@ -87,6 +98,24 @@ pub enum UpsertOutcome {
     Created,
     Updated,
     Unchanged,
+}
+
+/// Fold one per-spec [`UpsertOutcome`] into the running [`ImportReport`].
+fn tally(report: &mut ImportReport, outcome: UpsertOutcome) {
+    match outcome {
+        UpsertOutcome::Created => report.created += 1,
+        UpsertOutcome::Updated => report.updated += 1,
+        UpsertOutcome::Unchanged => report.unchanged += 1,
+    }
+}
+
+/// The `diff_json` for the system-level import audit row.
+fn import_diff(report: &ImportReport) -> Result<String> {
+    Ok(serde_json::to_string(&serde_json::json!({
+        "created": report.created,
+        "updated": report.updated,
+        "unchanged": report.unchanged,
+    }))?)
 }
 
 /// Fetch a single spec by id, deserializing `config_json` back to
@@ -487,6 +516,31 @@ async fn upsert_meta(
     Ok(())
 }
 
+/// Postgres twin of [`upsert_meta`]. SQLite's `INSERT OR REPLACE`
+/// becomes the standard `ON CONFLICT (key) DO UPDATE`.
+async fn upsert_meta_pg(
+    tx: &mut sqlx::Transaction<'_, sqlx::Postgres>,
+    key: &str,
+    value: &serde_json::Value,
+    now: DateTime<Utc>,
+) -> Result<()> {
+    let json = serde_json::to_string(value)?;
+    sqlx::query(
+        "INSERT INTO config_meta (key, value_json, updated_at)
+         VALUES ($1, $2, $3)
+         ON CONFLICT (key) DO UPDATE SET
+           value_json = excluded.value_json,
+           updated_at = excluded.updated_at",
+    )
+    .bind(key)
+    .bind(&json)
+    .bind(now)
+    .execute(&mut **tx)
+    .await
+    .with_context(|| format!("upsert config_meta[{key}]"))?;
+    Ok(())
+}
+
 fn kind_str(spec: &Spec) -> &'static str {
     use ruscker_config::SpecKind;
     match spec.kind() {
@@ -513,12 +567,12 @@ mod tests {
         let cfg = Config::from_yaml(&fixture_yaml()).unwrap();
         let n = cfg.proxy.specs.len();
 
-        let r1 = import_all(&pool, &cfg).await.unwrap();
+        let r1 = import_all(&ConfigDb::Sqlite(pool.clone()), &cfg).await.unwrap();
         assert_eq!(r1.created, n, "first import inserts all");
         assert_eq!(r1.updated, 0);
         assert_eq!(r1.unchanged, 0);
 
-        let r2 = import_all(&pool, &cfg).await.unwrap();
+        let r2 = import_all(&ConfigDb::Sqlite(pool.clone()), &cfg).await.unwrap();
         assert_eq!(r2.created, 0, "second import sees them as existing");
         assert_eq!(r2.updated, 0, "no changes → no version bumps");
         assert_eq!(r2.unchanged, n);
@@ -537,11 +591,11 @@ mod tests {
     async fn modifying_a_spec_bumps_version() {
         let pool = open_memory().await.unwrap();
         let mut cfg = Config::from_yaml(&fixture_yaml()).unwrap();
-        import_all(&pool, &cfg).await.unwrap();
+        import_all(&ConfigDb::Sqlite(pool.clone()), &cfg).await.unwrap();
 
         // Tweak one spec's description and re-import.
         cfg.proxy.specs[0].description = Some("Updated description".to_string());
-        let r = import_all(&pool, &cfg).await.unwrap();
+        let r = import_all(&ConfigDb::Sqlite(pool.clone()), &cfg).await.unwrap();
         assert_eq!(r.updated, 1);
         assert_eq!(r.unchanged, cfg.proxy.specs.len() - 1);
 
@@ -566,7 +620,7 @@ mod tests {
     async fn landing_customization_round_trips() {
         let pool = open_memory().await.unwrap();
         let cfg = Config::from_yaml(&fixture_yaml()).unwrap();
-        import_all(&pool, &cfg).await.unwrap();
+        import_all(&ConfigDb::Sqlite(pool.clone()), &cfg).await.unwrap();
 
         let row: (Option<String>, Option<String>, Option<String>, String) = sqlx::query_as(
             "SELECT header_bg, header_fg, intro, intro_locales_json
@@ -641,5 +695,44 @@ mod tests {
                 .await
                 .unwrap();
         assert_eq!(history, 0, "cascade cleared history");
+    }
+
+    // The full `import_all` transaction (specs + landing + blocks +
+    // config_meta + audit) through the Postgres arm, plus idempotency.
+    // Gated on `postgres-it`.
+    #[cfg(feature = "postgres-it")]
+    #[tokio::test]
+    async fn import_all_against_real_postgres() {
+        let _guard = crate::db::pg_test_lock().lock().await;
+        let url = std::env::var("RUSCKER_TEST_PG_URL")
+            .expect("set RUSCKER_TEST_PG_URL to a reachable postgres:// DSN");
+        let pool = crate::db::open_pg(&url).await.unwrap();
+        // Clear what the import writes (DELETE specs cascades spec_versions).
+        for stmt in [
+            "DELETE FROM specs",
+            "DELETE FROM landing_blocks",
+            "DELETE FROM config_meta",
+        ] {
+            sqlx::query(stmt).execute(&pool).await.unwrap();
+        }
+        let db = ConfigDb::Postgres(pool.clone());
+
+        let cfg = Config::from_yaml(&fixture_yaml()).unwrap();
+        let n = cfg.proxy.specs.len();
+
+        let r1 = import_all(&db, &cfg).await.unwrap();
+        assert_eq!(r1.created, n, "first import inserts all");
+        assert_eq!(r1.updated, 0);
+
+        let r2 = import_all(&db, &cfg).await.unwrap();
+        assert_eq!(r2.unchanged, n, "re-import sees them unchanged");
+        assert_eq!(r2.created, 0);
+
+        // proxy / server / logging round-tripped into config_meta.
+        let (meta,): (i64,) = sqlx::query_as("SELECT COUNT(*) FROM config_meta")
+            .fetch_one(&pool)
+            .await
+            .unwrap();
+        assert_eq!(meta, 3);
     }
 }

--- a/crates/ruscker-admin/src/routes/admin/audit.rs
+++ b/crates/ruscker-admin/src/routes/admin/audit.rs
@@ -104,7 +104,7 @@ async fn index(
     theme: Theme,
     Query(q): Query<AuditQuery>,
 ) -> Response {
-    let Some(pool) = state.sqlite() else {
+    let Some(pool) = state.db.as_ref() else {
         return (StatusCode::SERVICE_UNAVAILABLE, "no db").into_response();
     };
 
@@ -126,15 +126,7 @@ async fn index(
     // Distinct actors only worth showing when there are at least
     // two — single-operator installs leak no information by
     // omitting the select.
-    let distinct_actors: Vec<String> = match sqlx::query_as::<_, (String,)>(
-        "SELECT DISTINCT actor FROM audit_log WHERE actor IS NOT NULL ORDER BY actor ASC",
-    )
-    .fetch_all(pool)
-    .await
-    {
-        Ok(rows) => rows.into_iter().map(|(s,)| s).collect(),
-        Err(_) => Vec::new(),
-    };
+    let distinct_actors: Vec<String> = db::audit::distinct_actors(pool).await.unwrap_or_default();
 
     let page = AuditPage {
         locale: loc,

--- a/crates/ruscker-admin/src/routes/admin/specs.rs
+++ b/crates/ruscker-admin/src/routes/admin/specs.rs
@@ -136,7 +136,7 @@ async fn index(
     theme: Theme,
     Query(flash): Query<SpecsQuery>,
 ) -> Response {
-    let Some(pool) = state.sqlite() else {
+    let Some(database) = state.db.as_ref() else {
         return (
             StatusCode::SERVICE_UNAVAILABLE,
             "database not attached — start with --db <path>",
@@ -144,14 +144,15 @@ async fn index(
             .into_response();
     };
 
-    let specs: Vec<SpecRow> = match sqlx::query_as(
-        "SELECT id, display_name, kind, state, updated_at, version
+    // Placeholder-free SELECT, so one query string serves both backends.
+    let sql = "SELECT id, display_name, kind, state, updated_at, version
            FROM specs
-           ORDER BY updated_at DESC, id ASC",
-    )
-    .fetch_all(pool)
-    .await
-    {
+           ORDER BY updated_at DESC, id ASC";
+    let loaded = match database {
+        crate::db::ConfigDb::Sqlite(pool) => sqlx::query_as(sql).fetch_all(pool).await,
+        crate::db::ConfigDb::Postgres(pool) => sqlx::query_as(sql).fetch_all(pool).await,
+    };
+    let specs: Vec<SpecRow> = match loaded {
         Ok(rows) => rows,
         Err(err) => {
             tracing::error!(error = ?err, "load specs failed");
@@ -187,7 +188,7 @@ async fn import(
     State(state): State<AppState>,
     mut multipart: Multipart,
 ) -> Response {
-    let Some(pool) = state.sqlite() else {
+    let Some(pool) = state.db.as_ref() else {
         return (StatusCode::SERVICE_UNAVAILABLE, "no db").into_response();
     };
 

--- a/crates/ruscker-cli/src/main.rs
+++ b/crates/ruscker-cli/src/main.rs
@@ -229,7 +229,11 @@ fn cmd_import(yaml_path: &PathBuf, db_path: &PathBuf) -> Result<()> {
 
     let report = rt.block_on(async {
         let pool = ruscker_admin::db::open(db_path).await?;
-        let r = ruscker_admin::db::specs::import_all(&pool, &config).await?;
+        let r = ruscker_admin::db::specs::import_all(
+            &ruscker_admin::db::ConfigDb::Sqlite(pool.clone()),
+            &config,
+        )
+        .await?;
         pool.close().await;
         anyhow::Ok(r)
     })?;


### PR DESCRIPTION
The **last repository port**. Every admin DB path now runs against either backend — only the readyz probe and the CLI `--config-db-url` flag remain (the final wiring slice, 7c-9).

## What's here
- **`audit`**: `list` / `distinct_actions` / a new `distinct_actors` take `&ConfigDb`. The dynamic filter is built by a generic `push_filters<DB>` so the SQLite and Postgres `QueryBuilder`s share one filter definition — `push_bind` emits `?` vs `$n` per backend. The audit route's inline distinct-actors query moved into the repo.
- **`import_all(&ConfigDb)`**: dual arms over one transaction. SQLite arm keeps the existing `*_in_tx` writers; Postgres arm uses the twins — `upsert_in_tx_pg`, `landing::update_in_tx_pg`, a new `landing_blocks::replace_all_in_tx_pg` (binds `enabled` as `bool`), and a new `specs::upsert_meta_pg` (`INSERT OR REPLACE` → `ON CONFLICT (key) DO UPDATE`). Shared `tally` / `import_diff` helpers.
- The `/admin/specs` list (placeholder-free SELECT) is dual too, so the catalog page renders on Postgres.
- Callers updated: specs admin routes (list + import), the audit route, the `ruscker import` CLI and the `export` round-trip tests wrap their pool in `ConfigDb::Sqlite`.
- **Gated tests** (`--features postgres-it`): audit list/filter/distinct, and the full `import_all` (+ idempotency, config_meta round-trip) against real Postgres.

## Verification
- **317 default tests green**; edited files 0-drift; no warnings.
- All twelve `postgres-it` tests pass against a real `postgres:16-alpine` (`audit_against_real_postgres ... ok`, `import_all_against_real_postgres ... ok`, + the ten prior).

**The whole `db::*` layer is dual-dialect now.** Next (7c-9, final): the CLI `--config-db-url` flag + readyz PG probe wire Postgres mode end-to-end and close Phase 7c.

🤖 Generated with [Claude Code](https://claude.com/claude-code)