### PR TITLE
Fix #159: HA leader-election hardening (timeout, split-brain, gated reaping)

### DIFF
--- a/crates/ruscker-admin/src/leader.rs
+++ b/crates/ruscker-admin/src/leader.rs
@@ -24,14 +24,34 @@
 //! acquires it on its following check — automatic failover, no
 //! heartbeat table to reap.
 //!
+//! Failover isn't instantaneous: a leader whose connection goes
+//! half-open (Postgres released the lock, a standby acquired it, but the
+//! old leader's TCP hasn't reset yet) keeps believing it leads until its
+//! next liveness check fails. That check is bounded by
+//! [`LEADER_OP_TIMEOUT`], so the window in which two instances could
+//! both run a tick is at most one timeout — and a scaler tick is
+//! idempotent (it reconciles to the same target), so a transient overlap
+//! only risks a brief double-spawn-to-min, never divergence.
+//!
 //! Single-node (SQLite, or no config DB) installs use [`AlwaysLeader`]:
 //! there's only one process, so it's always the leader and the scaler
 //! runs unconditionally — zero added dependencies.
 
+use std::time::Duration;
 use sqlx::postgres::PgConnection;
 use sqlx::Connection;
 use tokio::sync::Mutex;
+use tokio::time::timeout;
 use tracing::warn;
+
+/// Wall-clock cap for any single leader-election round-trip (connect /
+/// ping / lock query). It must stay well under the scaler tick interval
+/// so a degraded-but-not-dead Postgres (e.g. a half-open TCP that hasn't
+/// reset yet) can't freeze a tick — and a standby's takeover — by
+/// blocking under the state mutex (#159 C1). A held leader whose
+/// liveness check exceeds this relinquishes, which also bounds any
+/// split-brain to a single tick (#159 C2).
+const LEADER_OP_TIMEOUT: Duration = Duration::from_secs(2);
 
 /// Decides whether *this* instance may run the auto-scaler. Consulted
 /// once per scaler tick; see the module docs.
