### PR TITLE
docs: fix diagram SVG arrowheads, lines-over-text, and stale labels

### DIFF
--- a/book/src/images/architecture.svg
+++ b/book/src/images/architecture.svg
@@ -3,7 +3,7 @@
   <title>Ruscker — how it works</title>
 
   <defs>
-    <marker id="arrow" viewBox="0 0 10 10" refX="8" refY="5" markerWidth="7" markerHeight="7" orient="auto-start-reverse">
+    <marker id="arrow" viewBox="0 0 10 10" refX="10" refY="5" markerWidth="7" markerHeight="7" orient="auto-start-reverse">
       <path d="M0,0 L10,5 L0,10 z" fill="#1D9E75"/>
     </marker>
   </defs>
@@ -26,7 +26,7 @@
     <polygon points="14,40 40,28 66,40 40,52" fill="#FFFFFF" opacity="0.72"/>
     <polygon points="14,28 40,16 66,28 40,40" fill="#FFFFFF"/>
   </g>
-  <text x="92" y="131" font-size="15" font-weight="600" fill="#FFFFFF">Ruscker — single static binary · ~14 MB · no JVM</text>
+  <text x="92" y="131" font-size="15" font-weight="600" fill="#FFFFFF">Ruscker — single static binary · ~16 MB · no JVM</text>
 
   <!-- component boxes -->
   <!-- (1) Landing -->

--- a/book/src/images/crate-map.svg
+++ b/book/src/images/crate-map.svg
@@ -3,16 +3,16 @@
   <title>Ruscker — crate map</title>
 
   <defs>
-    <marker id="up" viewBox="0 0 10 10" refX="5" refY="2" markerWidth="7" markerHeight="7" orient="auto">
+    <marker id="up" viewBox="0 0 10 10" refX="5" refY="0" markerWidth="7" markerHeight="7" orient="auto">
       <path d="M0,10 L5,0 L10,10 z" fill="#1D9E75"/>
     </marker>
   </defs>
 
   <!-- layer bands -->
   <rect x="24" y="120" width="672" height="92" rx="12" fill="#F4F8F7" stroke="#D7E5E0" stroke-width="1.5"/>
-  <text x="40" y="142" font-size="12" font-weight="600" fill="#5B6B66">I/O layer · async + tokio</text>
+  <text x="40" y="142" font-size="12" font-weight="600" fill="#5B6B66">I/O layer · async</text>
   <rect x="24" y="250" width="672" height="178" rx="12" fill="#E8F3EE" stroke="#D7E5E0" stroke-width="1.5"/>
-  <text x="40" y="272" font-size="12" font-weight="600" fill="#5B6B66">pure domain · no I/O, no async (trait defs aside)</text>
+  <text x="40" y="272" font-size="12" font-weight="600" fill="#5B6B66">pure domain · no I/O</text>
 
   <!-- ruscker-cli (binary) -->
   <rect x="270" y="28" width="180" height="58" rx="10" fill="#0F6E56" stroke="#0F6E56" stroke-width="2"/>

--- a/book/src/images/deployment.svg
+++ b/book/src/images/deployment.svg
@@ -1,9 +1,9 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 720 430" width="720" height="430" font-family="Jost, Inter, system-ui, -apple-system, sans-serif" role="img" aria-label="Two deployment shapes. Single-node (today): reverse proxy to one Ruscker to the local Docker daemon to app containers. Multi-node HA (planned, phase 7): an L4 load balancer fans to two Ruscker instances that share session state in Postgres and schedule onto Docker Swarm or Kubernetes.">
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 720 430" width="720" height="430" font-family="Jost, Inter, system-ui, -apple-system, sans-serif" role="img" aria-label="Two deployment shapes. Single-node (today): reverse proxy to one Ruscker to the local Docker daemon to app containers. Multi-node HA (active-active): an L4 load balancer fans to two Ruscker instances that share session state in Postgres and schedule across multiple Docker hosts.">
   <title>Ruscker — deployment shapes</title>
 
   <defs>
