### PR TITLE
#184: ergonomic Docker backend enablement (helper + boot WARN + Recommends)

### DIFF
--- a/crates/ruscker-cli/Cargo.toml
+++ b/crates/ruscker-cli/Cargo.toml
@@ -25,6 +25,13 @@ priority = "optional"
 # addgroup/adduser to create the service account (Ubuntu 24.04 minimal no
 # longer ships it in the base set).
 depends = "$auto, ca-certificates, adduser"
+# `docker.io` is the canonical Docker engine package in Debian/Ubuntu
+# main. It's a Recommends, not a Depends, because Ruscker's landing +
+# admin still serve without a backend (#184). Any Docker-API-compatible
+# engine works (docker-ce, podman with podman-docker, …) — operators
+# who pull from a third-party APT source already know how to satisfy
+# this themselves.
+recommends = "docker.io"
 extended-description = """\
 Ruscker is a lightweight Rust alternative to ShinyProxy and Shiny Server \
 Free. It hosts and load-balances containerized interactive web apps \
@@ -33,6 +40,7 @@ proxy with a custom landing page and an admin panel. Ships as a single \
 binary with no JVM."""
 assets = [
     ["target/release/ruscker", "usr/bin/", "755"],
+    ["../../packaging/debian/ruscker-enable-docker", "usr/sbin/ruscker-enable-docker", "755"],
     ["../../packaging/application.example.yml", "etc/ruscker/application.yml", "644"],
     ["../../packaging/ruscker.env.example", "etc/ruscker/ruscker.env", "640"],
     ["../../packaging/README.Debian", "usr/share/doc/ruscker/README.Debian", "644"],

--- a/crates/ruscker-cli/src/main.rs
+++ b/crates/ruscker-cli/src/main.rs
@@ -465,8 +465,9 @@ fn cmd_serve(
             // landing + admin still work in proxy-less mode).
             tracing::warn!(
                 "Docker socket is reachable at /var/run/docker.sock but --docker is OFF — \
-                 app containers will not spawn. On a Debian/Ubuntu install run \
-                 `sudo ruscker-enable-docker`; otherwise add --docker to the command line."
+                 app containers will not spawn. If you installed from the Ruscker .deb \
+                 package run `sudo ruscker-enable-docker`; otherwise add --docker to the \
+                 command line."
             );
         }
         // Config database: Postgres (shared HA catalog) takes precedence

--- a/crates/ruscker-cli/src/main.rs
+++ b/crates/ruscker-cli/src/main.rs
@@ -348,6 +348,36 @@ fn discover_images_dir(config_path: &Path, config: &Config) -> Option<PathBuf> {
     None
 }
 
+/// Default Docker socket path on Linux. Pulled out as a constant so
+/// the boot-time check has a single source of truth (`is_local_docker_reachable`)
+/// and the unit test can swap in a tempdir path.
+const DEFAULT_DOCKER_SOCKET: &str = "/var/run/docker.sock";
+
+/// Cheap, blocking probe: is the Docker socket reachable on this host?
+///
+/// Just checks the file system metadata for a Unix socket — does NOT
+/// open a connection or talk to `dockerd`. That's enough to decide
+/// whether to nudge the operator about `--docker`; the real connect
+/// only happens when the flag is set.
+fn is_local_docker_reachable() -> bool {
+    docker_socket_at(DEFAULT_DOCKER_SOCKET)
+}
+
+#[cfg(unix)]
+fn docker_socket_at(path: &str) -> bool {
+    use std::os::unix::fs::FileTypeExt;
+    std::fs::metadata(path)
+        .map(|m| m.file_type().is_socket())
+        .unwrap_or(false)
+}
+
+#[cfg(not(unix))]
+fn docker_socket_at(_path: &str) -> bool {
+    // Windows / non-Unix: Docker Desktop exposes a named pipe; we don't
+    // probe it here. The nudge is for the Debian / systemd path.
+    false
+}
+
 fn cmd_serve(
     config_path: &PathBuf,
     bind_override: Option<std::net::SocketAddr>,
@@ -427,6 +457,17 @@ fn cmd_serve(
                 )
             };
             server = server.with_backend(backend);
+        } else if is_local_docker_reachable() {
+            // #184: the operator started without `--docker` on a host
+            // where the daemon socket is reachable. Spawning containers
+            // is the whole point of the proxy, so nudge them once at
+            // startup — this is a hint, not a hard requirement (the
+            // landing + admin still work in proxy-less mode).
+            tracing::warn!(
+                "Docker socket is reachable at /var/run/docker.sock but --docker is OFF — \
+                 app containers will not spawn. On a Debian/Ubuntu install run \
+                 `sudo ruscker-enable-docker`; otherwise add --docker to the command line."
+            );
         }
         // Config database: Postgres (shared HA catalog) takes precedence
         // over the SQLite path when both are given.
