### PR TITLE
docs: fix crate-map/deployment arrowheads (orient=auto needs a right-pointing marker)

### DIFF
--- a/book/src/images/crate-map.svg
+++ b/book/src/images/crate-map.svg
@@ -3,8 +3,11 @@
   <title>Ruscker — crate map</title>
 
   <defs>
-    <marker id="up" viewBox="0 0 10 10" refX="5" refY="0" markerWidth="7" markerHeight="7" orient="auto">
-      <path d="M0,10 L5,0 L10,10 z" fill="#1D9E75"/>
+    <!-- Right-pointing triangle + orient="auto": the renderer rotates it
+         to follow each line's direction. (A fixed up/down triangle with
+         orient="auto" gets rotated sideways in real browsers.) -->
+    <marker id="up" viewBox="0 0 10 10" refX="10" refY="5" markerWidth="7" markerHeight="7" orient="auto">
+      <path d="M0,0 L10,5 L0,10 z" fill="#1D9E75"/>
     </marker>
   </defs>
 

--- a/book/src/images/deployment.svg
+++ b/book/src/images/deployment.svg
@@ -3,8 +3,11 @@
   <title>Ruscker — deployment shapes</title>
 
   <defs>
-    <marker id="dn" viewBox="0 0 10 10" refX="5" refY="10" markerWidth="7" markerHeight="7" orient="auto">
-      <path d="M0,0 L5,10 L10,0 z" fill="#1D9E75"/>
+    <!-- Right-pointing triangle + orient="auto": the renderer rotates it
+         to follow each line's direction. (A fixed up/down triangle with
+         orient="auto" gets rotated sideways in real browsers.) -->
+    <marker id="dn" viewBox="0 0 10 10" refX="10" refY="5" markerWidth="7" markerHeight="7" orient="auto">
+      <path d="M0,0 L10,5 L0,10 z" fill="#1D9E75"/>
     </marker>
   </defs>
 

--- a/docs/images/crate-map.svg
+++ b/docs/images/crate-map.svg
@@ -3,8 +3,11 @@
   <title>Ruscker — crate map</title>
 
   <defs>
-    <marker id="up" viewBox="0 0 10 10" refX="5" refY="0" markerWidth="7" markerHeight="7" orient="auto">
-      <path d="M0,10 L5,0 L10,10 z" fill="#1D9E75"/>
+    <!-- Right-pointing triangle + orient="auto": the renderer rotates it
+         to follow each line's direction. (A fixed up/down triangle with
+         orient="auto" gets rotated sideways in real browsers.) -->
+    <marker id="up" viewBox="0 0 10 10" refX="10" refY="5" markerWidth="7" markerHeight="7" orient="auto">
+      <path d="M0,0 L10,5 L0,10 z" fill="#1D9E75"/>
     </marker>
   </defs>
 

--- a/docs/images/deployment.svg
+++ b/docs/images/deployment.svg
@@ -3,8 +3,11 @@
   <title>Ruscker — deployment shapes</title>
 
   <defs>
-    <marker id="dn" viewBox="0 0 10 10" refX="5" refY="10" markerWidth="7" markerHeight="7" orient="auto">
-      <path d="M0,0 L5,10 L10,0 z" fill="#1D9E75"/>
+    <!-- Right-pointing triangle + orient="auto": the renderer rotates it
+         to follow each line's direction. (A fixed up/down triangle with
+         orient="auto" gets rotated sideways in real browsers.) -->
+    <marker id="dn" viewBox="0 0 10 10" refX="10" refY="5" markerWidth="7" markerHeight="7" orient="auto">
+      <path d="M0,0 L10,5 L0,10 z" fill="#1D9E75"/>
     </marker>
   </defs>
 


### PR DESCRIPTION
The arrowheads in **Crate map** and **Deployment shapes** were still wrong in the browser.

## Root cause
PR #149 fixed the marker *anchor* (overshoot) but kept the wrong marker **geometry**. Both diagrams drew **fixed up/down triangles** but used `orient="auto"`. `orient="auto"` makes the renderer **rotate** the marker to follow each line's direction — so an already-up/down triangle gets rotated sideways, and the heads render **skewed** in real browsers and librsvg.

It *looked* fixed because macOS QuickLook (`qlmanage`, what I used to verify #149) **ignores `orient="auto"`** and renders the marker as drawn. Browsers don't.

## Fix
Use a **right-pointing** triangle (`M0,0 L10,5 L0,10 z`, `refX=10 refY=5`) — the same marker `architecture.svg` already uses (which is exactly why *that* diagram was never wrong). With `orient="auto"`, the renderer now rotates the head to point **along** each line, vertical or diagonal.

## Verification
Re-rendered with **`rsvg-convert`** (librsvg honours `orient="auto"` like a browser, unlike qlmanage) — before: heads skewed sideways; after: vertical arrows point straight, diagonals follow the line. Synced across `docs/images/` and `book/src/images/`; XML validates.

🤖 Generated with [Claude Code](https://claude.com/claude-code)