### PR TITLE
docs: add Alternatives, Quickstart and FAQ pages

### DIFF
--- a/book/src/SUMMARY.md
+++ b/book/src/SUMMARY.md
@@ -2,15 +2,18 @@
 
 [Introduction](./introduction.md)
 [What Ruscker can serve](./use-cases.md)
+[Ruscker vs. alternatives](./alternatives.md)
 
 # User guide
 
+- [Quickstart](./quickstart.md)
 - [Installation](./installation.md)
 - [Migrating from ShinyProxy](./migrating.md)
 - [Configuration](./configuration.md)
 - [The admin panel](./admin.md)
 - [Deploying in production](./deploying.md)
 - [Troubleshooting](./troubleshooting.md)
+- [FAQ](./faq.md)
 
 # Reference
 

--- a/book/src/alternatives.md
+++ b/book/src/alternatives.md
@@ -1,0 +1,109 @@
+# Ruscker vs. the alternatives
+
+Ruscker is a **portal-and-orchestrator for container-per-session and
+container-per-API workloads**. That puts it next to a handful of
+established tools — some open source, some commercial, some R-only, some
+notebook-only. This page is an honest map of where Ruscker fits and what
+it replaces.
+
+The short version: if you run **ShinyProxy** or **Shiny Server** today
+and want the same model without the JVM weight (or without paying for a
+commercial product), Ruscker is a drop-in-shaped fit — it even reads
+ShinyProxy's `application.yml`.
+
+## At a glance
+
+| | **Ruscker** | **ShinyProxy** | **Shiny Server** (open source) | **Posit Connect** | **JupyterHub** |
+|---|---|---|---|---|---|
+| Runtime | Rust — single static binary | JVM (Java / Spring) | C++ / Node | proprietary | Python |
+| Idle footprint | **~16 MB** | ~300–540 MB | moderate | heavy | moderate–heavy |
+| Per-session isolation | ✅ container/session | ✅ container/session | ❌ shared R processes | ✅ | ✅ per-user |
+| Frameworks | Shiny, Streamlit, Dash, Voilà, Plumber, FastAPI — any HTTP/WS container | any container | **R/Shiny only** | R, Python, Quarto, APIs | Jupyter/Python (+ images) |
+| Admin UI | ✅ live dashboard + full CRUD | minimal | edit config + restart | ✅ rich | partial |
+| Multi-host scheduling | ✅ Docker over ssh/tcp | ✅ (Kubernetes / operator) | ❌ | ✅ | ✅ (Kubernetes) |
+| HA / active-active | ✅ (shared Postgres) | ✅ (operator) | ❌ | ✅ | ✅ |
+| Reads ShinyProxy YAML | ✅ | — (native) | ❌ | ❌ | ❌ |
+| License | open source | open source (Apache-2.0) | open source (free tier) | **commercial** | open source (BSD) |
+
+"Footprint" is the idle resident memory of the orchestrator itself, not
+the apps it runs. Feature checkmarks are deliberately coarse — see the
+per-tool notes for the nuance.
+
+## ShinyProxy
+
+The closest comparison, and the one Ruscker is YAML-compatible with.
+ShinyProxy is mature and capable, but it's a **Spring Boot application
+on the JVM**: it idles at hundreds of megabytes, takes seconds to start,
+and is configured by hand-editing `application.yml` and restarting.
+Theming is Thymeleaf templates.
+
+**What Ruscker changes:** the same container-per-session model and the
+*same config file*, but as a single static binary that idles in the low
+tens of MB, plus a real admin panel (apps CRUD, image library, encrypted
+credentials, live dashboard, audit log, user roles) instead of "edit
+YAML and restart". See [Migrating from ShinyProxy](./migrating.md).
+
+**What ShinyProxy still does that Ruscker doesn't (yet):** a mature
+Kubernetes operator and pluggable enterprise auth (OIDC/SAML/LDAP for
+*app access*). Ruscker's multi-host is Docker-over-ssh/tcp today, and
+its auth gates the *admin panel* (per-app ACLs are [Phase 8](./roadmap.md)).
+
+## Shiny Server (open source / "Free")
+
+Shiny Server's free edition runs R/Shiny apps but **does not isolate
+sessions** — users share R processes per app — and it **doesn't scale or
+load-balance**. Authentication, per-user resources and monitoring are
+Pro (commercial) features. Administration is "edit the config file and
+restart".
+
+**What Ruscker changes:** real per-session isolation (one container per
+visitor), an auto-scaler with replica pools, a monitoring dashboard, and
+it isn't limited to R — Streamlit, Dash, Voilà, FastAPI and anything in
+a container are first-class.
+
+## Posit Connect (formerly RStudio Connect)
+
+The polished commercial option: a publishing platform for R, Python,
+Quarto and APIs with push-button deploys, scheduling, and fine-grained
+access control. It does far more than Ruscker — but it's **commercial,
+per-seat licensed, and heavy**.
+
+**Where Ruscker fits:** when you want a self-hosted, open-source,
+lightweight orchestrator and don't need Connect's publishing workflow or
+are unwilling to pay per-seat. Ruscker is a proxy/orchestrator, not a
+publishing platform — you bring your own container images.
+
+## JupyterHub
+
+JupyterHub spawns a **per-user** server (notebook/Lab), typically via a
+Docker or Kubernetes spawner. It's excellent for interactive Python/data
+science, but it's Python-centric, leans on Kubernetes for real scale, and
+is organized around *users with notebooks* rather than *apps with
+sessions*.
+
+**Where Ruscker fits:** a per-**app** portal (each app a card, each
+visitor a container) across mixed frameworks, lighter to run, configured
+by one YAML file. You can still run a Jupyter/Lab image as a Ruscker spec.
+
+## Streamlit, Dash, Voilà, Gradio (self-hosted)
+
+These frameworks ship their own dev server but **no multi-app portal,
+session isolation, auth, or scaling** — self-hosting means rolling your
+own reverse proxy, container lifecycle and landing page. That glue is
+exactly what Ruscker is. Point a spec at your Streamlit/Dash/Voilà/Gradio
+image and you get the portal, sticky sessions, WebSocket forwarding,
+scaling and reaping for free. See [What Ruscker can serve](./use-cases.md).
+
+## When Ruscker is *not* the right tool
+
+- You need a **publishing/authoring workflow** (push from an IDE,
+  scheduled reports, content versioning) — that's Posit Connect.
+- You're **all-in on Kubernetes** and want a CRD-native operator today —
+  ShinyProxy's operator or a k8s-native platform is a better match
+  (Ruscker schedules onto Docker hosts, not k8s, as of Phase 6).
+- You need **enterprise SSO gating app access per user** right now —
+  that's [Phase 8](./roadmap.md); today Ruscker's auth covers the admin
+  panel (Viewer / Editor / Admin).
+
+If none of those apply and you want ShinyProxy's model without the JVM,
+start with the [Quickstart](./quickstart.md).