@@ -866,5 +907,34 @@ mod tests {
         let config =
             Config::from_yaml("proxy:\n  template-path: templates/x\n  specs: []\n").unwrap();
         assert!(discover_images_dir(&cfg_path, &config).is_none());
+    }
+
+    #[cfg(unix)]
+    #[test]
+    fn docker_socket_at_detects_a_unix_socket() {
+        use std::os::unix::net::UnixListener;
+        let tmp = std::env::temp_dir().join(format!(
+            "ruscker-sock-{}-{}.sock",
+            std::process::id(),
+            std::time::SystemTime::now()
+                .duration_since(std::time::UNIX_EPOCH)
+                .map(|d| d.as_nanos())
+                .unwrap_or(0)
+        ));
+        let _ = std::fs::remove_file(&tmp);
+
+        // Missing → false.
+        assert!(!docker_socket_at(tmp.to_str().unwrap()));
+
+        // Bind a real Unix socket → true.
+        let _listener = UnixListener::bind(&tmp).expect("bind unix socket");
+        assert!(docker_socket_at(tmp.to_str().unwrap()));
+
+        // A regular file under the same name → false.
+        std::fs::remove_file(&tmp).unwrap();
+        std::fs::write(&tmp, b"not a socket").unwrap();
+        assert!(!docker_socket_at(tmp.to_str().unwrap()));
+
+        std::fs::remove_file(&tmp).ok();
     }
 }

--- a/packaging/README.Debian
+++ b/packaging/README.Debian
@@ -41,24 +41,50 @@ Validate a config before restarting:
 
 Enabling the container backend (--docker)
 -----------------------------------------
-To let Ruscker spawn app containers, it must talk to the Docker daemon:
+To let Ruscker spawn app containers, it must talk to the Docker daemon.
+On a host with a working Docker install (`docker.io` is a Recommends of
+this package), run the helper:
 
-1. Add `--docker` (and usually `--db /var/lib/ruscker/ruscker.db`) to
-   ExecStart. Use a drop-in so package upgrades don't clobber it:
+  sudo ruscker-enable-docker
 
-     sudo systemctl edit ruscker
-     # then add:
-     [Service]
-     ExecStart=
-     ExecStart=/usr/bin/ruscker serve --config /etc/ruscker/application.yml \
-       --bind 0.0.0.0:8080 --docker --db /var/lib/ruscker/ruscker.db
+That writes a systemd drop-in at
+/etc/systemd/system/ruscker.service.d/docker.conf which:
 
-2. Give the `ruscker` user access to the Docker socket by uncommenting
-   `SupplementaryGroups=docker` in the same drop-in. NOTE: membership in
-   the docker group is effectively root on the host — the same trade-off
-   ShinyProxy carries.
+  - adds `--docker --db /var/lib/ruscker/ruscker.db` to ExecStart
+  - sets `SupplementaryGroups=docker` so the `ruscker` user can talk
+    to /var/run/docker.sock
 
-3. `sudo systemctl daemon-reload && sudo systemctl restart ruscker`
+then runs `systemctl daemon-reload && systemctl restart ruscker` and
+verifies /readyz comes up. Pass `--yes` to skip the confirmation prompt.
+
+SECURITY NOTE — docker group is effectively root. Members of the docker
+group can run privileged containers, which is equivalent to root on the
+host. The package therefore does NOT enable the backend silently; the
+helper requires explicit confirmation. This is the same trade-off
+ShinyProxy carries.
+
+To undo:
+
+  sudo rm /etc/systemd/system/ruscker.service.d/docker.conf
+  sudo systemctl daemon-reload && sudo systemctl restart ruscker
+
+Manual / advanced setup
+-----------------------
+If you can't or don't want to use the helper, write the drop-in by hand:
+
+  sudo systemctl edit ruscker
+  # then add:
+  [Service]
+  ExecStart=
+  ExecStart=/usr/bin/ruscker serve --config /etc/ruscker/application.yml \
+    --bind 0.0.0.0:8080 --docker --db /var/lib/ruscker/ruscker.db
+  SupplementaryGroups=docker
+
+  sudo systemctl daemon-reload && sudo systemctl restart ruscker
+
+Tip: if Ruscker is running without --docker on a host where the Docker
+socket is reachable, it logs a one-line WARN at startup pointing back to
+this section — a reminder, not a hard requirement.
 
 Health probes for load balancers / orchestrators: GET /healthz
 (liveness) and /readyz (readiness).

