### PR TITLE
ci: fix cosign-installer to @v3 (no @v4 exists)

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -251,7 +251,7 @@ jobs:
           echo "digest=${digest}" >> "$GITHUB_OUTPUT"
 
       - name: Install cosign
-        uses: sigstore/cosign-installer@v4
+        uses: sigstore/cosign-installer@v3
 
       - name: Sign the image (keyless)
         env:
@@ -278,7 +278,7 @@ jobs:
         run: ls -la dist
 
       - name: Install cosign
-        uses: sigstore/cosign-installer@v4
+        uses: sigstore/cosign-installer@v3
 
       - name: Sign release blobs (keyless)
         working-directory: dist


### PR DESCRIPTION
The v0.1.1 release run failed: `Unable to resolve action
sigstore/cosign-installer@v4, unable to find version v4`. PR #126
bumped it from `@v3` to a non-existent `@v4`; the action's current
major is **v3** (which v0.1.0 shipped with). Reverts those two refs to
`@v3`. The other action bumps in #126 resolved fine in the run.

After merge, the `v0.1.1` tag is moved to include this fix and the
release re-runs.

🤖 Generated with [Claude Code](https://claude.com/claude-code)