--- a/book/src/faq.md
+++ b/book/src/faq.md
@@ -1,0 +1,84 @@
+# FAQ
+
+### Is Ruscker really compatible with my ShinyProxy `application.yml`?
+
+Yes — Ruscker reads the ShinyProxy YAML schema. Point it at your existing
+file and run `ruscker validate application.yml --strict-compat` to get a
+report of any ShinyProxy feature Ruscker doesn't support yet (it refuses
+to silently ignore them). See [Migrating from ShinyProxy](./migrating.md).
+
+### Do I need Java or the JVM?
+
+No. Ruscker is a single static binary written in Rust. There's no JVM, no
+Java toolchain, and no application server to manage — the idle footprint
+is **~16 MB** instead of the hundreds of MB a JVM-based proxy idles at.
+
+### Which app frameworks can it host?
+
+Anything that runs in a container and speaks HTTP or WebSocket. R/Shiny is
+the reference case, but Streamlit, Dash, Voilà, Gradio, Panel, Bokeh,
+Plumber, FastAPI, Flask, and plain web services all work. The full list
+is in [What Ruscker can serve](./use-cases.md).
+
+### Does it isolate sessions like ShinyProxy (and unlike Shiny Server Free)?
+
+Yes. Stateful apps get **one container per session** with sticky routing
+and WebSocket forwarding by default. Stateless APIs are load-balanced
+across replicas with no sticky cookie.
+
+### Do I need Kubernetes?
+
+No. Ruscker drives the **Docker** daemon. A single Docker host is the
+common case; for more capacity it can schedule across several Docker
+daemons over `ssh://` or `tcp://` (see
+[multi-host scheduling](./deploying.md)). There's no Kubernetes
+requirement — if you're all-in on k8s, see the
+[alternatives](./alternatives.md).
+
+### How does scaling work?
+
+Each spec has a replica pool with `min`/`max` bounds. An auto-scaler keeps
+`min` replicas warm, spawns more on sustained saturation, and reaps idle
+ones after a grace period. Routing is least-connections (interactive) or
+round-robin (APIs). It's all in [Configuration](./configuration.md).
+
+### How does authentication work?
+
+The **admin panel** has user accounts with Viewer / Editor / Admin roles
+(plus a break-glass token). Gating *app access* per user (OIDC / SAML /
+LDAP, per-app ACLs) is [Phase 8](./roadmap.md) — today any visitor can
+reach a published app, as with Shiny Server Free.
+
+### Where is configuration and state stored?
+
+By default in a local **SQLite** database (`--db`), with YAML as the
+import/export format. For multi-instance HA the same admin catalog and the
+session store live in shared **Postgres** (`--config-db-url` /
+`--session-store-url`). Secrets never go in YAML — use `${ENV_VAR}`
+interpolation; the credentials store is AES-encrypted at rest.
+
+### Can I run more than one instance for high availability?
+
+Yes. Several instances share one Postgres for the catalog and session
+state, behind a load balancer; a Postgres advisory lock elects a single
+auto-scaler leader with automatic failover. There's a runnable two-node
+harness in `examples/ha/` — see the
+[active-active section](./deploying.md) of the deploy guide.
+
+### Is it production-ready?
+
+Ruscker shipped **v0.1.0** and runs in production. Releases are multi-arch
+and cosign-signed. The [Roadmap](./roadmap.md) tracks what's shipped
+(Phases 0–7) and what's planned (Phase 8: external auth).
+
+### What platforms does it run on?
+
+Ruscker runs on a Linux Docker host — install via the multi-arch Docker
+image, a Debian package with a `systemd` unit, or a static musl tarball.
+A Homebrew tap builds it on macOS for local development. The apps
+themselves are Linux containers.
+
+### An app won't load behind Ruscker — what now?
+
+Most issues are URL-rewriting, cookie-key, or backend-readiness related.
+Start with [Troubleshooting](./troubleshooting.md).