-    <marker id="dn" viewBox="0 0 10 10" refX="5" refY="8" markerWidth="7" markerHeight="7" orient="auto">
+    <marker id="dn" viewBox="0 0 10 10" refX="5" refY="10" markerWidth="7" markerHeight="7" orient="auto">
       <path d="M0,0 L5,10 L10,0 z" fill="#1D9E75"/>
     </marker>
   </defs>
@@ -35,7 +35,7 @@
   <text x="185" y="372" text-anchor="middle" font-size="11" fill="#5B6B66">what 99% of installs run — simple and fast</text>
 
   <!-- ───────────── Multi-node HA (right) ───────────── -->
-  <text x="535" y="34" text-anchor="middle" font-size="14" font-weight="700" fill="#085041">Multi-node HA · planned (Phase 7)</text>
+  <text x="535" y="34" text-anchor="middle" font-size="14" font-weight="700" fill="#085041">Multi-node HA · active-active</text>
 
   <rect x="405" y="50" width="260" height="44" rx="9" fill="#FFFFFF" stroke="#5DCAA5" stroke-width="1.6"/>
   <text x="535" y="77" text-anchor="middle" font-size="12.5" fill="#085041">L4 load balancer</text>
@@ -55,8 +55,8 @@
   <line x1="535" y1="256" x2="535" y2="282" stroke="#1D9E75" stroke-width="2.2" marker-end="url(#dn)"/>
 
   <rect x="405" y="286" width="260" height="56" rx="9" fill="#F4F8F7" stroke="#5DCAA5" stroke-width="1.6"/>
-  <text x="535" y="310" text-anchor="middle" font-size="12.5" font-weight="600" fill="#085041">Docker Swarm / Kubernetes</text>
-  <text x="535" y="328" text-anchor="middle" font-size="10.5" fill="#5B6B66">multi-host scheduling (Phase 6)</text>
+  <text x="535" y="310" text-anchor="middle" font-size="12.5" font-weight="600" fill="#085041">Docker hosts ×M</text>
+  <text x="535" y="328" text-anchor="middle" font-size="10.5" fill="#5B6B66">multi-host scheduling · ssh / tcp</text>
 
   <text x="535" y="372" text-anchor="middle" font-size="11" fill="#5B6B66">for teams needing failover + horizontal scale</text>
 </svg>

--- a/book/src/images/roadmap.svg
+++ b/book/src/images/roadmap.svg
@@ -1,10 +1,10 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 720 520" width="720" height="520" font-family="Jost, Inter, system-ui, -apple-system, sans-serif" role="img" aria-label="Roadmap timeline. Phases 0 through 5 are shipped (scaffolding, landing page, persistence and admin CRUD, proxy and Docker backend, monitoring dashboard, production polish — v0.1.0). Phases 6 to 8 are planned and optional: multi-host scheduling, high availability, and external auth.">
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 720 520" width="720" height="520" font-family="Jost, Inter, system-ui, -apple-system, sans-serif" role="img" aria-label="Roadmap timeline. Phases 0 through 7 are done: 0 to 5 shipped in v0.1.0 (scaffolding, landing page, persistence and admin CRUD, proxy and Docker backend, monitoring dashboard, production polish); 6 (multi-host scheduling) and 7 (HA / multi-instance) are complete on main. Phase 8 (external auth) is planned and optional.">
   <title>Ruscker — roadmap</title>
 
-  <!-- rail: solid teal through the shipped phases, dashed grey after -->
-  <line x1="60" y1="52" x2="60" y2="312" stroke="#1D9E75" stroke-width="3"/>
-  <line x1="60" y1="312" x2="60" y2="476" stroke="#B9CDC6" stroke-width="3" stroke-dasharray="3 6"/>
+  <!-- rail: solid teal through the done phases (0–7), dashed grey after -->
+  <line x1="60" y1="52" x2="60" y2="420" stroke="#1D9E75" stroke-width="3"/>
+  <line x1="60" y1="420" x2="60" y2="476" stroke="#B9CDC6" stroke-width="3" stroke-dasharray="3 6"/>
 
   <!-- done phases -->
   <g font-size="13">
