### PR TITLE
release: bump workspace version to 0.1.1

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2779,7 +2779,7 @@ dependencies = [
 
 [[package]]
 name = "ruscker-admin"
-version = "0.1.0"
+version = "0.1.1"
 dependencies = [
  "aes-gcm",
  "anyhow",
@@ -2826,7 +2826,7 @@ dependencies = [
 
 [[package]]
 name = "ruscker-cli"
-version = "0.1.0"
+version = "0.1.1"
 dependencies = [
  "anyhow",
  "clap",
@@ -2846,7 +2846,7 @@ dependencies = [
 
 [[package]]
 name = "ruscker-config"
-version = "0.1.0"
+version = "0.1.1"
 dependencies = [
  "chrono",
  "ordered-float",
@@ -2861,7 +2861,7 @@ dependencies = [
 
 [[package]]
 name = "ruscker-core"
-version = "0.1.0"
+version = "0.1.1"
 dependencies = [
  "async-trait",
  "chrono",
@@ -2874,7 +2874,7 @@ dependencies = [
 
 [[package]]
 name = "ruscker-docker"
-version = "0.1.0"
+version = "0.1.1"
 dependencies = [
  "anyhow",
  "async-stream",
@@ -2893,7 +2893,7 @@ dependencies = [
 
 [[package]]
 name = "ruscker-proxy"
-version = "0.1.0"
+version = "0.1.1"
 dependencies = [
  "anyhow",
  "axum",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -10,7 +10,7 @@ members = [
 ]
 
 [workspace.package]
-version = "0.1.0"
+version = "0.1.1"
 edition = "2021"
 rust-version = "1.85"
 license = "Apache-2.0"

--- a/README.md
+++ b/README.md
@@ -73,7 +73,7 @@ tool" cases) is in
 
 ## Status
 
-**v0.1.0 — production-ready and running in production.** Releases are
+**v0.1.1 — production-ready and running in production.** Releases are
 multi-arch (amd64 + arm64) and [cosign-signed]. Where the JVM-based
 stack it replaced idled at hundreds of megabytes, Ruscker idles in the
 low tens:
@@ -124,7 +124,7 @@ curl -fsSL https://raw.githubusercontent.com/StrategicProjects/ruscker/main/inst
 Picks the right artifact from the latest release: the `.deb` (with the
 `systemd` unit + an auto-generated admin token) on Debian/Ubuntu, or the
 static binary into `/usr/local/bin` elsewhere. Pin a version or target
-dir with `./install.sh v0.1.0` or `PREFIX=~/.local/bin ./install.sh`.
+dir with `./install.sh v0.1.1` or `PREFIX=~/.local/bin ./install.sh`.
 
 ### Homebrew (macOS / Linux)
 


### PR DESCRIPTION
Cuts **v0.1.1** from `main`. Since v0.1.0 this picks up:

- **#155** per-group app visibility (slices #166–#169): spec
  `access-groups`/`access-users`, per-user groups, landing filtering +
  sign-in affordance, and `/app` + `/api` enforcement.
- **#158** (#170) HA Postgres session-accounting fixes: supported
  insert-detection (no `xmax`), immediate takeover `len()`, race-free
  register reconcile.

`ruscker --version` now reports `0.1.1`; README version references
updated. The release workflow derives artifact names from the tag, so
tagging `v0.1.1` after merge builds the multi-arch `.deb` + musl
tarballs + ghcr image and attaches them to the GitHub release.

🤖 Generated with [Claude Code](https://claude.com/claude-code)