### PR TITLE
#173: serve Ruscker under a base path (context-path / subpath mounting)

### DIFF
--- a/book/src/deploying.md
+++ b/book/src/deploying.md
@@ -165,6 +165,34 @@ Cut over by reloading nginx; roll back by restoring the previous
 config. Keep a backup of the site file and run `nginx -t` before every
 reload.
 
+## 4b. Mounting under a base path (subpath)
+
+When you can't create a subdomain (no DNS governance), serve the whole
+portal under a subpath like `example.org/box/`. Start Ruscker with
+`--base-path /box` (or `server.context-path: /box` in the config —
+ShinyProxy's `server.servlet.context-path` is also accepted), and point
+nginx at it **preserving the prefix** (no trailing path on `proxy_pass`,
+so the `/box` stays in the forwarded URL):
+
+```nginx
+# Forward both the bare /box and everything under /box/ — without an
+# nginx-side redirect (Ruscker does its own canonicalization below).
+location = /box  { proxy_pass http://127.0.0.1:8080; /* + proxy_set_header from §3 */ }
+location /box/   { proxy_pass http://127.0.0.1:8080; /* + proxy_set_header from §3 */ }
+```
+
+Ruscker then nests every route under `/box` (`/box`, `/box/admin/…`,
+`/box/app/{spec}/…`), rewrites the URLs/redirects it emits to carry the
+prefix, and injects a small runtime shim so JS-built requests (the live
+dashboard's SSE, `fetch`, etc.) resolve under `/box` too. `/healthz` and
+`/readyz` stay at the **root** for load-balancer probes — don't put them
+behind the `/box` locations. `--base-path` is empty by default, so
+root-mounted deploys are unaffected.
+
+> The canonical landing URL is `/box` (no trailing slash); a request to
+> `/box/` 308-redirects to it. Keeping nginx as a plain `proxy_pass`
+> (never redirecting) means that single hop can't loop.
+
 ## 5. Health checks
 
 Point your load balancer / orchestrator at:

--- a/crates/ruscker-admin/src/lib.rs
+++ b/crates/ruscker-admin/src/lib.rs
@@ -499,6 +499,25 @@ pub fn router_with_images(state: AppState, _images_dir: Option<&Path>) -> Router
         .merge(routes::admin::routes())
         .layer(axum::middleware::from_fn(security_headers));
 
+    // Base-path mounting (#173): when served under a subpath, rewrite the
+    // chrome's root-absolute URLs / redirects to carry the prefix. Only
+    // the chrome needs it — the proxy's `/app` responses get the prefix
+    // through their own rewriter, and `/api`/metrics carry no chrome URLs.
+    // No-op layer cost when there's no base path (we skip adding it).
+    let own = {
+        let base = state.base_path.clone();
+        if base.is_empty() {
+            own
+        } else {
+            own.layer(axum::middleware::from_fn(
+                move |req: axum::extract::Request, next: axum::middleware::Next| {
+                    let base = base.clone();
+                    async move { routes::rewrite::prefix_base_path(next.run(req).await, &base).await }
+                },
+            ))
+        }
+    };
+
     // Health probes (`/healthz`, `/readyz`) sit outside the
     // `security_headers` layer: they return JSON for orchestrators,
     // not HTML for browsers, so CSP / X-Frame-Options are

--- a/crates/ruscker-admin/src/lib.rs
+++ b/crates/ruscker-admin/src/lib.rs
@@ -46,6 +46,11 @@ use sqlx::SqlitePool;
 pub struct AppState {
     pub config: Arc<Config>,
     pub locales: Arc<i18n::Locales>,
+    /// Normalized base path the portal is served under (#173): `""` for
+    /// root (default) or e.g. `"/box"`. The router nests everything
+    /// under it and the response rewriter prefixes generated URLs /
+    /// redirects / cookie paths with it.
+    pub base_path: Arc<str>,
     pub admin_auth: auth::AdminAuth,
     /// Opaque server-side admin session store. The cookie holds a
     /// random session id (not the token); shared so every cloned
@@ -166,6 +171,7 @@ impl AdminServer {
         let state = AppState {
             config: Arc::new(config),
             locales: Arc::new(locales),
+            base_path: Arc::from(""),
             admin_auth: auth::AdminAuth::from_env(),
             admin_sessions: Arc::new(auth::AdminSessions::default_policy()),
             login_limiter: Arc::new(auth::LoginRateLimiter::default_policy()),
@@ -229,6 +235,15 @@ impl AdminServer {
     /// Created and populated by a `tracing` layer in `ruscker-cli`.
     pub fn with_log_buffer(mut self, buffer: logbuf::LogBuffer) -> Self {
         self.state.log_buffer = Some(buffer);
+        self
+    }
+
+    /// Serve the whole portal under a base path (#173), e.g. `/box` for
+    /// mounting at `example.org/box/`. Normalized via
+    /// [`ruscker_config::normalize_base_path`]; empty ⇒ root (default).
+    pub fn with_base_path(mut self, path: impl AsRef<str>) -> Self {
+        let norm = ruscker_config::normalize_base_path(path.as_ref());
+        self.state.base_path = Arc::from(norm.as_str());
         self
     }
 
@@ -489,12 +504,42 @@ pub fn router_with_images(state: AppState, _images_dir: Option<&Path>) -> Router
     // not HTML for browsers, so CSP / X-Frame-Options are
     // irrelevant. Like the proxy routes, they're merged at the
     // outer level.
-    own.merge(routes::proxy::routes())
-        .merge(routes::health::routes())
+    // The full portal surface (chrome + proxy + metrics). Health is
+    // kept separate so it can stay at the root even under a base path —
+    // load-balancer probes shouldn't have to know the prefix.
+    let portal = own
+        .merge(routes::proxy::routes())
         // `/metrics` (opt-in via proxy.metrics-enabled) is likewise
         // unauthenticated and outside `security_headers` — it serves
         // Prometheus text for a scraper, not HTML for a browser.
-        .merge(routes::metrics::routes())
+        .merge(routes::metrics::routes());
+
+    // Mount under the configured base path (#173). `""` ⇒ root (the
+    // default), so single-host deploys are unchanged. With e.g. `/box`,
+    // every portal route matches under `/box/...`; the response rewriter
+    // (added in a later slice) prefixes the URLs the handlers emit.
+    let base = state.base_path.clone();
+    let portal = if base.is_empty() {
+        portal
+    } else {
+        // axum 0.8 `nest` maps the inner `/` route to exactly `/box`
+        // (no trailing slash) and does NOT match `/box/` — but that's
+        // the URL a browser / nginx sends for the landing root. Redirect
+        // `/box/` → `/box` so both forms work (the deeper routes like
+        // `/box/admin/...` are matched by nest directly).
+        let canonical = base.to_string();
+        let trailing = format!("{base}/");
+        Router::new().nest(&base, portal).route(
+            &trailing,
+            axum::routing::get(move || {
+                let to = canonical.clone();
+                async move { axum::response::Redirect::permanent(&to) }
+            }),
+        )
+    };
+
+    portal
+        .merge(routes::health::routes())
         .layer(CookieManagerLayer::new())
         .with_state(state)
 }

--- a/crates/ruscker-admin/src/routes/proxy.rs
+++ b/crates/ruscker-admin/src/routes/proxy.rs
@@ -426,7 +426,9 @@ async fn forward(
     //     the transform per spec (`inject-base-href: false`) once the
     //     app self-routes from the forwarded-prefix headers above.
     let resp = if route_prefix == APP_PREFIX && spec.effective_inject_base_href() {
-        let base = format!("{route_prefix}{}/", spec.id);
+        // Include the portal base path (#173) so the app's `<base href>`
+        // is `/box/app/{spec}/` when Ruscker is mounted under `/box`.
+        let base = format!("{}{route_prefix}{}/", state.base_path, spec.id);
         rewrite::inject_base_href(resp, &base).await
     } else {
         resp

--- a/crates/ruscker-admin/src/routes/proxy.rs
+++ b/crates/ruscker-admin/src/routes/proxy.rs
@@ -1193,6 +1193,7 @@ mod tests {
         let cfg = Config::from_yaml("specs: []").expect("empty config");
         AppState {
             config: std::sync::Arc::new(cfg),
+            base_path: std::sync::Arc::from(""),
             locales: std::sync::Arc::new(
                 crate::i18n::Locales::load().expect("load locales"),
             ),

--- a/crates/ruscker-admin/src/routes/rewrite.rs
+++ b/crates/ruscker-admin/src/routes/rewrite.rs
@@ -383,6 +383,209 @@ fn transform(html: &[u8], base_path: &str) -> Result<Vec<u8>, lol_html::errors::
     Ok(out)
 }
 
+// ════════════════════════════════════════════════════════════════
+// Base-path mounting (#173)
+//
+// The opposite job to the `/app/{spec}/` rewrite above: when Ruscker
+// itself is served under a subpath (e.g. `/box`), the *chrome*
+// (landing + admin) emits root-absolute URLs (`/admin/x`, `/assets/x`,
+// `/__set/...`) and redirects (`Location: /admin/dashboard`) that must
+// all be prefixed with the base. We reuse the same lol_html plumbing,
+// but the rewrite rule is inverted: prefix *every* root-absolute URL
+// that isn't already under the base (no skip-list — those Ruscker paths
+// are exactly what we want to move under the prefix).
+// ════════════════════════════════════════════════════════════════
+
+/// Prefix a root-absolute URL with `base` (e.g. `/box`), unless it's
+/// relative, protocol-relative, or already under `base`. `base` has a
+/// leading slash and no trailing slash.
+fn rewrite_url_base(value: &str, base: &str) -> Option<String> {
+    let t = value.trim_start();
+    if !t.starts_with('/') || t.starts_with("//") {
+        return None; // relative, anchor (#/?), protocol-relative, scheme
+    }
+    if t == base || t.starts_with(&format!("{base}/")) {
+        return None; // already prefixed
+    }
+    Some(format!("{base}{t}"))
+}
+
+/// If `resp` is HTML, prefix its absolute chrome URLs with `base` and
+/// inject the runtime shim; always prefix a root-absolute `Location`
+/// header (redirects) so they stay under the base. Cookies set
+/// `Path=/`, which the browser already sends for `{base}/...`, so they
+/// need no rewrite. No-op when `base` is empty.
+pub async fn prefix_base_path(resp: Response<Body>, base: &str) -> Response<Body> {
+    if base.is_empty() {
+        return resp;
+    }
+    let (mut parts, body) = resp.into_parts();
+
+    // Redirects: `Location: /admin/x` → `/box/admin/x`.
+    if let Some(loc) = parts.headers.get(header::LOCATION).and_then(|v| v.to_str().ok()) {
+        if let Some(new_loc) = rewrite_url_base(loc, base) {
+            if let Ok(v) = HeaderValue::from_str(&new_loc) {
+                parts.headers.insert(header::LOCATION, v);
+            }
+        }
+    }
+
+    let is_html = parts
+        .headers
+        .get(header::CONTENT_TYPE)
+        .and_then(|v| v.to_str().ok())
+        .map(|s| s.trim().to_ascii_lowercase().starts_with("text/html"))
+        .unwrap_or(false);
+    if !is_html {
+        return Response::from_parts(parts, body);
+    }
+
+    let declared_len = parts
+        .headers
+        .get(header::CONTENT_LENGTH)
+        .and_then(|v| v.to_str().ok())
+        .and_then(|s| s.parse::<usize>().ok());
+    if declared_len.is_some_and(|n| n > MAX_HTML_BYTES) {
+        return Response::from_parts(parts, body);
+    }
+    let bytes = match to_bytes(body, MAX_HTML_BYTES).await {
+        Ok(b) => b,
+        Err(e) => {
+            tracing::warn!(error = ?e, "chrome HTML exceeded transform cap; can't prefix base path");
+            return Response::builder()
+                .status(502)
+                .body(Body::from("response too large to mount under base path"))
+                .unwrap_or_else(|_| Response::new(Body::empty()));
+        }
+    };
+    if bytes.is_empty() {
+        return Response::from_parts(parts, Body::empty());
+    }
+
+    let rewritten = match transform_base(bytes.as_ref(), base) {
+        Ok(r) => r,
+        Err(e) => {
+            tracing::warn!(error = ?e, "base-path transform failed; serving body as-is");
+            bytes.to_vec()
+        }
+    };
+    parts.headers.remove(header::CONTENT_LENGTH);
+    if let Ok(v) = HeaderValue::from_str(&rewritten.len().to_string()) {
+        parts.headers.insert(header::CONTENT_LENGTH, v);
+    }
+    Response::from_parts(parts, Body::from(rewritten))
+}
+
+/// lol_html pass for the chrome: prefix absolute URL attributes with
+/// `base` and prepend the runtime shim to `<head>`. No `<base href>` —
+/// the chrome uses absolute URLs, which `<base href>` wouldn't affect.
+fn transform_base(html: &[u8], base: &str) -> Result<Vec<u8>, lol_html::errors::RewritingError> {
+    let mut out = Vec::with_capacity(html.len() + 256);
+    let shim = build_base_shim(base);
+    let base = base.to_string();
+
+    let url_attrs: &[(&str, &str)] = &[
+        ("a[href]", "href"),
+        ("link[href]", "href"),
+        ("script[src]", "src"),
+        ("img[src]", "src"),
+        ("iframe[src]", "src"),
+        ("source[src]", "src"),
+        ("form[action]", "action"),
+        ("button[formaction]", "formaction"),
+        ("input[formaction]", "formaction"),
+        ("img[data-src]", "data-src"),
+    ];
+    let mut handlers: Vec<_> = Vec::with_capacity(url_attrs.len() + 1);
+    handlers.push(element!("head", move |el| {
+        el.prepend(&shim, ContentType::Html);
+        Ok(())
+    }));
+    for (selector, attr) in url_attrs {
+        let attr = *attr;
+        let base = base.clone();
+        handlers.push(element!(*selector, move |el| {
+            if let Some(v) = el.get_attribute(attr) {
+                if let Some(nv) = rewrite_url_base(&v, &base) {
+                    el.set_attribute(attr, &nv)?;
+                }
+            }
+            Ok(())
+        }));
+    }
+    let mut rewriter = HtmlRewriter::new(
+        Settings {
+            element_content_handlers: handlers,
+            ..Settings::default()
+        },
+        |c: &[u8]| out.extend_from_slice(c),
+    );
+    rewriter.write(html)?;
+    rewriter.end()?;
+    Ok(out)
+}
+
+/// Runtime shim for the chrome: monkey-patch `fetch`,
+/// `XMLHttpRequest.open`, `WebSocket`, and `EventSource` to prefix
+/// absolute-path URLs built in JS at call time (the dashboard SSE,
+/// `/__set/*`, logs stream, etc.) with `base`. Skips URLs already under
+/// `base` and non-absolute/external ones. IIFE-wrapped, each patch in
+/// its own try/catch.
+fn build_base_shim(base: &str) -> String {
+    format!(
+        r##"<script>(function(){{
+  var BASE = "{base}";
+  // Exposed so server-rendered page JS that builds navigational URLs
+  // (anchor hrefs, form actions the network shim can't intercept) can
+  // prefix them: `(window.RUSCKER_BASE || '') + '/admin/...'`.
+  window.RUSCKER_BASE = BASE;
+  function prefix(u) {{
+    if (typeof u !== "string" || u.charAt(0) !== "/" || u.charAt(1) === "/") return u;
+    if (u === BASE || u.indexOf(BASE + "/") === 0) return u;
+    return BASE + u;
+  }}
+  function prefixWs(u) {{
+    try {{
+      if (typeof u !== "string") return u;
+      var m = u.match(/^(wss?:\/\/[^/]+)(\/.*)?$/i);
+      if (!m) return u;
+      return m[1] + prefix(m[2] || "/");
+    }} catch (_) {{ return u; }}
+  }}
+  try {{
+    var of = window.fetch;
+    if (of) window.fetch = function(input, init) {{
+      if (typeof input === "string") input = prefix(input);
+      else if (input && input.url) {{ try {{ input = new Request(prefix(input.url), input); }} catch (_) {{}} }}
+      return of.call(this, input, init);
+    }};
+  }} catch (_) {{}}
+  try {{
+    var oo = XMLHttpRequest.prototype.open;
+    XMLHttpRequest.prototype.open = function(m, u) {{
+      arguments[1] = prefix(u);
+      return oo.apply(this, arguments);
+    }};
+  }} catch (_) {{}}
+  try {{
+    var OW = window.WebSocket;
+    if (OW) {{
+      window.WebSocket = function(u, p) {{ return p === undefined ? new OW(prefixWs(u)) : new OW(prefixWs(u), p); }};
+      window.WebSocket.prototype = OW.prototype;
+    }}
+  }} catch (_) {{}}
+  try {{
+    var OE = window.EventSource;
+    if (OE) {{
+      window.EventSource = function(u, c) {{ return c === undefined ? new OE(prefix(u)) : new OE(prefix(u), c); }};
+      window.EventSource.prototype = OE.prototype;
+    }}
+  }} catch (_) {{}}
+}})();</script>"##,
+        base = base
+    )
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
@@ -706,5 +909,55 @@ mod tests {
             .unwrap();
         let out = inject_base_href(resp, "/app/foo/").await;
         assert_eq!(out.status(), StatusCode::BAD_GATEWAY);
+    }
+
+    // ── base-path (#173) ────────────────────────────────────
+
+    #[test]
+    fn rewrite_url_base_prefixes_and_skips() {
+        assert_eq!(rewrite_url_base("/admin/x", "/box").as_deref(), Some("/box/admin/x"));
+        assert_eq!(rewrite_url_base("/assets/a.css", "/box").as_deref(), Some("/box/assets/a.css"));
+        assert_eq!(rewrite_url_base("/", "/box").as_deref(), Some("/box/"));
+        // already under base, relative, anchor, protocol, external ⇒ skip
+        assert_eq!(rewrite_url_base("/box/admin/x", "/box"), None);
+        assert_eq!(rewrite_url_base("/box", "/box"), None);
+        assert_eq!(rewrite_url_base("admin/x", "/box"), None);
+        assert_eq!(rewrite_url_base("#top", "/box"), None);
+        assert_eq!(rewrite_url_base("//cdn/x", "/box"), None);
+        assert_eq!(rewrite_url_base("https://x/y", "/box"), None);
+    }
+
+    #[tokio::test]
+    async fn prefix_base_path_rewrites_chrome_html() {
+        let resp = html_response(
+            r#"<html><head></head><body><a href="/admin/specs">x</a><form action="/admin/users"></form></body></html>"#,
+        );
+        let out = prefix_base_path(resp, "/box").await;
+        let s = body_string(out).await;
+        assert!(s.contains(r#"href="/box/admin/specs""#), "link prefixed");
+        assert!(s.contains(r#"action="/box/admin/users""#), "form action prefixed");
+        assert!(s.contains("BASE = \"/box\""), "runtime shim injected");
+    }
+
+    #[tokio::test]
+    async fn prefix_base_path_rewrites_redirect_location() {
+        let resp = Response::builder()
+            .status(StatusCode::SEE_OTHER)
+            .header(header::LOCATION, "/admin/dashboard")
+            .body(Body::empty())
+            .unwrap();
+        let out = prefix_base_path(resp, "/box").await;
+        assert_eq!(
+            out.headers().get(header::LOCATION).unwrap().to_str().unwrap(),
+            "/box/admin/dashboard"
+        );
+    }
+
+    #[tokio::test]
+    async fn prefix_base_path_empty_base_is_noop() {
+        let resp = html_response(r#"<html><head></head><body><a href="/admin/x">x</a></body></html>"#);
+        let s = body_string(prefix_base_path(resp, "").await).await;
+        assert!(s.contains(r#"href="/admin/x""#), "no base ⇒ unchanged");
+        assert!(!s.contains("BASE ="), "no shim when no base");
     }
 }

--- a/crates/ruscker-admin/src/scaler.rs
+++ b/crates/ruscker-admin/src/scaler.rs
@@ -531,6 +531,7 @@ mod tests {
         let cfg = Config::from_yaml(yaml).expect("parse config");
         AppState {
             config: Arc::new(cfg),
+            base_path: Arc::from(""),
             locales: Arc::new(crate::i18n::Locales::load().expect("load locales")),
             admin_auth: Default::default(),
             admin_sessions: Default::default(),

--- a/crates/ruscker-admin/templates/admin/dashboard.html
+++ b/crates/ruscker-admin/templates/admin/dashboard.html
@@ -276,11 +276,11 @@
       ? escapeHtml(row.memory_display)
       : '<span style="color: var(--text-faint)" title="' + escapeHtml(pendingLabel) + '">—</span>';
     var actions = !canManage ? '' : ''
-      + '<form method="post" action="/admin/dashboard/replicas/' + encodeURIComponent(row.replica_id)
+      + '<form method="post" action="' + (window.RUSCKER_BASE || '') + '/admin/dashboard/replicas/' + encodeURIComponent(row.replica_id)
         + '/restart" style="display:inline" onsubmit="return confirm(' + JSON.stringify(confirmRestart) + ')">'
         + '<button type="submit" class="dash-action" title="' + escapeHtml(restartLabel) + '"><i class="ti ti-refresh"></i></button>'
       + '</form>'
-      + '<form method="post" action="/admin/dashboard/replicas/' + encodeURIComponent(row.replica_id)
+      + '<form method="post" action="' + (window.RUSCKER_BASE || '') + '/admin/dashboard/replicas/' + encodeURIComponent(row.replica_id)
         + '/stop" style="display:inline" onsubmit="return confirm(' + JSON.stringify(confirmStop) + ')">'
         + '<button type="submit" class="dash-action dash-action--danger" title="' + escapeHtml(stopLabel) + '"><i class="ti ti-player-stop"></i></button>'
       + '</form>';
@@ -300,7 +300,7 @@
       + '<td>' + (row.host ? escapeHtml(row.host) : '<span style="color:var(--text-faint)">local</span>') + '</td>'
       + '<td class="dash-mono">' + escapeHtml(row.container_short) + '</td>'
       + '<td style="white-space: nowrap;">'
-        + '<a href="/admin/dashboard/logs/' + encodeURIComponent(row.replica_id)
+        + '<a href="' + (window.RUSCKER_BASE || '') + '/admin/dashboard/logs/' + encodeURIComponent(row.replica_id)
           + '" title="' + escapeHtml(logsTitle)
           + '" class="dash-action" style="color: var(--text-muted)"><i class="ti ti-file-text"></i></a>'
         + actions

--- a/crates/ruscker-admin/tests/api_policies.rs
+++ b/crates/ruscker-admin/tests/api_policies.rs
@@ -41,6 +41,7 @@ fn state() -> AppState {
     let locales = ruscker_admin::i18n::Locales::load().expect("load locales");
     AppState {
         config: Arc::new(config),
+        base_path: Arc::from(""),
         locales: Arc::new(locales),
         admin_auth: Default::default(),
         admin_sessions: Default::default(),

--- a/crates/ruscker-admin/tests/health_probes.rs
+++ b/crates/ruscker-admin/tests/health_probes.rs
@@ -25,6 +25,7 @@ fn base_state() -> AppState {
     let locales = ruscker_admin::i18n::Locales::load().expect("load locales");
     AppState {
         config: Arc::new(config),
+        base_path: Arc::from(""),
         locales: Arc::new(locales),
         admin_auth: Default::default(),
         admin_sessions: Default::default(),

--- a/crates/ruscker-admin/tests/landing_access.rs
+++ b/crates/ruscker-admin/tests/landing_access.rs
@@ -57,6 +57,7 @@ async fn app_state(db: ConfigDb) -> AppState {
     let locales = Locales::load().expect("load locales");
     AppState {
         config: Arc::new(config),
+        base_path: Arc::from(""),
         locales: Arc::new(locales),
         admin_auth: AdminAuth {
             admin: Some(Arc::from("test-token")),
@@ -137,6 +138,36 @@ proxy:
         !body.contains(r#"href="/admin/login""#),
         "sign-in entrance hidden when show-admin-link=false"
     );
+}
+
+#[tokio::test]
+async fn base_path_nests_the_portal_and_keeps_health_at_root() {
+    // #173 slice 1: with a base path the whole portal moves under it,
+    // while /healthz stays at the root for load-balancer probes.
+    let mut state = app_state(open_db().await).await;
+    state.base_path = Arc::from("/box");
+    let app = router(state);
+
+    async fn code(app: axum::Router, uri: &str) -> StatusCode {
+        app.oneshot(Request::builder().uri(uri).body(Body::empty()).unwrap())
+            .await
+            .unwrap()
+            .status()
+    }
+
+    // Landing lives under /box now; the bare root no longer matches.
+    assert_eq!(code(app.clone(), "/box").await, StatusCode::OK);
+    // `/box/` (what a browser/nginx sends) redirects to the canonical /box.
+    assert_eq!(
+        code(app.clone(), "/box/").await,
+        StatusCode::PERMANENT_REDIRECT
+    );
+    // Deeper routes match under the prefix directly.
+    assert_eq!(code(app.clone(), "/box/admin/login").await, StatusCode::OK);
+    assert_eq!(code(app.clone(), "/").await, StatusCode::NOT_FOUND);
+    // Health is mounted at the root regardless of the base path.
+    assert_eq!(code(app.clone(), "/healthz").await, StatusCode::OK);
+    assert_eq!(code(app, "/box/healthz").await, StatusCode::NOT_FOUND);
 }
 
 #[tokio::test]

--- a/crates/ruscker-admin/tests/landing_render.rs
+++ b/crates/ruscker-admin/tests/landing_render.rs
@@ -23,6 +23,7 @@ fn app_state() -> AppState {
     let locales = Locales::load().expect("load locales");
     AppState {
         config: Arc::new(config),
+        base_path: Arc::from(""),
         locales: Arc::new(locales),
         admin_auth: Default::default(),
         admin_sessions: Default::default(),

--- a/crates/ruscker-admin/tests/max_body_size.rs
+++ b/crates/ruscker-admin/tests/max_body_size.rs
@@ -40,6 +40,7 @@ fn state() -> AppState {
     let locales = ruscker_admin::i18n::Locales::load().expect("load locales");
     AppState {
         config: Arc::new(config),
+        base_path: Arc::from(""),
         locales: Arc::new(locales),
         admin_auth: Default::default(),
         admin_sessions: Default::default(),

--- a/crates/ruscker-admin/tests/metrics.rs
+++ b/crates/ruscker-admin/tests/metrics.rs
@@ -13,6 +13,7 @@ fn state(yaml: &str) -> AppState {
     let locales = ruscker_admin::i18n::Locales::load().expect("load locales");
     AppState {
         config: Arc::new(config),
+        base_path: Arc::from(""),
         locales: Arc::new(locales),
         admin_auth: Default::default(),
         admin_sessions: Default::default(),

--- a/crates/ruscker-admin/tests/proxy_access.rs
+++ b/crates/ruscker-admin/tests/proxy_access.rs
@@ -58,6 +58,7 @@ async fn app_state(db: ConfigDb) -> AppState {
     let locales = Locales::load().expect("load locales");
     AppState {
         config: Arc::new(config),
+        base_path: Arc::from(""),
         locales: Arc::new(locales),
         admin_auth: AdminAuth {
             admin: Some(Arc::from("test-token")),

--- a/crates/ruscker-admin/tests/rbac.rs
+++ b/crates/ruscker-admin/tests/rbac.rs
@@ -34,6 +34,7 @@ fn state() -> AppState {
     let locales = ruscker_admin::i18n::Locales::load().expect("load locales");
     AppState {
         config: Arc::new(config),
+        base_path: Arc::from(""),
         locales: Arc::new(locales),
         // Break-glass admin token configured.
         admin_auth: AdminAuth {

--- a/crates/ruscker-admin/tests/user_accounts.rs
+++ b/crates/ruscker-admin/tests/user_accounts.rs
@@ -24,6 +24,7 @@ async fn state_with_db() -> (AppState, sqlx::SqlitePool) {
     let locales = ruscker_admin::i18n::Locales::load().expect("load locales");
     let state = AppState {
         config: Arc::new(config),
+        base_path: Arc::from(""),
         locales: Arc::new(locales),
         admin_auth: AdminAuth::with_token("break-glass-tok"),
         admin_sessions: Default::default(),

--- a/crates/ruscker-cli/src/main.rs
+++ b/crates/ruscker-cli/src/main.rs
@@ -174,6 +174,13 @@ enum Command {
         /// Omitted → the single-node in-memory store (default).
         #[arg(long, env = "RUSCKER_SESSION_STORE_URL")]
         session_store_url: Option<String>,
+
+        /// Serve the whole portal under a base path, for mounting behind
+        /// a reverse proxy at a subpath when you can't make a subdomain
+        /// (e.g. `--base-path /box` ⇒ `example.org/box/`). Overrides
+        /// `server.context-path` in the config. Empty ⇒ root (default).
+        #[arg(long, env = "RUSCKER_BASE_PATH")]
+        base_path: Option<String>,
     },
 }
 
@@ -206,6 +213,7 @@ fn main() -> Result<()> {
             master_key,
             docker,
             session_store_url,
+            base_path,
         } => cmd_serve(
             &config,
             bind,
@@ -216,6 +224,7 @@ fn main() -> Result<()> {
             master_key,
             docker,
             session_store_url,
+            base_path,
             log_buffer,
         ),
     }
@@ -349,6 +358,7 @@ fn cmd_serve(
     master_key: Option<String>,
     docker: bool,
     session_store_url: Option<String>,
+    base_path_override: Option<String>,
     log_buffer: ruscker_admin::logbuf::LogBuffer,
 ) -> Result<()> {
     let config = Config::from_file(config_path).with_context(|| {
@@ -379,12 +389,21 @@ fn cmd_serve(
     // multi-host backend when `proxy.hosts` is set (Phase 6).
     let hosts = config.proxy.hosts.clone();
 
+    // Base path (#173): the `--base-path` flag wins over
+    // `server.context-path`. Normalized once; `""` ⇒ root.
+    let base_path = match base_path_override {
+        Some(p) => ruscker_config::normalize_base_path(&p),
+        None => config.server.effective_base_path(),
+    };
+
     let rt = tokio::runtime::Builder::new_multi_thread()
         .enable_all()
         .build()?;
 
     rt.block_on(async {
-        let mut server = ruscker_admin::AdminServer::new(addr, config)?.with_log_buffer(log_buffer);
+        let mut server = ruscker_admin::AdminServer::new(addr, config)?
+            .with_log_buffer(log_buffer)
+            .with_base_path(&base_path);
         if let Some(dir) = images_dir {
             server = server.with_images_dir(dir);
         }

--- a/crates/ruscker-config/src/lib.rs
+++ b/crates/ruscker-config/src/lib.rs
@@ -42,9 +42,9 @@ pub mod validate;
 
 pub use error::{Error, Result};
 pub use schema::{
-    is_valid_memory_size, ApiSpec, Config, Host, HostTls, LandingBlock, LandingCustomization,
-    Logging, Placement, Proxy, RatePolicy, RoutingStrategy, Server, Spec, SpecKind,
-    SpecKindOverride, TemplateProperties,
+    is_valid_memory_size, normalize_base_path, ApiSpec, Config, Host, HostTls, LandingBlock,
+    LandingCustomization, Logging, Placement, Proxy, RatePolicy, RoutingStrategy, Server, Spec,
+    SpecKind, SpecKindOverride, TemplateProperties,
 };
 pub use validate::{is_valid_volume_bind, CompatWarning, ValidationReport, Warning};
 

--- a/crates/ruscker-config/src/schema.rs
+++ b/crates/ruscker-config/src/schema.rs
@@ -67,6 +67,48 @@ pub struct Server {
     /// existing ShinyProxy configs.
     #[serde(rename = "servlet.session.timeout")]
     pub flat_servlet_session_timeout: Option<u64>,
+
+    /// Base path to serve the whole portal under, for mounting behind a
+    /// reverse proxy at a subpath (e.g. `/box` ⇒ `example.org/box/`)
+    /// when you can't create a subdomain (#173). Maps to ShinyProxy's
+    /// `server.servlet.context-path`; we also accept the flat
+    /// `server.context-path`. Empty/absent ⇒ served at the root.
+    #[serde(rename = "context-path")]
+    pub context_path: Option<String>,
+
+    /// ShinyProxy's nested `server.servlet.context-path`. Resolved by
+    /// [`Self::effective_base_path`] when the flat form isn't set.
+    #[serde(rename = "servlet.context-path")]
+    pub flat_servlet_context_path: Option<String>,
+}
+
+impl Server {
+    /// The normalized base path the portal is served under: a leading
+    /// slash, no trailing slash, never just `"/"`. Empty string ⇒ root
+    /// (the default). Resolves the flat `context-path` first, then the
+    /// ShinyProxy `servlet.context-path`. `normalize_base_path` does the
+    /// shaping so the CLI `--base-path` override and this agree.
+    pub fn effective_base_path(&self) -> String {
+        let raw = self
+            .context_path
+            .as_deref()
+            .or(self.flat_servlet_context_path.as_deref())
+            .unwrap_or("");
+        normalize_base_path(raw)
+    }
+}
+
+/// Shape an operator-supplied base path into the canonical form the
+/// router and rewriter expect: trimmed, with exactly one leading slash
+/// and no trailing slash; `""` (root) for anything empty or `"/"`.
+/// E.g. `"box"`, `"/box/"`, `"box/"` all become `"/box"`.
+pub fn normalize_base_path(raw: &str) -> String {
+    let t = raw.trim().trim_matches('/');
+    if t.is_empty() {
+        String::new()
+    } else {
+        format!("/{t}")
+    }
 }
 
 impl Server {
@@ -1200,6 +1242,40 @@ pub struct LoggingFile {
 #[cfg(test)]
 mod tests {
     use super::*;
+
+    #[test]
+    fn normalize_base_path_canonicalizes() {
+        assert_eq!(normalize_base_path(""), "");
+        assert_eq!(normalize_base_path("/"), "");
+        assert_eq!(normalize_base_path("   "), "");
+        assert_eq!(normalize_base_path("box"), "/box");
+        assert_eq!(normalize_base_path("/box"), "/box");
+        assert_eq!(normalize_base_path("/box/"), "/box");
+        assert_eq!(normalize_base_path("  box/  "), "/box");
+        assert_eq!(normalize_base_path("a/b"), "/a/b");
+    }
+
+    #[test]
+    fn server_resolves_base_path_flat_then_servlet() {
+        let flat = Server {
+            context_path: Some("/box/".into()),
+            ..Default::default()
+        };
+        assert_eq!(flat.effective_base_path(), "/box");
+        let nested = Server {
+            flat_servlet_context_path: Some("portal".into()),
+            ..Default::default()
+        };
+        assert_eq!(nested.effective_base_path(), "/portal");
+        // Flat wins when both present.
+        let both = Server {
+            context_path: Some("/a".into()),
+            flat_servlet_context_path: Some("/b".into()),
+            ..Default::default()
+        };
+        assert_eq!(both.effective_base_path(), "/a");
+        assert_eq!(Server::default().effective_base_path(), "");
+    }
 
     #[test]
     fn parses_minimal_config() {


### PR DESCRIPTION
Lets the whole portal be served under a subpath (e.g. `example.org/box/`)
for deployments without subdomain governance. Opt-in via
`server.context-path` / `--base-path`; **empty by default**, so
root-mounted deploys are unchanged.

### How (5 mechanisms)

1. **Config + CLI + routing** — `server.context-path` (and ShinyProxy's
   `server.servlet.context-path`) / `--base-path`, normalized by
   `normalize_base_path`. `router()` nests the whole portal under the
   base; `/healthz`+`/readyz` stay at the root for LB probes. `/box/`
   308-redirects to the canonical `/box` (axum nest maps the inner `/`
   to `/box`).
2. **Chrome URL rewriting** — a response middleware (reusing the lol_html
   machinery from `/app` #21/#27/#28, inverted: prefix every
   root-absolute URL instead of skipping Ruscker paths) rewrites
   `href/src/action/formaction/data-src` in the body.
3. **Redirects** — the same middleware prefixes a root-absolute
   `Location` header, so redirects stay under the base.
4. **Runtime JS** — an injected shim prefixes `fetch` / `XMLHttpRequest`
   / `WebSocket` / `EventSource` URLs built in JS (dashboard SSE, logs
   stream, `/__set/*`, blocks reorder), and exposes `window.RUSCKER_BASE`
   for server-rendered JS that builds navigational URLs (the dashboard's
   live patcher uses `(window.RUSCKER_BASE || '')` for the logs link +
   stop/restart form actions — safe at root).
5. **`/app` proxy** — the app `<base href>` now includes the base path
   (`/box/app/{spec}/`).

Cookies set `Path=/`, already sent for `/box/...`, so they're untouched.

### Testing

- Unit: `normalize_base_path`, `Server::effective_base_path`,
  `rewrite_url_base`, `prefix_base_path` (HTML body + `Location` +
  empty-base no-op).
- Integration: `base_path_nests_the_portal_and_keeps_health_at_root`.
- Real smoke under `--base-path /box`: landing + admin render with
  `/box/...` URLs, token→setup→dashboard redirects all stay under
  `/box`, `/healthz` at root, `/` 404s; and the default (no base) is
  unchanged (no shim, `/admin/...` links).
- 23 test binaries green.

Docs: deploy guide § "Mounting under a base path" (nginx two-location
config).

### Known minor limitation

The login referer-honoring (#155) doesn't strip the base prefix, so
under a base path a non-admin signing in lands on the dashboard rather
than the exact referer page — redirects still stay under the base (via
the middleware), so nothing breaks.

Closes #173.

🤖 Generated with [Claude Code](https://claude.com/claude-code)