--- a/book/src/introduction.md
+++ b/book/src/introduction.md
@@ -69,8 +69,11 @@ the [Roadmap](./roadmap.md) tracks what's shipped and what's next.
 
 ## Where to next
 
+- [Quickstart](./quickstart.md) — from zero to a running app in minutes.
 - [What Ruscker can serve](./use-cases.md) — Shiny, Streamlit, Dash,
   FastAPI, JupyterLab, LLM UIs, BI tools, and more.
+- [Ruscker vs. alternatives](./alternatives.md) — how it compares to
+  ShinyProxy, Shiny Server, Posit Connect, and JupyterHub.
 - [Installation](./installation.md) — Docker, the `.deb`, or `brew`.
 - [Migrating from ShinyProxy](./migrating.md) — point Ruscker at your
   existing `application.yml`.

--- a/book/src/quickstart.md
+++ b/book/src/quickstart.md
@@ -1,0 +1,96 @@
+# Quickstart — your first app
+
+From nothing to a running app behind Ruscker in a few minutes. You need
+**Docker** running locally and the `ruscker` binary (see
+[Installation](./installation.md) — or just `docker run` the image,
+shown below).
+
+## 1. Write a config
+
+One spec is enough. Save this as `application.yml` — it serves
+`traefik/whoami`, a tiny stateless echo image, so there's nothing to
+build:
+
+```yaml
+proxy:
+  title: My Ruscker
+  bind-address: 0.0.0.0
+  port: 8080
+  specs:
+    - id: hello
+      display-name: Hello
+      description: A stateless echo server.
+      container-image: traefik/whoami:latest
+      port: 80
+```
+
+The schema is ShinyProxy-compatible, so an existing `application.yml`
+works here too — see [Migrating from ShinyProxy](./migrating.md).
+
+## 2. Validate it
+
+Catch typos and unsupported features before starting:
+
+```sh
+ruscker validate application.yml
+# add --strict-compat to flag any ShinyProxy feature Ruscker would ignore
+```
+
+## 3. Run it
+
+```sh
+ruscker serve --config application.yml --bind 127.0.0.1:8080 --docker
+```
+
+`--docker` enables the backend that spawns app containers; without it the
+landing page and admin still work but `/app/*` returns 503. To unlock the
+admin panel, also pass an admin token and a DB:
+
+```sh
+RUSCKER_ADMIN_TOKEN=$(openssl rand -hex 32) \
+ruscker serve --config application.yml --bind 127.0.0.1:8080 \
+  --docker --db ruscker.db
+```
+
+Prefer the container image? Mount your config and the Docker socket:
+
+```sh
+docker run --rm -p 8080:8080 \
+  -v "$PWD/application.yml:/etc/ruscker/application.yml:ro" \
+  -v /var/run/docker.sock:/var/run/docker.sock \
+  ghcr.io/strategicprojects/ruscker:latest \
+  serve --config /etc/ruscker/application.yml --bind 0.0.0.0:8080 --docker
+```
+
+## 4. Open it
+
+| URL | What you get |
+|---|---|
+| <http://127.0.0.1:8080/> | the landing page — one card per spec |
+| <http://127.0.0.1:8080/app/hello/> | the app — Ruscker spawns the container on first hit |
+| <http://127.0.0.1:8080/admin> | the admin panel (with `RUSCKER_ADMIN_TOKEN` set) |
+| <http://127.0.0.1:8080/healthz> | liveness (always `200`) |
+
+The first request to `/app/hello/` spawns a container on demand; it's
+reaped automatically once idle. Refresh the [admin dashboard](./admin.md)
+to watch the replica start, serve, and stop.
+
+## What just happened
+
+Ruscker rendered the landing page from your config, and on the first
+request to the app it asked Docker to start `traefik/whoami`, routed you
+to it, and will reap it when idle. For a real interactive app (Shiny,
+Streamlit, Dash, Voilà) the model is the same — Ruscker adds sticky
+sessions and WebSocket forwarding automatically. See
+[What Ruscker can serve](./use-cases.md) for the framework list and
+[Configuration](./configuration.md) for every spec field (replica pools,
+CPU/memory limits, registry credentials, routing, rate limits…).
+
+## Next steps
+
+- [Configuration](./configuration.md) — the full YAML reference.
+- [The admin panel](./admin.md) — manage specs, images, users, and the
+  live dashboard without editing YAML.
+- [Deploying in production](./deploying.md) — systemd + nginx, TLS,
+  multi-host, and active-active HA.
+- [Troubleshooting](./troubleshooting.md) — when an app won't load.


