### PR TITLE
Phase 7c-9: wire Postgres mode end-to-end — CLI flag + readyz probe (#128)

### DIFF
--- a/crates/ruscker-admin/src/lib.rs
+++ b/crates/ruscker-admin/src/lib.rs
@@ -257,6 +257,14 @@ impl AdminServer {
         self
     }
 
+    /// Attach a config database directly as a [`db::ConfigDb`] — used to
+    /// select the shared Postgres catalog for HA. `with_db` is the
+    /// SQLite shorthand for `with_config_db(ConfigDb::Sqlite(pool))`.
+    pub fn with_config_db(mut self, db: db::ConfigDb) -> Self {
+        self.state.db = Some(db);
+        self
+    }
+
     /// Start listening. Blocks until the process is shut down.
     pub async fn run(self) -> Result<()> {
         // Reconcile the in-memory replica registry with whatever

--- a/crates/ruscker-admin/src/routes/health.rs
+++ b/crates/ruscker-admin/src/routes/health.rs
@@ -73,14 +73,18 @@ async fn readyz(State(state): State<AppState>) -> Response {
     let mut checks = serde_json::Map::new();
     let mut ready = true;
 
-    // SQLite: a trivial round-trip confirms the pool can hand out a
-    // live connection (catches a deleted/locked DB file or an
-    // exhausted pool). In Postgres mode `sqlite()` is `None` and this
-    // probe is skipped until readiness learns to probe that pool too
-    // (a later Phase 7c slice, when the CLI can select Postgres).
-    if let Some(pool) = state.sqlite() {
-        match sqlx::query("SELECT 1").fetch_one(pool).await {
-            Ok(_) => {
+    // Config database: a trivial round-trip confirms the pool can hand
+    // out a live connection (catches a deleted/locked SQLite file, an
+    // unreachable Postgres, or an exhausted pool). Probes whichever
+    // backend is attached.
+    if let Some(db) = state.db.as_ref() {
+        use crate::db::ConfigDb;
+        let probe = match db {
+            ConfigDb::Sqlite(pool) => sqlx::query("SELECT 1").fetch_one(pool).await.map(|_| ()),
+            ConfigDb::Postgres(pool) => sqlx::query("SELECT 1").fetch_one(pool).await.map(|_| ()),
+        };
+        match probe {
+            Ok(()) => {
                 checks.insert("db".into(), json!("ok"));
             }
             Err(err) => {

--- a/crates/ruscker-cli/src/main.rs
+++ b/crates/ruscker-cli/src/main.rs
@@ -129,9 +129,17 @@ enum Command {
         images_dir: Option<PathBuf>,
 
         /// Path to the SQLite admin database. Required for `/admin/*`
-        /// routes to function. Without it, those routes return 503.
+        /// routes to function. Without it (and without
+        /// `--config-db-url`), those routes return 503.
         #[arg(long)]
         db: Option<PathBuf>,
+
+        /// Postgres DSN for the shared admin catalog (`postgres://…`).
+        /// HA alternative to `--db`: several instances share one
+        /// editable spec catalog / users / landing / audit store.
+        /// Takes precedence over `--db` when both are set.
+        #[arg(long, env = "RUSCKER_CONFIG_DB_URL")]
+        config_db_url: Option<String>,
 
         /// Admin auth token. Overrides `RUSCKER_ADMIN_TOKEN` env var
         /// when set. Without either, /admin/* routes return 503.
@@ -181,6 +189,7 @@ fn main() -> Result<()> {
             bind,
             images_dir,
             db,
+            config_db_url,
             admin_token,
             master_key,
             docker,
@@ -190,6 +199,7 @@ fn main() -> Result<()> {
             bind,
             images_dir,
             db,
+            config_db_url,
             admin_token,
             master_key,
             docker,
@@ -291,6 +301,7 @@ fn cmd_serve(
     bind_override: Option<std::net::SocketAddr>,
     images_dir_override: Option<PathBuf>,
     db_path: Option<PathBuf>,
+    config_db_url: Option<String>,
     admin_token: Option<String>,
     master_key: Option<String>,
     docker: bool,
@@ -355,7 +366,18 @@ fn cmd_serve(
             };
             server = server.with_backend(backend);
         }
-        if let Some(path) = db_path {
+        // Config database: Postgres (shared HA catalog) takes precedence
+        // over the SQLite path when both are given.
+        if let Some(url) = config_db_url {
+            if db_path.is_some() {
+                tracing::warn!("both --config-db-url and --db set; using Postgres");
+            }
+            tracing::info!("admin catalog: Postgres");
+            let pool = ruscker_admin::db::open_pg(&url)
+                .await
+                .context("connect to the Postgres admin catalog")?;
+            server = server.with_config_db(ruscker_admin::db::ConfigDb::Postgres(pool));
+        } else if let Some(path) = db_path {
             let pool = ruscker_admin::db::open(&path).await?;
             server = server.with_db(pool);
         }


### PR DESCRIPTION
Final 7c slice. With the whole `db::*` layer dual-dialect, this turns Postgres mode on for `serve` and closes the loop.

## What's here
- **`ruscker serve --config-db-url postgres://…`** (env `RUSCKER_CONFIG_DB_URL`) — opens the shared catalog via `open_pg` (runs the PG migrations) and attaches it through the new `AdminServer::with_config_db(ConfigDb)`. Takes precedence over `--db` when both are set (warns). `--db` stays the SQLite default.
- **readyz** now probes whichever backend is attached (SQLite *or* Postgres `SELECT 1`) instead of skipping the check in PG mode. **No `state.sqlite()` call sites remain** — every admin path flows through `ConfigDb`.

## Verification
- **Real smoke** (serve against a `postgres:16-alpine`, fresh catalog):
  - `/healthz` → 200
  - `/readyz` → 200 `{"checks":{"db":"ok"},"status":"ready"}` (the live PG probe)
  - landing `/` → 200 (live `db::landing::fetch` on Postgres)
  - `/admin` → 303 (live `users::any_user_exists` on Postgres)
- **317 default tests green**; edited files 0-drift.

## Phase 7c is complete
The admin catalog (specs, landing, blocks, credentials, users, audit, import) runs on shared Postgres for active-active, with SQLite still the zero-config single-node default. Bootstrapping a fresh PG catalog from YAML (`ruscker import --config-db-url`) is a small follow-up; today you seed it via the admin UI.

Next: **7d** (scaler leader election — required before running >1 instance) + **7e** (HA harness).

🤖 Generated with [Claude Code](https://claude.com/claude-code)