### PR TITLE
Fix #186: base-path login redirect honors referer

### DIFF
--- a/crates/ruscker-admin/src/routes/admin.rs
+++ b/crates/ruscker-admin/src/routes/admin.rs
@@ -297,11 +297,25 @@ async fn login_submit(
 /// Strip a normalized base-path prefix (e.g. `/box`) from a
 /// same-origin path so the `/admin/...` and `/` matchers behave the
 /// same with or without subpath mounting. `base` is the already-
-/// normalized prefix from `AppState.base_path` (`""` for root).
+/// normalized prefix from `AppState.base_path` (`""` for root —
+/// leading slash, no trailing slash for everything else, see
+/// [`ruscker_config::normalize_base_path`]).
+///
+/// Query strings ride along: `strip_base_prefix("/box/x?q=1", "/box")`
+/// returns `"/x?q=1"`. Callers that only want the path part should
+/// split on `?` themselves; today the matchers use `starts_with` /
+/// equality, so the query suffix is just preserved as-is.
 fn strip_base_prefix<'a>(path: &'a str, base: &str) -> &'a str {
     if base.is_empty() {
         return path;
     }
+    // `base` is the normalized form from `AppState.base_path`. If a
+    // caller hands us a trailing-slashed or empty-as-`/` form, the
+    // strip logic below silently misbehaves.
+    debug_assert!(
+        !base.ends_with('/') && base != "/" && base.starts_with('/'),
+        "base must be normalized: leading slash, no trailing slash, never bare `/` ({base:?})"
+    );
     if let Some(rest) = path.strip_prefix(base) {
         // `/box` → "" (the canonical landing) or `/box/foo` → `/foo`.
         if rest.is_empty() {
@@ -655,5 +669,16 @@ mod tests {
         // `/boxes` starts with `/box` but is not under the prefix.
         assert_eq!(strip_base_prefix("/boxes", "/box"), "/boxes");
         assert_eq!(strip_base_prefix("/other/path", "/box"), "/other/path");
+    }
+
+    #[test]
+    fn strip_base_prefix_preserves_query_strings() {
+        // Query strings ride along the suffix — same matcher
+        // behavior as a no-base-path deployment.
+        assert_eq!(
+            strip_base_prefix("/box/admin/specs?page=2", "/box"),
+            "/admin/specs?page=2"
+        );
+        assert_eq!(strip_base_prefix("/box/?theme=dark", "/box"), "/?theme=dark");
     }
 }

--- a/crates/ruscker-admin/src/routes/admin.rs
+++ b/crates/ruscker-admin/src/routes/admin.rs
@@ -271,21 +271,50 @@ async fn login_submit(
     }
 
     let referer = headers.get(REFERER).and_then(|v| v.to_str().ok());
-    let path = super::same_origin_path(referer, user.role.home());
+    let raw_path = super::same_origin_path(referer, user.role.home());
+    // Under a base path (#173), referer paths come in as
+    // `/box/admin/specs` — strip the prefix before the `/admin/`
+    // and `/` checks so a non-admin signing in from `/box/admin/X`
+    // returns to `X`, not the dashboard. The response middleware
+    // re-prefixes the `Location` on the way out.
+    let path = strip_base_prefix(&raw_path, &state.base_path);
     let target = if path == "/" {
         // Signed in from the public landing — return there so the
         // viewer sees the apps their groups unlock (#155), rather than
         // bouncing a non-admin into the panel.
-        path
+        path.to_string()
     } else if path.starts_with("/admin/")
         && !path.starts_with("/admin/login")
-        && user.role.can_access_section(section_for_admin_path(&path))
+        && user.role.can_access_section(section_for_admin_path(path))
     {
-        path
+        path.to_string()
     } else {
         user.role.home().to_string()
     };
     Redirect::to(&target).into_response()
+}
+
+/// Strip a normalized base-path prefix (e.g. `/box`) from a
+/// same-origin path so the `/admin/...` and `/` matchers behave the
+/// same with or without subpath mounting. `base` is the already-
+/// normalized prefix from `AppState.base_path` (`""` for root).
+fn strip_base_prefix<'a>(path: &'a str, base: &str) -> &'a str {
+    if base.is_empty() {
+        return path;
+    }
+    if let Some(rest) = path.strip_prefix(base) {
+        // `/box` → "" (the canonical landing) or `/box/foo` → `/foo`.
+        if rest.is_empty() {
+            "/"
+        } else if rest.starts_with('/') {
+            rest
+        } else {
+            // `/boxes` happens to start with `/box` but isn't under it.
+            path
+        }
+    } else {
+        path
+    }
 }
 
 #[derive(Debug, Deserialize)]
