### PR TITLE
#189: post-v0.1.2 docs sweep — landing-customization, base-path, per-user access

### DIFF
--- a/book/src/configuration.md
+++ b/book/src/configuration.md
@@ -8,4 +8,72 @@ below is the same document shipped in the repository
 Secrets are never written in the YAML — use `${VAR}` interpolation and
 set the variables in the environment (or `/etc/ruscker/ruscker.env`).
 
+## Quick references
+
+A few cross-cutting concerns have dedicated chapters and field sets:
+
+- **Subpath mounting** (`server.context-path` / `--base-path`) — when
+  you can't dedicate a subdomain and need the portal under
+  `example.org/box/`. See [Mounting under a base path][base-path] in
+  the deploy guide and [`server.context-path`](#servercontext-path--subpath-mounting)
+  in the schema below.
+- **Per-user access** (`access-groups` / `access-users`) — restrict
+  which users see and reach each spec. See
+  [Per-user access](#per-user-access) below and
+  [`Spec.access-groups`](#containerized-specs-shiny-streamlit-dash-voilà-api)
+  in the schema. Group membership is set per user in the admin users
+  page.
+- **Active-active HA** — when running more than one Ruscker instance
+  behind a load balancer, the **sign-in session** must be
+  pinned to one upstream until the shared session store ships. See
+  [Sticky upstream for the sign-in session][ha-sticky] in the deploy
+  guide.
+- **Branding, SEO, analytics, custom HTML** — see
+  [`proxy.landing-customization`](#proxylanding-customization) below.
+
+[base-path]: ./deploying.md#4b-mounting-under-a-base-path-subpath
+[ha-sticky]: ./deploying.md#sticky-upstream-for-the-sign-in-session-admin-app-api
+
+## Per-user access
+
+`access-groups` / `access-users` on a spec scope who can **see** the
+card on the landing **and** reach the upstream at `/app` / `/api`. A
+spec with neither key is **open** — visible to everyone, including
+anonymous visitors. Otherwise:
+
+- An **admin** session sees everything.
+- A **signed-in user** sees a restricted spec when their username is
+  in `access-users` *or* one of their groups is in `access-groups`.
+- An **anonymous visitor** only sees open specs.
+
+Enforcement is real — the `/app` and `/api` guards reject unauthorized
+requests (anonymous on `/app` → redirected to login; otherwise 403),
+not just hide the landing card.
+
+Group membership is per-user and lives in the database. Set it in the
+admin **Users** page (groups column, inline edit). The same user
+record drives both portal visibility and admin role (Admin / Editor /
+Viewer) — see [The admin panel](./admin.md).
+
+Example:
+
+```yaml
+proxy:
+  specs:
+    - id: open-app
+      display-name: Open App
+      container-image: demo/img        # no access keys ⇒ open
+    - id: analysts-app
+      display-name: Analysts App
+      container-image: demo/img
+      access-groups: [analysts]
+    - id: vip-app
+      display-name: VIP App
+      container-image: demo/img
+      access-users: [carol]
+```
+
+The full schema, including every other Ruscker-specific extension,
+follows.
+
 {{#include ../../docs/YAML_SCHEMA.md}}

--- a/book/src/faq.md
+++ b/book/src/faq.md
@@ -44,10 +44,15 @@ round-robin (APIs). It's all in [Configuration](./configuration.md).
 
 ### How does authentication work?
 
-The **admin panel** has user accounts with Viewer / Editor / Admin roles
-(plus a break-glass token). Gating *app access* per user (OIDC / SAML /
-LDAP, per-app ACLs) is [Phase 8](./roadmap.md) — today any visitor can
-reach a published app, as with Shiny Server Free.
+The **admin panel** has user accounts with Viewer / Editor / Admin
+roles (plus a break-glass token). The same accounts gate **per-app
+visibility**: every spec can declare `access-groups` / `access-users`
+and only matching users see the card and reach `/app` / `/api`
+(specs with no access keys remain open to anyone) —
+see [Per-user access](./configuration.md#per-user-access).
+External identity providers (OIDC / SAML / LDAP) for end-user
+sign-in are [Phase 8](./roadmap.md); user accounts are managed in
+the admin **Users** page until then.
 
 ### Where is configuration and state stored?
 
@@ -64,6 +69,11 @@ state, behind a load balancer; a Postgres advisory lock elects a single
 auto-scaler leader with automatic failover. There's a runnable two-node
 harness in `examples/ha/` — see the
 [active-active section](./deploying.md) of the deploy guide.
+One operational caveat: until a shared admin-session store ships, pin
+the **sign-in session** paths to a single upstream — see
+[Sticky upstream for the sign-in session][ha-sticky].
+
+[ha-sticky]: ./deploying.md#sticky-upstream-for-the-sign-in-session-admin-app-api
 
 ### Is it production-ready?
 

--- a/book/src/quickstart.md
+++ b/book/src/quickstart.md
@@ -88,9 +88,17 @@ CPU/memory limits, registry credentials, routing, rate limits…).
 
 ## Next steps
 
-- [Configuration](./configuration.md) — the full YAML reference.
+- [Configuration](./configuration.md) — the full YAML reference. See
+  [Per-user access](./configuration.md#per-user-access) to restrict
+  apps by user / group.
 - [The admin panel](./admin.md) — manage specs, images, users, and the
   live dashboard without editing YAML.
 - [Deploying in production](./deploying.md) — systemd + nginx, TLS,
-  multi-host, and active-active HA.
+  multi-host, and active-active HA (including
+  [mounting the portal under a subpath][base-path] and the
+  [sticky-upstream requirement for sign-in sessions][ha-sticky] in
+  HA).
 - [Troubleshooting](./troubleshooting.md) — when an app won't load.
+
+[base-path]: ./deploying.md#4b-mounting-under-a-base-path-subpath
+[ha-sticky]: ./deploying.md#sticky-upstream-for-the-sign-in-session-admin-app-api

--- a/docs/IMAGES.md
+++ b/docs/IMAGES.md
@@ -95,9 +95,9 @@ re-reads from disk on every request.
 ## Bundled examples
 
 The repository ships ~57 real card images at
-`examples/assets/img/` (extracted from the SEPE / Monitoramento
-Estratégico ShinyProxy install, sanitized). They cover every spec
-in `examples/application.yml` — running `ruscker serve --config
+`examples/assets/img/` (extracted from a real-world ShinyProxy
+install, sanitized). They cover every spec in
+`examples/application.yml` — running `ruscker serve --config
 examples/application.yml` shows the portal with all images visible.
 
 ## What we explicitly don't do

--- a/docs/ROADMAP.md
+++ b/docs/ROADMAP.md
@@ -47,9 +47,10 @@ Tailwind 4. Specs and template properties drive what gets rendered.
   directory
 - [ ] Tailwind 4 build script (no Node required, uses standalone CLI)
 
-**Deliverable**: visit `localhost:8080` and see the SEPE portal
-rendered from the YAML, looking visually equivalent to today but in
-Tailwind. Cards are not yet clickable (no proxy yet).
+**Deliverable**: visit `localhost:8080` and see the bundled
+`examples/application.yml` portal rendered, looking visually
+equivalent to today but in Tailwind. Cards are not yet clickable
+(no proxy yet).
 
 ## Phase 2 — Persistence + admin CRUD (3 weeks)
 
@@ -160,8 +161,8 @@ drill into any container.
 
 ## Definition of "ready to replace ShinyProxy"
 
-After Phase 5, Ruscker can be deployed where SEPE currently runs
-ShinyProxy. The migration path:
+After Phase 5, Ruscker can be deployed as a drop-in replacement for
+existing ShinyProxy installations. The migration path:
 
 1. `ruscker import application.yml --db /var/ruscker/ruscker.db`
 2. Stop ShinyProxy

--- a/docs/YAML_SCHEMA.md
+++ b/docs/YAML_SCHEMA.md
@@ -28,9 +28,37 @@ server:
   servlet:
     session:
       timeout: 3600
+  context-path: /box                  # Mount portal under a subpath (see below)
+  # ShinyProxy's nested form is also accepted:
+  servlet.context-path: /box
 ```
 
 Resolved via `Server::session_timeout_secs()` — either form works.
+
+### `server.context-path` — subpath mounting
+
+Serves the whole portal under a URL prefix when you can't dedicate a
+subdomain (e.g. `example.org/box/` instead of `box.example.org/`).
+Normalized form: leading slash, no trailing slash (`"box"`,
+`"/box/"`, and `"/box"` all become `/box`). The CLI flag
+`--base-path /box` overrides the YAML.
+
+ShinyProxy emits this as `server.servlet.context-path`; the flat
+`server.context-path` form is also accepted. Empty / absent ⇒ served
+at the root (the default).
+
+Operational notes:
+
+- The health probes `/healthz` and `/readyz` stay at the root
+  regardless of the prefix — load balancers don't need to know it.
+- The chrome's root-absolute URLs (`/admin/...`, `/assets/...`,
+  redirects) are rewritten on the response so they all carry the
+  prefix; runtime fetches (`fetch`/`XMLHttpRequest`/`WebSocket`/
+  `EventSource`) get a small shim that prefixes them too.
+- Cookies set `Path=/` (already sent by browsers for `{base}/...`).
+- Configure your reverse proxy to pass requests through under the
+  same prefix — see the **Mounting under a base path** section of
+  `book/src/deploying.md`.
 
 Other `server.*` fields from Spring Boot are accepted by serde but
 ignored by Ruscker.
@@ -98,6 +126,7 @@ and `tls` mismatched with the scheme.
 | `port` | u16 | `8080` | HTTP listener port |
 | `bind-address` | string | `"0.0.0.0"` | Listener interface |
 | `authentication` | enum | `none` | `none` (MVP) / `openid` / `ldap` / `saml` / `simple` |
+| `landing-customization` | block | `{}` | Branding, SEO/social meta, analytics, custom HTML blocks, sign-in visibility — see [§ `proxy.landing-customization`](#proxylanding-customization). Ruscker extension |
 | `specs` | array | `[]` | List of apps/links/APIs |
 
 ### Authentication
@@ -109,6 +138,87 @@ real auth support.
 
 For applications that handle their own auth internally (a common
 case), `none` is the correct choice — Ruscker just routes traffic.
+
+### `proxy.landing-customization`
+
+Branding, SEO, analytics, and custom-HTML overrides for the public
+landing. Every subfield is optional; an empty `landing-customization`
+block (the default) renders the stock landing.
+
+```yaml
+proxy:
+  landing-customization:
+    # Branding — CSS colors applied to the landing header
+    header-bg: "#0f6e56"               # any CSS color
+    header-fg: "#ffffff"               # contrast override when bg is dark
+
+    # Intro paragraph between header and filters
+    intro: "Welcome to the portal."    # single-language fallback
+    intro-locales:                     # per-language overrides; locale code → text
+      pt: "Bem-vindo ao portal."
+      en: "Welcome to the portal."
+      es: "Bienvenido al portal."
+      fr: "Bienvenue sur le portail."
+
+    # SEO / social-share meta tags injected into the landing `<head>`
+    seo-title: "Portal — Org Name"     # overrides `proxy.title` for <title>
+    seo-description: "Internal apps."  # <meta name="description"> + og:description
+    og-image: /assets/img/og.png       # path or absolute URL for og:image
+
+    # Analytics — admin-trusted, injected verbatim into landing <head>
+    analytics-html: |
+      <script defer src="https://plausible.io/js/script.js"
+              data-domain="example.org"></script>
+    analytics-origins: "https://plausible.io"   # space-separated; widens landing CSP
+
+    # Sign-in visibility (anonymous viewers only)
+    show-admin-link: true              # default true; false hides the entrance
+
+    # Custom HTML blocks (admin-managed; YAML round-trips via import/export)
+    blocks:
+      - slot: top                       # `top` (after header) | `bottom` (after grid)
+        title: "Maintenance banner"     # internal label, not shown publicly
+        html: '<div class="...">Scheduled downtime Sunday 02:00 UTC.</div>'
+        csp-origins: ""                 # space-separated origins this block needs
+        enabled: true                   # default true
+```
+
+Field reference:
+
+| Field | Type | Default | Notes |
+|---|---|---|---|
+| `header-bg` | CSS color | none | Header background. Match your brand's primary color. |
+| `header-fg` | CSS color | none | Header text — set when `header-bg` is dark and the default loses contrast. |
+| `intro` | string | none | Plain text (no HTML); single-language fallback. |
+| `intro-locales` | map | `{}` | Locale code → intro string. Wins over `intro` for matching locales. |
+| `seo-title` | string | `proxy.title` | Override for `<title>`. |
+| `seo-description` | string | resolved intro | `<meta name="description">` + `og:description`. |
+| `og-image` | path / URL | none | `og:image` for social-share. |
+| `analytics-html` | string | none | **Trusted** raw HTML, injected verbatim into landing `<head>`. |
+| `analytics-origins` | string | none | Space-separated origins added to the landing CSP (`script-src`/`connect-src`/`img-src`). |
+| `show-admin-link` | bool | `true` | When `false`, anonymous visitors don't see the "Sign in" entrance. Logged-in users still see their panel link. |
+| `blocks[]` | list | `[]` | Custom HTML blocks (see below). |
+
+`blocks[]` subfields:
+
+| Field | Type | Default | Notes |
+|---|---|---|---|
+| `slot` | enum | required | `top` or `bottom` — render position on the landing. |
+| `title` | string | required | Admin-only label; not rendered publicly. |
+| `html` | string | required | **Trusted** raw HTML, injected verbatim into the chosen slot. |
+| `csp-origins` | string | `""` | Space-separated origins this block's content needs, folded into the landing CSP. |
+| `enabled` | bool | `true` | Toggle without deleting. |
+
+> **Trust model:** `analytics-html` and `blocks[].html` are rendered
+> unescaped. Only set them from a trusted source. Anything the
+> snippet loads from outside Ruscker's origin must also be listed in
+> the matching `*-origins` field, otherwise the landing's CSP blocks
+> it.
+
+Blocks are admin-managed in the live landing editor; YAML
+round-tripping means `ruscker export` writes them back here and
+`ruscker import` consumes them. SEO, analytics, and `show-admin-link`
+are deploy-level policy and live only in this block.
 
 ## Specs
 

--- a/docs/YAML_SCHEMA.md
+++ b/docs/YAML_SCHEMA.md
@@ -174,7 +174,7 @@ proxy:
     # Sign-in visibility (anonymous viewers only)
     show-admin-link: true              # default true; false hides the entrance
 
-    # Custom HTML blocks (admin-managed; YAML round-trips via import/export)
+    # Custom HTML blocks (admin-managed in the live editor; see note below)
     blocks:
       - slot: top                       # `top` (after header) | `bottom` (after grid)
         title: "Maintenance banner"     # internal label, not shown publicly
@@ -215,9 +215,11 @@ Field reference:
 > the matching `*-origins` field, otherwise the landing's CSP blocks
 > it.
 
-Blocks are admin-managed in the live landing editor; YAML
-round-tripping means `ruscker export` writes them back here and
-`ruscker import` consumes them. SEO, analytics, and `show-admin-link`
+Blocks are **admin-managed in the live landing editor** and stored in
+their own DB table; the `blocks[]` slot in this YAML schema exists so
+a future `ruscker export` round-trip can serialize them, but at the
+moment the import/export path does **not** populate it — operators
+edit blocks from the admin UI. SEO, analytics, and `show-admin-link`
 are deploy-level policy and live only in this block.
 
 ## Specs


### PR DESCRIPTION
## Summary
Closes #189.

**Cleanup** (per the no-gov-in-public-docs policy):
- `docs/ROADMAP.md`, `docs/IMAGES.md` — drop SEPE / "Brazilian state government" call-outs; the 540 MB → 16 MB reduction datum stays generic.

**Document v0.1.2 features in `YAML_SCHEMA.md`** (and consequently in `book/configuration.md` via the `{{#include}}`):
- New **`server.context-path`** section + `--base-path` callout (#173), including operational notes (root-only health probes, chrome rewriter, runtime `fetch`/`XHR`/`WebSocket`/`EventSource` shim, cookie `Path`).
- New **`proxy.landing-customization`** section covering header-bg/fg, intro + intro-locales, seo-title/description, og-image, analytics-html + analytics-origins, **`show-admin-link`** (#156), and the custom landing **`blocks[]`** (slot / title / html / csp-origins / enabled) with the trust-model warning.
- Cross-reference the existing `access-groups` / `access-users` fields from the new top-level "Per-user access" prose.

**Book wiring:**
- `book/src/configuration.md` — add a cross-link block at the top to base-path, per-user access, HA sticky-upstream, and landing customization (this chapter previously was a 4-line wrapper around the schema include).
- `book/src/quickstart.md` — extend "Next steps" with the same cross-links so a new operator finds the HA caveat early.
- `book/src/faq.md` — rewrite the authentication FAQ entry (per-app ACLs *are* shipped via #155; only external IdPs are Phase 8); add the sticky-upstream caveat to the HA FAQ.

## Acceptance verification
- `grep -ri "sepe|pe.gov.br|seplag" README.md book/ docs/` returns nothing on tracked files. ✓
- `mdbook build` clean; intra-book anchors verified against the generated HTML (`#per-user-access`, `#proxylanding-customization`, `#servercontext-path--subpath-mounting`, `#4b-mounting-under-a-base-path-subpath`, `#sticky-upstream-for-the-sign-in-session-admin-app-api`). ✓
- `cargo test -p ruscker-config` green. ✓

## Notes
- `PLAN.md` has historical SEPE references too; it's not in the issue's acceptance grep (`README.md book/ docs/ CLAUDE.md`), so it was left alone. Worth a follow-up if the public-no-gov rule should extend to sprint planning notes.
- All `CLAUDE.md` files (workspace root + crate-level) are gitignored — the policy check passes on tracked content.

## Test plan
- [x] `cargo test -p ruscker-config` green.
- [x] `mdbook build` clean.
- [x] Acceptance grep returns empty on tracked files.
- [ ] Pages deploy on merge (validated by CI).

🤖 Generated with [Claude Code](https://claude.com/claude-code)