### PR TITLE
release: bump workspace version to 0.1.2

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2779,7 +2779,7 @@ dependencies = [
 
 [[package]]
 name = "ruscker-admin"
-version = "0.1.1"
+version = "0.1.2"
 dependencies = [
  "aes-gcm",
  "anyhow",
@@ -2826,7 +2826,7 @@ dependencies = [
 
 [[package]]
 name = "ruscker-cli"
-version = "0.1.1"
+version = "0.1.2"
 dependencies = [
  "anyhow",
  "clap",
@@ -2846,7 +2846,7 @@ dependencies = [
 
 [[package]]
 name = "ruscker-config"
-version = "0.1.1"
+version = "0.1.2"
 dependencies = [
  "chrono",
  "ordered-float",
@@ -2861,7 +2861,7 @@ dependencies = [
 
 [[package]]
 name = "ruscker-core"
-version = "0.1.1"
+version = "0.1.2"
 dependencies = [
  "async-trait",
  "chrono",
@@ -2874,7 +2874,7 @@ dependencies = [
 
 [[package]]
 name = "ruscker-docker"
-version = "0.1.1"
+version = "0.1.2"
 dependencies = [
  "anyhow",
  "async-stream",
@@ -2893,7 +2893,7 @@ dependencies = [
 
 [[package]]
 name = "ruscker-proxy"
-version = "0.1.1"
+version = "0.1.2"
 dependencies = [
  "anyhow",
  "axum",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -10,7 +10,7 @@ members = [
 ]
 
 [workspace.package]
-version = "0.1.1"
+version = "0.1.2"
 edition = "2021"
 rust-version = "1.85"
 license = "Apache-2.0"

--- a/README.md
+++ b/README.md
@@ -73,7 +73,7 @@ tool" cases) is in
 
 ## Status
 
-**v0.1.1 — production-ready and running in production.** Releases are
+**v0.1.2 — production-ready and running in production.** Releases are
 multi-arch (amd64 + arm64) and [cosign-signed]. Where the JVM-based
 stack it replaced idled at hundreds of megabytes, Ruscker idles in the
 low tens:
@@ -124,7 +124,7 @@ curl -fsSL https://raw.githubusercontent.com/StrategicProjects/ruscker/main/inst
 Picks the right artifact from the latest release: the `.deb` (with the
 `systemd` unit + an auto-generated admin token) on Debian/Ubuntu, or the
 static binary into `/usr/local/bin` elsewhere. Pin a version or target
-dir with `./install.sh v0.1.1` or `PREFIX=~/.local/bin ./install.sh`.
+dir with `./install.sh v0.1.2` or `PREFIX=~/.local/bin ./install.sh`.
 
 ### Homebrew (macOS / Linux)
 


### PR DESCRIPTION
Cuts **v0.1.2** from `main`. Closes the full open-issue batch since
v0.1.1:

- **#156** landing↔admin nav opt-out (`show-admin-link`)
- **#162** cleanup (stale docs, sqlx DSN-leak check, lint false-positives)
- **#160** multi-host robustness (placement prune, fan-out, IPv6, degraded start)
- **#159** HA leader-election hardening (timeout, split-brain, gated reaping)
- **#161** HA sign-in-session stickiness (documented deploy pattern)
- **#173** serve under a base path (context-path / subpath mounting)

`ruscker --version` → `0.1.2`; README updated. Tagging `v0.1.2` after
merge builds the multi-arch `.deb` + musl tarballs + ghcr image.

🤖 Generated with [Claude Code](https://claude.com/claude-code)