### PR TITLE
docs(site): add a working "collapse sidebar" chevron

### DIFF
--- a/book/book.toml
+++ b/book/book.toml
@@ -11,6 +11,7 @@ src = "src"
 default-theme = "light"
 preferred-dark-theme = "navy"
 additional-css = ["theme/ruscker.css"]
+additional-js = ["theme/ruscker.js"]
 git-repository-url = "https://github.com/StrategicProjects/ruscker"
 edit-url-template = "https://github.com/StrategicProjects/ruscker/edit/main/book/{path}"
 # Project Pages live under /ruscker/ — set so links/assets resolve there.

--- a/book/theme/ruscker.css
+++ b/book/theme/ruscker.css
@@ -62,3 +62,50 @@ html.ayu {
   border-left: 3px solid var(--sidebar-active);
   padding-left: calc(1rem - 3px);
 }
+
+/* "Collapse sidebar" chevron (injected by theme/ruscker.js). It's a
+ * <label for="mdbook-sidebar-toggle-anchor">, so clicking it toggles
+ * mdBook's own sidebar checkbox — no custom state to keep in sync.
+ *
+ * Pinned with `position: fixed` to the sidebar's inner-right edge via
+ * mdBook's `--sidebar-width` (so it tracks a resized sidebar and ignores
+ * the TOC iframe's own layout), just below the menu bar. Shown only when
+ * the sidebar is open; collapsing it hides the chevron — reopen with the
+ * top-bar hamburger. */
+.ruscker-sidebar-close {
+  position: fixed;
+  top: 3.4rem;
+  left: calc(var(--sidebar-width) - 2.3rem);
+  z-index: 1000;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  width: 1.8rem;
+  height: 1.8rem;
+  border-radius: 6px;
+  cursor: pointer;
+  color: var(--sidebar-fg);
+  background: var(--theme-hover, rgba(0, 0, 0, 0.05));
+  opacity: 0.7;
+  transition: opacity 0.15s, background 0.15s, color 0.15s;
+}
+.ruscker-sidebar-close:hover {
+  opacity: 1;
+  color: #ffffff;
+  background: var(--sidebar-active);
+}
+.ruscker-sidebar-close svg {
+  width: 1.05rem;
+  height: 1.05rem;
+}
+/* Gone when the sidebar is collapsed (the hamburger brings it back). */
+html:not(.sidebar-visible) .ruscker-sidebar-close {
+  display: none;
+}
+/* On narrow viewports the sidebar is a full overlay and the hamburger
+ * sits right next to it — the extra chevron just clutters, so hide it. */
+@media only screen and (max-width: 1080px) {
+  .ruscker-sidebar-close {
+    display: none;
+  }
+}

--- a/book/theme/ruscker.js
+++ b/book/theme/ruscker.js
@@ -1,0 +1,38 @@
+// Ruscker docs — a "collapse sidebar" chevron.
+//
+// mdBook's only sidebar control is the hamburger ("Toggle Table of
+// Contents") in the top bar; people expect a chevron *on the sidebar*
+// to close it. mdBook toggles the sidebar with a hidden checkbox
+// (#mdbook-sidebar-toggle-anchor) driven by `<label for=…>`, so we add a
+// second label pointing at the same anchor — native toggle, no custom
+// state to keep in sync. The chevron lives inside the sidebar, so it
+// naturally disappears when collapsed; reopen with the hamburger.
+(function () {
+  function inject() {
+    var sidebar = document.getElementById("mdbook-sidebar") ||
+      document.querySelector(".sidebar");
+    var anchor = document.getElementById("mdbook-sidebar-toggle-anchor");
+    if (!sidebar || !anchor) return;
+    if (sidebar.querySelector(".ruscker-sidebar-close")) return;
+
+    var label = document.createElement("label");
+    label.className = "ruscker-sidebar-close";
+    label.setAttribute("for", "mdbook-sidebar-toggle-anchor");
+    label.setAttribute("title", "Collapse sidebar");
+    label.setAttribute("aria-label", "Collapse sidebar");
+    // Inline SVG chevron — mdBook 0.5.x no longer ships Font Awesome, so
+    // an <i class="fa …"> would render blank. `currentColor` inherits
+    // the label's color (and the white-on-teal hover).
+    label.innerHTML =
+      '<svg viewBox="0 0 24 24" fill="none" stroke="currentColor" ' +
+      'stroke-width="2.5" stroke-linecap="round" stroke-linejoin="round" ' +
+      'aria-hidden="true"><polyline points="15 18 9 12 15 6"></polyline></svg>';
+    sidebar.appendChild(label);
+  }
+
+  if (document.readyState !== "loading") {
+    inject();
+  } else {
+    document.addEventListener("DOMContentLoaded", inject);
+  }
+})();


### PR DESCRIPTION
**Re: "ainda está ruim o chevron".** Two things were going on:
1. The `<i class="fa fa-angle-left">` you pointed at was the old 0.4.x theme's **previous-chapter** arrow, not a sidebar control.
2. mdBook **0.5.x dropped Font Awesome**, so any `fa fa-*` icon renders blank.

So this adds a real **collapse-sidebar chevron**:
- `theme/ruscker.js` (new, via `additional-js`) injects a `<label for="mdbook-sidebar-toggle-anchor">` with an **inline-SVG** left chevron. It points at mdBook's own sidebar checkbox — the same anchor the hamburger uses — so the toggle is native, nothing custom to keep in sync.
- `theme/ruscker.css` pins it `position: fixed` to the sidebar's inner-right edge via `--sidebar-width` (tracks a resized sidebar, ignores the TOC iframe), just below the menu bar; brand teal on hover. Shown only while the sidebar is open — collapsing hides it, the hamburger reopens it. Hidden on narrow viewports.

Verified in **headless Chrome** (real engine): the chevron renders at the sidebar's top-right and points left; clicking toggles mdBook's sidebar checkbox.

🤖 Generated with [Claude Code](https://claude.com/claude-code)