--- a/packaging/debian/ruscker-enable-docker
+++ b/packaging/debian/ruscker-enable-docker
@@ -2,13 +2,18 @@
 # ruscker-enable-docker — opt operators into the Docker backend without
 # hand-writing a systemd drop-in.
 #
-# What it does (idempotent):
-#   1. Drops a unit override at /etc/systemd/system/ruscker.service.d/docker.conf
-#      that replaces ExecStart with `... --docker --db /var/lib/ruscker/ruscker.db`
-#      and sets SupplementaryGroups=docker so the `ruscker` user can talk
-#      to /var/run/docker.sock.
+# What it does:
+#   1. Reads the unit's current effective ExecStart (so any operator
+#      customization to --bind / --config is preserved), appends
+#      --docker and --db (if missing), and writes a drop-in at
+#      /etc/systemd/system/ruscker.service.d/docker.conf with the new
+#      command + SupplementaryGroups=docker.
 #   2. systemctl daemon-reload + restart ruscker.
-#   3. Verifies /readyz returns 200.
+#   3. Verifies /readyz returns 200 on the bound port.
+#
+# Refuses to overwrite an existing drop-in or a unit that already runs
+# with --docker — both report "nothing to do" and exit 0. To re-run
+# from a clean slate, remove the drop-in first (see "To undo" below).
 #
 # Why this is opt-in: docker-group membership is effectively root on the
 # host (same trade-off ShinyProxy carries). The package does NOT do this
@@ -25,9 +30,7 @@ DROPIN_DIR=/etc/systemd/system/ruscker.service.d
 DROPIN=$DROPIN_DIR/docker.conf
 UNIT=ruscker.service
 SOCK=/var/run/docker.sock
-CONFIG=/etc/ruscker/application.yml
-DB=/var/lib/ruscker/ruscker.db
-PORT_HINT=8080
+DEFAULT_DB=/var/lib/ruscker/ruscker.db
 
 YES=0
 for a in "$@"; do
@@ -62,12 +65,73 @@ if [ ! -S "$SOCK" ]; then
     echo "  once dockerd is started (After=docker.service is already in the unit)."
 fi
 