@@ -99,54 +119,72 @@ impl LeaderElector for PgLeaderLock {
         let mut st = self.state.lock().await;
 
         // Reconnect if we have no live connection. A fresh connection
-        // never holds the lock yet.
+        // never holds the lock yet. Bounded so a stuck connect can't
+        // freeze the tick (#159 C1).
         if st.conn.is_none() {
-            match PgConnection::connect(&self.url).await {
-                Ok(c) => {
+            match timeout(LEADER_OP_TIMEOUT, PgConnection::connect(&self.url)).await {
+                Ok(Ok(c)) => {
                     st.conn = Some(c);
                     st.holds = false;
                 }
-                Err(e) => {
+                Ok(Err(e)) => {
                     warn!(error = %e, "leader: connect to Postgres failed; not leading this tick");
+                    return false;
+                }
+                Err(_) => {
+                    warn!("leader: connect to Postgres timed out; not leading this tick");
                     return false;
                 }
             }
         }
         if st.holds {
-            // Already leader — just confirm the connection (and thus the
-            // lock) is still alive. If it died, drop it so the next tick
-            // reconnects and re-contests. The `conn` borrow is scoped so
-            // it ends before we touch the other `st` fields.
+            // Already leader — re-validate by a *bounded* liveness check.
+            // The advisory lock is session-scoped and we never unlock it,
+            // so an alive session still holds it; a severed or half-open
+            // connection is caught within `LEADER_OP_TIMEOUT` and we
+            // relinquish, so any split-brain lasts at most one tick
+            // (#159 C2). We deliberately do NOT re-run
+            // `pg_try_advisory_lock` here: it *stacks* (each acquire
+            // needs a matching unlock), so re-acquiring every tick would
+            // leak lock depth.
             let alive = {
                 let conn = st.conn.as_mut().expect("connection present");
-                conn.ping().await.is_ok()
+                matches!(timeout(LEADER_OP_TIMEOUT, conn.ping()).await, Ok(Ok(())))
             };
             if alive {
                 return true;
             }
-            warn!("leader: lock connection died; relinquishing leadership");
+            warn!("leader: lock connection lost or timed out; relinquishing leadership");
             st.conn = None;
             st.holds = false;
             return false;
         }
 
-        // Not yet leader — try to acquire. `pg_try_advisory_lock` is
-        // non-blocking: `true` ⇒ we got it (or already hold it on this
-        // session), `false` ⇒ another instance holds it.
+        // Not yet leader — try to acquire (bounded). `pg_try_advisory_lock`
+        // is non-blocking: `true` ⇒ we got it, `false` ⇒ another instance
+        // holds it.
         let result = {
             let conn = st.conn.as_mut().expect("connection present");
-            sqlx::query_scalar::<_, bool>("SELECT pg_try_advisory_lock($1)")
-                .bind(SCALER_LOCK_KEY)
-                .fetch_one(&mut *conn)
-                .await
+            timeout(
+                LEADER_OP_TIMEOUT,
+                sqlx::query_scalar::<_, bool>("SELECT pg_try_advisory_lock($1)")
+                    .bind(SCALER_LOCK_KEY)
+                    .fetch_one(&mut *conn),
+            )
+            .await
         };
         match result {
-            Ok(got) => {
+            Ok(Ok(got)) => {
                 st.holds = got;
                 got
             }
-            Err(e) => {
+            Ok(Err(e)) => {
                 warn!(error = %e, "leader: advisory-lock query failed; not leading this tick");
+                st.conn = None;
+                false
+            }
+            Err(_) => {
+                warn!("leader: advisory-lock query timed out; not leading this tick");
                 st.conn = None;
                 false
             }

--- a/crates/ruscker-admin/src/lib.rs
+++ b/crates/ruscker-admin/src/lib.rs
@@ -347,6 +347,7 @@ impl AdminServer {
                 self.state.sessions.clone(),
                 self.state.replicas.clone(),
                 self.state.config.clone(),
+                self.state.leader.clone(),
             );
             // Dashboard metrics: keep `state.metrics` fresh in
             // the background so dashboard renders are read-only

--- a/crates/ruscker-admin/src/sessions.rs
+++ b/crates/ruscker-admin/src/sessions.rs
@@ -84,11 +84,19 @@ pub trait SessionStore: Send + Sync {
     /// One idle-expiry pass: evict sessions past their (per-spec)
     /// timeout and decrement the replica counter. Returns how many
     /// were evicted.
+    ///
+    /// `is_leader` gates the **destructive** part in shared-store (HA)
+    /// implementations: only the leader issues the idle-eviction
+    /// DELETEs, so M instances don't race identical deletes on the same
+    /// rows (#159 C3). The read-only reconcile (cluster-wide counts +
+    /// this node's `len()`) always runs, on every node. Single-node
+    /// stores ignore the flag — they're always the sole writer.
     async fn sweep(
         &self,
         registry: &RwLock<ReplicaRegistry>,
         global_ms: i64,
         overrides: &std::collections::HashMap<String, i64>,
+        is_leader: bool,
     ) -> usize;
 
     /// Number of tracked sessions (used by graceful-shutdown drain and
@@ -195,6 +203,9 @@ impl SessionStore for InMemorySessionStore {
         registry: &RwLock<ReplicaRegistry>,
         global_ms: i64,
         overrides: &std::collections::HashMap<String, i64>,
+        // Single-node store: this process is the only writer, so it
+        // always evicts (the flag only matters for the shared HA store).
+        _is_leader: bool,
     ) -> usize {
         let now = Instant::now();
         // Collect victims first so we don't hold DashMap shard
@@ -252,6 +263,7 @@ pub fn spawn(
     tracker: Arc<dyn SessionStore>,
     registry: Arc<RwLock<ReplicaRegistry>>,
     config: Arc<ruscker_config::Config>,
+    leader: Arc<dyn crate::leader::LeaderElector>,
 ) -> JoinHandle<()> {
     let global_ms = config.proxy.heartbeat_timeout;
     let overrides: std::collections::HashMap<String, i64> = config
@@ -271,7 +283,13 @@ pub fn spawn(
         ticker.set_missed_tick_behavior(tokio::time::MissedTickBehavior::Skip);
         loop {
             ticker.tick().await;
-            let evicted = tracker.sweep(&registry, global_ms, &overrides).await;
+            // Only the leader issues the idle-eviction DELETEs in a
+            // shared (HA) store; the reconcile runs regardless (#159 C3).
+            // `AlwaysLeader` (single-node) is always true.
+            let is_leader = leader.is_leader().await;
+            let evicted = tracker
+                .sweep(&registry, global_ms, &overrides, is_leader)
+                .await;
             if evicted > 0 {
                 info!(evicted, "session sweeper evicted idle sessions");
             }
@@ -319,7 +337,7 @@ mod tests {
         assert!(!store.is_empty());
         // Idle sweep through the trait object (is_empty is the trait default).
         let evicted = store
-            .sweep(&reg, 0, &std::collections::HashMap::new())
+            .sweep(&reg, 0, &std::collections::HashMap::new(), true)
             .await;
         assert_eq!(evicted, 1);
         assert!(store.is_empty());
@@ -377,7 +395,7 @@ mod tests {
         }
 
         let no_overrides = std::collections::HashMap::new();
-        let evicted = tracker.sweep(&reg, 10_000, &no_overrides).await;
+        let evicted = tracker.sweep(&reg, 10_000, &no_overrides, true).await;
         assert_eq!(evicted, 1);
         assert_eq!(reg.read().await.replicas_of("alpha")[0].sessions_active, 0);
         assert!(tracker.is_empty());
@@ -396,7 +414,7 @@ mod tests {
         // last_seen is now, sweep with 10s timeout — nothing
         // should evict.
         let no_overrides = std::collections::HashMap::new();
-        let evicted = tracker.sweep(&reg, 10_000, &no_overrides).await;
+        let evicted = tracker.sweep(&reg, 10_000, &no_overrides, true).await;
         assert_eq!(evicted, 0);
         assert_eq!(tracker.len(), 1);
         assert_eq!(reg.read().await.replicas_of("alpha")[0].sessions_active, 1);
@@ -431,7 +449,7 @@ mod tests {
         let mut overrides = std::collections::HashMap::new();
         overrides.insert("pinned".to_string(), -1_i64); // never expire
 
-        let evicted = tracker.sweep(&reg, 10_000, &overrides).await;
+        let evicted = tracker.sweep(&reg, 10_000, &overrides, true).await;
         assert_eq!(evicted, 1, "only the global-timeout session is reaped");
         // pinned survives, normal is gone
         assert!(tracker.sessions.contains_key(&s_pinned));
@@ -459,7 +477,7 @@ mod tests {
         overrides.insert("snappy".to_string(), 5_000_i64); // 5s override
 
         // Global is 1h (would keep it), but the 5s override reaps it.
-        let evicted = tracker.sweep(&reg, 3_600_000, &overrides).await;
+        let evicted = tracker.sweep(&reg, 3_600_000, &overrides, true).await;
         assert_eq!(evicted, 1);
     }
 }

--- a/crates/ruscker-admin/src/sessions_pg.rs
+++ b/crates/ruscker-admin/src/sessions_pg.rs
@@ -223,6 +223,7 @@ impl PostgresSessionStore {
         registry: &RwLock<ReplicaRegistry>,
         global_ms: i64,
         overrides: &HashMap<String, i64>,
+        is_leader: bool,
     ) -> sqlx::Result<usize> {
         let mut evicted: u64 = 0;
 
@@ -230,9 +231,13 @@ impl PostgresSessionStore {
         // each is handled (or skipped, if never-expire) below.
         let overridden: Vec<String> = overrides.keys().cloned().collect();
 
+        // Idle-eviction DELETEs run on the leader only (#159 C3): with M
+        // instances all sweeping every few seconds, ungated they'd race
+        // identical deletes on the same rows (harmless but O(M·rows)).
+        // The read-only reconcile + per-instance count below always run.
         // Global pass: every non-overridden spec, unless the global
         // timeout itself is the never-expire sentinel (< 0).
-        if global_ms >= 0 {
+        if is_leader && global_ms >= 0 {
             let res = sqlx::query(
                 "DELETE FROM proxy_sessions
                  WHERE last_seen < now() - ($1::float8 * interval '1 millisecond')
@@ -247,9 +252,10 @@ impl PostgresSessionStore {
 
         // Per-spec overrides: a non-negative override reaps that
         // spec's idle rows on its own clock; a negative one (-1) means
-        // "never expire", so we leave it alone.
+        // "never expire", so we leave it alone. Leader-gated like the
+        // global pass (#159 C3).
         for (spec_id, ms) in overrides {
-            if *ms < 0 {
+            if !is_leader || *ms < 0 {
                 continue;
             }
             let res = sqlx::query(
@@ -347,8 +353,9 @@ impl SessionStore for PostgresSessionStore {
         registry: &RwLock<ReplicaRegistry>,
         global_ms: i64,
         overrides: &HashMap<String, i64>,
+        is_leader: bool,
     ) -> usize {
-        match self.try_sweep(registry, global_ms, overrides).await {
+        match self.try_sweep(registry, global_ms, overrides, is_leader).await {
             Ok(n) => n,
             Err(e) => {
                 // Leave the registry counts as last reconciled rather
@@ -436,7 +443,7 @@ mod tests {
         // A no-op sweep keeps the fresh session and reconciles the
         // count to exactly 1 from the shared table.
         let no_overrides = HashMap::new();
-        let evicted = store.sweep(&reg, 3_600_000, &no_overrides).await;
+        let evicted = store.sweep(&reg, 3_600_000, &no_overrides, true).await;
         assert_eq!(evicted, 0);
         assert_eq!(reg.read().await.replicas_of("alpha")[0].sessions_active, 1);
 
@@ -446,7 +453,7 @@ mod tests {
             .execute(&store.pool)
             .await
             .unwrap();
-        let evicted = store.sweep(&reg, 1_000, &no_overrides).await;
+        let evicted = store.sweep(&reg, 1_000, &no_overrides, true).await;
         assert_eq!(evicted, 1);
         assert_eq!(reg.read().await.replicas_of("alpha")[0].sessions_active, 0);
         assert_eq!(store.len(), 0);
@@ -506,7 +513,7 @@ mod tests {
         // B's sweep reconciles the cluster-wide count from the shared
         // table and now sees A's session.
         let no_overrides = HashMap::new();
-        b.sweep(&reg_b, 3_600_000, &no_overrides).await;
+        b.sweep(&reg_b, 3_600_000, &no_overrides, true).await;
         assert_eq!(reg_b.read().await.replicas_of("alpha")[0].sessions_active, 1);
         // …and the session is node-local to A, not B.
         assert_eq!(a.len(), 1);
@@ -573,12 +580,12 @@ mod tests {
 
         // The cluster-wide count is still exactly 1 (one session, now on
         // B) — the takeover must not have double-counted the seat.
-        b.sweep(&reg_b, 3_600_000, &HashMap::new()).await;
+        b.sweep(&reg_b, 3_600_000, &HashMap::new(), true).await;
         assert_eq!(reg_b.read().await.replicas_of("alpha")[0].sessions_active, 1);
 
         // After A sweeps, the row's instance_id is B's, so A's len()
         // drains to 0 (A is no longer serving it).
-        a.sweep(&reg_a, 3_600_000, &HashMap::new()).await;
+        a.sweep(&reg_a, 3_600_000, &HashMap::new(), true).await;
         assert_eq!(a.len(), 0, "A no longer owns the session");
 
         // A repeat touch by the new owner is neither insert nor takeover
@@ -588,5 +595,61 @@ mod tests {
             TouchOutcome::Touched
         );
         assert_eq!(b.len(), 1);
+    }
+
+    // C3: a non-leader sweep must reconcile (read-only) but never issue
+    // the idle-eviction DELETEs — only the leader reaps, so M instances
+    // don't race identical deletes. Gated on `postgres-it`.
+    #[cfg(feature = "postgres-it")]
+    #[tokio::test]
+    async fn non_leader_sweep_reconciles_but_does_not_evict() {
+        use ruscker_core::{Replica, ReplicaState};
+        use std::net::SocketAddr;
+        use std::sync::Arc;
+
+        let _guard = crate::db::pg_test_lock().lock().await;
+        let url = std::env::var("RUSCKER_TEST_PG_URL")
+            .expect("set RUSCKER_TEST_PG_URL to a reachable postgres:// DSN");
+        let store = PostgresSessionStore::connect(&url).await.unwrap();
+        sqlx::query("DELETE FROM proxy_sessions")
+            .execute(&store.pool)
+            .await
+            .unwrap();
+
+        let reg = Arc::new(RwLock::new(ReplicaRegistry::new()));
+        let rid = ReplicaId(Uuid::new_v4());
+        reg.write().await.add(Replica {
+            id: rid.clone(),
+            spec_id: "alpha".into(),
+            container_id: "c".into(),
+            upstream: "127.0.0.1:1".parse::<SocketAddr>().unwrap(),
+            state: ReplicaState::Ready,
+            started_at: chrono::Utc::now(),
+            sessions_active: 0,
+            sessions_max: 5,
+            host: None,
+        });
+
+        let sid = Uuid::new_v4();
+        store
+            .touch_or_register(&reg, sid, "alpha", &rid)
+            .await;
+        // Age the row well past any tiny timeout.
+        sqlx::query("UPDATE proxy_sessions SET last_seen = now() - interval '1 hour'")
+            .execute(&store.pool)
+            .await
+            .unwrap();
+
+        let no_overrides = HashMap::new();
+        // Non-leader: nothing evicted, but the reconcile still ran (the
+        // surviving row is counted onto the replica).
+        let evicted = store.sweep(&reg, 1_000, &no_overrides, false).await;
+        assert_eq!(evicted, 0, "non-leader must not DELETE");
+        assert_eq!(reg.read().await.replicas_of("alpha")[0].sessions_active, 1);
+
+        // Leader: now the idle row is reaped and the count reconciles down.
+        let evicted = store.sweep(&reg, 1_000, &no_overrides, true).await;
+        assert_eq!(evicted, 1, "leader reaps the idle row");
+        assert_eq!(reg.read().await.replicas_of("alpha")[0].sessions_active, 0);
     }
 }


### PR DESCRIPTION
Three robustness fixes around `leader.rs` + the session sweeper.

- **C1 — per-call timeout.** `is_leader` had no timeout and held the
  state mutex across connect/ping/query, so a half-open Postgres could
  freeze a scaler tick (and a standby's takeover) indefinitely. Every
  round-trip is now wrapped in a 2 s `tokio::time::timeout` (< the 10 s
  tick); on timeout the connection is dropped and the tick is not-leader.
- **C2 — split-brain re-validation.** A held leader re-checked via an
  unbounded `ping()`; a severed connection left it believing it led
  until ping failed. The check is now timeout-bounded, capping
  split-brain to one tick. The advisory lock is session-scoped and never
  unlocked (alive session ⇒ still holds it), so we deliberately **don't**
  re-run `pg_try_advisory_lock` — it *stacks* (re-acquiring leaks lock
  depth). Docs state the bounded window + idempotent ticks.
- **C3 — leader-gated reaping.** The idle-eviction `DELETE`s ran on every
  node (M instances racing identical deletes). `SessionStore::sweep`
  gained an `is_leader` flag (threaded from the sweeper via the shared
  `LeaderElector`); the Postgres store DELETEs only when leader, while
  the read-only reconcile (counts + `len()`) runs everywhere. The
  in-memory store ignores it.

Tests: gated `non_leader_sweep_reconciles_but_does_not_evict` (C3);
existing leader-failover + sweep gated tests still green (197
postgres-it). Default suite green (23 binaries).

Closes #159.

🤖 Generated with [Claude Code](https://claude.com/claude-code)