### PR TITLE
fix(packaging): declare adduser dependency for minimal Ubuntu 24.04 (#163)

### DIFF
--- a/crates/ruscker-cli/Cargo.toml
+++ b/crates/ruscker-cli/Cargo.toml
@@ -21,8 +21,10 @@ copyright = "2025-2026, Ruscker contributors. Licensed under Apache-2.0."
 section = "web"
 priority = "optional"
 # $auto pulls the binary's shared-lib deps (libc, …); ca-certificates
-# is needed for TLS when pulling private images from registries.
-depends = "$auto, ca-certificates"
+# for TLS when pulling private images; adduser because the postinst uses
+# addgroup/adduser to create the service account (Ubuntu 24.04 minimal no
+# longer ships it in the base set).
+depends = "$auto, ca-certificates, adduser"
 extended-description = """\
 Ruscker is a lightweight Rust alternative to ShinyProxy and Shiny Server \
 Free. It hosts and load-balances containerized interactive web apps \


### PR DESCRIPTION
Closes #163. Found during the fresh-install dry-run.

`packaging/debian/postinst` uses `addgroup`/`adduser`, but the **`adduser`** package isn't in Ubuntu 24.04's minimal/base set anymore, and the `.deb` only declared `$auto, ca-certificates` — so on a minimal box the install failed with `addgroup: not found` (exit 127).

**Fix:** add `adduser` to `[package.metadata.deb] depends`.

**Verified** on a fresh minimal `ubuntu:24.04` (amd64) — `adduser` absent at start:
```
The following NEW packages will be installed:
  adduser ca-certificates openssl ruscker
Setting up adduser (3.137ubuntu1) ...
Setting up ruscker (0.1.0-1) ...
  | Ruscker admin token (generated now, shown ONCE): … |
Status: install ok installed   → ruscker user created ✓, token generated ✓
```
`apt-get install ./ruscker.deb` now resolves `adduser` automatically and configures cleanly.

🤖 Generated with [Claude Code](https://claude.com/claude-code)