### PR TITLE
Fix #181: locale picker on /admin/login + sign-in button polish

### DIFF
--- a/crates/ruscker-admin/assets/i18n/en/landing.ftl
+++ b/crates/ruscker-admin/assets/i18n/en/landing.ftl
@@ -164,6 +164,7 @@ admin-login-token-placeholder = Paste the token here
 admin-login-submit = Sign in
 admin-login-error-wrong = Wrong token. Please try again.
 admin-login-back-portal = ← public portal
+admin-login-locale-group = Language
 
 # Apps list
 admin-specs-title = Apps

--- a/crates/ruscker-admin/assets/i18n/es/landing.ftl
+++ b/crates/ruscker-admin/assets/i18n/es/landing.ftl
@@ -164,6 +164,7 @@ admin-login-token-placeholder = Pegue el token aquí
 admin-login-submit = Entrar
 admin-login-error-wrong = Token incorrecto. Intente de nuevo.
 admin-login-back-portal = ← portal público
+admin-login-locale-group = Idioma
 
 # Apps list
 admin-specs-title = Aplicaciones

--- a/crates/ruscker-admin/assets/i18n/fr/landing.ftl
+++ b/crates/ruscker-admin/assets/i18n/fr/landing.ftl
@@ -164,6 +164,7 @@ admin-login-token-placeholder = Collez le jeton ici
 admin-login-submit = Se connecter
 admin-login-error-wrong = Jeton incorrect. Réessayez.
 admin-login-back-portal = ← portail public
+admin-login-locale-group = Langue
 
 # Apps list
 admin-specs-title = Applications

--- a/crates/ruscker-admin/assets/i18n/pt/landing.ftl
+++ b/crates/ruscker-admin/assets/i18n/pt/landing.ftl
@@ -168,6 +168,7 @@ admin-login-token-placeholder = Cole o token aqui
 admin-login-submit = Entrar
 admin-login-error-wrong = Token incorreto. Tente de novo.
 admin-login-back-portal = ← portal público
+admin-login-locale-group = Idioma
 
 # Apps list
 admin-specs-title = Aplicações

--- a/crates/ruscker-admin/assets/tailwind/input.css
+++ b/crates/ruscker-admin/assets/tailwind/input.css
@@ -502,6 +502,13 @@ body {
 }
 .admin-login-btn:hover { background: var(--color-teal-800); }
 .admin-login-btn i { font-size: 14px; }
