### PR TITLE
#182 + #183: chrome cluster — theme + language + sign-in top-right

### DIFF
--- a/crates/ruscker-admin/assets/i18n/en/landing.ftl
+++ b/crates/ruscker-admin/assets/i18n/en/landing.ftl
@@ -164,7 +164,6 @@ admin-login-token-placeholder = Paste the token here
 admin-login-submit = Sign in
 admin-login-error-wrong = Wrong token. Please try again.
 admin-login-back-portal = ← public portal
-admin-login-locale-group = Language
 
 # Apps list
 admin-specs-title = Apps
@@ -352,11 +351,20 @@ card-state-inactive = Unavailable
 card-access-public = Public access
 card-access-restricted = Restricted access
 
-footer-language = Language
-footer-theme = Theme
 theme-light = Light
 theme-dark = Dark
 theme-auto = Auto
+
+# Top-right chrome cluster (#182 + #183)
+chrome-cluster-label = Page settings
+chrome-theme-label = Theme
+chrome-language-label = Language
+chrome-account-label = Account
+chrome-signin = Sign in
+chrome-signed-in-as-prefix = Signed in as
+chrome-panel = Panel
+chrome-change-password = Change password
+chrome-signout = Sign out
 
 # Admin logs viewer
 admin-logs-title = Container logs

--- a/crates/ruscker-admin/assets/i18n/es/landing.ftl
+++ b/crates/ruscker-admin/assets/i18n/es/landing.ftl
@@ -164,7 +164,6 @@ admin-login-token-placeholder = Pegue el token aquí
 admin-login-submit = Entrar
 admin-login-error-wrong = Token incorrecto. Intente de nuevo.
 admin-login-back-portal = ← portal público
-admin-login-locale-group = Idioma
 
 # Apps list
 admin-specs-title = Aplicaciones
@@ -352,11 +351,20 @@ card-state-inactive = No disponible
 card-access-public = Acceso público
 card-access-restricted = Acceso restringido
 
-footer-language = Idioma
-footer-theme = Tema
 theme-light = Claro
 theme-dark = Oscuro
 theme-auto = Automático
+
+# Top-right chrome cluster (#182 + #183)
+chrome-cluster-label = Preferencias de la página
+chrome-theme-label = Tema
+chrome-language-label = Idioma
+chrome-account-label = Cuenta
+chrome-signin = Iniciar sesión
+chrome-signed-in-as-prefix = Conectado como
+chrome-panel = Panel
+chrome-change-password = Cambiar contraseña
+chrome-signout = Cerrar sesión
 
 # Admin logs viewer
 admin-logs-title = Logs del contenedor

--- a/crates/ruscker-admin/assets/i18n/fr/landing.ftl
+++ b/crates/ruscker-admin/assets/i18n/fr/landing.ftl
@@ -164,7 +164,6 @@ admin-login-token-placeholder = Collez le jeton ici
 admin-login-submit = Se connecter
 admin-login-error-wrong = Jeton incorrect. Réessayez.
 admin-login-back-portal = ← portail public
-admin-login-locale-group = Langue
 
 # Apps list
 admin-specs-title = Applications
@@ -352,11 +351,20 @@ card-state-inactive = Indisponible
 card-access-public = Accès public
 card-access-restricted = Accès restreint
 
-footer-language = Langue
-footer-theme = Thème
 theme-light = Clair
 theme-dark = Sombre
 theme-auto = Automatique
+
+# Top-right chrome cluster (#182 + #183)
+chrome-cluster-label = Préférences de la page
+chrome-theme-label = Thème
+chrome-language-label = Langue
+chrome-account-label = Compte
+chrome-signin = Se connecter
+chrome-signed-in-as-prefix = Connecté en tant que
+chrome-panel = Panneau
+chrome-change-password = Changer le mot de passe
+chrome-signout = Se déconnecter
 
 # Admin logs viewer
 admin-logs-title = Logs du conteneur

--- a/crates/ruscker-admin/assets/i18n/pt/landing.ftl
+++ b/crates/ruscker-admin/assets/i18n/pt/landing.ftl
@@ -168,7 +168,6 @@ admin-login-token-placeholder = Cole o token aqui
 admin-login-submit = Entrar
 admin-login-error-wrong = Token incorreto. Tente de novo.
 admin-login-back-portal = ← portal público
-admin-login-locale-group = Idioma
 
 # Apps list
 admin-specs-title = Aplicações
@@ -356,11 +355,20 @@ card-state-inactive = Indisponível
 card-access-public = Acesso público
 card-access-restricted = Acesso restrito
 
-footer-language = Idioma
-footer-theme = Tema
 theme-light = Claro
 theme-dark = Escuro
 theme-auto = Automático
+
+# Top-right chrome cluster (#182 + #183)
+chrome-cluster-label = Preferências da página
+chrome-theme-label = Tema
+chrome-language-label = Idioma
+chrome-account-label = Conta
+chrome-signin = Entrar
+chrome-signed-in-as-prefix = Conectado como
+chrome-panel = Painel
+chrome-change-password = Mudar senha
+chrome-signout = Sair
 
 # Admin logs viewer
 admin-logs-title = Logs do container