@@ -49,15 +49,17 @@
 
   <!-- planned phases -->
   <g font-size="13">
-    <!-- 6 -->
-    <circle cx="60" cy="368" r="8.5" fill="#FFFFFF" stroke="#B9CDC6" stroke-width="2.5"/>
-    <text x="86" y="365" font-weight="700" fill="#5B6B66">Phase 6 · Multi-host scheduling</text>
-    <text x="86" y="381" font-size="11" fill="#90A39C">multiple Docker hosts · bin-pack / spread · anti-affinity</text>
+    <!-- 6 (done) -->
+    <circle cx="60" cy="368" r="9" fill="#0F6E56"/>
+    <path d="M55.5,368 l3,3 l6,-6.5" fill="none" stroke="#FFFFFF" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"/>
+    <text x="86" y="365" font-weight="700" fill="#085041">Phase 6 · Multi-host scheduling</text>
+    <text x="86" y="381" font-size="11" fill="#5B6B66">multiple Docker hosts · bin-pack / spread · anti-affinity</text>
 
-    <!-- 7 -->
-    <circle cx="60" cy="420" r="8.5" fill="#FFFFFF" stroke="#B9CDC6" stroke-width="2.5"/>
-    <text x="86" y="417" font-weight="700" fill="#5B6B66">Phase 7 · HA / multi-instance</text>
-    <text x="86" y="433" font-size="11" fill="#90A39C">Postgres session store · advisory locks · failover</text>
+    <!-- 7 (done) -->
+    <circle cx="60" cy="420" r="9" fill="#0F6E56"/>
+    <path d="M55.5,420 l3,3 l6,-6.5" fill="none" stroke="#FFFFFF" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"/>
+    <text x="86" y="417" font-weight="700" fill="#085041">Phase 7 · HA / multi-instance</text>
+    <text x="86" y="433" font-size="11" fill="#5B6B66">Postgres session store · advisory locks · failover</text>
 
     <!-- 8 -->
     <circle cx="60" cy="472" r="8.5" fill="#FFFFFF" stroke="#B9CDC6" stroke-width="2.5"/>

--- a/docs/architecture.svg
+++ b/docs/architecture.svg
@@ -3,7 +3,7 @@
   <title>Ruscker — how it works</title>
 
   <defs>
-    <marker id="arrow" viewBox="0 0 10 10" refX="8" refY="5" markerWidth="7" markerHeight="7" orient="auto-start-reverse">
+    <marker id="arrow" viewBox="0 0 10 10" refX="10" refY="5" markerWidth="7" markerHeight="7" orient="auto-start-reverse">
       <path d="M0,0 L10,5 L0,10 z" fill="#1D9E75"/>
     </marker>
   </defs>
@@ -26,7 +26,7 @@
     <polygon points="14,40 40,28 66,40 40,52" fill="#FFFFFF" opacity="0.72"/>
     <polygon points="14,28 40,16 66,28 40,40" fill="#FFFFFF"/>
   </g>
-  <text x="92" y="131" font-size="15" font-weight="600" fill="#FFFFFF">Ruscker — single static binary · ~14 MB · no JVM</text>
+  <text x="92" y="131" font-size="15" font-weight="600" fill="#FFFFFF">Ruscker — single static binary · ~16 MB · no JVM</text>
 
   <!-- component boxes -->
   <!-- (1) Landing -->

--- a/docs/images/architecture.svg
+++ b/docs/images/architecture.svg
@@ -3,7 +3,7 @@
   <title>Ruscker — how it works</title>
 
   <defs>
