### PR TITLE
#161: document sticky-upstream requirement for sign-in sessions in HA

### DIFF
--- a/book/src/deploying.md
+++ b/book/src/deploying.md
@@ -203,9 +203,53 @@ rest serve traffic. If the leader dies its lock releases and another
 takes over within one scaler tick — nothing to configure. Each instance
 logs its role at startup (`acquired leadership` / `standing by`).
 
-The load balancer does **not** need sticky upstreams — sessions are
-shared, so round-robin is fine. Keep `server.useForwardHeaders: true`
-and pass `X-Forwarded-*` as in the nginx section above.
+**App traffic** doesn't need sticky upstreams — proxy sessions are
+shared (the sticky cookie is a shared-key HMAC and the `proxy_sessions`
+table is shared), so round-robin is fine for `/app` and `/api`. Keep
+`server.useForwardHeaders: true` and pass `X-Forwarded-*` as in the
+nginx section above.
+
+### Sticky upstream for the sign-in session (`/admin`, `/app`, `/api`)
+
+One thing is **not** shared across instances yet: the **sign-in session**
+(`AdminSessions`) is an in-memory map per process. So an admin — or, with
+per-group app visibility ([access control](./configuration.md)), any
+signed-in user — who logs into instance A and is then round-robined to
+instance B is bounced back to the login screen (B doesn't know the
+session), and on the proxy path B would treat them as anonymous (so a
+restricted app could 403/redirect even though they're entitled to it).
+
+Until a shared session store lands ([#161]), pin the **session-bearing
+paths** to one instance with a sticky upstream. The simplest is
+`ip_hash` (route by client IP); a cookie-based sticky on the
+`ruscker_admin_session` cookie is more precise if you have nginx Plus or
+a similar LB.
+
+```nginx
+# Pin each client to one instance so its sign-in session is found.
+upstream ruscker {
+    ip_hash;                      # sticky by client IP
+    server 10.0.0.11:8080;
+    server 10.0.0.12:8080;
+}
+server {
+    # … TLS, proxy headers (see above) …
+    location / {                  # landing, /admin, /app, /api
+        proxy_pass http://ruscker;
+    }
+}
+```
+
+The shared catalog + session table mean **no data is lost** on a
+failover — the worst case is a re-login. If you can't make the LB
+sticky, document for your admins that a failover re-prompts login.
+
+> **Roadmap:** [#161] tracks backing `AdminSessions` with the shared
+> Postgres (a small `admin_sessions` table, fronted by a short-TTL local
+> cache so the hot proxy path stays DB-free) — that removes the need for
+> stickiness entirely.
+
+[#161]: https://github.com/StrategicProjects/ruscker/issues/161
 
 > Today the running proxy reads its spec list from the YAML
 > (`--config`), so deploy the same `application.yml` to every instance;

--- a/crates/ruscker-admin/src/auth.rs
+++ b/crates/ruscker-admin/src/auth.rs
@@ -188,6 +188,17 @@ pub struct SessionInfo {
 /// never exposes the master token, and logout actually invalidates the
 /// session instead of just clearing the browser's copy. The stored
 /// [`Role`] is what route guards and the nav dispatch on.
+///
+/// **HA note (#161):** this map is process-local. In active-active HA
+/// the admin catalog and `proxy_sessions` are shared, but sign-in
+/// sessions are not — a load-balancer hop to another instance re-prompts
+/// login (and, with per-group app visibility, the proxy on the other
+/// instance sees the request as anonymous). Until a shared session store
+/// lands, the deploy guide prescribes a **sticky upstream** for the
+/// session-bearing paths (`book/src/deploying.md` § "Sticky upstream for
+/// the sign-in session"). A signed stateless cookie was rejected on
+/// purpose — opaque server-side ids keep logout/restart revocable
+/// (SECURITY.md §1).
 #[derive(Debug)]
 pub struct AdminSessions {
     sessions: DashMap<String, SessionEntry>,


### PR DESCRIPTION
`AdminSessions` is a process-local map, so in active-active HA a
load-balancer hop bounces an admin (or, with #155 per-group visibility,
any signed-in user) to login — and the other instance's proxy treats the
request as anonymous. The deploy guide even claimed "the load balancer
does not need sticky upstreams," which holds for shared app/proxy
sessions but is wrong for the sign-in session.

Resolved via the issue's sanctioned immediate path (**option 2**):

- Deploy guide now prescribes a **sticky upstream** (nginx `ip_hash`, or
  a cookie sticky on `ruscker_admin_session`) for the session-bearing
  paths, with an nginx snippet; clarifies app traffic stays
  round-robin-safe; notes the shared catalog + session table mean a
  failover only costs a re-login (no data loss).
- `AdminSessions` gains a doc note recording the limitation + pointer to
  the guide. The opaque server-side session (no stateless cookie) is kept
  on purpose (SECURITY.md §1 — revocability).

**Why not the shared-store code fix (option 1) now:** `validate` runs on
the hot path (every `/admin` + every `MaybeSession` resolution on the
landing and `/app` proxy guard from #155), so a naive PG-per-request
lookup is a latency regression. The real fix needs a short-TTL local
cache in front of the shared table — documented as the roadmap follow-up
on the issue.

Closes #161.

🤖 Generated with [Claude Code](https://claude.com/claude-code)