--- a/crates/ruscker-admin/assets/tailwind/input.css
+++ b/crates/ruscker-admin/assets/tailwind/input.css
@@ -451,6 +451,113 @@ body {
 .admin-nav-link--logout { color: var(--color-lock); }
 .admin-nav-link--logout:hover { background: var(--color-lock); color: #fff; }
 
+/* ─── Chrome cluster: theme + language + sign-in (#182 + #183) ──
+ *
+ * Three icon-buttons in a row, anchored top-right on every public-
+ * facing page. Replaces the older footer theme/language pickers.
+ *
+ * Disclosure uses native `<details>/<summary>`. Each popover is
+ * absolutely positioned underneath its summary; only one is open at
+ * a time because clicking a sibling toggles the others closed in the
+ * browser's native handling. Keyboard nav: Tab moves between
+ * summaries, Enter/Space opens, Esc closes. No JS.
+ */
+.chrome-cluster {
+  display: flex; align-items: center; gap: 4px;
+  font-family: inherit;
+}
+.chrome-disclosure {
+  position: relative;
+}
+/* Kill the default disclosure triangle in every browser. */
+.chrome-disclosure summary { list-style: none; cursor: pointer; }
+.chrome-disclosure summary::-webkit-details-marker { display: none; }
+.chrome-disclosure summary::marker { content: ""; display: none; }
+
+.chrome-icon {
+  width: 32px; height: 32px;
+  display: inline-flex; align-items: center; justify-content: center;
+  background: transparent;
+  border: 0.5px solid var(--border);
+  border-radius: 10px;
+  color: inherit;
+  position: relative;
+  transition: background 0.12s, border-color 0.12s;
+}
+.chrome-icon:hover { background: var(--surface-soft); border-color: var(--border-strong); }
+.chrome-icon i { font-size: 16px; line-height: 1; }
+/* Open-state highlight on the summary itself (the parent details has
+   the `open` attribute, so we can target descendants via [open]). */
+.chrome-disclosure[open] > .chrome-icon {
+  background: var(--text); color: var(--bg); border-color: var(--text);
+}
+
+.chrome-icon-badge {
+  position: absolute; bottom: 3px; right: 3px;
+  font-size: 9px; font-weight: 600; letter-spacing: 0.04em;
+  padding: 0 3px;
+  background: var(--surface);
+  border: 0.5px solid var(--border);
+  border-radius: 4px;
+  line-height: 1.3;
+}
+.chrome-disclosure[open] > .chrome-icon .chrome-icon-badge {
+  background: var(--bg); color: var(--text); border-color: var(--bg);
+}
+
+/* Anonymous sign-in CTA — textual variant of the icon-button. */
+.chrome-signin {
+  display: inline-flex; align-items: center; gap: 6px;
+  height: 32px; padding: 0 12px;
+  background: transparent;
+  border: 0.5px solid var(--border);
+  border-radius: 10px;
+  color: inherit;
+  font-size: 12px; font-family: inherit;
+  text-decoration: none;
+}
+.chrome-signin:hover { background: var(--surface-soft); border-color: var(--border-strong); }
+.chrome-signin i { font-size: 14px; }
+
+/* Popover — anchored under the summary, right-aligned so it doesn't
+   spill off-screen on the cluster's rightmost slot. */
+.chrome-popover {
+  position: absolute; top: 38px; right: 0;
+  min-width: 168px;
+  background: var(--surface);
+  border: 0.5px solid var(--border);
+  border-radius: 10px;
+  box-shadow: 0 6px 24px rgba(0, 0, 0, 0.08);
+  padding: 5px;
+  display: flex; flex-direction: column;
+  z-index: 50;
+}
+.chrome-popover-item {
+  display: flex; align-items: center; gap: 8px;
+  padding: 7px 10px;
+  background: transparent;
+  border: 0; border-radius: 6px;
+  cursor: pointer;
+  font-family: inherit; font-size: 12.5px;
+  color: inherit; text-align: left; text-decoration: none;
+}
+.chrome-popover-item:hover { background: var(--surface-soft); }
+.chrome-popover-item.is-current { font-weight: 500; }
+.chrome-popover-item.is-current::after { content: "✓"; margin-left: auto; opacity: 0.7; }
+.chrome-popover-item i { font-size: 14px; opacity: 0.85; }
+.chrome-popover-code {
+  font-family: ui-monospace, SFMono-Regular, Menlo, monospace;
+  font-size: 11px; opacity: 0.55;
+  display: inline-block; width: 22px;
+}
+.chrome-popover-user {
+  padding: 8px 10px 4px;
+  font-size: 11px; color: var(--text-muted);
+}
+.chrome-popover-sep {
+  height: 0.5px; background: var(--border); margin: 4px 0;
+}
+
 /* ─── Admin login card ───────────────────────────────────────── */
 .admin-login-card {
   background: var(--surface);
@@ -531,18 +638,6 @@ body {
 .admin-login-footer--end { justify-content: flex-end; }
 .admin-login-footer a { color: var(--text-muted); text-decoration: none; }
 .admin-login-footer a:hover { color: var(--text); }
-.admin-login-footer-links { display: flex; align-items: center; gap: 14px; }
-.admin-login-locales { display: flex; align-items: center; gap: 2px; }
-.admin-login-locale {
-  background: transparent; border: none;
-  font-family: inherit; font-size: 10px;
-  color: var(--text-muted);
-  padding: 2px 5px; border-radius: 4px;
-  cursor: pointer; letter-spacing: 0.05em;
-}
-.admin-login-locale.is-active {
-  background: var(--text); color: var(--bg);
-}
 
 /* ─── Admin apps table ───────────────────────────────────────── */
 .admin-table {

--- a/crates/ruscker-admin/assets/tailwind/input.css
+++ b/crates/ruscker-admin/assets/tailwind/input.css
@@ -456,11 +456,14 @@ body {
  * Three icon-buttons in a row, anchored top-right on every public-
  * facing page. Replaces the older footer theme/language pickers.
  *
- * Disclosure uses native `<details>/<summary>`. Each popover is
- * absolutely positioned underneath its summary; only one is open at
- * a time because clicking a sibling toggles the others closed in the
- * browser's native handling. Keyboard nav: Tab moves between
- * summaries, Enter/Space opens, Esc closes. No JS.
+ * Disclosure uses native `<details>/<summary>` with `name=
+ * "chrome-cluster"` — the HTML ExclusiveAccordion pattern. Opening
+ * one popover closes its named siblings (Safari 17+, Firefox 124+,
+ * Chrome 120+). Older browsers fall back to "all stay open", which
+ * is graceful degradation. Keyboard nav: Tab moves between
+ * summaries, Enter/Space toggles the active one (native `<details>`
+ * doesn't close on Esc — clicking the summary again or another sibling
+ * is the dismiss path). No JS.
  */
 .chrome-cluster {
   display: flex; align-items: center; gap: 4px;

--- a/crates/ruscker-admin/templates/_chrome_cluster.html
+++ b/crates/ruscker-admin/templates/_chrome_cluster.html
@@ -1,0 +1,92 @@
+{# Top-right chrome cluster: theme + language + sign-in/account. #}
+{# #}
+{# Used by the public landing. For /admin/login + /admin/setup use the #}
+{# `_chrome_cluster_anon.html` variant (no account slot); for the admin #}
+{# chrome itself use `_chrome_cluster_admin.html` (account from `role`). #}
+{# #}
+{# Required template fields: locale, theme, locales_all, #}
+{#                          signed_in: bool, viewer_name: String, #}
+{#                          show_admin_link: bool. #}
+{# #}
+{# Disclosure uses native `<details>/<summary>` — keyboard-accessible, #}
+{# no JS. Each popover wraps its POST form. #}
+<div class="chrome-cluster" role="group" aria-label="{{ self.t("chrome-cluster-label") }}">
+
+  {# ── Theme ──────────────────────────────────────────────────── #}
+  <details class="chrome-disclosure">
+    <summary class="chrome-icon" aria-label="{{ self.t("chrome-theme-label") }}" title="{{ self.t("chrome-theme-label") }}">
+      {% if theme.is_light() %}<i class="ti ti-sun" aria-hidden="true"></i>
+      {% else if theme.is_dark() %}<i class="ti ti-moon" aria-hidden="true"></i>
+      {% else %}<i class="ti ti-device-desktop" aria-hidden="true"></i>{% endif %}
+    </summary>
+    <form method="post" action="/__set/theme" class="chrome-popover" role="menu">
+      <button type="submit" name="theme" value="light"
+              class="chrome-popover-item {% if theme.is_light() %}is-current{% endif %}"
+              role="menuitemradio" aria-checked="{% if theme.is_light() %}true{% else %}false{% endif %}">
+        <i class="ti ti-sun" aria-hidden="true"></i> {{ self.t("theme-light") }}
+      </button>
+      <button type="submit" name="theme" value="dark"
+              class="chrome-popover-item {% if theme.is_dark() %}is-current{% endif %}"
+              role="menuitemradio" aria-checked="{% if theme.is_dark() %}true{% else %}false{% endif %}">
+        <i class="ti ti-moon" aria-hidden="true"></i> {{ self.t("theme-dark") }}
+      </button>
+      <button type="submit" name="theme" value="auto"
+              class="chrome-popover-item {% if theme.is_auto() %}is-current{% endif %}"
+              role="menuitemradio" aria-checked="{% if theme.is_auto() %}true{% else %}false{% endif %}">
+        <i class="ti ti-device-desktop" aria-hidden="true"></i> {{ self.t("theme-auto") }}
+      </button>
+    </form>
+  </details>
+
+  {# ── Language ───────────────────────────────────────────────── #}
+  <details class="chrome-disclosure">
+    <summary class="chrome-icon" aria-label="{{ self.t("chrome-language-label") }}" title="{{ self.t("chrome-language-label") }}">
+      <i class="ti ti-world" aria-hidden="true"></i>
+      <span class="chrome-icon-badge">{{ locale.code()|upper }}</span>
+    </summary>
+    <form method="post" action="/__set/locale" class="chrome-popover" role="menu">
+      {% for loc in locales_all %}
+        <button type="submit" name="locale" value="{{ loc.code() }}"
+                class="chrome-popover-item {% if *loc == locale %}is-current{% endif %}"
+                role="menuitemradio" aria-checked="{% if *loc == locale %}true{% else %}false{% endif %}">
+          <span class="chrome-popover-code">{{ loc.code()|upper }}</span> {{ loc.native_name() }}
+        </button>
+      {% endfor %}
+    </form>
+  </details>
+
+  {# ── Account ────────────────────────────────────────────────── #}
+  {% if signed_in %}
+    <details class="chrome-disclosure">
+      <summary class="chrome-icon" aria-label="{{ self.t("chrome-account-label") }}" title="{{ self.t("chrome-account-label") }}">
+        <i class="ti ti-user" aria-hidden="true"></i>
+      </summary>
+      <div class="chrome-popover" role="menu">
+        {% if !viewer_name.is_empty() %}
+          <div class="chrome-popover-user">
+            <span class="opacity-60">{{ self.t("chrome-signed-in-as-prefix") }}</span>
+            <strong>{{ viewer_name }}</strong>
+          </div>
+          <div class="chrome-popover-sep"></div>
+        {% endif %}
+        <a class="chrome-popover-item" href="/admin/dashboard" role="menuitem">
+          <i class="ti ti-layout-dashboard" aria-hidden="true"></i> {{ self.t("chrome-panel") }}
+        </a>
+        <a class="chrome-popover-item" href="/admin/account/password" role="menuitem">
+          <i class="ti ti-key" aria-hidden="true"></i> {{ self.t("chrome-change-password") }}
+        </a>
+        <div class="chrome-popover-sep"></div>
+        <form method="post" action="/admin/logout" class="contents">
+          <button type="submit" class="chrome-popover-item" role="menuitem">
+            <i class="ti ti-logout" aria-hidden="true"></i> {{ self.t("chrome-signout") }}
+          </button>
+        </form>
+      </div>
+    </details>
+  {% else if show_admin_link %}
+    <a class="chrome-signin" href="/admin/login" role="button">
+      <i class="ti ti-login" aria-hidden="true"></i>
+      <span>{{ self.t("chrome-signin") }}</span>
+    </a>
+  {% endif %}
+</div>

--- a/crates/ruscker-admin/templates/_chrome_cluster.html
+++ b/crates/ruscker-admin/templates/_chrome_cluster.html
@@ -13,42 +13,42 @@
 <div class="chrome-cluster" role="group" aria-label="{{ self.t("chrome-cluster-label") }}">
 
   {# ── Theme ──────────────────────────────────────────────────── #}
-  <details class="chrome-disclosure">
+  <details class="chrome-disclosure" name="chrome-cluster">
     <summary class="chrome-icon" aria-label="{{ self.t("chrome-theme-label") }}" title="{{ self.t("chrome-theme-label") }}">
       {% if theme.is_light() %}<i class="ti ti-sun" aria-hidden="true"></i>
       {% else if theme.is_dark() %}<i class="ti ti-moon" aria-hidden="true"></i>
       {% else %}<i class="ti ti-device-desktop" aria-hidden="true"></i>{% endif %}
     </summary>
-    <form method="post" action="/__set/theme" class="chrome-popover" role="menu">
+    <form method="post" action="/__set/theme" class="chrome-popover">
       <button type="submit" name="theme" value="light"
               class="chrome-popover-item {% if theme.is_light() %}is-current{% endif %}"
-              role="menuitemradio" aria-checked="{% if theme.is_light() %}true{% else %}false{% endif %}">
+              {% if theme.is_light() %}aria-current="true"{% endif %}>
         <i class="ti ti-sun" aria-hidden="true"></i> {{ self.t("theme-light") }}
       </button>
       <button type="submit" name="theme" value="dark"
               class="chrome-popover-item {% if theme.is_dark() %}is-current{% endif %}"
-              role="menuitemradio" aria-checked="{% if theme.is_dark() %}true{% else %}false{% endif %}">
+              {% if theme.is_dark() %}aria-current="true"{% endif %}>
         <i class="ti ti-moon" aria-hidden="true"></i> {{ self.t("theme-dark") }}
       </button>
       <button type="submit" name="theme" value="auto"
               class="chrome-popover-item {% if theme.is_auto() %}is-current{% endif %}"
-              role="menuitemradio" aria-checked="{% if theme.is_auto() %}true{% else %}false{% endif %}">
+              {% if theme.is_auto() %}aria-current="true"{% endif %}>
         <i class="ti ti-device-desktop" aria-hidden="true"></i> {{ self.t("theme-auto") }}
       </button>
     </form>
   </details>
 
   {# ── Language ───────────────────────────────────────────────── #}
-  <details class="chrome-disclosure">
+  <details class="chrome-disclosure" name="chrome-cluster">
     <summary class="chrome-icon" aria-label="{{ self.t("chrome-language-label") }}" title="{{ self.t("chrome-language-label") }}">
       <i class="ti ti-world" aria-hidden="true"></i>
       <span class="chrome-icon-badge">{{ locale.code()|upper }}</span>
     </summary>
-    <form method="post" action="/__set/locale" class="chrome-popover" role="menu">
+    <form method="post" action="/__set/locale" class="chrome-popover">
       {% for loc in locales_all %}
         <button type="submit" name="locale" value="{{ loc.code() }}"
                 class="chrome-popover-item {% if *loc == locale %}is-current{% endif %}"
-                role="menuitemradio" aria-checked="{% if *loc == locale %}true{% else %}false{% endif %}">
+                {% if *loc == locale %}aria-current="true"{% endif %}>
           <span class="chrome-popover-code">{{ loc.code()|upper }}</span> {{ loc.native_name() }}
         </button>
       {% endfor %}
@@ -57,11 +57,11 @@
 
   {# ── Account ────────────────────────────────────────────────── #}
   {% if signed_in %}
-    <details class="chrome-disclosure">
+    <details class="chrome-disclosure" name="chrome-cluster">
       <summary class="chrome-icon" aria-label="{{ self.t("chrome-account-label") }}" title="{{ self.t("chrome-account-label") }}">
         <i class="ti ti-user" aria-hidden="true"></i>
       </summary>
-      <div class="chrome-popover" role="menu">
+      <div class="chrome-popover">
         {% if !viewer_name.is_empty() %}
           <div class="chrome-popover-user">
             <span class="opacity-60">{{ self.t("chrome-signed-in-as-prefix") }}</span>
@@ -69,22 +69,22 @@
           </div>
           <div class="chrome-popover-sep"></div>
         {% endif %}
-        <a class="chrome-popover-item" href="/admin/dashboard" role="menuitem">
+        <a class="chrome-popover-item" href="/admin/dashboard">
           <i class="ti ti-layout-dashboard" aria-hidden="true"></i> {{ self.t("chrome-panel") }}
         </a>
-        <a class="chrome-popover-item" href="/admin/account/password" role="menuitem">
+        <a class="chrome-popover-item" href="/admin/account/password">
           <i class="ti ti-key" aria-hidden="true"></i> {{ self.t("chrome-change-password") }}
         </a>
         <div class="chrome-popover-sep"></div>
         <form method="post" action="/admin/logout" class="contents">
-          <button type="submit" class="chrome-popover-item" role="menuitem">
+          <button type="submit" class="chrome-popover-item">
             <i class="ti ti-logout" aria-hidden="true"></i> {{ self.t("chrome-signout") }}
           </button>
         </form>
       </div>
     </details>
   {% else if show_admin_link %}
-    <a class="chrome-signin" href="/admin/login" role="button">
+    <a class="chrome-signin" href="/admin/login">
       <i class="ti ti-login" aria-hidden="true"></i>
       <span>{{ self.t("chrome-signin") }}</span>
     </a>

--- a/crates/ruscker-admin/templates/_chrome_cluster_admin.html
+++ b/crates/ruscker-admin/templates/_chrome_cluster_admin.html
@@ -1,0 +1,80 @@
+{# Admin variant of the chrome cluster: theme + language + account. #}
+{# Used by admin/_layout.html and admin/account_password.html — pages #}
+{# that are always signed-in via AdminSession. The account slot reads #}
+{# the role directly (no username field needed on the calling struct). #}
+{# #}
+{# Required template fields: locale, theme, locales_all, role: Role. #}
+{# #}
+{# NOTE: this partial intentionally lives OUTSIDE any other form. The #}
+{# admin navbar is itself a top-level <nav>, not nested in a <form>. #}
+<div class="chrome-cluster" role="group" aria-label="{{ self.t("chrome-cluster-label") }}">
+
+  {# ── Theme ──────────────────────────────────────────────────── #}
+  <details class="chrome-disclosure">
+    <summary class="chrome-icon" aria-label="{{ self.t("chrome-theme-label") }}" title="{{ self.t("chrome-theme-label") }}">
+      {% if theme.is_light() %}<i class="ti ti-sun" aria-hidden="true"></i>
+      {% else if theme.is_dark() %}<i class="ti ti-moon" aria-hidden="true"></i>
+      {% else %}<i class="ti ti-device-desktop" aria-hidden="true"></i>{% endif %}
+    </summary>
+    <form method="post" action="/__set/theme" class="chrome-popover" role="menu">
+      <button type="submit" name="theme" value="light"
+              class="chrome-popover-item {% if theme.is_light() %}is-current{% endif %}"
+              role="menuitemradio" aria-checked="{% if theme.is_light() %}true{% else %}false{% endif %}">
+        <i class="ti ti-sun" aria-hidden="true"></i> {{ self.t("theme-light") }}
+      </button>
+      <button type="submit" name="theme" value="dark"
+              class="chrome-popover-item {% if theme.is_dark() %}is-current{% endif %}"
+              role="menuitemradio" aria-checked="{% if theme.is_dark() %}true{% else %}false{% endif %}">
+        <i class="ti ti-moon" aria-hidden="true"></i> {{ self.t("theme-dark") }}
+      </button>
+      <button type="submit" name="theme" value="auto"
+              class="chrome-popover-item {% if theme.is_auto() %}is-current{% endif %}"
+              role="menuitemradio" aria-checked="{% if theme.is_auto() %}true{% else %}false{% endif %}">
+        <i class="ti ti-device-desktop" aria-hidden="true"></i> {{ self.t("theme-auto") }}
+      </button>
+    </form>
+  </details>
+
+  {# ── Language ───────────────────────────────────────────────── #}
+  <details class="chrome-disclosure">
+    <summary class="chrome-icon" aria-label="{{ self.t("chrome-language-label") }}" title="{{ self.t("chrome-language-label") }}">
+      <i class="ti ti-world" aria-hidden="true"></i>
+      <span class="chrome-icon-badge">{{ locale.code()|upper }}</span>
+    </summary>
+    <form method="post" action="/__set/locale" class="chrome-popover" role="menu">
+      {% for loc in locales_all %}
+        <button type="submit" name="locale" value="{{ loc.code() }}"
+                class="chrome-popover-item {% if *loc == locale %}is-current{% endif %}"
+                role="menuitemradio" aria-checked="{% if *loc == locale %}true{% else %}false{% endif %}">
+          <span class="chrome-popover-code">{{ loc.code()|upper }}</span> {{ loc.native_name() }}
+        </button>
+      {% endfor %}
+    </form>
+  </details>
+
+  {# ── Account ────────────────────────────────────────────────── #}
+  <details class="chrome-disclosure">
+    <summary class="chrome-icon" aria-label="{{ self.t("chrome-account-label") }}" title="{{ self.t("chrome-account-label") }}">
+      <i class="ti ti-user" aria-hidden="true"></i>
+    </summary>
+    <div class="chrome-popover" role="menu">
+      <div class="chrome-popover-user">
+        <span class="opacity-60">{{ self.t("role-current") }}:</span>
+        <strong>{{ self.t(role.label_key()) }}</strong>
+      </div>
+      <div class="chrome-popover-sep"></div>
+      <a class="chrome-popover-item" href="/" role="menuitem">
+        <i class="ti ti-arrow-back-up" aria-hidden="true"></i> {{ self.t("admin-nav-portal") }}
+      </a>
+      <a class="chrome-popover-item" href="/admin/account/password" role="menuitem">
+        <i class="ti ti-key" aria-hidden="true"></i> {{ self.t("chrome-change-password") }}
+      </a>
+      <div class="chrome-popover-sep"></div>
+      <form method="post" action="/admin/logout" class="contents">
+        <button type="submit" class="chrome-popover-item" role="menuitem">
+          <i class="ti ti-logout" aria-hidden="true"></i> {{ self.t("chrome-signout") }}
+        </button>
+      </form>
+    </div>
+  </details>
+</div>

--- a/crates/ruscker-admin/templates/_chrome_cluster_admin.html
+++ b/crates/ruscker-admin/templates/_chrome_cluster_admin.html
@@ -10,42 +10,42 @@
 <div class="chrome-cluster" role="group" aria-label="{{ self.t("chrome-cluster-label") }}">
 
   {# ── Theme ──────────────────────────────────────────────────── #}
-  <details class="chrome-disclosure">
+  <details class="chrome-disclosure" name="chrome-cluster">
     <summary class="chrome-icon" aria-label="{{ self.t("chrome-theme-label") }}" title="{{ self.t("chrome-theme-label") }}">
       {% if theme.is_light() %}<i class="ti ti-sun" aria-hidden="true"></i>
       {% else if theme.is_dark() %}<i class="ti ti-moon" aria-hidden="true"></i>
       {% else %}<i class="ti ti-device-desktop" aria-hidden="true"></i>{% endif %}
     </summary>
-    <form method="post" action="/__set/theme" class="chrome-popover" role="menu">
+    <form method="post" action="/__set/theme" class="chrome-popover">
       <button type="submit" name="theme" value="light"
               class="chrome-popover-item {% if theme.is_light() %}is-current{% endif %}"
-              role="menuitemradio" aria-checked="{% if theme.is_light() %}true{% else %}false{% endif %}">
+              {% if theme.is_light() %}aria-current="true"{% endif %}>
         <i class="ti ti-sun" aria-hidden="true"></i> {{ self.t("theme-light") }}
       </button>
       <button type="submit" name="theme" value="dark"
               class="chrome-popover-item {% if theme.is_dark() %}is-current{% endif %}"
-              role="menuitemradio" aria-checked="{% if theme.is_dark() %}true{% else %}false{% endif %}">
+              {% if theme.is_dark() %}aria-current="true"{% endif %}>
         <i class="ti ti-moon" aria-hidden="true"></i> {{ self.t("theme-dark") }}
       </button>
       <button type="submit" name="theme" value="auto"
               class="chrome-popover-item {% if theme.is_auto() %}is-current{% endif %}"
-              role="menuitemradio" aria-checked="{% if theme.is_auto() %}true{% else %}false{% endif %}">
+              {% if theme.is_auto() %}aria-current="true"{% endif %}>
         <i class="ti ti-device-desktop" aria-hidden="true"></i> {{ self.t("theme-auto") }}
       </button>
     </form>
   </details>
 
   {# ── Language ───────────────────────────────────────────────── #}
-  <details class="chrome-disclosure">
+  <details class="chrome-disclosure" name="chrome-cluster">
     <summary class="chrome-icon" aria-label="{{ self.t("chrome-language-label") }}" title="{{ self.t("chrome-language-label") }}">
       <i class="ti ti-world" aria-hidden="true"></i>
       <span class="chrome-icon-badge">{{ locale.code()|upper }}</span>
     </summary>
-    <form method="post" action="/__set/locale" class="chrome-popover" role="menu">
+    <form method="post" action="/__set/locale" class="chrome-popover">
       {% for loc in locales_all %}
         <button type="submit" name="locale" value="{{ loc.code() }}"
                 class="chrome-popover-item {% if *loc == locale %}is-current{% endif %}"
-                role="menuitemradio" aria-checked="{% if *loc == locale %}true{% else %}false{% endif %}">
+                {% if *loc == locale %}aria-current="true"{% endif %}>
           <span class="chrome-popover-code">{{ loc.code()|upper }}</span> {{ loc.native_name() }}
         </button>
       {% endfor %}
@@ -53,25 +53,25 @@
   </details>
 
   {# ── Account ────────────────────────────────────────────────── #}
-  <details class="chrome-disclosure">
+  <details class="chrome-disclosure" name="chrome-cluster">
     <summary class="chrome-icon" aria-label="{{ self.t("chrome-account-label") }}" title="{{ self.t("chrome-account-label") }}">
       <i class="ti ti-user" aria-hidden="true"></i>
     </summary>
-    <div class="chrome-popover" role="menu">
+    <div class="chrome-popover">
       <div class="chrome-popover-user">
         <span class="opacity-60">{{ self.t("role-current") }}:</span>
         <strong>{{ self.t(role.label_key()) }}</strong>
       </div>
       <div class="chrome-popover-sep"></div>
-      <a class="chrome-popover-item" href="/" role="menuitem">
+      <a class="chrome-popover-item" href="/">
         <i class="ti ti-arrow-back-up" aria-hidden="true"></i> {{ self.t("admin-nav-portal") }}
       </a>
-      <a class="chrome-popover-item" href="/admin/account/password" role="menuitem">
+      <a class="chrome-popover-item" href="/admin/account/password">
         <i class="ti ti-key" aria-hidden="true"></i> {{ self.t("chrome-change-password") }}
       </a>
       <div class="chrome-popover-sep"></div>
       <form method="post" action="/admin/logout" class="contents">
-        <button type="submit" class="chrome-popover-item" role="menuitem">
+        <button type="submit" class="chrome-popover-item">
           <i class="ti ti-logout" aria-hidden="true"></i> {{ self.t("chrome-signout") }}
         </button>
       </form>

--- a/crates/ruscker-admin/templates/_chrome_cluster_anon.html
+++ b/crates/ruscker-admin/templates/_chrome_cluster_anon.html
@@ -11,41 +11,41 @@
 {# (login.html / setup.html do this via `<div class="absolute top-4 right-4">` #}
 {# in `<body>` before the card form). #}
 <div class="chrome-cluster" role="group" aria-label="{{ self.t("chrome-cluster-label") }}">
-  <details class="chrome-disclosure">
+  <details class="chrome-disclosure" name="chrome-cluster">
     <summary class="chrome-icon" aria-label="{{ self.t("chrome-theme-label") }}" title="{{ self.t("chrome-theme-label") }}">
       {% if theme.is_light() %}<i class="ti ti-sun" aria-hidden="true"></i>
       {% else if theme.is_dark() %}<i class="ti ti-moon" aria-hidden="true"></i>
       {% else %}<i class="ti ti-device-desktop" aria-hidden="true"></i>{% endif %}
     </summary>
-    <form method="post" action="/__set/theme" class="chrome-popover" role="menu">
+    <form method="post" action="/__set/theme" class="chrome-popover">
       <button type="submit" name="theme" value="light"
               class="chrome-popover-item {% if theme.is_light() %}is-current{% endif %}"
-              role="menuitemradio" aria-checked="{% if theme.is_light() %}true{% else %}false{% endif %}">
+              {% if theme.is_light() %}aria-current="true"{% endif %}>
         <i class="ti ti-sun" aria-hidden="true"></i> {{ self.t("theme-light") }}
       </button>
       <button type="submit" name="theme" value="dark"
               class="chrome-popover-item {% if theme.is_dark() %}is-current{% endif %}"
-              role="menuitemradio" aria-checked="{% if theme.is_dark() %}true{% else %}false{% endif %}">
+              {% if theme.is_dark() %}aria-current="true"{% endif %}>
         <i class="ti ti-moon" aria-hidden="true"></i> {{ self.t("theme-dark") }}
       </button>
       <button type="submit" name="theme" value="auto"
               class="chrome-popover-item {% if theme.is_auto() %}is-current{% endif %}"
-              role="menuitemradio" aria-checked="{% if theme.is_auto() %}true{% else %}false{% endif %}">
+              {% if theme.is_auto() %}aria-current="true"{% endif %}>
         <i class="ti ti-device-desktop" aria-hidden="true"></i> {{ self.t("theme-auto") }}
       </button>
     </form>
   </details>
 
-  <details class="chrome-disclosure">
+  <details class="chrome-disclosure" name="chrome-cluster">
     <summary class="chrome-icon" aria-label="{{ self.t("chrome-language-label") }}" title="{{ self.t("chrome-language-label") }}">
       <i class="ti ti-world" aria-hidden="true"></i>
       <span class="chrome-icon-badge">{{ locale.code()|upper }}</span>
     </summary>
-    <form method="post" action="/__set/locale" class="chrome-popover" role="menu">
+    <form method="post" action="/__set/locale" class="chrome-popover">
       {% for loc in locales_all %}
         <button type="submit" name="locale" value="{{ loc.code() }}"
                 class="chrome-popover-item {% if *loc == locale %}is-current{% endif %}"
-                role="menuitemradio" aria-checked="{% if *loc == locale %}true{% else %}false{% endif %}">
+                {% if *loc == locale %}aria-current="true"{% endif %}>
           <span class="chrome-popover-code">{{ loc.code()|upper }}</span> {{ loc.native_name() }}
         </button>
       {% endfor %}

--- a/crates/ruscker-admin/templates/_chrome_cluster_anon.html
+++ b/crates/ruscker-admin/templates/_chrome_cluster_anon.html
@@ -1,0 +1,54 @@
+{# Anonymous variant of the chrome cluster: theme + language only. #}
+{# Used by /admin/login and /admin/setup — pages where the third slot #}
+{# (account) doesn't apply because the user is in the process of signing #}
+{# in. See `_chrome_cluster.html` for the full version. #}
+{# #}
+{# Required template fields: locale, theme, locales_all. #}
+{# #}
+{# This partial MUST sit outside the page's main form. The popovers wrap #}
+{# `<form>` tags, and HTML5 forbids nested forms — the calling template is #}
+{# responsible for positioning the cluster as a sibling of its main form #}
+{# (login.html / setup.html do this via `<div class="absolute top-4 right-4">` #}
+{# in `<body>` before the card form). #}
+<div class="chrome-cluster" role="group" aria-label="{{ self.t("chrome-cluster-label") }}">
+  <details class="chrome-disclosure">
+    <summary class="chrome-icon" aria-label="{{ self.t("chrome-theme-label") }}" title="{{ self.t("chrome-theme-label") }}">
+      {% if theme.is_light() %}<i class="ti ti-sun" aria-hidden="true"></i>
+      {% else if theme.is_dark() %}<i class="ti ti-moon" aria-hidden="true"></i>
+      {% else %}<i class="ti ti-device-desktop" aria-hidden="true"></i>{% endif %}
+    </summary>
+    <form method="post" action="/__set/theme" class="chrome-popover" role="menu">
+      <button type="submit" name="theme" value="light"
+              class="chrome-popover-item {% if theme.is_light() %}is-current{% endif %}"
+              role="menuitemradio" aria-checked="{% if theme.is_light() %}true{% else %}false{% endif %}">
+        <i class="ti ti-sun" aria-hidden="true"></i> {{ self.t("theme-light") }}
+      </button>
+      <button type="submit" name="theme" value="dark"
+              class="chrome-popover-item {% if theme.is_dark() %}is-current{% endif %}"
+              role="menuitemradio" aria-checked="{% if theme.is_dark() %}true{% else %}false{% endif %}">
+        <i class="ti ti-moon" aria-hidden="true"></i> {{ self.t("theme-dark") }}
+      </button>
+      <button type="submit" name="theme" value="auto"
+              class="chrome-popover-item {% if theme.is_auto() %}is-current{% endif %}"
+              role="menuitemradio" aria-checked="{% if theme.is_auto() %}true{% else %}false{% endif %}">
+        <i class="ti ti-device-desktop" aria-hidden="true"></i> {{ self.t("theme-auto") }}
+      </button>
+    </form>
+  </details>
+
+  <details class="chrome-disclosure">
+    <summary class="chrome-icon" aria-label="{{ self.t("chrome-language-label") }}" title="{{ self.t("chrome-language-label") }}">
+      <i class="ti ti-world" aria-hidden="true"></i>
+      <span class="chrome-icon-badge">{{ locale.code()|upper }}</span>
+    </summary>
+    <form method="post" action="/__set/locale" class="chrome-popover" role="menu">
+      {% for loc in locales_all %}
+        <button type="submit" name="locale" value="{{ loc.code() }}"
+                class="chrome-popover-item {% if *loc == locale %}is-current{% endif %}"
+                role="menuitemradio" aria-checked="{% if *loc == locale %}true{% else %}false{% endif %}">
+          <span class="chrome-popover-code">{{ loc.code()|upper }}</span> {{ loc.native_name() }}
+        </button>
+      {% endfor %}
+    </form>
+  </details>
+</div>

--- a/crates/ruscker-admin/templates/_layout.html
+++ b/crates/ruscker-admin/templates/_layout.html
@@ -21,37 +21,11 @@
 
 {% block content %}{% endblock %}
 
-<footer class="mt-auto border-t border-[color:var(--border)] py-4 px-6 text-xs text-[color:var(--text-muted)] flex flex-wrap items-center gap-6">
-  <div class="flex items-center gap-2">
-    <span>{{ self.t("footer-language") }}:</span>
-    <form method="post" action="/__set/locale" class="contents">
-      {% for loc in locales_all %}
-        <button type="submit" name="locale" value="{{ loc.code() }}"
-                class="px-2 py-0.5 rounded {% if *loc == locale %}bg-[color:var(--text)] text-[color:var(--bg)] font-medium{% else %}hover:bg-[color:var(--border)]{% endif %}"
-                aria-current="{% if *loc == locale %}true{% else %}false{% endif %}">
-          {{ loc.native_name() }}
-        </button>
-      {% endfor %}
-    </form>
-  </div>
-
-  <div class="flex items-center gap-2">
-    <span>{{ self.t("footer-theme") }}:</span>
-    <form method="post" action="/__set/theme" class="contents">
-      <button type="submit" name="theme" value="light"
-              class="px-2 py-0.5 rounded {% if theme.is_light() %}bg-[color:var(--text)] text-[color:var(--bg)] font-medium{% else %}hover:bg-[color:var(--border)]{% endif %}">{{ self.t("theme-light") }}</button>
-      <button type="submit" name="theme" value="dark"
-              class="px-2 py-0.5 rounded {% if theme.is_dark() %}bg-[color:var(--text)] text-[color:var(--bg)] font-medium{% else %}hover:bg-[color:var(--border)]{% endif %}">{{ self.t("theme-dark") }}</button>
-      <button type="submit" name="theme" value="auto"
-              class="px-2 py-0.5 rounded {% if theme.is_auto() %}bg-[color:var(--text)] text-[color:var(--bg)] font-medium{% else %}hover:bg-[color:var(--border)]{% endif %}">{{ self.t("theme-auto") }}</button>
-    </form>
-  </div>
-
-  {# "Powered by" lockup — uses the inline mark + wordmark text so
-     the typography matches whatever Jost variant the page already
-     loaded; doesn't require a second HTTP request for the SVG
-     lockup file. #}
-  <a class="ml-auto inline-flex items-center gap-2 opacity-70 hover:opacity-100 transition-opacity"
+{# Footer slimmed down to just the "powered by" lockup (#182). Theme
+   and language pickers moved into the top-right chrome cluster on every
+   page. #}
+<footer class="mt-auto border-t border-[color:var(--border)] py-4 px-6 text-xs text-[color:var(--text-muted)] flex items-center justify-end">
+  <a class="inline-flex items-center gap-2 opacity-70 hover:opacity-100 transition-opacity"
      href="https://github.com/StrategicProjects/ruscker"
      aria-label="Ruscker">
     <svg class="brand-mark-inline" viewBox="0 0 80 80" width="20" height="20" aria-hidden="true">

--- a/crates/ruscker-admin/templates/admin/_layout.html
+++ b/crates/ruscker-admin/templates/admin/_layout.html
@@ -92,20 +92,10 @@
   </div>
 
   <div class="admin-nav-actions">
-    <span class="admin-nav-role" title="{{ self.t("role-current") }}">
-      <i class="ti ti-user-shield" aria-hidden="true"></i>
-      <span>{{ self.t(role.label_key()) }}</span>
-    </span>
-    <a href="/" class="admin-nav-link" title="{{ self.t("admin-nav-portal") }}">
-      <i class="ti ti-arrow-back-up" aria-hidden="true"></i>
-      <span>{{ self.t("admin-nav-portal") }}</span>
-    </a>
-    <form method="post" action="/admin/logout" class="contents">
-      <button type="submit" class="admin-nav-link admin-nav-link--logout">
-        <i class="ti ti-logout" aria-hidden="true"></i>
-        <span>{{ self.t("admin-nav-logout") }}</span>
-      </button>
-    </form>
+    {# #182 + #183: chrome cluster replaces the per-link role/portal/logout
+       trio. Theme + language + account-popover (panel/change-password/
+       logout) all live here now. #}
+    {% include "_chrome_cluster_admin.html" %}
   </div>
 </nav>
 {% endblock %}
@@ -159,35 +149,19 @@ window.ruscker.bgMode = (value) =>
   {% block content %}{% endblock %}
 </main>
 
-{# Preference footer — same language + theme options as the public
-   portal. Posts to the shared /__set/* endpoints, which set the
-   cookie and redirect back here (Referer), so the admin re-renders
-   in the chosen locale/theme. #}
-<footer class="mt-auto border-t border-[color:var(--border)] py-4 px-6 text-xs text-[color:var(--text-muted)] flex flex-wrap items-center gap-6">
-  <div class="flex items-center gap-2">
-    <span>{{ self.t("footer-language") }}:</span>
-    <form method="post" action="/__set/locale" class="contents">
-      {% for loc in locales_all %}
-        <button type="submit" name="locale" value="{{ loc.code() }}"
-                class="px-2 py-0.5 rounded {% if *loc == locale %}bg-[color:var(--text)] text-[color:var(--bg)] font-medium{% else %}hover:bg-[color:var(--border)]{% endif %}"
-                aria-current="{% if *loc == locale %}true{% else %}false{% endif %}">
-          {{ loc.native_name() }}
-        </button>
-      {% endfor %}
-    </form>
-  </div>
-
-  <div class="flex items-center gap-2">
-    <span>{{ self.t("footer-theme") }}:</span>
-    <form method="post" action="/__set/theme" class="contents">
-      <button type="submit" name="theme" value="light"
-              class="px-2 py-0.5 rounded {% if theme.is_light() %}bg-[color:var(--text)] text-[color:var(--bg)] font-medium{% else %}hover:bg-[color:var(--border)]{% endif %}">{{ self.t("theme-light") }}</button>
-      <button type="submit" name="theme" value="dark"
-              class="px-2 py-0.5 rounded {% if theme.is_dark() %}bg-[color:var(--text)] text-[color:var(--bg)] font-medium{% else %}hover:bg-[color:var(--border)]{% endif %}">{{ self.t("theme-dark") }}</button>
-      <button type="submit" name="theme" value="auto"
-              class="px-2 py-0.5 rounded {% if theme.is_auto() %}bg-[color:var(--text)] text-[color:var(--bg)] font-medium{% else %}hover:bg-[color:var(--border)]{% endif %}">{{ self.t("theme-auto") }}</button>
-    </form>
-  </div>
+{# Footer trimmed — theme + language pickers moved into the top-right
+   chrome cluster in the navbar (#182 + #183). #}
+<footer class="mt-auto border-t border-[color:var(--border)] py-3 px-6 text-xs text-[color:var(--text-muted)] flex items-center justify-end">
+  <a class="inline-flex items-center gap-2 opacity-70 hover:opacity-100 transition-opacity"
+     href="https://github.com/StrategicProjects/ruscker"
+     aria-label="Ruscker">
+    <svg class="brand-mark-inline" viewBox="0 0 80 80" width="18" height="18" aria-hidden="true">
+      <polygon points="14,52 40,40 66,52 40,64" fill="#0F6E56"/>
+      <polygon points="14,40 40,28 66,40 40,52" fill="#1D9E75"/>
+      <polygon points="14,28 40,16 66,28 40,40" fill="#5DCAA5"/>
+    </svg>
+    <span class="brand-wordmark">ruscker · admin</span>
+  </a>
 </footer>
 
 </body>

--- a/crates/ruscker-admin/templates/admin/login.html
+++ b/crates/ruscker-admin/templates/admin/login.html
@@ -10,7 +10,14 @@
 <link rel="stylesheet" href="/assets/styles.css">
 <link rel="stylesheet" href="/assets/icons/tabler-icons.min.css">
 </head>
-<body class="min-h-screen flex flex-col items-center justify-center px-4">
+<body class="min-h-screen flex flex-col items-center justify-center px-4 relative">
+
+{# Top-right chrome cluster (#182 + #183). Lives outside the login form
+   so its POSTs to /__set/{theme,locale} aren't shadowed by the outer
+   form's action. Absolute-positioned in the body corner. #}
+<div class="absolute top-4 right-4 z-50">
+  {% include "_chrome_cluster_anon.html" %}
+</div>
 
 <form method="post" action="{% if bootstrap %}/admin/login/token{% else %}/admin/login{% endif %}"
       class="admin-login-card" autocomplete="off">
@@ -62,32 +69,15 @@
     {{ self.t("admin-login-submit") }}
   </button>
 
-  <div class="admin-login-footer">
-    <div class="admin-login-footer-links">
-      {% if bootstrap %}
-        <a href="/admin/login">{{ self.t("admin-login-use-password") }}</a>
-      {% else %}
-        <a href="/admin/login?token=1">{{ self.t("admin-login-use-token") }}</a>
-      {% endif %}
-      <a href="/">{{ self.t("admin-login-back-portal") }}</a>
-    </div>
-    {# #181: nesting a `<form>` inside the outer login form is invalid HTML —
-       browsers silently ignore the inner action and submit the outer one,
-       so picking a locale was posting empty credentials to /admin/login.
-       Use `formaction` + `formnovalidate` to override the submission target
-       per-button without leaving the parent form. The base-path rewriter
-       already covers `button[formaction]`. #}
-    <div class="admin-login-locales" role="group" aria-label="{{ self.t("admin-login-locale-group") }}">
-      {% for loc in locales_all %}
-        <button type="submit" name="locale" value="{{ loc.code() }}"
-                formaction="/__set/locale" formmethod="post" formnovalidate
-                aria-label="{{ loc.native_name() }}"
-                {% if *loc == locale %}aria-current="true"{% endif %}
-                class="admin-login-locale {% if *loc == locale %}is-active{% endif %}">
-          {{ loc.code()|upper }}
-        </button>
-      {% endfor %}
-    </div>
+  {# Secondary links only — theme + language moved to the top-right
+     chrome cluster (#182 + #183). #}
+  <div class="admin-login-footer admin-login-footer--end">
+    {% if bootstrap %}
+      <a href="/admin/login">{{ self.t("admin-login-use-password") }}</a>
+    {% else %}
+      <a href="/admin/login?token=1">{{ self.t("admin-login-use-token") }}</a>
+    {% endif %}
+    <a href="/">{{ self.t("admin-login-back-portal") }}</a>
   </div>
 </form>
 

--- a/crates/ruscker-admin/templates/admin/setup.html
+++ b/crates/ruscker-admin/templates/admin/setup.html
@@ -10,7 +10,12 @@
 <link rel="stylesheet" href="/assets/styles.css">
 <link rel="stylesheet" href="/assets/icons/tabler-icons.min.css">
 </head>
-<body class="min-h-screen flex flex-col items-center justify-center px-4">
+<body class="min-h-screen flex flex-col items-center justify-center px-4 relative">
+
+{# Top-right chrome cluster (#182 + #183). Outside the outer form. #}
+<div class="absolute top-4 right-4 z-50">
+  {% include "_chrome_cluster_anon.html" %}
+</div>
 
 <form method="post" action="/admin/setup" class="admin-login-card" autocomplete="off">
 
@@ -54,20 +59,7 @@
     {{ self.t("admin-setup-submit") }}
   </button>
 
-  <div class="admin-login-footer admin-login-footer--end">
-    {# #181: see login.html — nested forms are invalid; use `formaction`. #}
-    <div class="admin-login-locales" role="group" aria-label="{{ self.t("admin-login-locale-group") }}">
-      {% for loc in locales_all %}
-        <button type="submit" name="locale" value="{{ loc.code() }}"
-                formaction="/__set/locale" formmethod="post" formnovalidate
-                aria-label="{{ loc.native_name() }}"
-                {% if *loc == locale %}aria-current="true"{% endif %}
-                class="admin-login-locale {% if *loc == locale %}is-active{% endif %}">
-          {{ loc.code()|upper }}
-        </button>
-      {% endfor %}
-    </div>
-  </div>
+  {# Theme + language moved to the top-right chrome cluster (#182 + #183). #}
 </form>
 
 </body>

--- a/crates/ruscker-admin/templates/landing.html
+++ b/crates/ruscker-admin/templates/landing.html
@@ -17,31 +17,21 @@
 
 <header class="border-b border-[color:var(--border)]"
         {% if !header_style.is_empty() %}style="{{ header_style }}"{% endif %}>
-  <div class="max-w-6xl mx-auto px-6 py-5 flex items-center justify-between">
-    <div>
-      <h1 class="text-xl font-medium tracking-tight">{{ self.t("landing-title") }}</h1>
-      <p class="text-xs opacity-70 mt-1">{{ self.t("landing-subtitle") }}</p>
+  <div class="max-w-6xl mx-auto px-6 py-5 flex items-center justify-between gap-6">
+    <div class="flex items-center gap-3">
+      {# Small Ruscker mark left of the operator-provided title (#182).
+         Future: operators can override with `landing-customization.logo`. #}
+      <svg viewBox="0 0 80 80" width="28" height="28" aria-hidden="true" class="flex-none">
+        <polygon points="14,52 40,40 66,52 40,64" fill="#0F6E56"/>
+        <polygon points="14,40 40,28 66,40 40,52" fill="#1D9E75"/>
+        <polygon points="14,28 40,16 66,28 40,40" fill="#5DCAA5"/>
+      </svg>
+      <div>
+        <h1 class="text-xl font-medium tracking-tight">{{ self.t("landing-title") }}</h1>
+        <p class="text-xs opacity-70 mt-1">{{ self.t("landing-subtitle") }}</p>
+      </div>
     </div>
-    <div class="flex items-center gap-4 text-xs">
-      <span class="opacity-70">{{ counts.total }}</span>
-      {% if signed_in %}
-        {% if !viewer_name.is_empty() %}
-          <span class="opacity-70 hidden sm:inline">{{ self.t_with("landing-signed-in-as", "user", viewer_name.as_str()) }}</span>
-        {% endif %}
-        <a class="inline-flex items-center gap-1 opacity-80 hover:opacity-100" href="/admin/dashboard">
-          <i class="ti ti-layout-dashboard" aria-hidden="true"></i> {{ self.t("landing-panel") }}
-        </a>
-        <form method="post" action="/admin/logout" class="inline">
-          <button type="submit" class="inline-flex items-center gap-1 opacity-80 hover:opacity-100 bg-transparent border-0 cursor-pointer font-inherit text-inherit">
-            <i class="ti ti-logout" aria-hidden="true"></i> {{ self.t("landing-signout") }}
-          </button>
-        </form>
-      {% else if show_admin_link %}
-        <a class="inline-flex items-center gap-1 opacity-80 hover:opacity-100" href="/admin/login">
-          <i class="ti ti-login" aria-hidden="true"></i> {{ self.t("landing-signin") }}
-        </a>
-      {% endif %}
-    </div>
+    {% include "_chrome_cluster.html" %}
   </div>
 </header>
 

--- a/crates/ruscker-admin/tests/user_accounts.rs
+++ b/crates/ruscker-admin/tests/user_accounts.rs
@@ -129,14 +129,43 @@ async fn first_login_with_must_change_redirects_to_password() {
     assert_eq!(loc, "/admin/account/password");
 }
 
+/// Count `<form ` opens, then verify none of them is nested inside
+/// another `<form>`. Cheap structural check that doesn't need an HTML
+/// parser. Returns `(open_count, max_depth)`.
+fn form_nesting(body: &str) -> (usize, usize) {
+    let mut depth: usize = 0;
+    let mut max: usize = 0;
+    let mut opens: usize = 0;
+    let bytes = body.as_bytes();
+    let mut i = 0;
+    while i + 6 <= bytes.len() {
+        if &bytes[i..i + 6] == b"<form " {
+            opens += 1;
+            depth += 1;
+            if depth > max {
+                max = depth;
+            }
+            i += 6;
+        } else if i + 7 <= bytes.len() && &bytes[i..i + 7] == b"</form>" {
+            depth = depth.saturating_sub(1);
+            i += 7;
+        } else {
+            i += 1;
+        }
+    }
+    (opens, max)
+}
+
 #[tokio::test]
-async fn login_page_has_no_nested_form_and_uses_formaction_for_locale() {
-    // #181: the locale picker in /admin/login was wrapped in a second
-    // `<form action="/__set/locale">` inside the outer login form.
-    // Nested `<form>` is invalid HTML and browsers ignore the inner
-    // one — clicking a locale button posted empty credentials to
-    // /admin/login. The fix uses `formaction` + `formnovalidate` on the
-    // buttons so the per-button submission target is honored.
+async fn login_page_chrome_cluster_is_outside_the_login_form() {
+    // #182 + #183: theme + language pickers moved into a top-right
+    // chrome cluster that lives in `<body>` BEFORE the login form.
+    // Each picker is its own POST form sibling to the login form.
+    //
+    // Originally (#181) the cluster was inside the card and used
+    // `formaction` to escape the outer login form. With the cluster
+    // hoisted into the body, regular `<form>` wrappers are fine and
+    // the formaction trick is no longer needed.
     let (state, _pool) = state_with_db().await;
     let app = router(state);
     let resp = app
@@ -154,41 +183,38 @@ async fn login_page_has_no_nested_form_and_uses_formaction_for_locale() {
         .unwrap();
     let body = std::str::from_utf8(&bytes).unwrap();
 
-    // Exactly one `<form>` on the page (the outer login form). The old
-    // nested-form bug would push this above 1.
-    let form_count = body.matches("<form ").count();
-    assert_eq!(form_count, 1, "expected exactly one <form>, got {form_count}");
+    // 3 sibling forms expected: theme picker + locale picker + the
+    // outer login form. None nested.
+    let (opens, max_depth) = form_nesting(body);
+    assert_eq!(opens, 3, "expected 3 sibling <form> tags, got {opens}");
+    assert_eq!(max_depth, 1, "no <form> should be nested inside another");
 
-    // The locale buttons must override the submission via formaction.
+    // The chrome cluster's POSTs must target the same endpoints the
+    // old footer used.
     assert!(
-        body.contains(r#"formaction="/__set/locale""#),
-        "locale buttons missing formaction"
+        body.contains(r#"action="/__set/theme""#),
+        "chrome theme form should POST to /__set/theme"
     );
     assert!(
-        body.contains("formnovalidate"),
-        "locale buttons must skip required-field validation"
+        body.contains(r#"action="/__set/locale""#),
+        "chrome locale form should POST to /__set/locale"
     );
-    // Accessibility: the locale group + active locale must be
-    // announced (a screen-reader user otherwise hears "PT, submit
-    // button" four times in a row with no context).
-    // Role + a labelled group. Don't assert the label text — the
-    // default locale is pt-BR, so it'd be "Idioma"; assertion stays
-    // locale-agnostic by checking the attribute scaffolding only.
+    // The cluster itself.
     assert!(
-        body.contains(r#"class="admin-login-locales" role="group" aria-label="#),
-        "locale group should be announced as a labelled group"
+        body.contains(r#"class="chrome-cluster""#),
+        "chrome cluster scaffolding missing"
     );
+    // Active locale carries aria-checked=true via the menuitemradio.
     assert!(
-        body.contains(r#"aria-current="true""#),
-        "active locale should carry aria-current"
+        body.contains(r#"aria-checked="true""#),
+        "active locale/theme should carry aria-checked"
     );
 }
 
 #[tokio::test]
-async fn setup_page_has_no_nested_form_and_uses_formaction_for_locale() {
-    // Twin assertion of `login_page_has_no_nested_form_...` for the
-    // first-admin bootstrap (`/admin/setup`). The same nested-form
-    // bug existed here and was fixed in the same PR.
+async fn setup_page_chrome_cluster_is_outside_the_setup_form() {
+    // Twin of `login_page_chrome_cluster_is_outside_the_login_form` for
+    // /admin/setup.
     let (state, _pool) = state_with_db().await;
     let sid = state.admin_sessions.create(Role::Admin, None);
     let cookie = format!("{COOKIE_NAME}={sid}");
@@ -209,22 +235,20 @@ async fn setup_page_has_no_nested_form_and_uses_formaction_for_locale() {
         .unwrap();
     let body = std::str::from_utf8(&bytes).unwrap();
 
-    let form_count = body.matches("<form ").count();
-    assert_eq!(form_count, 1, "expected exactly one <form>, got {form_count}");
+    let (opens, max_depth) = form_nesting(body);
+    assert_eq!(opens, 3, "expected 3 sibling <form> tags, got {opens}");
+    assert_eq!(max_depth, 1, "no <form> should be nested inside another");
     assert!(
-        body.contains(r#"formaction="/__set/locale""#),
-        "setup locale buttons missing formaction"
+        body.contains(r#"action="/__set/theme""#),
+        "chrome theme form should POST to /__set/theme"
     );
     assert!(
-        body.contains("formnovalidate"),
-        "setup locale buttons must skip required-field validation"
+        body.contains(r#"action="/__set/locale""#),
+        "chrome locale form should POST to /__set/locale"
     );
-    // Role + a labelled group. Don't assert the label text — the
-    // default locale is pt-BR, so it'd be "Idioma"; assertion stays
-    // locale-agnostic by checking the attribute scaffolding only.
     assert!(
-        body.contains(r#"class="admin-login-locales" role="group" aria-label="#),
-        "locale group should be announced as a labelled group"
+        body.contains(r#"class="chrome-cluster""#),
+        "chrome cluster scaffolding missing"
     );
 }
 

--- a/crates/ruscker-admin/tests/user_accounts.rs
+++ b/crates/ruscker-admin/tests/user_accounts.rs
@@ -204,10 +204,12 @@ async fn login_page_chrome_cluster_is_outside_the_login_form() {
         body.contains(r#"class="chrome-cluster""#),
         "chrome cluster scaffolding missing"
     );
-    // Active locale carries aria-checked=true via the menuitemradio.
+    // Active locale + active theme carry aria-current="true" — the
+    // current-selection ARIA pattern (we dropped the menuitemradio
+    // role + aria-checked combo per the #195 review).
     assert!(
-        body.contains(r#"aria-checked="true""#),
-        "active locale/theme should carry aria-checked"
+        body.contains(r#"aria-current="true""#),
+        "active locale/theme should carry aria-current"
     );
 }
 

--- a/docs/mockups/landing-chrome-redesign.html
+++ b/docs/mockups/landing-chrome-redesign.html
@@ -1,0 +1,281 @@
+<!doctype html>
+<html lang="en">
+<head>
+<meta charset="utf-8">
+<title>Chrome redesign — top-right cluster (#182 + #183)</title>
+<link rel="stylesheet" href="_shared.css">
+<link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/@tabler/icons-webfont@3.5.0/dist/tabler-icons.min.css">
+<style>
+  body { font-family: var(--font-sans); background: var(--color-background-tertiary); margin: 0; padding: 36px 24px; color: var(--color-text-primary); }
+  h1 { font-size: 18px; font-weight: 600; margin: 0 0 6px; }
+  .lede { color: var(--color-text-secondary); font-size: 13px; margin: 0 0 28px; max-width: 720px; line-height: 1.5; }
+
+  /* Each preview is a self-contained card with a fake browser frame
+     so the user can compare the three states side-by-side. */
+  .preview { background: var(--color-background-primary); border: 0.5px solid var(--color-border-tertiary); border-radius: 12px; overflow: hidden; margin-bottom: 22px; }
+  .preview-bar { padding: 6px 10px; background: var(--color-background-secondary); border-bottom: 0.5px solid var(--color-border-tertiary); font-size: 10px; letter-spacing: 0.04em; text-transform: uppercase; color: var(--color-text-secondary); display: flex; align-items: center; gap: 6px; }
+  .preview-bar .url { font-family: var(--font-mono); text-transform: none; letter-spacing: 0; }
+
+  /* ── Chrome (header + footer) ──────────────────────────────────── */
+
+  .ruscker-header { padding: 16px 24px; border-bottom: 0.5px solid var(--color-border-tertiary); display: flex; align-items: center; justify-content: space-between; gap: 18px; background: var(--color-background-primary); }
+  .ruscker-header.dark { background: #1f1f1f; color: #f0f0f0; border-bottom-color: rgba(255,255,255,0.08); }
+
+  .ruscker-brand { display: flex; align-items: center; gap: 10px; }
+  .ruscker-mark { flex: 0 0 28px; }
+  .ruscker-title { font-size: 16px; font-weight: 500; letter-spacing: -0.01em; line-height: 1.1; }
+  .ruscker-subtitle { font-size: 11px; opacity: 0.6; margin-top: 2px; line-height: 1.1; }
+
+  /* The cluster itself: three icon-buttons in a row.
+     Each is round-ish (10px radius), 32px tall, subtle border.
+     The active popover anchors directly underneath. */
+  .chrome-cluster { display: flex; align-items: center; gap: 4px; position: relative; }
+  .chrome-icon { width: 32px; height: 32px; display: inline-flex; align-items: center; justify-content: center; background: transparent; border: 0.5px solid var(--color-border-tertiary); border-radius: 10px; cursor: pointer; color: inherit; transition: background 0.12s, border-color 0.12s; position: relative; font-size: 16px; }
+  .chrome-icon:hover { background: var(--color-background-secondary); border-color: var(--color-border-secondary); }
+  .chrome-icon.is-active { background: var(--color-text-primary); color: var(--color-background-primary); border-color: var(--color-text-primary); }
+  .dark .chrome-icon { border-color: rgba(255,255,255,0.1); }
+  .dark .chrome-icon:hover { background: rgba(255,255,255,0.06); border-color: rgba(255,255,255,0.2); }
+  .chrome-icon i { font-size: 16px; line-height: 1; }
+
+  /* The little badge sub-letters on the locale icon, e.g. "EN".
+     Avoids needing a separate dropdown to read the current locale at a glance. */
+  .chrome-icon .badge { font-size: 9px; font-weight: 600; letter-spacing: 0.04em; position: absolute; bottom: 3px; right: 3px; background: var(--color-background-primary); border-radius: 4px; padding: 0 3px; line-height: 1.3; border: 0.5px solid var(--color-border-tertiary); }
+  .dark .chrome-icon .badge { background: #1f1f1f; border-color: rgba(255,255,255,0.1); }
+
+  /* Sign-in/Panel/Logout has a textual variant for anonymous viewers
+     since "click to sign in" is a primary CTA, not a settings popover. */
+  .chrome-signin { display: inline-flex; align-items: center; gap: 6px; padding: 0 12px; height: 32px; border-radius: 10px; border: 0.5px solid var(--color-border-tertiary); font-size: 12px; cursor: pointer; background: transparent; color: inherit; font-family: inherit; }
+  .chrome-signin:hover { background: var(--color-background-secondary); border-color: var(--color-border-secondary); }
+  .dark .chrome-signin { border-color: rgba(255,255,255,0.1); }
+  .dark .chrome-signin:hover { background: rgba(255,255,255,0.06); border-color: rgba(255,255,255,0.2); }
+
+  /* Popover panel — anchored to the right of the cluster.
+     Pure CSS + <details>/<summary> for the disclosure semantics, so
+     a real implementation can keep zero JS for this. */
+  .chrome-popover { position: absolute; top: 38px; right: 0; min-width: 160px; background: var(--color-background-primary); border: 0.5px solid var(--color-border-tertiary); border-radius: 10px; box-shadow: 0 6px 24px rgba(0,0,0,0.08); padding: 6px; display: flex; flex-direction: column; z-index: 10; }
+  .dark .chrome-popover { background: #1f1f1f; border-color: rgba(255,255,255,0.1); box-shadow: 0 6px 24px rgba(0,0,0,0.3); }
+  .chrome-popover button, .chrome-popover a { display: flex; align-items: center; gap: 8px; padding: 7px 10px; background: transparent; border: 0; cursor: pointer; font-family: inherit; font-size: 12.5px; text-align: left; border-radius: 6px; color: inherit; text-decoration: none; }
+  .chrome-popover button:hover, .chrome-popover a:hover { background: var(--color-background-secondary); }
+  .dark .chrome-popover button:hover, .dark .chrome-popover a:hover { background: rgba(255,255,255,0.06); }
+  .chrome-popover .is-current { font-weight: 500; }
+  .chrome-popover .is-current::after { content: "✓"; margin-left: auto; opacity: 0.7; }
+  .chrome-popover .sep { height: 0.5px; background: var(--color-border-tertiary); margin: 4px 0; }
+  .dark .chrome-popover .sep { background: rgba(255,255,255,0.08); }
+  .chrome-popover .user-row { padding: 7px 10px 4px; font-size: 11px; color: var(--color-text-tertiary); }
+  .dark .chrome-popover .user-row { color: rgba(255,255,255,0.5); }
+
+  /* ── Body filler (just so previews aren't empty) ──────────────── */
+  .body-stub { padding: 20px 24px; font-size: 13px; color: var(--color-text-secondary); background: var(--color-background-primary); min-height: 80px; }
+  .dark.body-stub { background: #1f1f1f; color: rgba(255,255,255,0.6); }
+
+  /* ── Footer: minimal — just powered-by + version + links ──────── */
+  .ruscker-footer { padding: 12px 24px; border-top: 0.5px solid var(--color-border-tertiary); display: flex; align-items: center; gap: 18px; font-size: 11px; color: var(--color-text-secondary); background: var(--color-background-primary); }
+  .ruscker-footer.dark { background: #1f1f1f; color: rgba(255,255,255,0.5); border-top-color: rgba(255,255,255,0.08); }
+  .ruscker-footer a { color: inherit; text-decoration: none; }
+  .ruscker-footer a:hover { color: var(--color-text-primary); }
+  .ruscker-footer .powered { margin-left: auto; display: inline-flex; align-items: center; gap: 6px; opacity: 0.7; }
+
+  /* Section labels above each preview. */
+  .preview-label { font-size: 11px; letter-spacing: 0.05em; text-transform: uppercase; color: var(--color-text-tertiary); margin: 0 0 8px 4px; }
+
+  .notes { background: var(--color-background-primary); border: 0.5px solid var(--color-border-tertiary); border-radius: 12px; padding: 18px 22px; max-width: 760px; font-size: 13px; line-height: 1.55; color: var(--color-text-secondary); }
+  .notes h2 { font-size: 13px; font-weight: 600; margin: 0 0 8px; color: var(--color-text-primary); letter-spacing: 0.02em; }
+  .notes h2:not(:first-child) { margin-top: 16px; }
+  .notes ul { margin: 0; padding-left: 18px; }
+  .notes li { margin: 4px 0; }
+  .notes code { font-family: var(--font-mono); font-size: 12px; padding: 1px 5px; background: var(--color-background-secondary); border-radius: 4px; }
+</style>
+</head>
+<body>
+
+<h1>Chrome redesign — top-right cluster</h1>
+<p class="lede">
+  Proposal for #182 + #183: theme + language + sign-in move out of the footer into a
+  three-icon cluster anchored top-right on every public-facing page (landing,
+  <code>/admin/login</code>, <code>/admin/setup</code>, account-password). Footer keeps
+  only "powered by" / version / static links. Logo gets a small Ruscker mark to
+  the left of the operator-provided title. Dropdowns use <code>&lt;details&gt;</code> so
+  the implementation can stay zero-JS.
+</p>
+
+<!-- ── 1. Anonymous, light ──────────────────────────────────────── -->
+<p class="preview-label">1 · Public landing — anonymous viewer (light)</p>
+<div class="preview">
+  <div class="preview-bar"><i class="ti ti-lock"></i><span class="url">https://example.org/</span></div>
+  <header class="ruscker-header">
+    <div class="ruscker-brand">
+      <svg class="ruscker-mark" viewBox="0 0 80 80" width="28" height="28" aria-hidden="true">
+        <polygon points="14,52 40,40 66,52 40,64" fill="#0F6E56"/>
+        <polygon points="14,40 40,28 66,40 40,52" fill="#1D9E75"/>
+        <polygon points="14,28 40,16 66,28 40,40" fill="#5DCAA5"/>
+      </svg>
+      <div>
+        <div class="ruscker-title">Portal · Example Org</div>
+        <div class="ruscker-subtitle">Internal apps &amp; dashboards</div>
+      </div>
+    </div>
+    <div class="chrome-cluster">
+      <button class="chrome-icon" type="button" aria-label="Theme: light" title="Theme (light)">
+        <i class="ti ti-sun"></i>
+      </button>
+      <button class="chrome-icon" type="button" aria-label="Language: English" title="Language">
+        <i class="ti ti-world"></i><span class="badge">EN</span>
+      </button>
+      <button class="chrome-signin" type="button" aria-label="Sign in">
+        <i class="ti ti-login"></i> Sign in
+      </button>
+    </div>
+  </header>
+  <div class="body-stub">Cards grid would render here.</div>
+  <footer class="ruscker-footer">
+    <a href="#">Status</a>
+    <a href="#">Docs</a>
+    <span class="powered">
+      <svg viewBox="0 0 80 80" width="14" height="14"><polygon points="14,52 40,40 66,52 40,64" fill="#0F6E56"/><polygon points="14,40 40,28 66,40 40,52" fill="#1D9E75"/><polygon points="14,28 40,16 66,28 40,40" fill="#5DCAA5"/></svg>
+      powered by Ruscker · v0.1.2
+    </span>
+  </footer>
+</div>
+
+<!-- ── 2. Anonymous, dark ───────────────────────────────────────── -->
+<p class="preview-label">2 · Public landing — anonymous viewer (dark)</p>
+<div class="preview">
+  <div class="preview-bar"><i class="ti ti-lock"></i><span class="url">https://example.org/</span></div>
+  <header class="ruscker-header dark">
+    <div class="ruscker-brand">
+      <svg class="ruscker-mark" viewBox="0 0 80 80" width="28" height="28" aria-hidden="true">
+        <polygon points="14,52 40,40 66,52 40,64" fill="#0F6E56"/>
+        <polygon points="14,40 40,28 66,40 40,52" fill="#1D9E75"/>
+        <polygon points="14,28 40,16 66,28 40,40" fill="#5DCAA5"/>
+      </svg>
+      <div>
+        <div class="ruscker-title">Portal · Example Org</div>
+        <div class="ruscker-subtitle">Internal apps &amp; dashboards</div>
+      </div>
+    </div>
+    <div class="chrome-cluster">
+      <button class="chrome-icon" type="button" aria-label="Theme: dark">
+        <i class="ti ti-moon"></i>
+      </button>
+      <button class="chrome-icon" type="button" aria-label="Language: Português">
+        <i class="ti ti-world"></i><span class="badge">PT</span>
+      </button>
+      <button class="chrome-signin" type="button" aria-label="Sign in">
+        <i class="ti ti-login"></i> Sign in
+      </button>
+    </div>
+  </header>
+  <div class="body-stub dark">Cards grid would render here.</div>
+  <footer class="ruscker-footer dark">
+    <a href="#">Status</a>
+    <a href="#">Docs</a>
+    <span class="powered">
+      <svg viewBox="0 0 80 80" width="14" height="14"><polygon points="14,52 40,40 66,52 40,64" fill="#0F6E56"/><polygon points="14,40 40,28 66,40 40,52" fill="#1D9E75"/><polygon points="14,28 40,16 66,28 40,40" fill="#5DCAA5"/></svg>
+      powered by Ruscker · v0.1.2
+    </span>
+  </footer>
+</div>
+
+<!-- ── 3. Signed-in with dropdown open ─────────────────────────── -->
+<p class="preview-label">3 · Signed-in viewer — user dropdown open (theme icon active)</p>
+<div class="preview">
+  <div class="preview-bar"><i class="ti ti-lock"></i><span class="url">https://example.org/</span></div>
+  <header class="ruscker-header">
+    <div class="ruscker-brand">
+      <svg class="ruscker-mark" viewBox="0 0 80 80" width="28" height="28" aria-hidden="true">
+        <polygon points="14,52 40,40 66,52 40,64" fill="#0F6E56"/>
+        <polygon points="14,40 40,28 66,40 40,52" fill="#1D9E75"/>
+        <polygon points="14,28 40,16 66,28 40,40" fill="#5DCAA5"/>
+      </svg>
+      <div>
+        <div class="ruscker-title">Portal · Example Org</div>
+        <div class="ruscker-subtitle">Internal apps &amp; dashboards</div>
+      </div>
+    </div>
+    <div class="chrome-cluster">
+      <button class="chrome-icon" type="button" aria-label="Theme: light"><i class="ti ti-sun"></i></button>
+      <button class="chrome-icon" type="button" aria-label="Language: English"><i class="ti ti-world"></i><span class="badge">EN</span></button>
+      <button class="chrome-icon is-active" type="button" aria-label="Account: alice" aria-expanded="true"><i class="ti ti-user"></i></button>
+      <!-- Popover absolutely positioned under the cluster -->
+      <div class="chrome-popover" style="min-width:180px">
+        <div class="user-row">Signed in as <strong style="color:var(--color-text-primary)">alice</strong></div>
+        <div class="sep"></div>
+        <a href="/admin/dashboard"><i class="ti ti-layout-dashboard"></i> Panel</a>
+        <a href="/admin/account/password"><i class="ti ti-key"></i> Change password</a>
+        <div class="sep"></div>
+        <button type="button"><i class="ti ti-logout"></i> Sign out</button>
+      </div>
+    </div>
+  </header>
+  <div class="body-stub">Cards grid would render here.</div>
+  <footer class="ruscker-footer">
+    <a href="#">Status</a>
+    <a href="#">Docs</a>
+    <span class="powered">
+      <svg viewBox="0 0 80 80" width="14" height="14"><polygon points="14,52 40,40 66,52 40,64" fill="#0F6E56"/><polygon points="14,40 40,28 66,40 40,52" fill="#1D9E75"/><polygon points="14,28 40,16 66,28 40,40" fill="#5DCAA5"/></svg>
+      powered by Ruscker · v0.1.2
+    </span>
+  </footer>
+</div>
+
+<!-- ── 4. Language popover open ─────────────────────────────────── -->
+<p class="preview-label">4 · Language popover open (anonymous)</p>
+<div class="preview">
+  <div class="preview-bar"><i class="ti ti-lock"></i><span class="url">https://example.org/admin/login</span></div>
+  <header class="ruscker-header">
+    <div class="ruscker-brand">
+      <svg class="ruscker-mark" viewBox="0 0 80 80" width="28" height="28" aria-hidden="true">
+        <polygon points="14,52 40,40 66,52 40,64" fill="#0F6E56"/>
+        <polygon points="14,40 40,28 66,40 40,52" fill="#1D9E75"/>
+        <polygon points="14,28 40,16 66,28 40,40" fill="#5DCAA5"/>
+      </svg>
+      <div>
+        <div class="ruscker-title">Portal · Example Org</div>
+        <div class="ruscker-subtitle">Admin sign in</div>
+      </div>
+    </div>
+    <div class="chrome-cluster">
+      <button class="chrome-icon" type="button" aria-label="Theme: light"><i class="ti ti-sun"></i></button>
+      <button class="chrome-icon is-active" type="button" aria-label="Language" aria-expanded="true"><i class="ti ti-world"></i><span class="badge">EN</span></button>
+      <div class="chrome-popover" style="right:36px">
+        <button type="button"><span style="font-family:var(--font-mono);opacity:0.6;width:18px">PT</span> Português</button>
+        <button type="button" class="is-current"><span style="font-family:var(--font-mono);opacity:0.6;width:18px">EN</span> English</button>
+        <button type="button"><span style="font-family:var(--font-mono);opacity:0.6;width:18px">ES</span> Español</button>
+        <button type="button"><span style="font-family:var(--font-mono);opacity:0.6;width:18px">FR</span> Français</button>
+      </div>
+      <button class="chrome-signin" type="button" aria-label="Sign in"><i class="ti ti-login"></i> Sign in</button>
+    </div>
+  </header>
+  <div class="body-stub" style="min-height:160px;display:flex;align-items:center;justify-content:center">
+    <span style="opacity:0.5;font-size:12px">Login card would render here.</span>
+  </div>
+</div>
+
+<div class="notes">
+  <h2>Design notes</h2>
+  <ul>
+    <li><strong>Cluster anatomy:</strong> three slots — theme (icon-only) · language (icon + 2-letter badge) · account (icon-only when signed in, "Sign in" text-button when anonymous).</li>
+    <li><strong>Disclosure:</strong> the theme and language buttons open small popovers anchored under the cluster. Using native <code>&lt;details&gt;</code>/<code>&lt;summary&gt;</code> keeps it keyboard-accessible with zero JS — the form buttons inside POST to <code>/__set/theme</code> and <code>/__set/locale</code> just like today's footer.</li>
+    <li><strong>Account slot:</strong> anonymous viewers get a textual "Sign in" CTA (it's a primary action, not a settings menu). Signed-in viewers get a user-icon that opens a popover with the username, Panel link, Change-password link, and a Sign-out button.</li>
+    <li><strong>Logo:</strong> small Ruscker mark (28×28) left of the operator's title. When the operator later configures their own brand mark via <code>landing-customization.logo</code> (future), it slots into this same position.</li>
+    <li><strong>Footer:</strong> shrinks to status link + docs link + "powered by Ruscker · v0.1.2" right-aligned. Theme + language pickers leave the footer entirely.</li>
+  </ul>
+
+  <h2>Scope &amp; pages</h2>
+  <ul>
+    <li><code>templates/_layout.html</code> — replace footer chrome with the new cluster in the existing <code>templates/landing.html</code> header.</li>
+    <li><code>templates/landing.html</code> — host the cluster in the existing header row (already has the sign-in affordance from #155, easy to absorb).</li>
+    <li><code>templates/admin/login.html</code> + <code>setup.html</code> + <code>account_password.html</code> — replace the current bottom-of-card locale row with the same cluster at the top-right of the page (above the card).</li>
+    <li><code>templates/admin/_layout.html</code> — same cluster top-right of the admin chrome (replaces the footer pickers added in #53).</li>
+  </ul>
+
+  <h2>Open questions</h2>
+  <ul>
+    <li>Should the theme icon directly cycle on click (one click = next mode) instead of opening a popover? Faster but loses the visible "auto" state. The mockup uses popover for clarity; happy to swap.</li>
+    <li>Language popover shows native names ("English", "Português") with a 2-letter code prefix. Keep that, or just the code, or just the name?</li>
+    <li>Footer still has the "powered by Ruscker" lockup. Should the version number be a click-through to the GitHub release page?</li>
+  </ul>
+</div>
+
+</body>
+</html>


### PR DESCRIPTION
Closes #182 and #183.

Replaces the legacy footer pickers with a three-icon cluster pinned top-right on every public-facing page.

## Cluster anatomy

\`\`\`
[ theme-icon ]  [ language-icon + 2-letter badge ]  [ account ]
\`\`\`

- **Theme** — opens a popover with Light/Dark/Auto. Icon glyph reflects the current state (sun/moon/monitor).
- **Language** — globe + active locale code badge; popover lists all four locales by native name + 2-letter prefix.
- **Account** — when signed-in, user-icon → popover with "Signed in as $user", Panel, Change password, Sign out. When anonymous, the slot becomes a textual "Sign in" CTA. Honors \`show-admin-link\` (#156) — on a fully-public portal the slot is omitted entirely.

Disclosure uses native \`<details>/<summary>\` ⇒ **no JS**. Keyboard nav (Tab/Enter/Space/Esc) + focus management come for free. Each popover wraps a real POST form to \`/__set/{theme,locale}\`; \`prefs::redirect_back\` returns the user to the same page.

## Three partials

To avoid adding \`signed_in: bool\` + \`viewer_name: String\` to every admin page struct (~15 of them), the cluster is split into three variants:

| Partial | Used by | Account slot |
|---|---|---|
| \`_chrome_cluster.html\` | landing | conditional (signed_in/show_admin_link) |
| \`_chrome_cluster_anon.html\` | /admin/login, /admin/setup | omitted (you're signing in) |
| \`_chrome_cluster_admin.html\` | admin chrome, /admin/account/password | role-driven (always signed-in) |

Each variant only requires what its caller already has.

## Other changes

- Small Ruscker mark added to the left of the landing's title (#182). Future: an operator-overridable \`landing-customization.logo\`.
- Both layouts' footers shrink to "powered by ruscker" only.
- \`footer-language\` + \`footer-theme\` + \`admin-login-locale-group\` i18n keys dropped from all four FTL files (\`i18n-check.sh\` still green).
- 8 new \`chrome-*\` i18n keys, parity across pt / en / es / fr.
- New \`.chrome-*\` CSS in \`input.css\`; old \`.admin-login-locales\` + \`.admin-login-footer-links\` rules removed.

## Tests

- \`login_page_chrome_cluster_is_outside_the_login_form\` + \`setup_page_chrome_cluster_is_outside_the_setup_form\` — rewrites of the #181 nested-form guards. New \`form_nesting\` helper asserts **3 sibling \`<form>\` tags with depth 1** (theme + locale + outer card form). Proves the cluster's POST forms are NOT nested inside the page's card form.
- \`cargo test --workspace\` green (300+ tests).
- \`cargo clippy --workspace --all-targets\` → 0 warnings.
- \`i18n-check.sh\` green.

## Mockup

Approved layout lives at \`docs/mockups/landing-chrome-redesign.html\` (4 states: anonymous-light, anonymous-dark, signed-in with account popover open, language popover open).

## Smoke (darwin :8083)

- Landing: cluster renders top-right with the small logo + operator's teal header.
- /admin/login: just theme + language (no account slot, since you're signing in).
- /admin/dashboard: admin variant with role label + Panel + Change password + Sign out in the popover.

🤖 Generated with [Claude Code](https://claude.com/claude-code)