-    <marker id="arrow" viewBox="0 0 10 10" refX="8" refY="5" markerWidth="7" markerHeight="7" orient="auto-start-reverse">
+    <marker id="arrow" viewBox="0 0 10 10" refX="10" refY="5" markerWidth="7" markerHeight="7" orient="auto-start-reverse">
       <path d="M0,0 L10,5 L0,10 z" fill="#1D9E75"/>
     </marker>
   </defs>
@@ -26,7 +26,7 @@
     <polygon points="14,40 40,28 66,40 40,52" fill="#FFFFFF" opacity="0.72"/>
     <polygon points="14,28 40,16 66,28 40,40" fill="#FFFFFF"/>
   </g>
-  <text x="92" y="131" font-size="15" font-weight="600" fill="#FFFFFF">Ruscker — single static binary · ~14 MB · no JVM</text>
+  <text x="92" y="131" font-size="15" font-weight="600" fill="#FFFFFF">Ruscker — single static binary · ~16 MB · no JVM</text>
 
   <!-- component boxes -->
   <!-- (1) Landing -->

--- a/docs/images/crate-map.svg
+++ b/docs/images/crate-map.svg
@@ -3,16 +3,16 @@
   <title>Ruscker — crate map</title>
 
   <defs>
-    <marker id="up" viewBox="0 0 10 10" refX="5" refY="2" markerWidth="7" markerHeight="7" orient="auto">
+    <marker id="up" viewBox="0 0 10 10" refX="5" refY="0" markerWidth="7" markerHeight="7" orient="auto">
       <path d="M0,10 L5,0 L10,10 z" fill="#1D9E75"/>
     </marker>
   </defs>
 
   <!-- layer bands -->
   <rect x="24" y="120" width="672" height="92" rx="12" fill="#F4F8F7" stroke="#D7E5E0" stroke-width="1.5"/>
-  <text x="40" y="142" font-size="12" font-weight="600" fill="#5B6B66">I/O layer · async + tokio</text>
+  <text x="40" y="142" font-size="12" font-weight="600" fill="#5B6B66">I/O layer · async</text>
   <rect x="24" y="250" width="672" height="178" rx="12" fill="#E8F3EE" stroke="#D7E5E0" stroke-width="1.5"/>
-  <text x="40" y="272" font-size="12" font-weight="600" fill="#5B6B66">pure domain · no I/O, no async (trait defs aside)</text>
+  <text x="40" y="272" font-size="12" font-weight="600" fill="#5B6B66">pure domain · no I/O</text>
 
   <!-- ruscker-cli (binary) -->
   <rect x="270" y="28" width="180" height="58" rx="10" fill="#0F6E56" stroke="#0F6E56" stroke-width="2"/>

--- a/docs/images/deployment.svg
+++ b/docs/images/deployment.svg
@@ -1,9 +1,9 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 720 430" width="720" height="430" font-family="Jost, Inter, system-ui, -apple-system, sans-serif" role="img" aria-label="Two deployment shapes. Single-node (today): reverse proxy to one Ruscker to the local Docker daemon to app containers. Multi-node HA (planned, phase 7): an L4 load balancer fans to two Ruscker instances that share session state in Postgres and schedule onto Docker Swarm or Kubernetes.">
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 720 430" width="720" height="430" font-family="Jost, Inter, system-ui, -apple-system, sans-serif" role="img" aria-label="Two deployment shapes. Single-node (today): reverse proxy to one Ruscker to the local Docker daemon to app containers. Multi-node HA (active-active): an L4 load balancer fans to two Ruscker instances that share session state in Postgres and schedule across multiple Docker hosts.">
   <title>Ruscker — deployment shapes</title>
 
   <defs>