+# Refuse to silently rewrite an existing drop-in — the operator may
+# have customized it. Make them take it down explicitly to re-run.
+if [ -f "$DROPIN" ]; then
+    echo "ruscker-enable-docker: $DROPIN already exists — nothing to do."
+    echo "  Inspect:  cat $DROPIN"
+    echo "  Re-run from a clean slate:"
+    echo "    sudo rm $DROPIN && sudo systemctl daemon-reload && sudo systemctl restart $UNIT"
+    echo "    sudo ruscker-enable-docker"
+    exit 0
+fi
+
+# Resolve the currently effective ExecStart so we can preserve the
+# operator's `--bind` / `--config` / any other custom args. In
+# systemd's load order the LAST non-empty `ExecStart=` line wins
+# (prior `ExecStart=` (empty) lines reset the list). `systemctl cat`
+# concatenates the base unit + every drop-in in load order, so we just
+# take the last non-empty hit.
+CURRENT_EXEC=$(systemctl cat "$UNIT" 2>/dev/null \
+    | awk '/^ExecStart=./ { sub(/^ExecStart=/, "", $0); last = $0 } END { print last }')
+[ -n "$CURRENT_EXEC" ] || die "could not read current ExecStart for $UNIT"
+
+# Idempotency: if --docker is already there, we have nothing to do.
+case " $CURRENT_EXEC " in
+    *' --docker '*)
+        echo "$UNIT already runs with --docker — nothing to do."
+        echo "  Current: $CURRENT_EXEC"
+        exit 0 ;;
+esac
+
+# Append --docker and --db (if --db isn't already in the command).
+NEW_EXEC="$CURRENT_EXEC --docker"
+case " $CURRENT_EXEC " in
+    *' --db '*) : ;;
+    *) NEW_EXEC="$NEW_EXEC --db $DEFAULT_DB" ;;
+esac
+
+# Derive the probe URL from --bind in the current command. 0.0.0.0:N
+# and [::]:N wildcard binds get probed on the loopback (the unit binds
+# on every interface but curl talks to one address); explicit binds
+# are probed as-is. Default `--bind` from the base unit is
+# `0.0.0.0:8080`, so the fallback matches that.
+BIND_ARG=$(printf '%s\n' "$CURRENT_EXEC" \
+    | sed -n 's/.*--bind \([^ ]*\).*/\1/p')
+BIND_ARG=${BIND_ARG:-0.0.0.0:8080}
+case "$BIND_ARG" in
+    '[::]:'*)
+        PROBE_HOST="[::1]" ; PROBE_PORT=${BIND_ARG##*:} ;;
+    '0.0.0.0:'*)
+        PROBE_HOST="127.0.0.1" ; PROBE_PORT=${BIND_ARG##*:} ;;
+    *)
+        # Explicit interface (e.g. `127.0.0.1:9000`, `[::1]:8080`) —
+        # use it verbatim.
+        PROBE_HOST=${BIND_ARG%:*} ; PROBE_PORT=${BIND_ARG##*:} ;;
+esac
+PROBE_URL="http://$PROBE_HOST:$PROBE_PORT/readyz"
+
 # ── Plan output ──────────────────────────────────────────────────────
 echo "Ruscker will be configured to talk to the Docker daemon:"
 echo
 note "drop-in:        $DROPIN"
-note "ExecStart:      adds --docker --db $DB"
+note "ExecStart:      preserves the current bind/config; adds --docker"
+case " $CURRENT_EXEC " in
+    *' --db '*) note "                (--db already present — left alone)" ;;
+    *)          note "                (adds --db $DEFAULT_DB)" ;;
+esac
 note "user group:     ruscker → docker (SupplementaryGroups=docker)"
+note "verify probe:   $PROBE_URL"
 note "daemon-reload + systemctl restart $UNIT"
 echo
 echo "Security note: members of the docker group can run privileged"
@@ -87,14 +151,15 @@ fi
 
 # ── Apply ─────────────────────────────────────────────────────────────
 mkdir -p "$DROPIN_DIR"
-# Note: this REPLACES ExecStart (the leading empty assignment is required
-# by systemd to override the unit's ExecStart rather than appending to it).
+# The leading empty `ExecStart=` is required: systemd treats ExecStart
+# as a list-valued option, so we have to reset the list before
+# re-defining it.
 cat > "$DROPIN" <<EOF
-# Written by ruscker-enable-docker. Safe to edit by hand; the helper
-# only checks for the file's presence, not its contents.
+# Written by ruscker-enable-docker. The helper refuses to overwrite
+# this file — edit by hand, or remove and re-run.
 [Service]
 ExecStart=
-ExecStart=/usr/bin/ruscker serve --config $CONFIG --bind 0.0.0.0:$PORT_HINT --docker --db $DB
+ExecStart=$NEW_EXEC
 SupplementaryGroups=docker
 EOF
 chmod 644 "$DROPIN"
@@ -106,9 +171,9 @@ systemctl restart "$UNIT"
 # Give the service a couple seconds to come up before probing.
 SLEPT=0
 while [ "$SLEPT" -lt 10 ]; do
-    if curl -fsS "http://127.0.0.1:$PORT_HINT/readyz" >/dev/null 2>&1; then
+    if curl -fsS "$PROBE_URL" >/dev/null 2>&1; then
         echo "✓ Ruscker is running with the Docker backend."
-        echo "  /readyz returned 200 on port $PORT_HINT."
+        echo "  $PROBE_URL returned 200."
         echo "  View status: systemctl status $UNIT"
         echo "  Tail logs:   journalctl -u $UNIT -f"
         exit 0
@@ -117,6 +182,6 @@ while [ "$SLEPT" -lt 10 ]; do
     sleep 1
 done
 
-echo "Drop-in written but /readyz didn't come up within 10s." >&2
+echo "Drop-in written but $PROBE_URL didn't come up within 10s." >&2
 echo "Check: systemctl status $UNIT && journalctl -u $UNIT -n 50" >&2
 exit 1

