### PR TITLE
Phase 7d: scaler leader election via Postgres advisory lock (#128)

### DIFF
--- a/crates/ruscker-admin/src/leader.rs
+++ b/crates/ruscker-admin/src/leader.rs
@@ -1,0 +1,201 @@
+//! Scaler leader election (Phase 7d).
+//!
+//! ## Why this exists
+//!
+//! The auto-scaler spawns and reaps replicas to track demand. With one
+//! Ruscker process that's fine, but in active-active HA every instance
+//! runs its own scaler against the *same* Docker backend(s) — so they'd
+//! all independently spawn-to-min and fight over the replica count,
+//! thrashing containers.
+//!
+//! The fix is single-writer: exactly one instance — the **leader** —
+//! runs the scaler loop; the others serve traffic and track sessions
+//! normally but skip the scaling work. The proxy, session tracking and
+//! manual dashboard actions (stop / restart a replica) are **not**
+//! gated — only the automatic scaler is.
+//!
+//! ## How leadership is decided
+//!
+//! Via a Postgres **session-level advisory lock** on the shared
+//! database. `pg_try_advisory_lock(key)` succeeds for whichever
+//! instance grabs it first and stays held for the life of that
+//! connection; the others get `false`. If the leader crashes, its
+//! connection drops, Postgres releases the lock, and the next instance
+//! acquires it on its following check — automatic failover, no
+//! heartbeat table to reap.
+//!
+//! Single-node (SQLite, or no config DB) installs use [`AlwaysLeader`]:
+//! there's only one process, so it's always the leader and the scaler
+//! runs unconditionally — zero added dependencies.
+
+use sqlx::postgres::PgConnection;
+use sqlx::Connection;
+use tokio::sync::Mutex;
+use tracing::warn;
+
+/// Decides whether *this* instance may run the auto-scaler. Consulted
+/// once per scaler tick; see the module docs.
+#[async_trait::async_trait]
+pub trait LeaderElector: Send + Sync {
+    /// `true` if this instance currently holds leadership and should run
+    /// the scaler this tick. Implementations must be cheap (one round-
+    /// trip at most) and never panic — a transient failure returns
+    /// `false` so a non-leader never accidentally scales.
+    async fn is_leader(&self) -> bool;
+}
+
+/// The single-node default: this process is always the leader. No I/O,
+/// no dependency — the scaler runs every tick.
+#[derive(Debug, Default)]
+pub struct AlwaysLeader;
+
+#[async_trait::async_trait]
+impl LeaderElector for AlwaysLeader {
+    async fn is_leader(&self) -> bool {
+        true
+    }
+}
+
+/// The advisory-lock key for the scaler leader. A fixed application-
+/// chosen `bigint`; unrelated subsystems must pick different keys if
+/// they ever add their own advisory locks. (ASCII `"RUSCKR\x01"`.)
+const SCALER_LOCK_KEY: i64 = 0x0052_5553_434b_5201;
+
+struct LockState {
+    /// Dedicated connection that holds the advisory lock. `None` until
+    /// the first attempt or after the connection is found dead.
+    conn: Option<PgConnection>,
+    /// Whether we currently hold the lock on `conn`.
+    holds: bool,
+}
+
+/// Postgres advisory-lock leader elector for HA. Holds its own
+/// dedicated connection (separate from the shared pool) so the lock's
+/// lifetime is exactly this elector's — dropping it, or the process
+/// dying, releases leadership.
+pub struct PgLeaderLock {
+    url: String,
+    state: Mutex<LockState>,
+}
+
+impl PgLeaderLock {
+    /// Build an elector that competes for leadership on the Postgres at
+    /// `url`. The connection is established lazily on the first
+    /// [`is_leader`](LeaderElector::is_leader) call.
+    pub fn new(url: impl Into<String>) -> Self {
+        Self {
+            url: url.into(),
+            state: Mutex::new(LockState {
+                conn: None,
+                holds: false,
+            }),
+        }
+    }
+}
+
+#[async_trait::async_trait]
+impl LeaderElector for PgLeaderLock {
+    async fn is_leader(&self) -> bool {
+        let mut st = self.state.lock().await;
+
+        // Reconnect if we have no live connection. A fresh connection
+        // never holds the lock yet.
+        if st.conn.is_none() {
+            match PgConnection::connect(&self.url).await {
+                Ok(c) => {
+                    st.conn = Some(c);
+                    st.holds = false;
+                }
+                Err(e) => {
+                    warn!(error = %e, "leader: connect to Postgres failed; not leading this tick");
+                    return false;
+                }
+            }
+        }
+        if st.holds {
+            // Already leader — just confirm the connection (and thus the
+            // lock) is still alive. If it died, drop it so the next tick
+            // reconnects and re-contests. The `conn` borrow is scoped so
+            // it ends before we touch the other `st` fields.
+            let alive = {
+                let conn = st.conn.as_mut().expect("connection present");
+                conn.ping().await.is_ok()
+            };
+            if alive {
+                return true;
+            }
+            warn!("leader: lock connection died; relinquishing leadership");
+            st.conn = None;
+            st.holds = false;
+            return false;
+        }
+
+        // Not yet leader — try to acquire. `pg_try_advisory_lock` is
+        // non-blocking: `true` ⇒ we got it (or already hold it on this
+        // session), `false` ⇒ another instance holds it.
+        let result = {
+            let conn = st.conn.as_mut().expect("connection present");
+            sqlx::query_scalar::<_, bool>("SELECT pg_try_advisory_lock($1)")
+                .bind(SCALER_LOCK_KEY)
+                .fetch_one(&mut *conn)
+                .await
+        };
+        match result {
+            Ok(got) => {
+                st.holds = got;
+                got
+            }
+            Err(e) => {
+                warn!(error = %e, "leader: advisory-lock query failed; not leading this tick");
+                st.conn = None;
+                false
+            }
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[tokio::test]
+    async fn always_leader_is_always_true() {
+        assert!(AlwaysLeader.is_leader().await);
+        // Through the trait object, as the scaler uses it.
+        let e: std::sync::Arc<dyn LeaderElector> = std::sync::Arc::new(AlwaysLeader);
+        assert!(e.is_leader().await);
+    }
+
+    // Two electors contend for the same lock against a real Postgres:
+    // the first wins, the second waits, and dropping the first hands
+    // leadership over (failover). Gated on `postgres-it`.
+    #[cfg(feature = "postgres-it")]
+    #[tokio::test]
+    async fn pg_lock_elects_one_leader_and_fails_over() {
+        let _guard = crate::db::pg_test_lock().lock().await;
+        let url = std::env::var("RUSCKER_TEST_PG_URL")
+            .expect("set RUSCKER_TEST_PG_URL to a reachable postgres:// DSN");
+
+        let a = PgLeaderLock::new(&url);
+        let b = PgLeaderLock::new(&url);
+
+        assert!(a.is_leader().await, "first contender becomes leader");
+        assert!(!b.is_leader().await, "second contender is not leader");
+        // Leadership is sticky for the holder.
+        assert!(a.is_leader().await);
+        assert!(!b.is_leader().await);
+
+        // Leader goes away → its connection closes → lock releases →
+        // the other contender takes over on a subsequent check.
+        drop(a);
+        let mut won = false;
+        for _ in 0..50 {
+            if b.is_leader().await {
+                won = true;
+                break;
+            }
+            tokio::time::sleep(std::time::Duration::from_millis(100)).await;
+        }
+        assert!(won, "surviving contender takes over leadership");
+    }
+}

--- a/crates/ruscker-admin/src/lib.rs
+++ b/crates/ruscker-admin/src/lib.rs
@@ -28,6 +28,7 @@ pub mod crypto;
 pub mod db;
 pub mod i18n;
 pub mod images;
+pub mod leader;
 pub mod logbuf;
 pub mod metrics_cache;
 pub mod ratelimit;
@@ -113,6 +114,12 @@ pub struct AppState {
     /// `proxy.heartbeat_timeout` ms.
     pub sessions: std::sync::Arc<dyn sessions::SessionStore>,
 
+    /// Decides whether this instance runs the auto-scaler. Single-node
+    /// installs use [`leader::AlwaysLeader`]; HA installs inject a
+    /// [`leader::PgLeaderLock`] so exactly one instance scales. The
+    /// proxy and session tracking never consult this — only the scaler.
+    pub leader: std::sync::Arc<dyn leader::LeaderElector>,
+
     /// Per-replica metrics cache. Filled by a background
     /// refresher that fans out `backend.metrics()` calls every
     /// [`metrics_cache::REFRESH_INTERVAL`]; the dashboard reads
@@ -175,6 +182,7 @@ impl AdminServer {
                 .context("load sticky cookie key")?,
             spawn_locks: std::sync::Arc::new(dashmap::DashMap::new()),
             sessions: std::sync::Arc::new(sessions::InMemorySessionStore::new()),
+            leader: std::sync::Arc::new(leader::AlwaysLeader),
             metrics: metrics_cache::MetricsCache::new(),
             draining: Arc::new(std::sync::atomic::AtomicBool::new(false)),
         };
@@ -262,6 +270,17 @@ impl AdminServer {
     /// SQLite shorthand for `with_config_db(ConfigDb::Sqlite(pool))`.
     pub fn with_config_db(mut self, db: db::ConfigDb) -> Self {
         self.state.db = Some(db);
+        self
+    }
+
+    /// Replace the leader elector. Default is [`leader::AlwaysLeader`]
+    /// (single node). HA installs pass a [`leader::PgLeaderLock`] so
+    /// only one instance runs the auto-scaler.
+    pub fn with_leader_elector(
+        mut self,
+        elector: std::sync::Arc<dyn leader::LeaderElector>,
+    ) -> Self {
+        self.state.leader = elector;
         self
     }
 

--- a/crates/ruscker-admin/src/routes/proxy.rs
+++ b/crates/ruscker-admin/src/routes/proxy.rs
@@ -1160,6 +1160,7 @@ mod tests {
             cookie_key: CookieKey::random(),
             spawn_locks: StdArc::new(dashmap::DashMap::new()),
             sessions: StdArc::new(crate::sessions::InMemorySessionStore::new()),
+            leader: StdArc::new(crate::leader::AlwaysLeader),
             metrics: crate::metrics_cache::MetricsCache::new(),
             draining: StdArc::new(std::sync::atomic::AtomicBool::new(false)),
         }

--- a/crates/ruscker-admin/src/scaler.rs
+++ b/crates/ruscker-admin/src/scaler.rs
@@ -110,8 +110,32 @@ pub fn spawn(state: AppState, interval: Duration) -> JoinHandle<()> {
         // a backlog of ticks queued — we just resume on the next
         // boundary.
         ticker.set_missed_tick_behavior(tokio::time::MissedTickBehavior::Skip);
+        // Tracks leadership across ticks so we log only on change.
+        // `true` initially so a single-node (always-leader) instance
+        // logs nothing.
+        let mut was_leader = true;
         loop {
             ticker.tick().await;
+
+            // HA: only the leader scales — otherwise every instance
+            // would fight over the replica count against the shared
+            // backend. Single-node uses `AlwaysLeader`, so this is a
+            // free `true`. Stale per-spec/replica counters held in this
+            // task are harmless: a new leader rebuilds them from the
+            // live registry over the next few ticks.
+            let is_leader = state.leader.is_leader().await;
+            if is_leader != was_leader {
+                if is_leader {
+                    info!("auto-scaler: acquired leadership; scaling active");
+                } else {
+                    info!("auto-scaler: standing by (another instance leads)");
+                }
+                was_leader = is_leader;
+            }
+            if !is_leader {
+                continue;
+            }
+
             tick(
                 &state,
                 &mut idle_ticks,
@@ -517,6 +541,7 @@ mod tests {
             cookie_key: ruscker_proxy::sticky::CookieKey::random(),
             spawn_locks: Arc::new(dashmap::DashMap::new()),
             sessions: Arc::new(crate::sessions::InMemorySessionStore::new()),
+            leader: Arc::new(crate::leader::AlwaysLeader),
             metrics: crate::metrics_cache::MetricsCache::new(),
             draining: Arc::new(std::sync::atomic::AtomicBool::new(false)),
         }

--- a/crates/ruscker-admin/tests/api_policies.rs
+++ b/crates/ruscker-admin/tests/api_policies.rs
@@ -55,6 +55,7 @@ fn state() -> AppState {
         cookie_key: ruscker_proxy::sticky::CookieKey::random(),
         spawn_locks: Arc::new(dashmap::DashMap::new()),
         sessions: Arc::new(ruscker_admin::sessions::InMemorySessionStore::new()),
+        leader: Arc::new(ruscker_admin::leader::AlwaysLeader),
         metrics: ruscker_admin::metrics_cache::MetricsCache::new(),
         draining: Arc::new(std::sync::atomic::AtomicBool::new(false)),
     }

--- a/crates/ruscker-admin/tests/health_probes.rs
+++ b/crates/ruscker-admin/tests/health_probes.rs
@@ -39,6 +39,7 @@ fn base_state() -> AppState {
         cookie_key: ruscker_proxy::sticky::CookieKey::random(),
         spawn_locks: Arc::new(dashmap::DashMap::new()),
         sessions: Arc::new(ruscker_admin::sessions::InMemorySessionStore::new()),
+        leader: Arc::new(ruscker_admin::leader::AlwaysLeader),
         metrics: ruscker_admin::metrics_cache::MetricsCache::new(),
         draining: Arc::new(std::sync::atomic::AtomicBool::new(false)),
     }

--- a/crates/ruscker-admin/tests/landing_render.rs
+++ b/crates/ruscker-admin/tests/landing_render.rs
@@ -37,6 +37,7 @@ fn app_state() -> AppState {
         cookie_key: ruscker_proxy::sticky::CookieKey::random(),
         spawn_locks: std::sync::Arc::new(dashmap::DashMap::new()),
         sessions: std::sync::Arc::new(ruscker_admin::sessions::InMemorySessionStore::new()),
+        leader: std::sync::Arc::new(ruscker_admin::leader::AlwaysLeader),
         metrics: ruscker_admin::metrics_cache::MetricsCache::new(),
         draining: std::sync::Arc::new(std::sync::atomic::AtomicBool::new(false)),
     }

--- a/crates/ruscker-admin/tests/max_body_size.rs
+++ b/crates/ruscker-admin/tests/max_body_size.rs
@@ -54,6 +54,7 @@ fn state() -> AppState {
         cookie_key: ruscker_proxy::sticky::CookieKey::random(),
         spawn_locks: Arc::new(dashmap::DashMap::new()),
         sessions: Arc::new(ruscker_admin::sessions::InMemorySessionStore::new()),
+        leader: Arc::new(ruscker_admin::leader::AlwaysLeader),
         metrics: ruscker_admin::metrics_cache::MetricsCache::new(),
         draining: Arc::new(std::sync::atomic::AtomicBool::new(false)),
     }

--- a/crates/ruscker-admin/tests/metrics.rs
+++ b/crates/ruscker-admin/tests/metrics.rs
@@ -27,6 +27,7 @@ fn state(yaml: &str) -> AppState {
         cookie_key: ruscker_proxy::sticky::CookieKey::random(),
         spawn_locks: Arc::new(dashmap::DashMap::new()),
         sessions: Arc::new(ruscker_admin::sessions::InMemorySessionStore::new()),
+        leader: Arc::new(ruscker_admin::leader::AlwaysLeader),
         metrics: ruscker_admin::metrics_cache::MetricsCache::new(),
         draining: Arc::new(std::sync::atomic::AtomicBool::new(false)),
     }

--- a/crates/ruscker-admin/tests/rbac.rs
+++ b/crates/ruscker-admin/tests/rbac.rs
@@ -51,6 +51,7 @@ fn state() -> AppState {
         cookie_key: ruscker_proxy::sticky::CookieKey::random(),
         spawn_locks: Arc::new(dashmap::DashMap::new()),
         sessions: Arc::new(ruscker_admin::sessions::InMemorySessionStore::new()),
+        leader: Arc::new(ruscker_admin::leader::AlwaysLeader),
         metrics: ruscker_admin::metrics_cache::MetricsCache::new(),
         draining: Arc::new(std::sync::atomic::AtomicBool::new(false)),
     }

--- a/crates/ruscker-admin/tests/user_accounts.rs
+++ b/crates/ruscker-admin/tests/user_accounts.rs
@@ -38,6 +38,7 @@ async fn state_with_db() -> (AppState, sqlx::SqlitePool) {
         cookie_key: ruscker_proxy::sticky::CookieKey::random(),
         spawn_locks: Arc::new(dashmap::DashMap::new()),
         sessions: Arc::new(ruscker_admin::sessions::InMemorySessionStore::new()),
+        leader: Arc::new(ruscker_admin::leader::AlwaysLeader),
         metrics: ruscker_admin::metrics_cache::MetricsCache::new(),
         draining: Arc::new(std::sync::atomic::AtomicBool::new(false)),
     };

--- a/crates/ruscker-cli/src/main.rs
+++ b/crates/ruscker-cli/src/main.rs
@@ -377,6 +377,12 @@ fn cmd_serve(
                 .await
                 .context("connect to the Postgres admin catalog")?;
             server = server.with_config_db(ruscker_admin::db::ConfigDb::Postgres(pool));
+            // HA: elect a single scaler leader via a Postgres advisory
+            // lock on the same database, so instances don't fight over
+            // the replica count.
+            server = server.with_leader_elector(std::sync::Arc::new(
+                ruscker_admin::leader::PgLeaderLock::new(url),
+            ));
         } else if let Some(path) = db_path {
             let pool = ruscker_admin::db::open(&path).await?;
             server = server.with_db(pool);


### PR DESCRIPTION
In active-active HA every instance ran its own auto-scaler against the same Docker backend(s) — they'd all spawn-to-min and fight over the replica count, thrashing containers. This makes scaling **single-writer**: exactly one instance (the leader) runs the scaler loop; the rest serve traffic, track sessions and handle manual dashboard actions normally but skip the automatic scaling.

## What's here
- **`leader::LeaderElector`** trait, consulted once per scaler tick:
  - `AlwaysLeader` — the single-node default: always leader, no I/O, no dependency.
  - `PgLeaderLock` — holds a dedicated Postgres connection + a session-level `pg_try_advisory_lock(key)`. First instance wins; others get `false`. If the leader crashes, its connection drops, Postgres releases the lock, and the next instance acquires it on its following tick — **automatic failover, no heartbeat table**.
- The scaler loop gates `tick()` on `is_leader()` and logs only on leadership change. A new leader rebuilds its in-task hysteresis counters from the live registry over the next few ticks.
- Wiring: `AppState.leader` + `AdminServer::with_leader_elector` (default `AlwaysLeader`); the CLI injects a `PgLeaderLock` on the config-db Postgres whenever `--config-db-url` is set. All `AppState` literal construction sites (incl. test fixtures) gained the field.
- **Gated test** (`--features postgres-it`): two electors contend on one Postgres — one wins, the other waits, and dropping the leader hands leadership over (failover).

## Verification
- **318 default tests green**; new file 0-drift, edited files no new drift.
- All thirteen `postgres-it` tests pass against a real `postgres:16-alpine`:
  ```
  test leader::tests::always_leader_is_always_true ... ok
  test leader::tests::pg_lock_elects_one_leader_and_fails_over ... ok
  ```

Now >1 instance can run safely against shared Postgres. Next: **7e** — the HA harness (two instances + LB, session continuity + failover).

🤖 Generated with [Claude Code](https://claude.com/claude-code)