-    <marker id="dn" viewBox="0 0 10 10" refX="5" refY="8" markerWidth="7" markerHeight="7" orient="auto">
+    <marker id="dn" viewBox="0 0 10 10" refX="5" refY="10" markerWidth="7" markerHeight="7" orient="auto">
       <path d="M0,0 L5,10 L10,0 z" fill="#1D9E75"/>
     </marker>
   </defs>
@@ -35,7 +35,7 @@
   <text x="185" y="372" text-anchor="middle" font-size="11" fill="#5B6B66">what 99% of installs run — simple and fast</text>
 
   <!-- ───────────── Multi-node HA (right) ───────────── -->
-  <text x="535" y="34" text-anchor="middle" font-size="14" font-weight="700" fill="#085041">Multi-node HA · planned (Phase 7)</text>
+  <text x="535" y="34" text-anchor="middle" font-size="14" font-weight="700" fill="#085041">Multi-node HA · active-active</text>
 
   <rect x="405" y="50" width="260" height="44" rx="9" fill="#FFFFFF" stroke="#5DCAA5" stroke-width="1.6"/>
   <text x="535" y="77" text-anchor="middle" font-size="12.5" fill="#085041">L4 load balancer</text>
@@ -55,8 +55,8 @@
   <line x1="535" y1="256" x2="535" y2="282" stroke="#1D9E75" stroke-width="2.2" marker-end="url(#dn)"/>
 
   <rect x="405" y="286" width="260" height="56" rx="9" fill="#F4F8F7" stroke="#5DCAA5" stroke-width="1.6"/>
-  <text x="535" y="310" text-anchor="middle" font-size="12.5" font-weight="600" fill="#085041">Docker Swarm / Kubernetes</text>
-  <text x="535" y="328" text-anchor="middle" font-size="10.5" fill="#5B6B66">multi-host scheduling (Phase 6)</text>
+  <text x="535" y="310" text-anchor="middle" font-size="12.5" font-weight="600" fill="#085041">Docker hosts ×M</text>
+  <text x="535" y="328" text-anchor="middle" font-size="10.5" fill="#5B6B66">multi-host scheduling · ssh / tcp</text>
 
   <text x="535" y="372" text-anchor="middle" font-size="11" fill="#5B6B66">for teams needing failover + horizontal scale</text>
 </svg>

--- a/docs/images/roadmap.svg
+++ b/docs/images/roadmap.svg
@@ -1,10 +1,10 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 720 520" width="720" height="520" font-family="Jost, Inter, system-ui, -apple-system, sans-serif" role="img" aria-label="Roadmap timeline. Phases 0 through 5 are shipped (scaffolding, landing page, persistence and admin CRUD, proxy and Docker backend, monitoring dashboard, production polish — v0.1.0). Phases 6 to 8 are planned and optional: multi-host scheduling, high availability, and external auth.">
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 720 520" width="720" height="520" font-family="Jost, Inter, system-ui, -apple-system, sans-serif" role="img" aria-label="Roadmap timeline. Phases 0 through 7 are done: 0 to 5 shipped in v0.1.0 (scaffolding, landing page, persistence and admin CRUD, proxy and Docker backend, monitoring dashboard, production polish); 6 (multi-host scheduling) and 7 (HA / multi-instance) are complete on main. Phase 8 (external auth) is planned and optional.">
   <title>Ruscker — roadmap</title>
 
-  <!-- rail: solid teal through the shipped phases, dashed grey after -->
-  <line x1="60" y1="52" x2="60" y2="312" stroke="#1D9E75" stroke-width="3"/>
-  <line x1="60" y1="312" x2="60" y2="476" stroke="#B9CDC6" stroke-width="3" stroke-dasharray="3 6"/>
+  <!-- rail: solid teal through the done phases (0–7), dashed grey after -->
+  <line x1="60" y1="52" x2="60" y2="420" stroke="#1D9E75" stroke-width="3"/>
+  <line x1="60" y1="420" x2="60" y2="476" stroke="#B9CDC6" stroke-width="3" stroke-dasharray="3 6"/>
 
   <!-- done phases -->
   <g font-size="13">
