### PR TITLE
#162: cleanup — stale docs, sqlx DSN-leak check, lint false-positives

### DIFF
--- a/crates/ruscker-admin/src/auth.rs
+++ b/crates/ruscker-admin/src/auth.rs
@@ -12,8 +12,8 @@
 //! never be locked out — treat it as a sensitive secret. When it isn't
 //! set, admin routes 503.
 //!
-//! Roles (see [`Role`]): **Viewer** (dashboard only), **Editor** (apps
-//! + media + dashboard), **Admin** (everything, incl. user
+//! Roles (see [`Role`]): **Viewer** (dashboard only), **Editor**
+//! (apps + media + dashboard), and **Admin** (everything, incl. user
 //! management). External IdPs (OIDC/SAML/LDAP) and per-app ACLs land
 //! in Phase 8.
 //!

--- a/crates/ruscker-admin/src/db/specs.rs
+++ b/crates/ruscker-admin/src/db/specs.rs
@@ -365,8 +365,8 @@ async fn upsert_in_tx(
 }
 
 /// Postgres twin of [`upsert_in_tx`] — identical logic, `$n`
-/// placeholders. Used by the Postgres arm of [`upsert_one`].
-/// (`import_all` stays SQLite-only for now and keeps `upsert_in_tx`.)
+/// placeholders. Used by the Postgres arms of [`upsert_one`] and
+/// [`import_all`] (each dispatches on the `ConfigDb` dialect).
 async fn upsert_in_tx_pg(
     tx: &mut sqlx::Transaction<'_, sqlx::Postgres>,
     spec: &Spec,

--- a/crates/ruscker-admin/src/lib.rs
+++ b/crates/ruscker-admin/src/lib.rs
@@ -331,12 +331,18 @@ impl AdminServer {
         // deliberately dropped — there's no graceful shutdown
         // protocol for the scaler because every tick is idempotent.
         if let Some(backend) = self.state.backend.clone() {
+            // These `spawn`s return a `JoinHandle` (itself a future) we
+            // deliberately detach — each loop is idempotent and has no
+            // shutdown protocol — so the `let_underscore_future` lint is
+            // a false positive here.
+            #[allow(clippy::let_underscore_future)]
             let _ = scaler::spawn(self.state.clone(), scaler::DEFAULT_INTERVAL);
             // Session sweeper: evicts idle sessions per the
             // global `heartbeat-timeout`. `-1` (the ShinyProxy
             // idiom for "never expire") becomes a no-op loop
             // inside `sessions::spawn` so the call shape stays
             // uniform.
+            #[allow(clippy::let_underscore_future)]
             let _ = sessions::spawn(
                 self.state.sessions.clone(),
                 self.state.replicas.clone(),
@@ -345,6 +351,7 @@ impl AdminServer {
             // Dashboard metrics: keep `state.metrics` fresh in
             // the background so dashboard renders are read-only
             // and never block on a Docker stats call.
+            #[allow(clippy::let_underscore_future)]
             let _ = metrics_cache::spawn(
                 self.state.metrics.clone(),
                 backend,

--- a/crates/ruscker-admin/src/ratelimit.rs
+++ b/crates/ruscker-admin/src/ratelimit.rs
@@ -19,7 +19,9 @@
 //! The caller passes a `client` key (see `proxy::client_key`). When
 //! Ruscker runs behind a reverse proxy that the operator has opted
 //! into trusting (`server.useForwardHeaders`), that key is the
-//! left-most `X-Forwarded-For` address; otherwise it's the TCP peer.
+//! right-most parseable `X-Forwarded-For` address (the entry the
+//! trusted proxy appended — the spoof-safe choice); otherwise it's the
+//! TCP peer.
 //! We never trust `X-Forwarded-For` unless the operator opted in,
 //! because otherwise a client could rotate the header to evade the
 //! limit — the same reasoning the login limiter documents.

--- a/crates/ruscker-cli/src/main.rs
+++ b/crates/ruscker-cli/src/main.rs
@@ -629,7 +629,7 @@ fn cmd_inspect(path: &PathBuf) -> Result<()> {
     Ok(())
 }
 
-fn print_human_report(path: &PathBuf, config: &Config, report: &ValidationReport) {
+fn print_human_report(path: &Path, config: &Config, report: &ValidationReport) {
     println!();
     println!("  Ruscker config validation");
     println!("  ─────────────────────────");

--- a/crates/ruscker-config/src/schema.rs
+++ b/crates/ruscker-config/src/schema.rs
@@ -544,8 +544,10 @@ pub struct Spec {
 
     // -- Ruscker extensions: spec type --
     /// Spec type. When absent:
+    ///
     /// - `App` if `container_image` is set
     /// - `External` otherwise
+    ///
     /// Use this field explicitly to mark a containerized API
     /// (`api`), a Streamlit/Dash app, etc.
     #[serde(rename = "type")]


### PR DESCRIPTION
Low-severity hygiene from the audit; no behaviour change.

- **Stale docs (mislead-into-regression risk):**
  - `ratelimit.rs` said the trusted-XFF client key is the *left-most*
    `X-Forwarded-For`; the code correctly uses the *right-most* parseable
    entry (the spoof-safe choice). Fixed so nobody "corrects" it into a
    rate-limit-evasion bug.
  - `db/specs.rs`: `upsert_in_tx_pg` claimed `import_all` "stays
    SQLite-only" — its Postgres arm is fully wired + tested. Fixed.
- **sqlx DSN-in-error — verified no leakage:** connect errors are wrapped
  with `.context(...)` (no URL); logs use `error = %e` (sqlx Display
  doesn't echo the password); the CLI prints "Postgres admin catalog",
  never the DSN.
- **`let_underscore_future` false positives** (scaler/sweeper/metrics
  detached `JoinHandle`s) — `#[allow]` + comment.
- Easy clippy: `&PathBuf`→`&Path`; doc-list indentation in `schema.rs`/
  `auth.rs`.

Residual ~20 clippy warnings are test-only style + larger refactors
(`too-many-args`, `complex-type`, large-`Err`) — non-behavioural,
deferred per the issue's "all style/pedantic, optional" note.

Closes #162.

🤖 Generated with [Claude Code](https://claude.com/claude-code)