+/* Primary CTA variant: fills the card so the submit reads as a
+   primary action stacked with the inputs above it (#181 polish). */
+.admin-login-btn--primary {
+  display: flex; width: 100%;
+  padding: 11px 12px;
+  margin-top: 4px;
+}
 .admin-login-error {
   display: flex; align-items: center; gap: 8px;
   background: rgba(239, 68, 68, 0.08);
@@ -514,11 +521,14 @@ body {
 .admin-login-error i { font-size: 14px; }
 .admin-login-footer {
   display: flex; align-items: center; justify-content: space-between;
+  gap: 12px; flex-wrap: wrap;
   font-size: 11px;
   margin-top: 4px;
 }
 .admin-login-footer a { color: var(--text-muted); text-decoration: none; }
 .admin-login-footer a:hover { color: var(--text); }
+.admin-login-footer-links { display: flex; align-items: center; gap: 14px; }
+.admin-login-locales { display: flex; align-items: center; gap: 2px; }
 .admin-login-locale {
   background: transparent; border: none;
   font-family: inherit; font-size: 10px;

--- a/crates/ruscker-admin/assets/tailwind/input.css
+++ b/crates/ruscker-admin/assets/tailwind/input.css
@@ -525,6 +525,10 @@ body {
   font-size: 11px;
   margin-top: 4px;
 }
+/* Right-aligned variant for pages with no secondary links (setup,
+   password-reset) so the locale group doesn't sit on the left under
+   `space-between` with a single child. */
+.admin-login-footer--end { justify-content: flex-end; }
 .admin-login-footer a { color: var(--text-muted); text-decoration: none; }
 .admin-login-footer a:hover { color: var(--text); }
 .admin-login-footer-links { display: flex; align-items: center; gap: 14px; }

--- a/crates/ruscker-admin/templates/admin/login.html
+++ b/crates/ruscker-admin/templates/admin/login.html
@@ -57,26 +57,35 @@
     </label>
   {% endif %}
 
-  <button type="submit" class="admin-login-btn">
+  <button type="submit" class="admin-login-btn admin-login-btn--primary">
     <i class="ti ti-login" aria-hidden="true"></i>
     {{ self.t("admin-login-submit") }}
   </button>
 
   <div class="admin-login-footer">
-    {% if bootstrap %}
-      <a href="/admin/login">{{ self.t("admin-login-use-password") }}</a>
-    {% else %}
-      <a href="/admin/login?token=1">{{ self.t("admin-login-use-token") }}</a>
-    {% endif %}
-    <a href="/">{{ self.t("admin-login-back-portal") }}</a>
-    <form method="post" action="/__set/locale" class="contents">
+    <div class="admin-login-footer-links">
+      {% if bootstrap %}
+        <a href="/admin/login">{{ self.t("admin-login-use-password") }}</a>
+      {% else %}
+        <a href="/admin/login?token=1">{{ self.t("admin-login-use-token") }}</a>
+      {% endif %}
+      <a href="/">{{ self.t("admin-login-back-portal") }}</a>
+    </div>
+    {# #181: nesting a `<form>` inside the outer login form is invalid HTML —
+       browsers silently ignore the inner action and submit the outer one,
+       so picking a locale was posting empty credentials to /admin/login.
+       Use `formaction` + `formnovalidate` to override the submission target
+       per-button without leaving the parent form. The base-path rewriter
+       already covers `button[formaction]`. #}
+    <div class="admin-login-locales">
       {% for loc in locales_all %}
         <button type="submit" name="locale" value="{{ loc.code() }}"
+                formaction="/__set/locale" formmethod="post" formnovalidate
                 class="admin-login-locale {% if *loc == locale %}is-active{% endif %}">
           {{ loc.code()|upper }}
         </button>
       {% endfor %}
-    </form>
+    </div>
   </div>
 </form>
 

--- a/crates/ruscker-admin/templates/admin/login.html
+++ b/crates/ruscker-admin/templates/admin/login.html
@@ -77,10 +77,12 @@
        Use `formaction` + `formnovalidate` to override the submission target
        per-button without leaving the parent form. The base-path rewriter
        already covers `button[formaction]`. #}
-    <div class="admin-login-locales">
+    <div class="admin-login-locales" role="group" aria-label="{{ self.t("admin-login-locale-group") }}">
       {% for loc in locales_all %}
         <button type="submit" name="locale" value="{{ loc.code() }}"
                 formaction="/__set/locale" formmethod="post" formnovalidate
+                aria-label="{{ loc.native_name() }}"
+                {% if *loc == locale %}aria-current="true"{% endif %}
                 class="admin-login-locale {% if *loc == locale %}is-active{% endif %}">
           {{ loc.code()|upper }}
         </button>

--- a/crates/ruscker-admin/templates/admin/setup.html
+++ b/crates/ruscker-admin/templates/admin/setup.html
@@ -49,20 +49,23 @@
     <input type="password" name="confirm" required autocomplete="new-password">
   </label>
 
-  <button type="submit" class="admin-login-btn">
+  <button type="submit" class="admin-login-btn admin-login-btn--primary">
     <i class="ti ti-user-check" aria-hidden="true"></i>
     {{ self.t("admin-setup-submit") }}
   </button>
 
   <div class="admin-login-footer">
-    <form method="post" action="/__set/locale" class="contents">
+    <div class="admin-login-footer-links"></div>
+    {# #181: see login.html — nested forms are invalid; use `formaction`. #}
+    <div class="admin-login-locales">
       {% for loc in locales_all %}
         <button type="submit" name="locale" value="{{ loc.code() }}"
+                formaction="/__set/locale" formmethod="post" formnovalidate
                 class="admin-login-locale {% if *loc == locale %}is-active{% endif %}">
           {{ loc.code()|upper }}
         </button>
       {% endfor %}
-    </form>
+    </div>
   </div>
 </form>
 

--- a/crates/ruscker-admin/templates/admin/setup.html
+++ b/crates/ruscker-admin/templates/admin/setup.html
@@ -54,13 +54,14 @@
     {{ self.t("admin-setup-submit") }}
   </button>
 
-  <div class="admin-login-footer">
-    <div class="admin-login-footer-links"></div>
+  <div class="admin-login-footer admin-login-footer--end">
     {# #181: see login.html — nested forms are invalid; use `formaction`. #}
-    <div class="admin-login-locales">
+    <div class="admin-login-locales" role="group" aria-label="{{ self.t("admin-login-locale-group") }}">
       {% for loc in locales_all %}
         <button type="submit" name="locale" value="{{ loc.code() }}"
                 formaction="/__set/locale" formmethod="post" formnovalidate
+                aria-label="{{ loc.native_name() }}"
+                {% if *loc == locale %}aria-current="true"{% endif %}
                 class="admin-login-locale {% if *loc == locale %}is-active{% endif %}">
           {{ loc.code()|upper }}
         </button>

--- a/crates/ruscker-admin/tests/user_accounts.rs
+++ b/crates/ruscker-admin/tests/user_accounts.rs
@@ -130,6 +130,47 @@ async fn first_login_with_must_change_redirects_to_password() {
 }
 
 #[tokio::test]
+async fn login_page_has_no_nested_form_and_uses_formaction_for_locale() {
+    // #181: the locale picker in /admin/login was wrapped in a second
+    // `<form action="/__set/locale">` inside the outer login form.
+    // Nested `<form>` is invalid HTML and browsers ignore the inner
+    // one — clicking a locale button posted empty credentials to
+    // /admin/login. The fix uses `formaction` + `formnovalidate` on the
+    // buttons so the per-button submission target is honored.
+    let (state, _pool) = state_with_db().await;
+    let app = router(state);
+    let resp = app
+        .oneshot(
+            Request::builder()
+                .uri("/admin/login")
+                .body(Body::empty())
+                .unwrap(),
+        )
+        .await
+        .unwrap();
+    assert_eq!(resp.status(), StatusCode::OK);
+    let bytes = axum::body::to_bytes(resp.into_body(), 1 << 20)
+        .await
+        .unwrap();
+    let body = std::str::from_utf8(&bytes).unwrap();
+
+    // Exactly one `<form>` on the page (the outer login form). The old
+    // nested-form bug would push this above 1.
+    let form_count = body.matches("<form ").count();
+    assert_eq!(form_count, 1, "expected exactly one <form>, got {form_count}");
+
+    // The locale buttons must override the submission via formaction.
+    assert!(
+        body.contains(r#"formaction="/__set/locale""#),
+        "locale buttons missing formaction"
+    );
+    assert!(
+        body.contains("formnovalidate"),
+        "locale buttons must skip required-field validation"
+    );
+}
+
+#[tokio::test]
 async fn last_admin_cannot_be_deleted() {
     let (state, pool) = state_with_db().await;
     ruscker_admin::db::users::create(&ruscker_admin::db::ConfigDb::Sqlite(pool.clone()), "root", "rootpass1", Role::Admin, false, &[], None)

--- a/crates/ruscker-admin/tests/user_accounts.rs
+++ b/crates/ruscker-admin/tests/user_accounts.rs
@@ -168,6 +168,64 @@ async fn login_page_has_no_nested_form_and_uses_formaction_for_locale() {
         body.contains("formnovalidate"),
         "locale buttons must skip required-field validation"
     );
+    // Accessibility: the locale group + active locale must be
+    // announced (a screen-reader user otherwise hears "PT, submit
+    // button" four times in a row with no context).
+    // Role + a labelled group. Don't assert the label text — the
+    // default locale is pt-BR, so it'd be "Idioma"; assertion stays
+    // locale-agnostic by checking the attribute scaffolding only.
+    assert!(
+        body.contains(r#"class="admin-login-locales" role="group" aria-label="#),
+        "locale group should be announced as a labelled group"
+    );
+    assert!(
+        body.contains(r#"aria-current="true""#),
+        "active locale should carry aria-current"
+    );
+}
+
+#[tokio::test]
+async fn setup_page_has_no_nested_form_and_uses_formaction_for_locale() {
+    // Twin assertion of `login_page_has_no_nested_form_...` for the
+    // first-admin bootstrap (`/admin/setup`). The same nested-form
+    // bug existed here and was fixed in the same PR.
+    let (state, _pool) = state_with_db().await;
+    let sid = state.admin_sessions.create(Role::Admin, None);
+    let cookie = format!("{COOKIE_NAME}={sid}");
+    let app = router(state);
+    let resp = app
+        .oneshot(
+            Request::builder()
+                .uri("/admin/setup")
+                .header("cookie", cookie)
+                .body(Body::empty())
+                .unwrap(),
+        )
+        .await
+        .unwrap();
+    assert_eq!(resp.status(), StatusCode::OK);
+    let bytes = axum::body::to_bytes(resp.into_body(), 1 << 20)
+        .await
+        .unwrap();
+    let body = std::str::from_utf8(&bytes).unwrap();
+
+    let form_count = body.matches("<form ").count();
+    assert_eq!(form_count, 1, "expected exactly one <form>, got {form_count}");
+    assert!(
+        body.contains(r#"formaction="/__set/locale""#),
+        "setup locale buttons missing formaction"
+    );
+    assert!(
+        body.contains("formnovalidate"),
+        "setup locale buttons must skip required-field validation"
+    );
+    // Role + a labelled group. Don't assert the label text — the
+    // default locale is pt-BR, so it'd be "Idioma"; assertion stays
+    // locale-agnostic by checking the attribute scaffolding only.
+    assert!(
+        body.contains(r#"class="admin-login-locales" role="group" aria-label="#),
+        "locale group should be announced as a labelled group"
+    );
 }
 
 #[tokio::test]


### PR DESCRIPTION
## Summary
- Replace the **nested `<form action=\"/__set/locale\">`** inside the outer login form with `formaction` + `formnovalidate` on each locale button. Nested `<form>` is invalid HTML — the browser was ignoring the inner action and posting empty credentials to `/admin/login`, which is why picking a language seemed to do nothing.
- Same fix applied to `/admin/setup` (identical bug).
- Polish the sign-in button into a full-width primary CTA (new `admin-login-btn--primary` modifier) so it visually stacks with the inputs above it. Footer is split into two flex clusters with explicit gaps so the locale picker doesn't fight the secondary links for `space-between`.

## Bug repro
`https://castlab.org/box/admin/login` → click PT / EN / ES / FR → page doesn't switch locale. The outer login form swallows the click because nested forms are invalid.

## Test plan
- [x] `user_accounts::login_page_has_no_nested_form_and_uses_formaction_for_locale` — renders `/admin/login` and asserts exactly one `<form>` plus `formaction=\"/__set/locale\"` + `formnovalidate` on the buttons.
- [x] Full `cargo test -p ruscker-admin` green (186 lib + integration).
- [x] Live smoke on `127.0.0.1:8082` (light + dark): the primary CTA renders full-width, locales sit on their own row, `POST /__set/locale` (Referer: `/admin/login`) returns 303 → `/admin/login` with `Set-Cookie: ruscker_locale=pt`.

### Screenshots
Light:

![light](https://github.com/user-attachments/assets/placeholder-login-light) <!-- attach /tmp/login-181.png in the PR UI -->

Dark:

![dark](https://github.com/user-attachments/assets/placeholder-login-dark) <!-- attach /tmp/login-181-dark2.png -->

Closes #181.

🤖 Generated with [Claude Code](https://claude.com/claude-code)