### PR TITLE
Slice 4 of #155: enforce app access at /app and /api (closes #155)

### DIFF
--- a/crates/ruscker-admin/src/routes/proxy.rs
+++ b/crates/ruscker-admin/src/routes/proxy.rs
@@ -122,40 +122,44 @@ async fn forward_app(
     cookies: Cookies,
     ws: MaybeWs,
     peer: MaybePeer,
+    session: crate::auth::MaybeSession,
     Path((spec_id, rest)): Path<(String, String)>,
     req: Request,
 ) -> Response {
-    forward(state, cookies, ws, peer.0, APP_PREFIX, spec_id, format!("/{rest}"), req).await
+    forward(state, cookies, ws, peer.0, session, APP_PREFIX, spec_id, format!("/{rest}"), req).await
 }
 async fn forward_app_root(
     state: State<AppState>,
     cookies: Cookies,
     ws: MaybeWs,
     peer: MaybePeer,
+    session: crate::auth::MaybeSession,
     Path(spec_id): Path<String>,
     req: Request,
 ) -> Response {
-    forward(state, cookies, ws, peer.0, APP_PREFIX, spec_id, "/".to_string(), req).await
+    forward(state, cookies, ws, peer.0, session, APP_PREFIX, spec_id, "/".to_string(), req).await
 }
 async fn forward_api(
     state: State<AppState>,
     cookies: Cookies,
     ws: MaybeWs,
     peer: MaybePeer,
+    session: crate::auth::MaybeSession,
     Path((spec_id, rest)): Path<(String, String)>,
     req: Request,
 ) -> Response {
-    forward(state, cookies, ws, peer.0, API_PREFIX, spec_id, format!("/{rest}"), req).await
+    forward(state, cookies, ws, peer.0, session, API_PREFIX, spec_id, format!("/{rest}"), req).await
 }
 async fn forward_api_root(
     state: State<AppState>,
     cookies: Cookies,
     ws: MaybeWs,
     peer: MaybePeer,
+    session: crate::auth::MaybeSession,
     Path(spec_id): Path<String>,
     req: Request,
 ) -> Response {
-    forward(state, cookies, ws, peer.0, API_PREFIX, spec_id, "/".to_string(), req).await
+    forward(state, cookies, ws, peer.0, session, API_PREFIX, spec_id, "/".to_string(), req).await
 }
 
 // ── Core forward ───────────────────────────────────────────────────
