### PR TITLE
Slice 3 of #155: landing filters apps by viewer + sign-in affordance

### DIFF
--- a/crates/ruscker-admin/assets/i18n/en/landing.ftl
+++ b/crates/ruscker-admin/assets/i18n/en/landing.ftl
@@ -2,6 +2,10 @@
 
 landing-title = Ruscker
 landing-subtitle = Application and API portal
+landing-signin = Sign in
+landing-panel = Panel
+landing-signout = Sign out
+landing-signed-in-as = { $user }
 
 filter-search-placeholder = Search application…
 filter-access-all = All

--- a/crates/ruscker-admin/assets/i18n/es/landing.ftl
+++ b/crates/ruscker-admin/assets/i18n/es/landing.ftl
@@ -2,6 +2,10 @@
 
 landing-title = Ruscker
 landing-subtitle = Portal de aplicaciones y APIs
+landing-signin = Entrar
+landing-panel = Panel
+landing-signout = Salir
+landing-signed-in-as = { $user }
 
 filter-search-placeholder = Buscar aplicación…
 filter-access-all = Todos

--- a/crates/ruscker-admin/assets/i18n/fr/landing.ftl
+++ b/crates/ruscker-admin/assets/i18n/fr/landing.ftl
@@ -2,6 +2,10 @@
 
 landing-title = Ruscker
 landing-subtitle = Portail d'applications et d'APIs
+landing-signin = Connexion
+landing-panel = Panneau
+landing-signout = Déconnexion
+landing-signed-in-as = { $user }
 
 filter-search-placeholder = Rechercher une application…
 filter-access-all = Tous

--- a/crates/ruscker-admin/assets/i18n/pt/landing.ftl
+++ b/crates/ruscker-admin/assets/i18n/pt/landing.ftl
@@ -3,6 +3,10 @@
 
 landing-title = Ruscker
 landing-subtitle = Portal de aplicações e APIs
+landing-signin = Entrar
+landing-panel = Painel
+landing-signout = Sair
+landing-signed-in-as = { $user }
 
 filter-search-placeholder = Buscar aplicação…
 filter-access-all = Todos

--- a/crates/ruscker-admin/src/auth.rs
+++ b/crates/ruscker-admin/src/auth.rs
@@ -523,6 +523,26 @@ impl FromRequestParts<crate::AppState> for MaybeAdminSession {
     }
 }
 