--- a/packaging/debian/ruscker-enable-docker
+++ b/packaging/debian/ruscker-enable-docker
@@ -1,0 +1,122 @@
+#!/bin/sh
+# ruscker-enable-docker — opt operators into the Docker backend without
+# hand-writing a systemd drop-in.
+#
+# What it does (idempotent):
+#   1. Drops a unit override at /etc/systemd/system/ruscker.service.d/docker.conf
+#      that replaces ExecStart with `... --docker --db /var/lib/ruscker/ruscker.db`
+#      and sets SupplementaryGroups=docker so the `ruscker` user can talk
+#      to /var/run/docker.sock.
+#   2. systemctl daemon-reload + restart ruscker.
+#   3. Verifies /readyz returns 200.
+#
+# Why this is opt-in: docker-group membership is effectively root on the
+# host (same trade-off ShinyProxy carries). The package does NOT do this
+# silently at install time. See README.Debian.
+#
+# Run as root (sudo). To skip the confirmation prompt: pass --yes.
+#
+# To undo: `sudo rm /etc/systemd/system/ruscker.service.d/docker.conf &&
+#          sudo systemctl daemon-reload && sudo systemctl restart ruscker`.
+
+set -eu
+
+DROPIN_DIR=/etc/systemd/system/ruscker.service.d
+DROPIN=$DROPIN_DIR/docker.conf
+UNIT=ruscker.service
+SOCK=/var/run/docker.sock
+CONFIG=/etc/ruscker/application.yml
+DB=/var/lib/ruscker/ruscker.db
+PORT_HINT=8080
+
+YES=0
+for a in "$@"; do
+    case "$a" in
+        -y|--yes) YES=1 ;;
+        -h|--help)
+            sed -n '2,/^$/p' "$0" | sed 's/^# \{0,1\}//'
+            exit 0 ;;
+        *)
+            echo "ruscker-enable-docker: unknown option '$a'" >&2
+            echo "Try: ruscker-enable-docker --help" >&2
+            exit 2 ;;
+    esac
+done
+
+die() { echo "ruscker-enable-docker: $*" >&2; exit 1; }
+note() { echo "  • $*"; }
+
+# ── Pre-flight checks ─────────────────────────────────────────────────
+[ "$(id -u)" -eq 0 ] || die "must run as root — try: sudo ruscker-enable-docker"
+
+command -v systemctl >/dev/null 2>&1 || die "systemctl not found (this helper assumes systemd)"
+systemctl list-unit-files "$UNIT" >/dev/null 2>&1 \
+    || die "$UNIT not installed — install the ruscker package first"
+
+getent group docker >/dev/null 2>&1 \
+    || die "the 'docker' group does not exist — install Docker first (apt install docker.io)"
+
+if [ ! -S "$SOCK" ]; then
+    echo "ruscker-enable-docker: warning — $SOCK is not a socket; the Docker"
+    echo "  daemon may not be running yet. Continuing — the unit will pick it up"
+    echo "  once dockerd is started (After=docker.service is already in the unit)."
+fi
+
+# ── Plan output ──────────────────────────────────────────────────────
+echo "Ruscker will be configured to talk to the Docker daemon:"
+echo
+note "drop-in:        $DROPIN"
+note "ExecStart:      adds --docker --db $DB"
+note "user group:     ruscker → docker (SupplementaryGroups=docker)"
+note "daemon-reload + systemctl restart $UNIT"
+echo
+echo "Security note: members of the docker group can run privileged"
+echo "containers, which is effectively root on this host. Only enable"
+echo "this on hosts where you trust everyone with write access to"
+echo "$SOCK."
+echo
+
+if [ "$YES" -ne 1 ]; then
+    printf "Proceed? [y/N] "
+    read -r ANS
+    case "$ANS" in
+        y|Y|yes|YES) : ;;
+        *) echo "Aborted."; exit 1 ;;
+    esac
+fi
+
+# ── Apply ─────────────────────────────────────────────────────────────
+mkdir -p "$DROPIN_DIR"
+# Note: this REPLACES ExecStart (the leading empty assignment is required
+# by systemd to override the unit's ExecStart rather than appending to it).
+cat > "$DROPIN" <<EOF
+# Written by ruscker-enable-docker. Safe to edit by hand; the helper
+# only checks for the file's presence, not its contents.
+[Service]
+ExecStart=
+ExecStart=/usr/bin/ruscker serve --config $CONFIG --bind 0.0.0.0:$PORT_HINT --docker --db $DB
+SupplementaryGroups=docker
+EOF
+chmod 644 "$DROPIN"
+
+systemctl daemon-reload
+systemctl restart "$UNIT"
+
+# ── Verify ────────────────────────────────────────────────────────────
+# Give the service a couple seconds to come up before probing.
+SLEPT=0
+while [ "$SLEPT" -lt 10 ]; do
+    if curl -fsS "http://127.0.0.1:$PORT_HINT/readyz" >/dev/null 2>&1; then
+        echo "✓ Ruscker is running with the Docker backend."
+        echo "  /readyz returned 200 on port $PORT_HINT."
+        echo "  View status: systemctl status $UNIT"
+        echo "  Tail logs:   journalctl -u $UNIT -f"
+        exit 0
+    fi
+    SLEPT=$((SLEPT + 1))
+    sleep 1
+done
+
+echo "Drop-in written but /readyz didn't come up within 10s." >&2
+echo "Check: systemctl status $UNIT && journalctl -u $UNIT -n 50" >&2
+exit 1

