### PR TITLE
#156: config opt-out to hide the landing's admin entrance

### DIFF
--- a/crates/ruscker-admin/src/db/landing.rs
+++ b/crates/ruscker-admin/src/db/landing.rs
@@ -67,6 +67,9 @@ pub async fn fetch(db: &ConfigDb) -> Result<LandingCustomization> {
                 // Blocks live in their own table; callers that render
                 // or export them load via `landing_blocks`.
                 blocks: Vec::new(),
+                // Deploy policy (#156) read from YAML config, not the
+                // DB-backed editable customization.
+                show_admin_link: None,
             })
         }
     }

--- a/crates/ruscker-admin/src/routes/admin/landing.rs
+++ b/crates/ruscker-admin/src/routes/admin/landing.rs
@@ -130,6 +130,9 @@ impl LandingForm {
             // screen does); `landing::update` ignores this field, so
             // an empty Vec here never clobbers stored blocks.
             blocks: Vec::new(),
+            // `show-admin-link` is a YAML deploy policy (#156), not an
+            // editor field — never persisted from the form.
+            show_admin_link: None,
         }
     }
 }

--- a/crates/ruscker-admin/src/routes/landing.rs
+++ b/crates/ruscker-admin/src/routes/landing.rs
@@ -69,6 +69,10 @@ struct LandingPage<'a> {
     /// Display name of the signed-in viewer (username, or empty for a
     /// break-glass token session). Shown next to the panel link.
     viewer_name: String,
+    /// Whether to render the anonymous "Sign in" entrance (#156). A
+    /// deploy policy from `landing-customization.show-admin-link`
+    /// (default true); false hides the admin entrance on public portals.
+    show_admin_link: bool,
 }
 
 impl<'a> LandingPage<'a> {
@@ -209,6 +213,13 @@ async fn index(
         blocks_bottom,
         signed_in: session.is_some(),
         viewer_name: username.unwrap_or_default(),
+        // Deploy policy from YAML config (not the DB editor): whether
+        // anonymous visitors see the "Sign in" entrance (#156).
+        show_admin_link: state
+            .config
+            .proxy
+            .landing_customization
+            .effective_show_admin_link(),
     };
     let mut resp = render(&page);
     // Widen *this page's* CSP so the analytics script can load/report.

--- a/crates/ruscker-admin/templates/landing.html
+++ b/crates/ruscker-admin/templates/landing.html
@@ -36,7 +36,7 @@
             <i class="ti ti-logout" aria-hidden="true"></i> {{ self.t("landing-signout") }}
           </button>
         </form>
-      {% else %}
+      {% else if show_admin_link %}
         <a class="inline-flex items-center gap-1 opacity-80 hover:opacity-100" href="/admin/login">
           <i class="ti ti-login" aria-hidden="true"></i> {{ self.t("landing-signin") }}
         </a>

--- a/crates/ruscker-admin/tests/landing_access.rs
+++ b/crates/ruscker-admin/tests/landing_access.rs
@@ -113,6 +113,33 @@ async fn anonymous_sees_only_open_specs() {
 }
 
 #[tokio::test]
+async fn show_admin_link_false_hides_signin_for_anonymous() {
+    // #156: a fully-public portal can hide the admin entrance.
+    const CFG: &str = r#"
+proxy:
+  title: Public Portal
+  port: 8088
+  landing-customization:
+    show-admin-link: false
+  specs:
+    - id: open-app
+      display-name: Open App
+      container-image: demo/img
+"#;
+    std::env::set_var("DOCKER_REGISTRY_PASSWORD", "test");
+    let config = Config::from_yaml(CFG).expect("parse config");
+    let mut state = app_state(open_db().await).await;
+    state.config = Arc::new(config);
+    let body = landing_body(state, None).await;
+
+    assert!(has_card(&body, "open app"), "cards still render");
+    assert!(
+        !body.contains(r#"href="/admin/login""#),
+        "sign-in entrance hidden when show-admin-link=false"
+    );
+}
+
+#[tokio::test]
 async fn admin_session_sees_every_spec() {
     let db = open_db().await;
     let state = app_state(db).await;

--- a/crates/ruscker-config/src/schema.rs
+++ b/crates/ruscker-config/src/schema.rs
@@ -341,6 +341,25 @@ pub struct LandingCustomization {
     /// slot is the render order.
     #[serde(default)]
     pub blocks: Vec<LandingBlock>,
+
+    /// Whether the public landing shows the "Sign in" entrance to
+    /// `/admin/login` for **anonymous** visitors (#156). Defaults to
+    /// `true` (the sign-in affordance from #155). Set `false` on a
+    /// fully-public, no-login portal to hide the admin entrance
+    /// entirely — logged-in users still see their panel link. A
+    /// deploy-level policy, so it lives in YAML config rather than the
+    /// live landing editor.
+    #[serde(default, rename = "show-admin-link")]
+    pub show_admin_link: Option<bool>,
+}
+
+impl LandingCustomization {
+    /// Resolve [`Self::show_admin_link`] — defaults to `true` so the
+    /// landing keeps the anonymous "Sign in" entrance unless an
+    /// operator opts out.
+    pub fn effective_show_admin_link(&self) -> bool {
+        self.show_admin_link.unwrap_or(true)
+    }
 }
 
 /// A custom HTML block on the public landing (admin-authored,


### PR DESCRIPTION
The two halves of #156 already shipped: the **admin→landing** button (the
nav "View portal" link → `/`) and the **landing→admin** entrance (the
#155 "Sign in" / "Panel" affordance). This closes the remaining gap — a
deploy-level opt-out so a fully-public, no-login portal can hide the admin
entrance.

- `landing-customization.show-admin-link` (default `true`, preserving
  #155). `false` hides the anonymous "Sign in" link; logged-in users keep
  their panel link.
- Read from YAML `proxy.landing-customization` (a set-once deploy policy),
  not the DB-backed live editor.
- Render test covers the hidden-entrance case.

Closes #156.

🤖 Generated with [Claude Code](https://claude.com/claude-code)