### PR TITLE
Phase 7e: HA harness + cross-instance session test (#128)

### DIFF
--- a/book/src/deploying.md
+++ b/book/src/deploying.md
@@ -176,6 +176,45 @@ Point your load balancer / orchestrator at:
 On `SIGTERM` Ruscker flips `/readyz` to `draining`, lets in-flight
 sessions wind down up to `proxy.shutdown-grace-ms`, then exits.
 
+## Running active-active (HA, Phase 7)
+
+For high availability you can run **several Ruscker instances behind a
+load balancer**, all sharing one Postgres. There's a runnable harness
+(two instances + nginx + Postgres) in [`examples/ha/`][ha] — start
+there. The three things every instance must share:
+
+- **`--config-db-url postgres://…`** — the admin catalog (specs,
+  landing, users, credentials, audit) lives in Postgres instead of a
+  per-node SQLite file, so an edit on any instance is seen by all. Runs
+  the same migrations as SQLite; `--db` stays the single-node default.
+- **`--session-store-url postgres://…`** — one shared `proxy_sessions`
+  table. Each instance reconciles the cluster-wide per-replica session
+  counts, so routing and the scaler agree across the fleet.
+- **the same `RUSCKER_COOKIE_KEY`** on every instance — the sticky
+  cookie is an HMAC, so a shared key lets any instance validate a cookie
+  another minted. With that, the shared session table, and every
+  instance pointed at the same Docker backend (so they reconcile the
+  same replicas), a session survives the load balancer moving it
+  between instances.
+
+**Scaler leader election is automatic:** instances elect one leader via
+a Postgres advisory lock; only the leader spawns/reaps replicas, the
+rest serve traffic. If the leader dies its lock releases and another
+takes over within one scaler tick — nothing to configure. Each instance
+logs its role at startup (`acquired leadership` / `standing by`).
+
+The load balancer does **not** need sticky upstreams — sessions are
+shared, so round-robin is fine. Keep `server.useForwardHeaders: true`
+and pass `X-Forwarded-*` as in the nginx section above.
+
+> Today the running proxy reads its spec list from the YAML
+> (`--config`), so deploy the same `application.yml` to every instance;
+> the Postgres catalog backs the **admin UI**. Seeding a fresh Postgres
+> catalog from YAML over the CLI (`ruscker import --config-db-url`) is a
+> small planned follow-up — for now the admin UI writes it.
+
+[ha]: https://github.com/StrategicProjects/ruscker/tree/main/examples/ha
+
 ## Running with Docker instead of the `.deb`
 
 If you'd rather run the container image, mount your config and the

--- a/crates/ruscker-admin/src/scaler.rs
+++ b/crates/ruscker-admin/src/scaler.rs
@@ -111,9 +111,13 @@ pub fn spawn(state: AppState, interval: Duration) -> JoinHandle<()> {
         // boundary.
         ticker.set_missed_tick_behavior(tokio::time::MissedTickBehavior::Skip);
         // Tracks leadership across ticks so we log only on change.
-        // `true` initially so a single-node (always-leader) instance
-        // logs nothing.
-        let mut was_leader = true;
+        // `None` until the first observation so the first tick always
+        // logs this instance's role — a single-node instance logs
+        // "acquired leadership" once (confirming the scaler is live);
+        // in HA the leader and every standby each announce themselves,
+        // which the operator and the HA harness rely on to see who's
+        // scaling. Subsequent ticks log only on a leadership change.
+        let mut was_leader: Option<bool> = None;
         loop {
             ticker.tick().await;
 
@@ -124,13 +128,13 @@ pub fn spawn(state: AppState, interval: Duration) -> JoinHandle<()> {
             // task are harmless: a new leader rebuilds them from the
             // live registry over the next few ticks.
             let is_leader = state.leader.is_leader().await;
-            if is_leader != was_leader {
+            if was_leader != Some(is_leader) {
                 if is_leader {
                     info!("auto-scaler: acquired leadership; scaling active");
                 } else {
                     info!("auto-scaler: standing by (another instance leads)");
                 }
-                was_leader = is_leader;
+                was_leader = Some(is_leader);
             }
             if !is_leader {
                 continue;

--- a/crates/ruscker-admin/src/sessions_pg.rs
+++ b/crates/ruscker-admin/src/sessions_pg.rs
@@ -372,4 +372,65 @@ mod tests {
         assert_eq!(reg.read().await.replicas_of("alpha")[0].sessions_active, 0);
         assert_eq!(store.len(), 0);
     }
+
+    // Session continuity across instances (the HA core, Phase 7e): a
+    // session registered by instance A is visible to instance B once B
+    // reconciles from the shared table — so B's router/scaler see A's
+    // load. Two stores (distinct instance_ids) over one Postgres, with
+    // separate registries (as each node reconciles the same replica
+    // from the shared Docker backend). Gated on `postgres-it`.
+    #[cfg(feature = "postgres-it")]
+    #[tokio::test]
+    async fn session_registered_on_a_is_seen_by_b() {
+        use ruscker_core::{Replica, ReplicaState};
+        use std::net::SocketAddr;
+        use std::sync::Arc;
+
+        let _guard = crate::db::pg_test_lock().lock().await;
+        let url = std::env::var("RUSCKER_TEST_PG_URL")
+            .expect("set RUSCKER_TEST_PG_URL to a reachable postgres:// DSN");
+        let a = PostgresSessionStore::connect(&url).await.unwrap();
+        let b = PostgresSessionStore::connect(&url).await.unwrap();
+        sqlx::query("DELETE FROM proxy_sessions")
+            .execute(&a.pool)
+            .await
+            .unwrap();
+
+        // Same replica id on both nodes (each reconciles it from the
+        // shared backend) — but separate registries.
+        let rid = ReplicaId(Uuid::new_v4());
+        let mk = || Replica {
+            id: rid.clone(),
+            spec_id: "alpha".into(),
+            container_id: "c".into(),
+            upstream: "127.0.0.1:1".parse::<SocketAddr>().unwrap(),
+            state: ReplicaState::Ready,
+            started_at: chrono::Utc::now(),
+            sessions_active: 0,
+            sessions_max: 5,
+            host: None,
+        };
+        let reg_a = Arc::new(RwLock::new(ReplicaRegistry::new()));
+        let reg_b = Arc::new(RwLock::new(ReplicaRegistry::new()));
+        reg_a.write().await.add(mk());
+        reg_b.write().await.add(mk());
+
+        // A registers a session.
+        let sid = Uuid::new_v4();
+        assert_eq!(
+            a.touch_or_register(&reg_a, sid, "alpha", &rid).await,
+            TouchOutcome::Registered
+        );
+        // B hasn't reconciled yet — its registry shows nothing.
+        assert_eq!(reg_b.read().await.replicas_of("alpha")[0].sessions_active, 0);
+
+        // B's sweep reconciles the cluster-wide count from the shared
+        // table and now sees A's session.
+        let no_overrides = HashMap::new();
+        b.sweep(&reg_b, 3_600_000, &no_overrides).await;
+        assert_eq!(reg_b.read().await.replicas_of("alpha")[0].sessions_active, 1);
+        // …and the session is node-local to A, not B.
+        assert_eq!(a.len(), 1);
+        assert_eq!(b.len(), 0);
+    }
 }

--- a/examples/ha/README.md
+++ b/examples/ha/README.md
@@ -1,0 +1,66 @@
+# Active-active HA harness
+
+A runnable two-instance Ruscker cluster: two app instances behind an
+nginx load balancer, sharing one Postgres for the admin catalog **and**
+the session store. It exercises the Phase 7 HA pieces end-to-end —
+shared catalog, cross-instance sticky sessions, and scaler leader
+election with failover.
+
+```sh
+docker compose -f examples/ha/docker-compose.yml up --build
+```
+
+`--build` compiles Ruscker from the repo (the published image predates
+these flags; once a release ships with Phase 7, swap `build:` for
+`image:`).
+
+## What to check
+
+**Both instances are live and share the database.** The LB is on
+`localhost:8080`:
+
+```sh
+curl -s localhost:8080/readyz        # {"checks":{"db":"ok"},"status":"ready"}
+curl -s localhost:8080/              # the landing page (read from shared Postgres)
+```
+
+**Exactly one instance scales.** Leader election logs on startup:
+
+```sh
+docker compose -f examples/ha/docker-compose.yml logs ruscker-1 ruscker-2 \
+  | grep -i leadership
+#  ruscker-1 … "auto-scaler: acquired leadership; scaling active"
+#  ruscker-2 … "auto-scaler: standing by (another instance leads)"
+```
+
+**Failover.** Kill the leader; the survivor takes over within one
+scaler tick (~10 s):
+
+```sh
+docker compose -f examples/ha/docker-compose.yml stop ruscker-1
+docker compose -f examples/ha/docker-compose.yml logs ruscker-2 | grep -i leadership
+#  ruscker-2 … "auto-scaler: acquired leadership; scaling active"
+```
+
+**Session continuity.** Open an app through the LB, then keep using it
+as the LB round-robins between instances — the sticky cookie (minted
+with a shared `RUSCKER_COOKIE_KEY`) validates on either instance, and
+the session row lives in shared Postgres, so the binding survives the
+hop.
+
+## How it fits together
+
+- **`--config-db-url`** — both instances read/write one Postgres admin
+  catalog (specs, landing, users, audit). Edit on either; both see it.
+- **`--session-store-url`** — one shared `proxy_sessions` table; each
+  instance reconciles the cluster-wide per-replica session counts, so
+  routing and scaling agree.
+- **shared `RUSCKER_COOKIE_KEY`** — the sticky-session cookie is an
+  HMAC; a common key lets either instance validate the other's cookies.
+- **leader election** — a Postgres advisory lock picks one scaler
+  leader; the rest serve traffic but don't spawn/reap. The leader's
+  death releases the lock for automatic failover.
+
+The keys in the compose file are throwaway dev values — generate real
+ones for production and keep them out of YAML (see
+`book/src/deploying.md`).

--- a/examples/ha/application.yml
+++ b/examples/ha/application.yml
@@ -1,0 +1,14 @@
+# Minimal config for the HA harness. One stateless demo app
+# (traefik/whoami) so you can watch requests land on whichever Ruscker
+# instance the load balancer picked. Swap in your own specs to try the
+# real thing.
+proxy:
+  title: Ruscker HA Demo
+  bind-address: 0.0.0.0
+  port: 8080
+  specs:
+    - id: whoami
+      display-name: Who Am I
+      description: Stateless echo server — prints the container it ran on.
+      container-image: traefik/whoami:latest
+      port: 80

--- a/examples/ha/docker-compose.yml
+++ b/examples/ha/docker-compose.yml
@@ -1,0 +1,79 @@
+# Ruscker active-active HA harness (Phase 7).
+#
+# Two Ruscker instances behind an nginx load balancer, sharing one
+# Postgres for BOTH the admin catalog (--config-db-url) and the session
+# store (--session-store-url). They use the SAME RUSCKER_COOKIE_KEY so a
+# sticky-session cookie minted by one instance validates on the other —
+# that, plus the shared session table and both instances reconciling the
+# same Docker daemon, is what makes sessions survive an instance moving.
+#
+# Exactly one instance runs the auto-scaler (Postgres advisory-lock
+# leader election); the rest stand by. Kill the leader and the survivor
+# takes over within one scaler tick.
+#
+#   docker compose -f examples/ha/docker-compose.yml up --build
+#   curl localhost:8080/readyz        # both instances report db: ok
+#   docker compose ... logs | grep leadership   # one "acquired", one "standing by"
+#
+# ⚠️  The keys below are throwaway DEV values for a local demo. Generate
+#     real ones (`openssl rand -hex 32`) and keep them out of YAML for
+#     production — see book/src/deploying.md.
+
+x-ruscker-env: &ruscker-env
+  RUSCKER_ADMIN_TOKEN: dev-admin-token-change-me
+  RUSCKER_MASTER_KEY: 00000000000000000000000000000000000000000000000000000000000000aa
+  # Shared across instances — REQUIRED for cross-instance sticky sessions.
+  RUSCKER_COOKIE_KEY: 00000000000000000000000000000000000000000000000000000000000000bb
+  DOCKER_REGISTRY_PASSWORD: unused
+
+x-ruscker-cmd: &ruscker-cmd
+  - serve
+  - --config=/etc/ruscker/application.yml
+  - --bind=0.0.0.0:8080
+  - --docker
+  - --config-db-url=postgres://ruscker:ruscker@postgres/ruscker
+  - --session-store-url=postgres://ruscker:ruscker@postgres/ruscker
+  - --log-format=json
+
+services:
+  postgres:
+    image: postgres:16-alpine
+    environment:
+      POSTGRES_USER: ruscker
+      POSTGRES_PASSWORD: ruscker
+      POSTGRES_DB: ruscker
+    healthcheck:
+      test: ["CMD-SHELL", "pg_isready -U ruscker"]
+      interval: 2s
+      timeout: 3s
+      retries: 15
+
+  ruscker-1: &ruscker
+    build:
+      context: ../..
+      dockerfile: Dockerfile
+    command: *ruscker-cmd
+    environment: *ruscker-env
+    volumes:
+      - ./application.yml:/etc/ruscker/application.yml:ro
+      # The host Docker daemon — both instances reconcile the same
+      # containers. The image runs as a non-root `ruscker` user, so it
+      # needs access to the socket; `user: root` keeps the demo simple.
+      - /var/run/docker.sock:/var/run/docker.sock
+    user: root
+    depends_on:
+      postgres:
+        condition: service_healthy
+
+  ruscker-2:
+    <<: *ruscker
+
+  nginx:
+    image: nginx:alpine
+    ports:
+      - "8080:8080"
+    volumes:
+      - ./nginx.conf:/etc/nginx/conf.d/default.conf:ro
+    depends_on:
+      - ruscker-1
+      - ruscker-2

--- a/examples/ha/nginx.conf
+++ b/examples/ha/nginx.conf
@@ -1,0 +1,33 @@
+# Round-robins across the two Ruscker instances. Sessions are shared
+# (Postgres session store + a common cookie key), so the LB does NOT
+# need sticky upstreams — any instance can serve any request. WebSocket
+# upgrade + X-Forwarded-* are passed through for the proxied apps.
+upstream ruscker {
+    server ruscker-1:8080;
+    server ruscker-2:8080;
+}
+
+server {
+    listen 8080;
+
+    location / {
+        proxy_pass http://ruscker;
+        proxy_http_version 1.1;
+        proxy_set_header Upgrade            $http_upgrade;   # WebSocket
+        proxy_set_header Connection         "upgrade";
+        proxy_read_timeout 600s;
+        proxy_set_header Host               $http_host;
+        proxy_set_header X-Real-IP          $remote_addr;
+        proxy_set_header X-Forwarded-For    $proxy_add_x_forwarded_for;
+        proxy_set_header X-Forwarded-Proto  $scheme;
+    }
+
+    # The live dashboard streams over SSE — don't buffer it.
+    location = /admin/dashboard/events {
+        proxy_pass http://ruscker;
+        proxy_buffering off;
+        proxy_read_timeout 1h;
+        proxy_set_header Host            $http_host;
+        proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
+    }
+}


### PR DESCRIPTION
**Closes Phase 7.** The HA building blocks (Postgres config DB, Postgres session store, advisory-lock leader election) already exist; this slice ties them into a runnable **active-active** cluster and validates the end-to-end invariants.

## What's here
- **`examples/ha/`** — a two-instance harness: `docker-compose.yml` (Postgres + 2× Ruscker built from the repo + nginx LB), `nginx.conf` (round-robin; sessions are shared so no sticky upstreams needed), a minimal `application.yml`, and a `README.md` walking through the checks.
- **Scaler leadership is now observable**: the loop tracks `Option<bool>` and logs its role on the first tick, so the leader (`acquired leadership`) *and* every standby (`standing by`) announce themselves. Previously only a *change* logged, so a steady-state standby was silent.
- **Gated test** (`--features postgres-it`): a session registered on instance A is seen by instance B after B reconciles from the shared table (and stays node-local to A's `len()`) — the session-continuity core.
- Deploy guide gains a **"Running active-active (HA)"** section: the three things every instance must share (`--config-db-url`, `--session-store-url`, a common `RUSCKER_COOKIE_KEY`), automatic leader failover, and the round-robin LB note.

## Verification
**Real two-instance smoke** (two binaries on one Postgres):
```
A /readyz: 200   B /readyz: 200
A: acquired leadership; scaling active
B: standing by (another instance leads)
=== failover: kill -9 A (leader) ===
B assumiu após ~7s
```
Both `/readyz` report `db:ok` against the shared Postgres; one instance leads, the other stands by; killing the leader hands over in ~7 s. **318 default tests green; 14 `postgres-it` tests green; 0-drift.**

## Phase 7 (HA / active-active) is complete
Sessions + the full admin catalog in shared Postgres, single-leader scaling with failover, and a harness to run it. SQLite single-node stays the zero-config default. (Small follow-up: `ruscker import --config-db-url` to seed a fresh PG from YAML over the CLI.)

🤖 Generated with [Claude Code](https://claude.com/claude-code)