@@ -166,6 +170,7 @@ async fn forward(
     cookies: Cookies,
     ws_upgrade: MaybeWs,
     peer: Option<SocketAddr>,
+    session: crate::auth::MaybeSession,
     route_prefix: &'static str,
     spec_id: String,
     upstream_path: String,
@@ -265,6 +270,50 @@ async fn forward(
     }
     // Byte cap to hand to the forward step; `None` ⇒ unlimited.
     let body_cap = max_body.map(|l| usize::try_from(l).unwrap_or(usize::MAX));
+
+    // 2d. Access control (#155). An open spec (no `access-groups` /
+    //     `access-users`) stays reachable by anyone — including
+    //     anonymous `/api` clients, so unrestricted APIs keep working.
+    //     A restricted spec requires a session whose username or groups
+    //     match; an Admin role (incl. the break-glass token) passes
+    //     everything. This is the *enforcement* that the landing's card
+    //     filtering only hints at — hiding a card never stopped a direct
+    //     hit on `/app/{spec}`. We resolve groups per request (only for
+    //     restricted specs) from the same `users` store the landing uses.
+    if !spec.is_open() {
+        let session = session.0;
+        let is_admin = session
+            .as_ref()
+            .map(|s| s.role == crate::auth::Role::Admin)
+            .unwrap_or(false);
+        let username = session.as_ref().and_then(|s| s.actor.clone());
+        let groups: Vec<String> = match (username.as_deref(), state.db.as_ref()) {
+            (Some(user), Some(db)) => crate::db::users::fetch(db, user)
+                .await
+                .ok()
+                .flatten()
+                .map(|row| row.groups)
+                .unwrap_or_default(),
+            _ => Vec::new(),
+        };
+        if !spec.access_allows(is_admin, username.as_deref(), &groups) {
+            tracing::info!(
+                spec = %spec.id,
+                user = username.as_deref().unwrap_or("-"),
+                "access denied to restricted spec"
+            );
+            // An anonymous visitor hitting a restricted interactive app
+            // is sent to log in; everyone else (and all API clients) get
+            // a flat 403 (CORS-wrapped for the `/api/` family).
+            if route_prefix == APP_PREFIX && session.is_none() {
+                return Redirect::to("/admin/login").into_response();
+            }
+            return with_cors(
+                (StatusCode::FORBIDDEN, "access denied\n").into_response(),
+                cors_on,
+            );
+        }
+    }
 
     // 3. Backend required to proxy.
     if state.backend.is_none() {

--- a/crates/ruscker-admin/tests/proxy_access.rs
+++ b/crates/ruscker-admin/tests/proxy_access.rs
@@ -1,0 +1,188 @@
+//! Integration test for the `/app` + `/api` access-enforcement guard
+//! (#155, Slice 4). Hiding a card on the landing doesn't stop a direct
+//! request; this guard rejects one for a spec the viewer can't reach.
+//!
+//! No container backend is wired, so an *allowed* request falls through
+//! to the backend check (503) — we assert it was NOT rejected (no 403 /
+//! login redirect). A *denied* request returns before the backend is
+//! ever consulted.
+
+use axum::body::Body;
+use axum::http::{header, Request, StatusCode};
+use ruscker_admin::auth::{AdminAuth, Role, COOKIE_NAME};
+use ruscker_admin::db::ConfigDb;
+use ruscker_admin::i18n::Locales;
+use ruscker_admin::{router, AppState};
+use ruscker_config::Config;
+use std::sync::Arc;
+use tower::ServiceExt;
+
+const CONFIG: &str = r#"
+proxy:
+  title: Ruscker Test
+  port: 8088
+  specs:
+    - id: open-app
+      display-name: Open App
+      container-image: demo/img
+    - id: analysts-app
+      display-name: Analysts App
+      container-image: demo/img
+      access-groups: [analysts]
+    - id: open-api
+      display-name: Open API
+      type: api
+      container-image: demo/img
+    - id: locked-api
+      display-name: Locked API
+      type: api
+      container-image: demo/img
+      access-groups: [analysts]
+"#;
+
+async fn open_db() -> ConfigDb {
+    use std::sync::atomic::{AtomicU64, Ordering};
+    static N: AtomicU64 = AtomicU64::new(0);
+    let path = std::env::temp_dir().join(format!(
+        "ruscker-proxy-access-{}-{}.db",
+        std::process::id(),
+        N.fetch_add(1, Ordering::Relaxed)
+    ));
+    let _ = std::fs::remove_file(&path);
+    ConfigDb::Sqlite(ruscker_admin::db::open(&path).await.unwrap())
+}
+
+async fn app_state(db: ConfigDb) -> AppState {
+    std::env::set_var("DOCKER_REGISTRY_PASSWORD", "test");
+    let config = Config::from_yaml(CONFIG).expect("parse config");
+    let locales = Locales::load().expect("load locales");
+    AppState {
+        config: Arc::new(config),
+        locales: Arc::new(locales),
+        admin_auth: AdminAuth {
+            admin: Some(Arc::from("test-token")),
+        },
+        admin_sessions: Default::default(),
+        log_buffer: None,
+        login_limiter: Arc::new(ruscker_admin::auth::LoginRateLimiter::default_policy()),
+        api_limiter: Arc::new(ruscker_admin::ratelimit::ApiRateLimiter::new()),
+        db: Some(db),
+        images_dir: None,
+        master_key: Default::default(),
+        backend: None,
+        replicas: Arc::new(tokio::sync::RwLock::new(Default::default())),
+        cookie_key: ruscker_proxy::sticky::CookieKey::random(),
+        spawn_locks: Arc::new(dashmap::DashMap::new()),
+        sessions: Arc::new(ruscker_admin::sessions::InMemorySessionStore::new()),
+        leader: Arc::new(ruscker_admin::leader::AlwaysLeader),
+        metrics: ruscker_admin::metrics_cache::MetricsCache::new(),
+        draining: Arc::new(std::sync::atomic::AtomicBool::new(false)),
+    }
+}
+
+async fn get(state: AppState, path: &str, cookie: Option<String>) -> StatusCode {
+    let app = router(state);
+    let mut req = Request::builder().method("GET").uri(path);
+    if let Some(c) = cookie {
+        req = req.header(header::COOKIE, c);
+    }
+    let resp = app.oneshot(req.body(Body::empty()).unwrap()).await.unwrap();
+    resp.status()
+}
+
+/// A request that the guard lets through lands on the "no backend"
+/// 503 — never a 403 or a login redirect.
+const ALLOWED: StatusCode = StatusCode::SERVICE_UNAVAILABLE;
+
+#[tokio::test]
+async fn open_spec_reachable_anonymously() {
+    let state = app_state(open_db().await).await;
+    assert_eq!(get(state, "/app/open-app/", None).await, ALLOWED);
+}
+
+#[tokio::test]
+async fn open_api_reachable_anonymously() {
+    let state = app_state(open_db().await).await;
+    assert_eq!(get(state, "/api/open-api/", None).await, ALLOWED);
+}
+
+#[tokio::test]
+async fn restricted_app_redirects_anonymous_to_login() {
+    let state = app_state(open_db().await).await;
+    // Redirect::to ⇒ 303 See Other to /admin/login (guard fires before
+    // the backend check, so this is not a 503).
+    let st = get(state, "/app/analysts-app/", None).await;
+    assert_eq!(st, StatusCode::SEE_OTHER, "anon → login redirect");
+}
+
+#[tokio::test]
+async fn restricted_api_forbids_anonymous() {
+    let state = app_state(open_db().await).await;
+    assert_eq!(
+        get(state, "/api/locked-api/", None).await,
+        StatusCode::FORBIDDEN,
+        "anon API client gets 403, never a redirect"
+    );
+}
+
+#[tokio::test]
+async fn admin_session_reaches_restricted_app() {
+    let state = app_state(open_db().await).await;
+    let sid = state.admin_sessions.create(Role::Admin, None);
+    assert_eq!(
+        get(state, "/app/analysts-app/", Some(format!("{COOKIE_NAME}={sid}"))).await,
+        ALLOWED,
+        "admin passes the guard"
+    );
+}
+
+#[tokio::test]
+async fn group_member_reaches_restricted_app() {
+    let db = open_db().await;
+    ruscker_admin::db::users::create(
+        &db,
+        "alice",
+        "alicepass1",
+        Role::Viewer,
+        false,
+        &["analysts".to_string()],
+        Some("admin"),
+    )
+    .await
+    .unwrap();
+    let state = app_state(db).await;
+    let sid = state
+        .admin_sessions
+        .create(Role::Viewer, Some("alice".to_string()));
+    assert_eq!(
+        get(state, "/app/analysts-app/", Some(format!("{COOKIE_NAME}={sid}"))).await,
+        ALLOWED,
+        "alice is in analysts → guard passes"
+    );
+}
+
+#[tokio::test]
+async fn non_member_forbidden_from_restricted_app() {
+    let db = open_db().await;
+    ruscker_admin::db::users::create(
+        &db,
+        "dave",
+        "davepass12",
+        Role::Viewer,
+        false,
+        &[],
+        Some("admin"),
+    )
+    .await
+    .unwrap();
+    let state = app_state(db).await;
+    let sid = state
+        .admin_sessions
+        .create(Role::Viewer, Some("dave".to_string()));
+    // Logged in but not in the group ⇒ 403, not a login redirect.
+    assert_eq!(
+        get(state, "/app/analysts-app/", Some(format!("{COOKIE_NAME}={sid}"))).await,
+        StatusCode::FORBIDDEN,
+        "dave lacks the group → 403"
+    );
+}


### PR DESCRIPTION
The landing only *hides* cards a viewer can't reach (Slice 3); a direct
hit on `/app/{spec}` or `/api/{spec}` still bypassed that. This is the
real enforcement boundary — the security-critical part of #155.

## Where & how

In the proxy `forward()` pipeline, **after** the cheap metadata checks
(CORS preflight / rate-limit / max-body) and **before** any container
spawn or backend touch:

- an **open** spec (no `access-groups` / `access-users`) stays reachable
  by anyone — unrestricted apps and APIs are unaffected (no session/DB
  lookup at all);
- a **restricted** spec resolves the viewer from the session — Admin role
  or the break-glass token ⇒ everything; otherwise the username + its
  groups (looked up in the `users` store) — and checks
  `Spec::access_allows`;
- on denial:
  - anonymous → restricted `/app`: redirect to `/admin/login`;
  - everyone else, and every `/api` client: flat **403** (CORS-wrapped
    for the API family).

The check runs before the backend is consulted, so a denied request never
spawns a container.

`auth::MaybeSession` is threaded through the four `/app|/api` handlers and
`forward()`; being `FromRequestParts` it sits safely before the
body-consuming `Request`.

## Testing

New `tests/proxy_access.rs` (7 cases):

| Request | Result |
|---|---|
| anon `/app/open` , `/api/open` | reachable (→ no-backend 503) |
| anon `/app/restricted` | 303 → `/admin/login` |
| anon `/api/locked` | 403 (never a redirect) |
| admin session `/app/restricted` | reachable |
| group member `/app/restricted` | reachable |
| logged-in non-member `/app/restricted` | 403 |

(Allowed requests land on the no-backend 503, which proves the guard let
them through.) Full suite green (23 test binaries). Verified end-to-end
over HTTP on a wired server: anon open 503, anon restricted 303→login,
anon locked-api 403, admin restricted 503.

Churn-free diff (the only removed lines are the four `forward(...)` call
sites, now passing the session).

## Note / follow-up

Groups are resolved per request, but only for restricted specs (open
specs skip the lookup). Caching the viewer's groups in the session at
login is a possible later optimization.

Closes #155 (Slices 1–4: spec ACL → user groups → landing filter →
enforcement).

🤖 Generated with [Claude Code](https://claude.com/claude-code)