### PR DESCRIPTION
Third slice of the docs/site overhaul — expand the docs benchmarked against the ShinyProxy and Shiny Server sites, and add the **competitor comparison** they don't have.

## New pages
- **Ruscker vs. alternatives** (`alternatives.md`) — an at-a-glance comparison **table** + honest per-tool notes covering **ShinyProxy, Shiny Server (open source), Posit Connect, JupyterHub**, and self-hosted **Streamlit/Dash/Voilà/Gradio**. Says what Ruscker replaces *and* when it's not the right tool (publishing workflow → Posit Connect; k8s-native operator → ShinyProxy; per-user app SSO → Phase 8).
- **Quickstart** (`quickstart.md`) — zero → running app in minutes: a minimal ShinyProxy-compatible config (`traefik/whoami`), `validate`, `serve --docker`, the Docker one-liner, and the URLs to open. This is the "Getting Started / Deploying Apps" page the docs were missing.
- **FAQ** (`faq.md`) — the recurring questions: YAML compatibility, no-JVM footprint, session isolation vs Shiny Server Free, no-Kubernetes, scaling, auth scope, SQLite vs Postgres, HA, platforms.

## Wiring
Added to `SUMMARY.md` (Alternatives by the intro; Quickstart first in the user guide; FAQ after Troubleshooting) and linked from the intro's "Where to next". Book builds; all three pages render.

Benchmarked against `https://shinyproxy.io/documentation/` and `https://docs.posit.co/shiny-server/` — this closes the biggest gaps (a getting-started tutorial, an FAQ, and a comparison).

🤖 Generated with [Claude Code](https://claude.com/claude-code)