@@ -49,15 +49,17 @@
 
   <!-- planned phases -->
   <g font-size="13">
-    <!-- 6 -->
-    <circle cx="60" cy="368" r="8.5" fill="#FFFFFF" stroke="#B9CDC6" stroke-width="2.5"/>
-    <text x="86" y="365" font-weight="700" fill="#5B6B66">Phase 6 · Multi-host scheduling</text>
-    <text x="86" y="381" font-size="11" fill="#90A39C">multiple Docker hosts · bin-pack / spread · anti-affinity</text>
+    <!-- 6 (done) -->
+    <circle cx="60" cy="368" r="9" fill="#0F6E56"/>
+    <path d="M55.5,368 l3,3 l6,-6.5" fill="none" stroke="#FFFFFF" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"/>
+    <text x="86" y="365" font-weight="700" fill="#085041">Phase 6 · Multi-host scheduling</text>
+    <text x="86" y="381" font-size="11" fill="#5B6B66">multiple Docker hosts · bin-pack / spread · anti-affinity</text>
 
-    <!-- 7 -->
-    <circle cx="60" cy="420" r="8.5" fill="#FFFFFF" stroke="#B9CDC6" stroke-width="2.5"/>
-    <text x="86" y="417" font-weight="700" fill="#5B6B66">Phase 7 · HA / multi-instance</text>
-    <text x="86" y="433" font-size="11" fill="#90A39C">Postgres session store · advisory locks · failover</text>
+    <!-- 7 (done) -->
+    <circle cx="60" cy="420" r="9" fill="#0F6E56"/>
+    <path d="M55.5,420 l3,3 l6,-6.5" fill="none" stroke="#FFFFFF" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"/>
+    <text x="86" y="417" font-weight="700" fill="#085041">Phase 7 · HA / multi-instance</text>
+    <text x="86" y="433" font-size="11" fill="#5B6B66">Postgres session store · advisory locks · failover</text>
 
     <!-- 8 -->
     <circle cx="60" cy="472" r="8.5" fill="#FFFFFF" stroke="#B9CDC6" stroke-width="2.5"/>


### PR DESCRIPTION
Second slice of the docs/site overhaul — the diagram SVGs.

## Arrowheads positioned wrong
Each marker was anchored a couple of marker-units *before* its tip (`refX`/`refY` off), so the head overshot the line end — poking into target boxes (deployment, architecture) or sitting mid-line (crate-map). Anchored each at its tip so the head lands exactly at the line end:
- `architecture.svg`: arrow `refX` 8 → 10
- `crate-map.svg`: up-arrow `refY` 2 → 0
- `deployment.svg`: down-arrow `refY` 8 → 10

## Lines over text
`crate-map.svg`: the converging dependency lines ran across the band labels. Shortened them (`I/O layer · async + tokio` → `I/O layer · async`; `pure domain · no I/O, no async (trait defs aside)` → `pure domain · no I/O`) so the lines clear the text.

## Stale content (fixed while in here)
- `deployment.svg`: HA column said "planned (Phase 7)" + "Docker Swarm / Kubernetes" — Phases 6/7 are **done**, and multi-host is plain Docker daemons over ssh/tcp (not Swarm/k8s). Now "active-active" + "Docker hosts ×M · multi-host scheduling · ssh / tcp".
- `roadmap.svg`: Phases 6 & 7 marked **done** (filled + checkmark), solid rail through Phase 7; only Phase 8 (external auth) stays dashed/planned.
- `architecture.svg`: idle footprint "~14 MB" → "~16 MB" (matches README/site).

All four diagrams kept in sync across `docs/`, `docs/images/`, `book/src/images/`; XML validates; book builds; each re-rasterized and visually verified (arrowheads at box edges, labels clear, roadmap accurate).

🤖 Generated with [Claude Code](https://claude.com/claude-code)