+/// Like [`MaybeAdminSession`] but keeps the whole session (role +
+/// username) instead of just the role. Used by the public landing to
+/// resolve the viewer's group memberships and show a "signed in"
+/// affordance. `None` ⇒ anonymous visitor.
+pub struct MaybeSession(pub Option<AdminSession>);
+
+impl FromRequestParts<crate::AppState> for MaybeSession {
+    type Rejection = Infallible;
+
+    async fn from_request_parts(
+        parts: &mut Parts,
+        state: &crate::AppState,
+    ) -> Result<Self, Self::Rejection> {
+        match AdminSession::from_request_parts(parts, state).await {
+            Ok(s) => Ok(MaybeSession(Some(s))),
+            Err(_) => Ok(MaybeSession(None)),
+        }
+    }
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;

--- a/crates/ruscker-admin/src/routes/admin.rs
+++ b/crates/ruscker-admin/src/routes/admin.rs
@@ -272,7 +272,12 @@ async fn login_submit(
 
     let referer = headers.get(REFERER).and_then(|v| v.to_str().ok());
     let path = super::same_origin_path(referer, user.role.home());
-    let target = if path.starts_with("/admin/")
+    let target = if path == "/" {
+        // Signed in from the public landing — return there so the
+        // viewer sees the apps their groups unlock (#155), rather than
+        // bouncing a non-admin into the panel.
+        path
+    } else if path.starts_with("/admin/")
         && !path.starts_with("/admin/login")
         && user.role.can_access_section(section_for_admin_path(&path))
     {

--- a/crates/ruscker-admin/src/routes/landing.rs
+++ b/crates/ruscker-admin/src/routes/landing.rs
@@ -14,6 +14,7 @@ use axum::{
 };
 use fluent_bundle::{FluentArgs, FluentValue};
 
+use crate::auth::{MaybeSession, Role};
 use crate::i18n::{Locale, Locales};
 use crate::theme::Theme;
 use crate::view_model::{
@@ -61,6 +62,13 @@ struct LandingPage<'a> {
     /// after the card grid (`bottom` slot), in `position` order.
     blocks_top: Vec<crate::db::landing_blocks::LandingBlock>,
     blocks_bottom: Vec<crate::db::landing_blocks::LandingBlock>,
+    /// True when the request carries a live admin session. Drives the
+    /// header affordance: a "go to the panel" link + sign-out instead
+    /// of "sign in".
+    signed_in: bool,
+    /// Display name of the signed-in viewer (username, or empty for a
+    /// break-glass token session). Shown next to the panel link.
+    viewer_name: String,
 }
 
 impl<'a> LandingPage<'a> {
@@ -81,12 +89,35 @@ impl<'a> LandingPage<'a> {
     }
 }
 
-async fn index(State(state): State<AppState>, loc: Locale, theme: Theme) -> Response {
+async fn index(
+    State(state): State<AppState>,
+    loc: Locale,
+    theme: Theme,
+    MaybeSession(session): MaybeSession,
+) -> Response {
+    // Resolve the viewer for app-visibility filtering (#155):
+    //  - an Admin role (incl. the break-glass token) sees every spec;
+    //  - a named login sees open specs plus those matching its username
+    //    or any of its groups;
+    //  - an anonymous visitor sees only the open specs.
+    let is_admin = session.as_ref().map(|s| s.role == Role::Admin).unwrap_or(false);
+    let username = session.as_ref().and_then(|s| s.actor.clone());
+    let groups: Vec<String> = match (username.as_deref(), state.db.as_ref()) {
+        (Some(user), Some(db)) => crate::db::users::fetch(db, user)
+            .await
+            .ok()
+            .flatten()
+            .map(|row| row.groups)
+            .unwrap_or_default(),
+        _ => Vec::new(),
+    };
+
     let mut cards: Vec<CardCtx<'_>> = state
         .config
         .proxy
         .specs
         .iter()
+        .filter(|spec| spec.access_allows(is_admin, username.as_deref(), &groups))
         .map(CardCtx::from_spec)
         .collect();
     sort_by_recent(&mut cards);
@@ -176,6 +207,8 @@ async fn index(State(state): State<AppState>, loc: Locale, theme: Theme) -> Resp
         analytics_html,
         blocks_top,
         blocks_bottom,
+        signed_in: session.is_some(),
+        viewer_name: username.unwrap_or_default(),
     };
     let mut resp = render(&page);
     // Widen *this page's* CSP so the analytics script can load/report.

--- a/crates/ruscker-admin/templates/landing.html
+++ b/crates/ruscker-admin/templates/landing.html
@@ -22,7 +22,26 @@
       <h1 class="text-xl font-medium tracking-tight">{{ self.t("landing-title") }}</h1>
       <p class="text-xs opacity-70 mt-1">{{ self.t("landing-subtitle") }}</p>
     </div>
-    <div class="text-xs opacity-70">{{ counts.total }}</div>
+    <div class="flex items-center gap-4 text-xs">
+      <span class="opacity-70">{{ counts.total }}</span>
+      {% if signed_in %}
+        {% if !viewer_name.is_empty() %}
+          <span class="opacity-70 hidden sm:inline">{{ self.t_with("landing-signed-in-as", "user", viewer_name.as_str()) }}</span>
+        {% endif %}
+        <a class="inline-flex items-center gap-1 opacity-80 hover:opacity-100" href="/admin/dashboard">
+          <i class="ti ti-layout-dashboard" aria-hidden="true"></i> {{ self.t("landing-panel") }}
+        </a>
+        <form method="post" action="/admin/logout" class="inline">
+          <button type="submit" class="inline-flex items-center gap-1 opacity-80 hover:opacity-100 bg-transparent border-0 cursor-pointer font-inherit text-inherit">
+            <i class="ti ti-logout" aria-hidden="true"></i> {{ self.t("landing-signout") }}
+          </button>
+        </form>
+      {% else %}
+        <a class="inline-flex items-center gap-1 opacity-80 hover:opacity-100" href="/admin/login">
+          <i class="ti ti-login" aria-hidden="true"></i> {{ self.t("landing-signin") }}
+        </a>
+      {% endif %}
+    </div>
   </div>
 </header>
 

--- a/crates/ruscker-admin/tests/landing_access.rs
+++ b/crates/ruscker-admin/tests/landing_access.rs
@@ -1,0 +1,178 @@
+//! Integration test for per-group app visibility on the public landing
+//! (#155, Slice 3). Builds a config with one open spec and two
+//! restricted ones (by group and by username) and asserts the landing
+//! shows the right cards for anonymous / admin / per-group sessions.
+//!
+//! Uses an in-process `Router::oneshot` plus an in-memory SQLite for the
+//! user → groups lookup. No socket bound.
+
+use axum::body::Body;
+use axum::http::{header, Request, StatusCode};
+use ruscker_admin::auth::{AdminAuth, Role, COOKIE_NAME};
+use ruscker_admin::db::ConfigDb;
+use ruscker_admin::i18n::Locales;
+use ruscker_admin::{router, AppState};
+use ruscker_config::Config;
+use std::sync::Arc;
+use tower::ServiceExt;
+
+const CONFIG: &str = r#"
+proxy:
+  title: Ruscker Test
+  port: 8088
+  specs:
+    - id: open-app
+      display-name: Open App
+      container-image: demo/img
+    - id: analysts-app
+      display-name: Analysts App
+      container-image: demo/img
+      access-groups: [analysts]
+    - id: vip-user-app
+      display-name: VIP User App
+      container-image: demo/img
+      access-users: [carol]
+"#;
+
+/// A fresh, migrated SQLite at a unique temp path. (The crate's
+/// `open_memory` is `#[cfg(test)]`-only, so integration tests open a
+/// file instead.)
+async fn open_db() -> ConfigDb {
+    use std::sync::atomic::{AtomicU64, Ordering};
+    static N: AtomicU64 = AtomicU64::new(0);
+    let path = std::env::temp_dir().join(format!(
+        "ruscker-landing-access-{}-{}.db",
+        std::process::id(),
+        N.fetch_add(1, Ordering::Relaxed)
+    ));
+    let _ = std::fs::remove_file(&path);
+    ConfigDb::Sqlite(ruscker_admin::db::open(&path).await.unwrap())
+}
+
+/// AppState with admin auth configured (so sessions resolve) and an
+/// in-memory DB for the user → groups lookup.
+async fn app_state(db: ConfigDb) -> AppState {
+    std::env::set_var("DOCKER_REGISTRY_PASSWORD", "test");
+    let config = Config::from_yaml(CONFIG).expect("parse config");
+    let locales = Locales::load().expect("load locales");
+    AppState {
+        config: Arc::new(config),
+        locales: Arc::new(locales),
+        admin_auth: AdminAuth {
+            admin: Some(Arc::from("test-token")),
+        },
+        admin_sessions: Default::default(),
+        log_buffer: None,
+        login_limiter: Arc::new(ruscker_admin::auth::LoginRateLimiter::default_policy()),
+        api_limiter: Arc::new(ruscker_admin::ratelimit::ApiRateLimiter::new()),
+        db: Some(db),
+        images_dir: None,
+        master_key: Default::default(),
+        backend: None,
+        replicas: Arc::new(tokio::sync::RwLock::new(Default::default())),
+        cookie_key: ruscker_proxy::sticky::CookieKey::random(),
+        spawn_locks: Arc::new(dashmap::DashMap::new()),
+        sessions: Arc::new(ruscker_admin::sessions::InMemorySessionStore::new()),
+        leader: Arc::new(ruscker_admin::leader::AlwaysLeader),
+        metrics: ruscker_admin::metrics_cache::MetricsCache::new(),
+        draining: Arc::new(std::sync::atomic::AtomicBool::new(false)),
+    }
+}
+
+async fn landing_body(state: AppState, cookie: Option<String>) -> String {
+    let app = router(state);
+    let mut req = Request::builder().method("GET").uri("/");
+    if let Some(c) = cookie {
+        req = req.header(header::COOKIE, c);
+    }
+    let resp = app.oneshot(req.body(Body::empty()).unwrap()).await.unwrap();
+    assert_eq!(resp.status(), StatusCode::OK);
+    let bytes = axum::body::to_bytes(resp.into_body(), 1 << 20)
+        .await
+        .unwrap();
+    String::from_utf8(bytes.to_vec()).unwrap()
+}
+
+/// Cards render `data-name="{display_name|lower}"`; this matches the
+/// presence of a specific card without tripping on other markup.
+fn has_card(body: &str, lower_name: &str) -> bool {
+    body.contains(&format!(r#"data-name="{lower_name}""#))
+}
+
+#[tokio::test]
+async fn anonymous_sees_only_open_specs() {
+    let db = open_db().await;
+    let state = app_state(db).await;
+    let body = landing_body(state, None).await;
+
+    assert!(has_card(&body, "open app"), "open spec visible to anyone");
+    assert!(!has_card(&body, "analysts app"), "group-restricted spec hidden");
+    assert!(!has_card(&body, "vip user app"), "user-restricted spec hidden");
+    // Anonymous visitor gets the sign-in affordance.
+    assert!(body.contains(r#"href="/admin/login""#), "sign-in link present");
+}
+
+#[tokio::test]
+async fn admin_session_sees_every_spec() {
+    let db = open_db().await;
+    let state = app_state(db).await;
+    // A break-glass token session: Admin role, no username.
+    let sid = state.admin_sessions.create(Role::Admin, None);
+    let body = landing_body(state, Some(format!("{COOKIE_NAME}={sid}"))).await;
+
+    assert!(has_card(&body, "open app"));
+    assert!(has_card(&body, "analysts app"), "admin sees group-restricted");
+    assert!(has_card(&body, "vip user app"), "admin sees user-restricted");
+    // Signed-in affordance instead of sign-in.
+    assert!(body.contains(r#"action="/admin/logout""#), "sign-out present");
+}
+
+#[tokio::test]
+async fn group_member_sees_their_group_spec() {
+    let db = open_db().await;
+    ruscker_admin::db::users::create(
+        &db,
+        "alice",
+        "alicepass1",
+        Role::Viewer,
+        false,
+        &["analysts".to_string()],
+        Some("admin"),
+    )
+    .await
+    .unwrap();
+    let state = app_state(db).await;
+    let sid = state
+        .admin_sessions
+        .create(Role::Viewer, Some("alice".to_string()));
+    let body = landing_body(state, Some(format!("{COOKIE_NAME}={sid}"))).await;
+
+    assert!(has_card(&body, "open app"));
+    assert!(has_card(&body, "analysts app"), "alice is in analysts");
+    assert!(!has_card(&body, "vip user app"), "alice is not the VIP user");
+}
+
+#[tokio::test]
+async fn named_user_sees_their_user_spec() {
+    let db = open_db().await;
+    ruscker_admin::db::users::create(
+        &db,
+        "carol",
+        "carolpass1",
+        Role::Viewer,
+        false,
+        &[],
+        Some("admin"),
+    )
+    .await
+    .unwrap();
+    let state = app_state(db).await;
+    let sid = state
+        .admin_sessions
+        .create(Role::Viewer, Some("carol".to_string()));
+    let body = landing_body(state, Some(format!("{COOKIE_NAME}={sid}"))).await;
+
+    assert!(has_card(&body, "open app"));
+    assert!(has_card(&body, "vip user app"), "carol is the VIP user");
+    assert!(!has_card(&body, "analysts app"), "carol is not in analysts");
+}


### PR DESCRIPTION
The public landing now shows each visitor only the apps they may launch.
Closes the visible half of #155 (enforcement at `/app` is Slice 4).

## Behaviour

| Viewer | Sees |
|---|---|
| Anonymous | open specs only |
| Logged-in (named) | open + specs matching their username or any of their groups |
| Admin role / break-glass token | everything |

Built on **Slice 1** (`Spec::access_allows`, #166) and **Slice 2**
(per-user groups, #167).

## Changes

- **`auth::MaybeSession`** — infallible extractor that keeps the whole
  session (role + username) for the public route (the existing
  `MaybeAdminSession` only carried the role).
- **Landing handler** resolves `(is_admin, username, groups)` — groups
  via `db::users::fetch` — and filters `proxy.specs` *before* building
  cards, so the count and type/subject chips reflect the visible set too.
- **Header affordance**: "Sign in" when anonymous; username + a link to
  the panel + a sign-out form when logged in.
- **Login redirect** honours a same-origin `/` referer, so signing in
  from the landing returns there (a non-admin no longer bounces into the
  panel). `/admin/*` referers and the no-referer default are unchanged.
- **i18n**: 4 new keys × 4 locales (parity checked).

## Testing

- New `tests/landing_access.rs`: anonymous / admin / group-member /
  named-user visibility via `Router::oneshot` + in-memory SQLite.
- Full suite green (22 test binaries).
- End-to-end over HTTP with a 3-spec config (open + group-restricted +
  user-restricted): anon→1 card, admin→3, alice(analysts)→2, carol(VIP)→2,
  dave(no group)→1; login-from-landing redirects back to `/`.

Churn-free diff (no unrelated rustfmt reflow).

## Next

- **Slice 4 (security-critical)**: `/app` + `/api` enforcement guard —
  *reject* a request for a spec the viewer can't access, not just hide
  the card. Hiding a card doesn't stop someone hitting `/app/{spec}`
  directly.
- Admin→landing "view site" link tracked as #156.

Part of #155.

🤖 Generated with [Claude Code](https://claude.com/claude-code)