### PR TITLE
ci(docs): build the site with mdBook 0.5.3 (was 0.4.40)

### DIFF
--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -32,7 +32,11 @@ jobs:
       name: github-pages
       url: ${{ steps.deployment.outputs.page_url }}
     env:
-      MDBOOK_VERSION: "0.4.40"
+      # Match the version built locally. 0.4.x shipped an older theme
+      # whose wide-screen edge chevrons (prev/next chapter) were easy to
+      # mistake for a broken sidebar toggle; 0.5.x has the clean
+      # "Toggle Table of Contents" sidebar button.
+      MDBOOK_VERSION: "0.5.3"
     steps:
       - uses: actions/checkout@v6
 


### PR DESCRIPTION
**Re: the "chevron that doesn't close the sidebar."** That `<i class="fa fa-angle-left">` is mdBook's **Previous chapter** arrow, not a sidebar toggle — and on the old **0.4.40** theme it renders as a big chevron on the wide-screen left edge, right next to the sidebar, so it reads like a (broken) collapse control. The actual sidebar toggle is the **"Toggle Table of Contents"** hamburger in the top-left.

The live site was pinned to mdBook **0.4.40** in CI while the book is developed/verified locally against **0.5.3** — so the deployed theme wasn't the one being tested. 0.5.x drops the confusing edge chevrons and keeps the clean sidebar toggle.

This bumps `MDBOOK_VERSION` → **0.5.3** (asset URL verified to return 200) so:
- production matches local,
- the sidebar UX is the modern, clear one,
- and the next deploy also picks up this session's brand re-theme + the SVG arrowhead fixes.

Book builds clean on 0.5.3 locally. If you'd still like a *dedicated* "collapse sidebar" chevron added on top of the stock toggle, say so and I'll wire one into the theme.

🤖 Generated with [Claude Code](https://claude.com/claude-code)