### PR TITLE
docs: drop CLAUDE.md references + re-theme the site in brand teal

### DIFF
--- a/README.md
+++ b/README.md
@@ -231,8 +231,8 @@ ruscker/
     └── application.yml   # a generic, comprehensive reference config
 ```
 
-Each crate has its own `CLAUDE.md` documenting scope, conventions, and
-how to extend it.
+Each crate carries module-level docs (`cargo doc --open`) describing its
+scope and how to extend it.
 
 ## Documentation
 

--- a/book/book.toml
+++ b/book/book.toml
@@ -6,8 +6,10 @@ language = "en"
 src = "src"
 
 [output.html]
-default-theme = "rust"
-preferred-dark-theme = "ayu"
+# A neutral light base, re-tinted to the brand teal in theme/ruscker.css
+# (mdBook's "rust" theme is orange/brown — off-brand for Ruscker's teal).
+default-theme = "light"
+preferred-dark-theme = "navy"
 additional-css = ["theme/ruscker.css"]
 git-repository-url = "https://github.com/StrategicProjects/ruscker"
 edit-url-template = "https://github.com/StrategicProjects/ruscker/edit/main/book/{path}"

--- a/book/theme/ruscker.css
+++ b/book/theme/ruscker.css
@@ -28,3 +28,37 @@ html.navy .ruscker-logo-dark,
 html.ayu .ruscker-logo-dark {
   display: inline-block;
 }
+
+/* Brand re-tint — paint mdBook's accents in the Ruscker teal palette
+ * (#0F6E56 / #1D9E75 / #5DCAA5) instead of the stock theme colours. This
+ * additional-css loads after the built-in theme CSS, so these override
+ * the per-theme custom-property values. */
+
+/* Light theme (the default): primary teal reads well on white. */
+html.light {
+  --links: #0f6e56;
+  --sidebar-active: #0f6e56;
+  --icons-hover: #0f6e56;
+  --searchbar-border-color: #5dcaa5;
+  --search-mark-bg: #b9e6d5;
+  --searchresults-header-fg: #0f6e56;
+  --inline-code-color: #0b5d49;
+}
+
+/* Dark themes: the lighter teal keeps contrast on dark backgrounds. */
+html.coal,
+html.navy,
+html.ayu {
+  --links: #5dcaa5;
+  --sidebar-active: #5dcaa5;
+  --icons-hover: #5dcaa5;
+  --search-mark-bg: #1d9e75;
+  --searchresults-header-fg: #5dcaa5;
+}
+
+/* The active page in the sidebar gets a subtle teal rail in every
+ * theme — cheap wayfinding that reinforces the brand. */
+.chapter li.chapter-item a.active {
+  border-left: 3px solid var(--sidebar-active);
+  padding-left: calc(1rem - 3px);
+}

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -168,8 +168,8 @@ without touching proxy code.
 
 ## What's not covered here
 
-- The admin UI internals — see `crates/ruscker-admin/CLAUDE.md`.
-- The proxy's WebSocket handling — see
-  `crates/ruscker-proxy/CLAUDE.md`.
+- The admin UI internals — see the `ruscker-admin` crate
+  (`cargo doc --open`).
+- The proxy's WebSocket handling — see the `ruscker-proxy` crate.
 - Specific algorithm choices — see `docs/adr/`.
 - The YAML schema — see `docs/YAML_SCHEMA.md`.

--- a/docs/ROADMAP.md
+++ b/docs/ROADMAP.md
@@ -25,7 +25,7 @@ dashboard).
 - [x] Two-phase validation (raw text scan + typed model checks)
 - [x] CLI binary with `validate`, `show`, `inspect`
 - [x] Integration tests against the real `application.yml`
-- [x] CLAUDE.md memory for every crate
+- [x] Per-crate developer docs (module-level)
 - [x] Mockups in `docs/mockups/`
 - [x] Architecture, roadmap, ADRs
 


### PR DESCRIPTION
First slice of the docs/site overhaul.

## CLAUDE.md references
`CLAUDE.md` files are local developer-tooling, not something a project reader should be pointed at. Removed the public-facing mentions:
- `README.md` — "each crate has its own `CLAUDE.md`" → points to `cargo doc`.
- `docs/ARCHITECTURE.md` — "see `crates/…/CLAUDE.md`" → points to the crates / `cargo doc`.
- `docs/ROADMAP.md` — "CLAUDE.md memory for every crate" → "per-crate developer docs".

The mdBook site (`book/src`) had none. The ADRs keep their mention as a dated historical record.

## Brand theme
The stock mdBook **`rust`** theme is orange/brown — off-brand for Ruscker's teal logo. Now:
- `default-theme = "light"` (neutral base), `preferred-dark-theme = "navy"`.
- `theme/ruscker.css` re-tints mdBook's accent custom-properties (`--links`, `--sidebar-active`, `--icons-hover`, search highlight, inline-code) to the logo palette **#0F6E56 / #1D9E75 / #5DCAA5**, with the lighter teal on dark themes. The active sidebar item gets a teal rail.

Book builds clean. Next slices: fix the diagram SVGs (arrowheads / lines over text) and add an "Alternatives" comparison + expand the docs benchmarked against ShinyProxy / Shiny Server.

🤖 Generated with [Claude Code](https://claude.com/claude-code)