@@ -600,5 +629,31 @@ pub(crate) fn render<T: Template>(t: &T) -> Response {
             tracing::error!(error = ?err, "admin template render failed");
             (StatusCode::INTERNAL_SERVER_ERROR, "template error").into_response()
         }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::strip_base_prefix;
+
+    #[test]
+    fn strip_base_prefix_root_is_noop() {
+        assert_eq!(strip_base_prefix("/admin/specs", ""), "/admin/specs");
+        assert_eq!(strip_base_prefix("/", ""), "/");
+    }
+
+    #[test]
+    fn strip_base_prefix_removes_matching_prefix() {
+        assert_eq!(strip_base_prefix("/box/admin/specs", "/box"), "/admin/specs");
+        assert_eq!(strip_base_prefix("/box/", "/box"), "/");
+        // Bare canonical landing under the prefix.
+        assert_eq!(strip_base_prefix("/box", "/box"), "/");
+    }
+
+    #[test]
+    fn strip_base_prefix_keeps_non_matching_paths() {
+        // `/boxes` starts with `/box` but is not under the prefix.
+        assert_eq!(strip_base_prefix("/boxes", "/box"), "/boxes");
+        assert_eq!(strip_base_prefix("/other/path", "/box"), "/other/path");
     }
 }

--- a/crates/ruscker-admin/src/routes/prefs.rs
+++ b/crates/ruscker-admin/src/routes/prefs.rs
@@ -77,6 +77,14 @@ fn persistent_cookie(name: &'static str, value: String) -> Cookie<'static> {
 fn redirect_back(headers: &HeaderMap) -> Redirect {
     // Same-origin only: an attacker-controlled `Referer` must not
     // turn this 303 into an open redirect off our origin.
+    //
+    // Note: unlike `admin::login_submit` this does NOT strip
+    // `state.base_path` first. It doesn't need to — the response
+    // middleware's `rewrite_url_base` skips already-prefixed
+    // `Location` headers (`t == base || t.starts_with("{base}/")`),
+    // so passing through `/box/admin/specs` here yields the same
+    // final `Location: /box/admin/specs`. The fallback path `/`
+    // becomes `/box/` via the middleware, which is correct.
     let referer = headers.get(REFERER).and_then(|v| v.to_str().ok());
     Redirect::to(&super::same_origin_path(referer, "/"))
 }

--- a/crates/ruscker-admin/tests/landing_access.rs
+++ b/crates/ruscker-admin/tests/landing_access.rs
@@ -171,6 +171,99 @@ async fn base_path_nests_the_portal_and_keeps_health_at_root() {
 }
 
 #[tokio::test]
+async fn login_under_base_path_honors_admin_referer() {
+    // #186 (#173 follow-up): a non-admin signing in from
+    // `/box/admin/specs` should land back on `/box/admin/specs`, not
+    // be bounced into `/box/admin/dashboard`. The handler must strip
+    // the base prefix before its `starts_with("/admin/")` check; the
+    // response middleware re-prefixes the `Location` on the way out.
+    let db = open_db().await;
+    ruscker_admin::db::users::create(
+        &db,
+        "alice",
+        "alicepass1",
+        Role::Admin,
+        false,
+        &[],
+        Some("admin"),
+    )
+    .await
+    .unwrap();
+    let mut state = app_state(db).await;
+    state.base_path = Arc::from("/box");
+    let app = router(state);
+
+    // Same-host referer mimicking what a real browser sends when the
+    // user submitted the form from `/box/admin/specs`.
+    let req = Request::builder()
+        .method("POST")
+        .uri("/box/admin/login")
+        .header(header::HOST, "example.test")
+        .header(header::REFERER, "https://example.test/box/admin/specs")
+        .header(
+            header::CONTENT_TYPE,
+            "application/x-www-form-urlencoded",
+        )
+        .body(Body::from("username=alice&password=alicepass1"))
+        .unwrap();
+    let resp = app.oneshot(req).await.unwrap();
+    assert_eq!(resp.status(), StatusCode::SEE_OTHER);
+    let loc = resp
+        .headers()
+        .get(header::LOCATION)
+        .and_then(|v| v.to_str().ok())
+        .unwrap_or_default()
+        .to_string();
+    assert_eq!(loc, "/box/admin/specs", "expected base-prefixed referer");
+}
+
+#[tokio::test]
+async fn login_under_base_path_honors_landing_referer() {
+    // The `/` short-circuit (#155) has to survive the base-path strip too:
+    // a non-admin signing in from `/box/` should land on `/box/`, not
+    // `/box/admin/dashboard`.
+    let db = open_db().await;
+    ruscker_admin::db::users::create(
+        &db,
+        "alice",
+        "alicepass1",
+        Role::Viewer,
+        false,
+        &[],
+        Some("admin"),
+    )
+    .await
+    .unwrap();
+    let mut state = app_state(db).await;
+    state.base_path = Arc::from("/box");
+    let app = router(state);
+
+    let req = Request::builder()
+        .method("POST")
+        .uri("/box/admin/login")
+        .header(header::HOST, "example.test")
+        .header(header::REFERER, "https://example.test/box/")
+        .header(
+            header::CONTENT_TYPE,
+            "application/x-www-form-urlencoded",
+        )
+        .body(Body::from("username=alice&password=alicepass1"))
+        .unwrap();
+    let resp = app.oneshot(req).await.unwrap();
+    assert_eq!(resp.status(), StatusCode::SEE_OTHER);
+    let loc = resp
+        .headers()
+        .get(header::LOCATION)
+        .and_then(|v| v.to_str().ok())
+        .unwrap_or_default()
+        .to_string();
+    // The handler emits `Location: /`; the middleware prefixes it to
+    // `/box/`. (The canonical landing is `/box`; the `/box/` form gets
+    // a 308 to it on the next request — that's covered elsewhere.)
+    assert_eq!(loc, "/box/", "landing referer should round-trip under prefix");
+}
+
+#[tokio::test]
 async fn admin_session_sees_every_spec() {
     let db = open_db().await;
     let state = app_state(db).await;


### PR DESCRIPTION
## Summary
- Strip `state.base_path` from the referer-resolved path before the `starts_with(\"/admin/\")` and `== \"/\"` matchers in `login_submit`.
- The response middleware re-prefixes the `Location` on the way out, so the redirect target stays unprefixed internally.

## Bug
After #173, a non-admin signing in from any `/box/admin/...` page **always** landed on `/box/admin/dashboard` instead of the page they came from, because the raw referer path (`/box/admin/specs`) doesn't match `starts_with(\"/admin/\")`.

## Test plan
- [x] 3 unit tests on the new `strip_base_prefix` helper (empty base no-op; matching prefix removal incl. `/box` → `/`; `/boxes` not under `/box`).
- [x] `landing_access::login_under_base_path_honors_admin_referer` — POST `/box/admin/login` with referer `/box/admin/specs` ⇒ `Location: /box/admin/specs`.
- [x] `landing_access::login_under_base_path_honors_landing_referer` — POST with referer `/box/` ⇒ `Location: /box/`.
- [x] Full `cargo test -p ruscker-admin` green (189 lib + integration).

Closes #186.

🤖 Generated with [Claude Code](https://claude.com/claude-code)