--- a/packaging/systemd/ruscker.service
+++ b/packaging/systemd/ruscker.service
@@ -28,8 +28,10 @@ WorkingDirectory=/var/lib/ruscker
 
 # --- Hardening -------------------------------------------------------
 # Ruscker needs very little of the host. If you enable the --docker
-# backend, the `ruscker` user also needs access to the Docker socket;
-# uncomment SupplementaryGroups below (note: docker group ≈ root).
+# backend, the `ruscker` user also needs access to the Docker socket.
+# Preferred path: `sudo ruscker-enable-docker` (writes a drop-in with
+# --docker + SupplementaryGroups=docker; see README.Debian). Or
+# uncomment the line below by hand — note: docker group ≈ root.
 #SupplementaryGroups=docker
 NoNewPrivileges=true
 ProtectSystem=strict


### PR DESCRIPTION
Closes #184.

The `.deb` installs Ruscker with `--docker` OFF. Landing+admin work without a backend, and docker-group membership is effectively root, so it's not safe to flip on silently at install. Until now the only path was hand-writing a systemd drop-in (the cast deploy carries an `apply-docker.sh` doing exactly that). This packages the ritual.

## Summary
- **`packaging/debian/ruscker-enable-docker`** (new helper, installed at `/usr/sbin/`). Drops `/etc/systemd/system/ruscker.service.d/docker.conf` with `--docker --db /var/lib/ruscker/ruscker.db` + `SupplementaryGroups=docker`, runs `daemon-reload + restart`, polls `/readyz` for up to 10s. Pre-flight: root check, systemd present, docker group exists, socket-present hint. Confirmation prompt (`--yes` to skip). Surfaces the security caveat (docker group ≈ root) in the plan output.
- **Boot-time WARN** in `cmd_serve`. When `--docker` is off but `/var/run/docker.sock` is a real Unix socket, log one line pointing back at the helper. Cheap (`fs::metadata`, follows symlinks so macOS Docker Desktop's link is detected), Unix-only via `cfg`. Unit test covers missing / real socket / regular file.
- **Cargo-deb config**: `recommends = "docker.io"` (Debian/Ubuntu main package; not Depends so landing-only deploys still work). Ships the helper to `/usr/sbin/`.
- **README.Debian** rewritten — helper path first, manual drop-in second, plus the security note and an undo recipe.

## Test plan
- [x] `cargo test -p ruscker-cli` green (6 lib tests incl. new `docker_socket_at_detects_a_unix_socket`).
- [x] `cargo test --workspace` green.
- [x] Smoke on darwin (`/var/run/docker.sock` → real socket symlink to `~/.docker/run/docker.sock`):
  - `ruscker serve` (no `--docker`) emits the WARN exactly once at startup.
  - `ruscker serve --docker` emits **no** new WARN, backend connects.
- [x] `sh -n` + `bash -n` on the helper script.
- [ ] Tested end-to-end on a real Debian/Ubuntu .deb install (manual, post-merge).

## Security
- The `recommends` keeps Docker out of the `.deb`'s hard-dep chain, so an operator can still install Ruscker for landing-only use without pulling docker.io.
- The helper requires explicit confirmation (`y` or `--yes`) before flipping the unit; the WARN is just a nudge.
- `SupplementaryGroups=docker` in the drop-in is documented as equivalent to root on the host — same trade-off ShinyProxy carries.

🤖 Generated with [Claude Code](https://claude.com/claude-code)