### PR TITLE
#185: shared admin session store (Postgres + TTL cache)

### DIFF
--- a/book/src/deploying.md
+++ b/book/src/deploying.md
@@ -266,6 +266,12 @@ needed.
 This removes the need for a sticky LB. Round-robin (or least-conn) is
 fine; any node can serve any session-bearing path.
 
+> **One database, three tables.** `--config-db-url` (shared spec
+> catalog), `--session-store-url` (proxy `proxy_sessions` table from
+> Phase 7), and `--admin-session-store-url` (sign-in sessions, #185)
+> can all point at the **same** Postgres URL — each store creates and
+> owns its own table. No need to provision three databases.
+
 #### Fallback: sticky upstream
 
 If you can't host shared Postgres for admin sessions, pin the

--- a/book/src/deploying.md
+++ b/book/src/deploying.md
@@ -237,21 +237,42 @@ table is shared), so round-robin is fine for `/app` and `/api`. Keep
 `server.useForwardHeaders: true` and pass `X-Forwarded-*` as in the
 nginx section above.
 
-### Sticky upstream for the sign-in session (`/admin`, `/app`, `/api`)
+### Shared admin sessions (eliminate the sticky-upstream caveat)
 
-One thing is **not** shared across instances yet: the **sign-in session**
-(`AdminSessions`) is an in-memory map per process. So an admin — or, with
-per-group app visibility ([access control](./configuration.md)), any
-signed-in user — who logs into instance A and is then round-robined to
-instance B is bounced back to the login screen (B doesn't know the
-session), and on the proxy path B would treat them as anonymous (so a
-restricted app could 403/redirect even though they're entitled to it).
+By default the **sign-in session** (the cookie minted at `/admin/login`)
+lives in an in-memory map per process. An admin — or, with per-group app
+visibility ([access control](./configuration.md)), any signed-in user —
+who logs into instance A and is then round-robined to instance B is
+bounced back to the login screen (B doesn't know the session), and on
+the proxy path B would treat them as anonymous (so a restricted app
+could 403/redirect even though they're entitled to it).
 
-Until a shared session store lands ([#161]), pin the **session-bearing
-paths** to one instance with a sticky upstream. The simplest is
-`ip_hash` (route by client IP); a cookie-based sticky on the
-`ruscker_admin_session` cookie is more precise if you have nginx Plus or
-a similar LB.
+**Recommended fix:** point Ruscker at a shared Postgres for the admin
+session table (#185):
+
+```bash
+ruscker serve … --admin-session-store-url postgres://ruscker:pw@pg:5432/ruscker
+```
+
+(or `RUSCKER_ADMIN_SESSION_STORE_URL=…`). All instances then read and
+write the same `admin_sessions` table. A short node-local TTL cache
+(default **5 s**) means the hot path — every authenticated request and
+every `/app` proxy guard — keeps serving from memory; the DB is only
+hit on cache miss or after a write. Logout propagates to sibling
+instances within one cache window (worst case 5 s of "still signed in"
+on a peer). The table auto-creates on connect; no migration step is
+needed.
+
+This removes the need for a sticky LB. Round-robin (or least-conn) is
+fine; any node can serve any session-bearing path.
+
+#### Fallback: sticky upstream
+
+If you can't host shared Postgres for admin sessions, pin the
+session-bearing paths to one instance with a sticky upstream. The
+simplest is `ip_hash` (route by client IP); a cookie-based sticky on
+the `ruscker_admin_session` cookie is more precise if you have nginx
+Plus or a similar LB.
 
 ```nginx
 # Pin each client to one instance so its sign-in session is found.
@@ -268,14 +289,9 @@ server {
 }
 ```
 
-The shared catalog + session table mean **no data is lost** on a
-failover — the worst case is a re-login. If you can't make the LB
-sticky, document for your admins that a failover re-prompts login.
-
-> **Roadmap:** [#161] tracks backing `AdminSessions` with the shared
-> Postgres (a small `admin_sessions` table, fronted by a short-TTL local
-> cache so the hot proxy path stays DB-free) — that removes the need for
-> stickiness entirely.
+Either path — shared store or sticky upstream — keeps **no data lost**
+on a failover. The shared store skips the re-login; sticky upstream
+re-logs in the user only when the pinned node falls over.
 
 [#161]: https://github.com/StrategicProjects/ruscker/issues/161
 

--- a/crates/ruscker-admin/src/admin_sessions_pg.rs
+++ b/crates/ruscker-admin/src/admin_sessions_pg.rs
@@ -137,6 +137,27 @@ async fn ensure_schema(pool: &PgPool) -> sqlx::Result<()> {
     .map(|_| ())
 }
 
+/// Clip a cache `valid_until` so it never outlives the DB-recorded
+/// `expires_at`. Returns the earlier of the two, so a positive
+/// cached answer is invalidated as soon as PG would refuse it.
+///
+/// Converts `expires_at` (calendar time) to a monotonic [`Instant`]
+/// by anchoring it against `Utc::now()` and `Instant::now()` — same
+/// pair sampled close together so monotonic-vs-wall-clock drift is
+/// negligible.
+fn clip_to_expiry(cache_until: Instant, expires_at: DateTime<Utc>) -> Instant {
+    let wall_now = Utc::now();
+    if expires_at <= wall_now {
+        // Already expired by wall clock — clamp to "now" so the cache
+        // entry is stale immediately on the next lookup.
+        return Instant::now();
+    }
+    // expires_at > wall_now ⇒ the delta is positive.
+    let delta = (expires_at - wall_now).to_std().unwrap_or_default();
+    let expiry_instant = Instant::now() + delta;
+    cache_until.min(expiry_instant)
+}
+
 fn role_to_str(role: Role) -> &'static str {
     match role {
         Role::Admin => "admin",
@@ -173,16 +194,27 @@ impl AdminSessionStore for PostgresAdminSessionStore {
             // The store-level contract is "best-effort" — if the DB is
             // unreachable we still return an id so the cookie path
             // doesn't 500. The local cache lets the just-signed-in user
-            // browse this node; a failover lands them at login.
-            warn!(error = ?e, "admin session insert failed; serving from local cache only");
+            // browse THIS node; a failover lands them at login because
+            // sibling instances never see the row. Log loud so ops
+            // notices the divergence in their dashboards.
+            tracing::error!(
+                error = ?e,
+                "admin session INSERT failed; cookie works on this node only — sibling instances will treat it as unknown until the DB recovers"
+            );
         }
         // Write-through to the cache so this node sees its own writes
-        // instantly without re-querying.
+        // instantly without re-querying. Clip the cache window to the
+        // session's `expires_at` so a cached positive answer never
+        // outlives the DB-recorded expiry (review on #196 finding #1).
+        // At default TTLs (24h session, 5s cache) the clip is a no-op;
+        // it matters at the boundary and in test configurations with
+        // short session TTLs.
+        let valid_until = clip_to_expiry(Instant::now() + self.cache_ttl, expires_at);
         self.cache.insert(
             id.clone(),
             CachedEntry {
                 info: Some(SessionInfo { role, actor }),
-                valid_until: Instant::now() + self.cache_ttl,
+                valid_until,
             },
         );
         id
@@ -208,7 +240,9 @@ impl AdminSessionStore for PostgresAdminSessionStore {
         .fetch_optional(&self.pool)
         .await;
 
-        let info = match row {
+        // (info, expires_at-from-row) — the second slot is only used
+        // to clip the cache window on the positive branch.
+        let (info, expires_at): (Option<SessionInfo>, Option<DateTime<Utc>>) = match row {
             Ok(Some(r)) => {
                 let role_str: String = r.get("role");
                 let actor: Option<String> = r.get("actor");
@@ -234,12 +268,12 @@ impl AdminSessionStore for PostgresAdminSessionStore {
                         .bind(id)
                         .execute(&self.pool)
                         .await;
-                    None
+                    (None, None)
                 } else {
-                    Some(SessionInfo { role, actor })
+                    (Some(SessionInfo { role, actor }), Some(expires_at))
                 }
             }
-            Ok(None) => None,
+            Ok(None) => (None, None),
             Err(e) => {
                 // DB hiccup — log and fall back to "unknown". Don't poison
                 // the cache, so the next request retries instead of
@@ -250,12 +284,19 @@ impl AdminSessionStore for PostgresAdminSessionStore {
         };
 
         // Cache the result (positive or negative) so a flood of the
-        // same sid stays single-DB-hit per TTL window.
+        // same sid stays single-DB-hit per TTL window. For positive
+        // answers, clip the cache window to the row's `expires_at` so
+        // a cached entry never outlives the DB-recorded expiry (review
+        // on #196 finding #1).
+        let valid_until = match expires_at {
+            Some(exp) => clip_to_expiry(now + self.cache_ttl, exp),
+            None => now + self.cache_ttl,
+        };
         self.cache.insert(
             id.to_string(),
             CachedEntry {
                 info: info.clone(),
-                valid_until: now + self.cache_ttl,
+                valid_until,
             },
         );
         info
@@ -415,6 +456,31 @@ mod postgres_it {
         assert!(
             b.validate(&sid).await.is_none(),
             "logout must propagate within cache_ttl"
+        );
+    }
+
+    #[tokio::test]
+    async fn cache_window_is_clipped_to_session_expiry() {
+        // #196 review finding #1: if the session is about to expire
+        // *before* the cache window ends, the cached entry must NOT
+        // outlive the row's `expires_at`. Set session_ttl smaller than
+        // cache_ttl so the clip actually fires.
+        let _guard = crate::db::pg_test_lock().lock().await;
+        let session_ttl = Duration::from_millis(100);
+        let cache_ttl = Duration::from_secs(60); // would otherwise dominate
+        let store =
+            PostgresAdminSessionStore::connect_with(&pg_url(), session_ttl, cache_ttl)
+                .await
+                .unwrap();
+        reset_rows(&store.pool).await;
+        let sid = store.create(Role::Admin, None).await;
+        // Sleep past `session_ttl` but well inside `cache_ttl`. With
+        // the clip the cache window stopped at `expires_at`, so the
+        // next validate must NOT return the (now-expired) session.
+        tokio::time::sleep(session_ttl + Duration::from_millis(30)).await;
+        assert!(
+            store.validate(&sid).await.is_none(),
+            "cache window must be clipped to expires_at"
         );
     }
 

--- a/crates/ruscker-admin/src/admin_sessions_pg.rs
+++ b/crates/ruscker-admin/src/admin_sessions_pg.rs
@@ -1,0 +1,444 @@
+//! Postgres-backed [`crate::auth::AdminSessionStore`] — the HA seam
+//! for sign-in sessions (#185).
+//!
+//! ## Why this exists
+//!
+//! The default [`crate::auth::InMemoryAdminSessionStore`] is
+//! process-local: a load-balancer hop to another Ruscker instance
+//! sees the cookie as unknown and bounces the user to login. The
+//! deploy guide's "sticky upstream for the sign-in session"
+//! workaround (#161) papers over it; this store removes the need by
+//! moving the session table into shared Postgres.
+//!
+//! ## Hot path
+//!
+//! `validate(sid)` is called on **every** admin route AND every
+//! `MaybeSession` resolution — the landing and the `/app` proxy
+//! guard from #155. A naive PG-per-request adds a DB round-trip to
+//! every authenticated request, which is unacceptable for a proxy
+//! built for sub-millisecond hops.
+//!
+//! We keep a small node-local cache: a [`DashMap`] keyed by session
+//! id holding the resolved [`SessionInfo`] plus a `valid_until`
+//! [`Instant`]. Cache hit (fresh) returns immediately; cache miss
+//! (or stale) does one `SELECT`, repopulates, and returns. `create`
+//! and `remove` write through to PG and update the cache, so the
+//! local node observes its own writes instantly.
+//!
+//! The cache TTL bounds cross-instance staleness: a logout on
+//! instance A propagates to instance B within at most one TTL
+//! window. Default is **5 seconds**, picked to keep the hot path
+//! sub-ms while keeping the "logged out everywhere" UX snappy.
+//!
+//! ## Schema management
+//!
+//! Idempotent `CREATE TABLE IF NOT EXISTS` on connect — same pattern
+//! as [`crate::sessions_pg::PostgresSessionStore`].
+
+use crate::auth::{mint_session_id, AdminSessionStore, Role, SessionInfo};
+use chrono::{DateTime, Utc};
+use dashmap::DashMap;
+use sqlx::postgres::{PgPool, PgPoolOptions};
+use sqlx::Row;
+use std::time::{Duration, Instant};
+use tracing::warn;
+
+/// Default lifetime of a sign-in session in Postgres. Matches the
+/// in-memory default (`24h`) and the cookie's `Max-Age`.
+const DEFAULT_TTL: Duration = Duration::from_secs(24 * 60 * 60);
+
+/// Default node-local cache TTL. Picked small enough that a logout
+/// propagates across instances within ~one window, large enough that
+/// the hot path stays effectively DB-free for a long-running session.
+const DEFAULT_CACHE_TTL: Duration = Duration::from_secs(5);
+
+/// Postgres implementation of [`AdminSessionStore`]. Cheap to
+/// `Arc`-share; `PgPool` is itself an `Arc` internally and the cache
+/// uses `DashMap` shards.
+#[derive(Debug)]
+pub struct PostgresAdminSessionStore {
+    pool: PgPool,
+    /// How long a session stays valid after `create`.
+    ttl: Duration,
+    /// How long a cached `validate` result is considered fresh.
+    cache_ttl: Duration,
+    /// Local cache: sid → (info, valid_until). A `None` info means
+    /// "we know the sid is invalid (deleted or expired)", which lets
+    /// repeated lookups of a stale cookie also skip the DB.
+    cache: DashMap<String, CachedEntry>,
+}
+
+#[derive(Clone, Debug)]
+struct CachedEntry {
+    /// `None` ⇒ the sid is known-invalid (revoked or expired). Lets
+    /// repeated lookups of a stale cookie also skip the DB.
+    info: Option<SessionInfo>,
+    /// When this cache entry becomes stale and must be re-resolved.
+    valid_until: Instant,
+}
+
+impl PostgresAdminSessionStore {
+    /// Connect to Postgres, ensure the schema, and return a store
+    /// ready to back [`crate::AppState::admin_sessions`]. Uses the
+    /// default lifetimes (24h sessions, 5s cache).
+    pub async fn connect(url: &str) -> sqlx::Result<Self> {
+        Self::connect_with(url, DEFAULT_TTL, DEFAULT_CACHE_TTL).await
+    }
+
+    /// Same as [`Self::connect`] but lets the operator pick a custom
+    /// session TTL and cache TTL. Mostly used by tests.
+    pub async fn connect_with(
+        url: &str,
+        ttl: Duration,
+        cache_ttl: Duration,
+    ) -> sqlx::Result<Self> {
+        let pool = PgPoolOptions::new()
+            .max_connections(5)
+            .acquire_timeout(Duration::from_secs(5))
+            .connect(url)
+            .await?;
+        ensure_schema(&pool).await?;
+        Ok(Self {
+            pool,
+            ttl,
+            cache_ttl,
+            cache: DashMap::new(),
+        })
+    }
+
+    /// Returns the current node-local cache size. Used by the
+    /// `postgres-it` tests to verify the hot path actually serves
+    /// from cache.
+    #[doc(hidden)]
+    pub fn cache_len(&self) -> usize {
+        self.cache.len()
+    }
+}
+
+async fn ensure_schema(pool: &PgPool) -> sqlx::Result<()> {
+    // sqlx prepares each call as a single statement, so split the two
+    // DDLs across two `execute`s rather than `;`-joining them.
+    sqlx::query(
+        r#"CREATE TABLE IF NOT EXISTS admin_sessions (
+            sid        TEXT PRIMARY KEY,
+            role       TEXT NOT NULL,
+            actor      TEXT,
+            expires_at TIMESTAMPTZ NOT NULL
+        )"#,
+    )
+    .execute(pool)
+    .await?;
+    sqlx::query(
+        "CREATE INDEX IF NOT EXISTS admin_sessions_expires_at_idx
+            ON admin_sessions (expires_at)",
+    )
+    .execute(pool)
+    .await
+    .map(|_| ())
+}
+
+fn role_to_str(role: Role) -> &'static str {
+    match role {
+        Role::Admin => "admin",
+        Role::Editor => "editor",
+        Role::Viewer => "viewer",
+    }
+}
+
+fn role_from_str(s: &str) -> Option<Role> {
+    match s {
+        "admin" => Some(Role::Admin),
+        "editor" => Some(Role::Editor),
+        "viewer" => Some(Role::Viewer),
+        _ => None,
+    }
+}
+
+#[async_trait::async_trait]
+impl AdminSessionStore for PostgresAdminSessionStore {
+    async fn create(&self, role: Role, actor: Option<String>) -> String {
+        let id = mint_session_id();
+        let expires_at: DateTime<Utc> = Utc::now() + chrono::Duration::from_std(self.ttl).unwrap();
+        let result = sqlx::query(
+            "INSERT INTO admin_sessions (sid, role, actor, expires_at)
+             VALUES ($1, $2, $3, $4)",
+        )
+        .bind(&id)
+        .bind(role_to_str(role))
+        .bind(&actor)
+        .bind(expires_at)
+        .execute(&self.pool)
+        .await;
+        if let Err(e) = result {
+            // The store-level contract is "best-effort" — if the DB is
+            // unreachable we still return an id so the cookie path
+            // doesn't 500. The local cache lets the just-signed-in user
+            // browse this node; a failover lands them at login.
+            warn!(error = ?e, "admin session insert failed; serving from local cache only");
+        }
+        // Write-through to the cache so this node sees its own writes
+        // instantly without re-querying.
+        self.cache.insert(
+            id.clone(),
+            CachedEntry {
+                info: Some(SessionInfo { role, actor }),
+                valid_until: Instant::now() + self.cache_ttl,
+            },
+        );
+        id
+    }
+
+    async fn validate(&self, id: &str) -> Option<SessionInfo> {
+        let now = Instant::now();
+
+        // Cache hit (fresh) — the hot path.
+        if let Some(entry) = self.cache.get(id) {
+            if entry.valid_until > now {
+                return entry.info.clone();
+            }
+        }
+
+        // Cache miss / stale — query Postgres.
+        let row = sqlx::query(
+            "SELECT role, actor, expires_at
+               FROM admin_sessions
+              WHERE sid = $1",
+        )
+        .bind(id)
+        .fetch_optional(&self.pool)
+        .await;
+
+        let info = match row {
+            Ok(Some(r)) => {
+                let role_str: String = r.get("role");
+                let actor: Option<String> = r.get("actor");
+                let expires_at: DateTime<Utc> = r.get("expires_at");
+                let role = match role_from_str(&role_str) {
+                    Some(r) => r,
+                    None => {
+                        warn!(role = %role_str, sid_short = &id[..8], "unknown role in admin_sessions row — treating as invalid");
+                        // Cache the negative answer too.
+                        self.cache.insert(
+                            id.to_string(),
+                            CachedEntry {
+                                info: None,
+                                valid_until: now + self.cache_ttl,
+                            },
+                        );
+                        return None;
+                    }
+                };
+                if expires_at <= Utc::now() {
+                    // Expired — lazy GC, then cache the negative answer.
+                    let _ = sqlx::query("DELETE FROM admin_sessions WHERE sid = $1")
+                        .bind(id)
+                        .execute(&self.pool)
+                        .await;
+                    None
+                } else {
+                    Some(SessionInfo { role, actor })
+                }
+            }
+            Ok(None) => None,
+            Err(e) => {
+                // DB hiccup — log and fall back to "unknown". Don't poison
+                // the cache, so the next request retries instead of
+                // stalling on a stale "invalid" answer.
+                warn!(error = ?e, "admin session SELECT failed");
+                return None;
+            }
+        };
+
+        // Cache the result (positive or negative) so a flood of the
+        // same sid stays single-DB-hit per TTL window.
+        self.cache.insert(
+            id.to_string(),
+            CachedEntry {
+                info: info.clone(),
+                valid_until: now + self.cache_ttl,
+            },
+        );
+        info
+    }
+
+    async fn remove(&self, id: &str) {
+        // Best-effort delete + cache eviction (write-through). If the
+        // DB delete fails the cache still drops the entry, so the
+        // signed-out user can't bounce on this node.
+        if let Err(e) = sqlx::query("DELETE FROM admin_sessions WHERE sid = $1")
+            .bind(id)
+            .execute(&self.pool)
+            .await
+        {
+            warn!(error = ?e, "admin session DELETE failed");
+        }
+        self.cache.remove(id);
+        // Drop a tombstone so a sibling instance with a still-cached
+        // positive answer doesn't keep serving the deleted session for
+        // up to its own cache_ttl on this node specifically. Cross-node
+        // staleness still rides the cache_ttl window.
+        self.cache.insert(
+            id.to_string(),
+            CachedEntry {
+                info: None,
+                valid_until: Instant::now() + self.cache_ttl,
+            },
+        );
+    }
+}
+
+// ── Tests ─────────────────────────────────────────────────────────────
+
+#[cfg(all(test, feature = "postgres-it"))]
+mod postgres_it {
+    use super::*;
+
+    /// `RUSCKER_TEST_PG_URL` points at a throwaway Postgres for these
+    /// tests. Same convention as the `sessions_pg` integration tests.
+    fn pg_url() -> String {
+        std::env::var("RUSCKER_TEST_PG_URL")
+            .expect("set RUSCKER_TEST_PG_URL to a reachable postgres:// DSN")
+    }
+
+    /// Wipe the table contents so each test starts clean. Uses
+    /// `DELETE` not `DROP/CREATE` — concurrent `CREATE TABLE` races
+    /// on `pg_type` and `cargo test` runs in parallel by default.
+    async fn reset_rows(pool: &PgPool) {
+        sqlx::query("DELETE FROM admin_sessions")
+            .execute(pool)
+            .await
+            .unwrap();
+    }
+
+    #[tokio::test]
+    async fn create_then_validate_roundtrips() {
+        let _guard = crate::db::pg_test_lock().lock().await;
+        let store = PostgresAdminSessionStore::connect(&pg_url()).await.unwrap();
+        reset_rows(&store.pool).await;
+        let sid = store
+            .create(Role::Editor, Some("alice".to_string()))
+            .await;
+        let info = store.validate(&sid).await.expect("freshly created is live");
+        assert_eq!(info.role, Role::Editor);
+        assert_eq!(info.actor.as_deref(), Some("alice"));
+    }
+
+    #[tokio::test]
+    async fn validate_hits_cache_after_first_lookup() {
+        // After one validate, subsequent validates within the cache
+        // window must NOT round-trip to the DB. We can't easily count
+        // PG round trips from here; instead we DELETE the row out
+        // from under the cache and verify the cached lookup still
+        // succeeds.
+        let _guard = crate::db::pg_test_lock().lock().await;
+        let store = PostgresAdminSessionStore::connect_with(
+            &pg_url(),
+            Duration::from_secs(60),
+            Duration::from_secs(30), // wide cache window
+        )
+        .await
+        .unwrap();
+        reset_rows(&store.pool).await;
+        let sid = store.create(Role::Admin, None).await;
+        // First validate populates the cache from the just-written row.
+        assert!(store.validate(&sid).await.is_some());
+        // Now make the DB row invisible — if validate still returns
+        // Some, it MUST have served from cache.
+        sqlx::query("DELETE FROM admin_sessions WHERE sid = $1")
+            .bind(&sid)
+            .execute(&store.pool)
+            .await
+            .unwrap();
+        assert!(
+            store.validate(&sid).await.is_some(),
+            "fresh cache entry should skip the DB"
+        );
+    }
+
+    #[tokio::test]
+    async fn cross_instance_visibility_via_shared_table() {
+        // Two store handles sharing the same Postgres → emulates two
+        // Ruscker instances behind a load balancer. A session created on
+        // A must validate on B without re-login.
+        let _guard = crate::db::pg_test_lock().lock().await;
+        let a = PostgresAdminSessionStore::connect_with(
+            &pg_url(),
+            Duration::from_secs(60),
+            // Tiny cache window on B so we hit the DB; A's cache is
+            // irrelevant (it never validates).
+            Duration::from_millis(50),
+        )
+        .await
+        .unwrap();
+        reset_rows(&a.pool).await;
+        let b = PostgresAdminSessionStore::connect_with(
+            &pg_url(),
+            Duration::from_secs(60),
+            Duration::from_millis(50),
+        )
+        .await
+        .unwrap();
+
+        let sid = a.create(Role::Viewer, Some("bob".to_string())).await;
+        let info = b.validate(&sid).await.expect("session survives LB hop");
+        assert_eq!(info.role, Role::Viewer);
+        assert_eq!(info.actor.as_deref(), Some("bob"));
+    }
+
+    #[tokio::test]
+    async fn remove_revokes_within_cache_ttl_on_other_node() {
+        // Logout propagation: A revokes, B sees revoked within
+        // `cache_ttl` (B's cache window bounds the staleness).
+        let _guard = crate::db::pg_test_lock().lock().await;
+        let cache_ttl = Duration::from_millis(50);
+        let a =
+            PostgresAdminSessionStore::connect_with(&pg_url(), Duration::from_secs(60), cache_ttl)
+                .await
+                .unwrap();
+        reset_rows(&a.pool).await;
+        let b =
+            PostgresAdminSessionStore::connect_with(&pg_url(), Duration::from_secs(60), cache_ttl)
+                .await
+                .unwrap();
+
+        let sid = a.create(Role::Viewer, None).await;
+        // Warm B's cache with a live answer.
+        assert!(b.validate(&sid).await.is_some());
+
+        // A logs the user out.
+        a.remove(&sid).await;
+
+        // Within the TTL, B's cache may still serve "live" — that's
+        // acceptable per the design. After the TTL expires, B MUST
+        // observe the revocation.
+        tokio::time::sleep(cache_ttl + Duration::from_millis(20)).await;
+        assert!(
+            b.validate(&sid).await.is_none(),
+            "logout must propagate within cache_ttl"
+        );
+    }
+
+    #[tokio::test]
+    async fn expired_session_returns_none_and_is_pruned() {
+        let _guard = crate::db::pg_test_lock().lock().await;
+        let store =
+            PostgresAdminSessionStore::connect_with(&pg_url(), Duration::from_millis(0), Duration::from_millis(50))
+                .await
+                .unwrap();
+        reset_rows(&store.pool).await;
+        let sid = store.create(Role::Viewer, None).await;
+        // Sleep past the cache window so validate hits PG.
+        tokio::time::sleep(Duration::from_millis(80)).await;
+        assert!(
+            store.validate(&sid).await.is_none(),
+            "expired session is invalid"
+        );
+        // Lazy GC removed the row.
+        let row = sqlx::query("SELECT 1 FROM admin_sessions WHERE sid = $1")
+            .bind(&sid)
+            .fetch_optional(&store.pool)
+            .await
+            .unwrap();
+        assert!(row.is_none(), "expired row should be GC'd on lookup");
+    }
+}

--- a/crates/ruscker-admin/src/auth.rs
+++ b/crates/ruscker-admin/src/auth.rs
@@ -189,23 +189,44 @@ pub struct SessionInfo {
 /// session instead of just clearing the browser's copy. The stored
 /// [`Role`] is what route guards and the nav dispatch on.
 ///
-/// **HA note (#161):** this map is process-local. In active-active HA
-/// the admin catalog and `proxy_sessions` are shared, but sign-in
-/// sessions are not — a load-balancer hop to another instance re-prompts
-/// login (and, with per-group app visibility, the proxy on the other
-/// instance sees the request as anonymous). Until a shared session store
-/// lands, the deploy guide prescribes a **sticky upstream** for the
-/// session-bearing paths (`book/src/deploying.md` § "Sticky upstream for
-/// the sign-in session"). A signed stateless cookie was rejected on
-/// purpose — opaque server-side ids keep logout/restart revocable
-/// (SECURITY.md §1).
+/// **HA note (#161 → #185):** the default implementation
+/// ([`InMemoryAdminSessionStore`]) is process-local — in active-active
+/// HA, a load-balancer hop to another instance re-prompts login (and,
+/// with per-group app visibility, the proxy on the other instance sees
+/// the request as anonymous on `/app`). When operators wire up
+/// `--admin-session-store-url postgres://…` the trait dispatches to
+/// [`crate::admin_sessions_pg::PostgresAdminSessionStore`] instead,
+/// which backs the store in a shared Postgres table with a short-TTL
+/// local cache so the proxy hot path stays effectively DB-free.
+///
+/// A signed stateless cookie was rejected on purpose — opaque
+/// server-side ids keep logout/restart revocable (SECURITY.md §1).
+#[async_trait::async_trait]
+pub trait AdminSessionStore: Send + Sync + std::fmt::Debug {
+    /// Mint a new session for `role`/`actor` and return its opaque id.
+    /// `actor` is the DB username (or `None` for a break-glass token
+    /// session).
+    async fn create(&self, role: Role, actor: Option<String>) -> String;
+
+    /// Resolve `id` to its [`SessionInfo`] when the session is live, or
+    /// `None` if the id is unknown or expired. Implementations may
+    /// prune expired entries lazily on lookup.
+    async fn validate(&self, id: &str) -> Option<SessionInfo>;
+
+    /// Invalidate a session (logout / forced revoke).
+    async fn remove(&self, id: &str);
+}
+
+/// Single-node admin session store. The default; replaced by
+/// [`crate::admin_sessions_pg::PostgresAdminSessionStore`] when the
+/// operator passes `--admin-session-store-url`.
 #[derive(Debug)]
-pub struct AdminSessions {
+pub struct InMemoryAdminSessionStore {
     sessions: DashMap<String, SessionEntry>,
     ttl: Duration,
 }
 
-impl AdminSessions {
+impl InMemoryAdminSessionStore {
     pub fn new(ttl: Duration) -> Self {
         Self {
             sessions: DashMap::new(),
@@ -217,17 +238,23 @@ impl AdminSessions {
     pub fn default_policy() -> Self {
         Self::new(Duration::from_secs(24 * 60 * 60))
     }
+}
 
-    /// Mint a new session for `role`/`actor` and return its opaque id
-    /// (244 bits of random, unguessable). Caller stores the id in the
-    /// cookie. `actor` is the DB username (or `None` for a break-glass
-    /// token session).
-    pub fn create(&self, role: Role, actor: Option<String>) -> String {
-        let id = format!(
-            "{}{}",
-            uuid::Uuid::new_v4().simple(),
-            uuid::Uuid::new_v4().simple()
-        );
+/// Mint an opaque session id. Two concatenated UUID-v4 simples →
+/// 244 bits of random, unguessable. Shared between the in-memory and
+/// Postgres stores so the wire format stays uniform.
+pub(crate) fn mint_session_id() -> String {
+    format!(
+        "{}{}",
+        uuid::Uuid::new_v4().simple(),
+        uuid::Uuid::new_v4().simple()
+    )
+}
+
+#[async_trait::async_trait]
+impl AdminSessionStore for InMemoryAdminSessionStore {
+    async fn create(&self, role: Role, actor: Option<String>) -> String {
+        let id = mint_session_id();
         self.sessions.insert(
             id.clone(),
             SessionEntry {
@@ -239,10 +266,7 @@ impl AdminSessions {
         id
     }
 
-    /// The [`SessionInfo`] of a live (non-expired) session named by
-    /// `id`, or `None` if the id is unknown or expired. Expired entries
-    /// are pruned lazily on lookup.
-    pub fn validate(&self, id: &str) -> Option<SessionInfo> {
+    async fn validate(&self, id: &str) -> Option<SessionInfo> {
         let info = self.sessions.get(id).map(|e| {
             let v = e.value();
             (v.expiry, v.role, v.actor.clone())
@@ -259,13 +283,12 @@ impl AdminSessions {
         }
     }
 
-    /// Invalidate a session (logout).
-    pub fn remove(&self, id: &str) {
+    async fn remove(&self, id: &str) {
         self.sessions.remove(id);
     }
 }
 
-impl Default for AdminSessions {
+impl Default for InMemoryAdminSessionStore {
     fn default() -> Self {
         Self::default_policy()
     }
@@ -424,7 +447,7 @@ impl FromRequestParts<crate::AppState> for AdminSession {
         // the server-side store — not the token itself. A live session
         // yields its role + actor.
         match cookies.get(COOKIE_NAME).map(|c| c.value().to_string()) {
-            Some(c) => match state.admin_sessions.validate(&c) {
+            Some(c) => match state.admin_sessions.validate(&c).await {
                 Some(info) => Ok(AdminSession {
                     role: info.role,
                     actor: info.actor,
@@ -560,37 +583,43 @@ mod tests {
     use axum::http::HeaderMap;
     use std::time::Duration;
 
-    #[test]
-    fn admin_sessions_create_validate_remove() {
-        let s = AdminSessions::default_policy();
-        let id = s.create(Role::Editor, Some("alice".into()));
-        let info = s.validate(&id).expect("freshly created session is valid");
+    #[tokio::test]
+    async fn admin_sessions_create_validate_remove() {
+        let s = InMemoryAdminSessionStore::default_policy();
+        let id = s.create(Role::Editor, Some("alice".into())).await;
+        let info = s
+            .validate(&id)
+            .await
+            .expect("freshly created session is valid");
         assert_eq!(info.role, Role::Editor);
         assert_eq!(info.actor.as_deref(), Some("alice"));
         assert!(
-            s.validate("not-a-real-id").is_none(),
+            s.validate("not-a-real-id").await.is_none(),
             "unknown id is invalid"
         );
-        s.remove(&id);
+        s.remove(&id).await;
         assert!(
-            s.validate(&id).is_none(),
+            s.validate(&id).await.is_none(),
             "removed (logged-out) session is invalid"
         );
     }
 
-    #[test]
-    fn admin_sessions_expire() {
-        let s = AdminSessions::new(Duration::from_millis(0));
-        let id = s.create(Role::Admin, None);
+    #[tokio::test]
+    async fn admin_sessions_expire() {
+        let s = InMemoryAdminSessionStore::new(Duration::from_millis(0));
+        let id = s.create(Role::Admin, None).await;
         std::thread::sleep(Duration::from_millis(2));
-        assert!(s.validate(&id).is_none(), "expired session is invalid");
+        assert!(
+            s.validate(&id).await.is_none(),
+            "expired session is invalid"
+        );
     }
 
-    #[test]
-    fn admin_session_ids_are_distinct_and_not_the_token() {
-        let s = AdminSessions::default_policy();
-        let a = s.create(Role::Viewer, None);
-        let b = s.create(Role::Viewer, None);
+    #[tokio::test]
+    async fn admin_session_ids_are_distinct_and_not_the_token() {
+        let s = InMemoryAdminSessionStore::default_policy();
+        let a = s.create(Role::Viewer, None).await;
+        let b = s.create(Role::Viewer, None).await;
         assert_ne!(a, b, "each session gets a fresh id");
         assert!(
             a.len() >= 32,

--- a/crates/ruscker-admin/src/auth.rs
+++ b/crates/ruscker-admin/src/auth.rs
@@ -173,8 +173,8 @@ struct SessionEntry {
     actor: Option<String>,
 }
 
-/// What [`AdminSessions::validate`] yields for a live session — the
-/// role and acting identity carried by the extractors.
+/// What [`AdminSessionStore::validate`] yields for a live session —
+/// the role and acting identity carried by the extractors.
 #[derive(Clone, Debug)]
 pub struct SessionInfo {
     pub role: Role,

--- a/crates/ruscker-admin/src/lib.rs
+++ b/crates/ruscker-admin/src/lib.rs
@@ -33,6 +33,7 @@ pub mod logbuf;
 pub mod metrics_cache;
 pub mod ratelimit;
 pub mod routes;
+pub mod admin_sessions_pg;
 pub mod scaler;
 pub mod sessions;
 pub mod sessions_pg;
@@ -54,8 +55,10 @@ pub struct AppState {
     pub admin_auth: auth::AdminAuth,
     /// Opaque server-side admin session store. The cookie holds a
     /// random session id (not the token); shared so every cloned
-    /// `AppState` sees the same live sessions.
-    pub admin_sessions: Arc<auth::AdminSessions>,
+    /// `AppState` sees the same live sessions. `Arc<dyn …>` so the
+    /// in-memory default and the HA Postgres-backed store (#185) drop
+    /// in identically.
+    pub admin_sessions: Arc<dyn auth::AdminSessionStore>,
     /// Global rate limiter for `/admin/login` — bounds brute
     /// force against the admin token. Shared (Arc) so every
     /// cloned `AppState` sees the same window.
@@ -173,7 +176,7 @@ impl AdminServer {
             locales: Arc::new(locales),
             base_path: Arc::from(""),
             admin_auth: auth::AdminAuth::from_env(),
-            admin_sessions: Arc::new(auth::AdminSessions::default_policy()),
+            admin_sessions: Arc::new(auth::InMemoryAdminSessionStore::default_policy()),
             login_limiter: Arc::new(auth::LoginRateLimiter::default_policy()),
             api_limiter: Arc::new(ratelimit::ApiRateLimiter::new()),
             db: None,
@@ -268,6 +271,19 @@ impl AdminServer {
         store: std::sync::Arc<dyn sessions::SessionStore>,
     ) -> Self {
         self.state.sessions = store;
+        self
+    }
+
+    /// Replace the admin sign-in session store (#185). Default is
+    /// the in-memory [`auth::InMemoryAdminSessionStore`]; pass an
+    /// [`admin_sessions_pg::PostgresAdminSessionStore`] to make
+    /// sign-in sessions survive a load-balancer hop between HA
+    /// instances.
+    pub fn with_admin_session_store(
+        mut self,
+        store: std::sync::Arc<dyn auth::AdminSessionStore>,
+    ) -> Self {
+        self.state.admin_sessions = store;
         self
     }
 

--- a/crates/ruscker-admin/src/routes/admin.rs
+++ b/crates/ruscker-admin/src/routes/admin.rs
@@ -261,7 +261,8 @@ async fn login_submit(
     state.login_limiter.record_success();
     let session_id = state
         .admin_sessions
-        .create(user.role, Some(user.username.clone()));
+        .create(user.role, Some(user.username.clone()))
+        .await;
     issue_session_cookie(&cookies, &headers, session_id);
 
     // First login with an admin-assigned password ⇒ ask whether to
@@ -364,7 +365,7 @@ async fn token_login(
     }
 
     state.login_limiter.record_success();
-    let session_id = state.admin_sessions.create(Role::Admin, None);
+    let session_id = state.admin_sessions.create(Role::Admin, None).await;
     issue_session_cookie(&cookies, &headers, session_id);
 
     // No admin account yet (and a DB to create one in) ⇒ run setup.
@@ -477,9 +478,12 @@ async fn setup_submit(
 
     // Swap the break-glass token session for a real account session.
     if let Some(c) = cookies.get(COOKIE_NAME) {
-        state.admin_sessions.remove(c.value());
+        state.admin_sessions.remove(c.value()).await;
     }
-    let session_id = state.admin_sessions.create(Role::Admin, Some(username));
+    let session_id = state
+        .admin_sessions
+        .create(Role::Admin, Some(username))
+        .await;
     issue_session_cookie(&cookies, &headers, session_id);
     Redirect::to("/admin/dashboard").into_response()
 }
@@ -627,7 +631,7 @@ async fn logout(_: MaybeAdminSession, State(state): State<AppState>, cookies: Co
     // Invalidate the session server-side so a copied cookie is dead too,
     // then clear the browser's copy.
     if let Some(c) = cookies.get(COOKIE_NAME) {
-        state.admin_sessions.remove(c.value());
+        state.admin_sessions.remove(c.value()).await;
     }
     let mut c = Cookie::new(COOKIE_NAME, "");
     c.set_path("/");

--- a/crates/ruscker-admin/src/routes/proxy.rs
+++ b/crates/ruscker-admin/src/routes/proxy.rs
@@ -1200,7 +1200,7 @@ mod tests {
                 crate::i18n::Locales::load().expect("load locales"),
             ),
             admin_auth: Default::default(),
-            admin_sessions: Default::default(),
+            admin_sessions: StdArc::new(crate::auth::InMemoryAdminSessionStore::default()),
             log_buffer: None,
             login_limiter: StdArc::new(crate::auth::LoginRateLimiter::default_policy()),
             api_limiter: StdArc::new(crate::ratelimit::ApiRateLimiter::new()),

--- a/crates/ruscker-admin/src/scaler.rs
+++ b/crates/ruscker-admin/src/scaler.rs
@@ -534,7 +534,7 @@ mod tests {
             base_path: Arc::from(""),
             locales: Arc::new(crate::i18n::Locales::load().expect("load locales")),
             admin_auth: Default::default(),
-            admin_sessions: Default::default(),
+            admin_sessions: Arc::new(crate::auth::InMemoryAdminSessionStore::default()),
             log_buffer: None,
             login_limiter: Arc::new(crate::auth::LoginRateLimiter::default_policy()),
             api_limiter: Arc::new(crate::ratelimit::ApiRateLimiter::new()),

--- a/crates/ruscker-admin/tests/api_policies.rs
+++ b/crates/ruscker-admin/tests/api_policies.rs
@@ -44,7 +44,7 @@ fn state() -> AppState {
         base_path: Arc::from(""),
         locales: Arc::new(locales),
         admin_auth: Default::default(),
-        admin_sessions: Default::default(),
+        admin_sessions: Arc::new(ruscker_admin::auth::InMemoryAdminSessionStore::default()),
         log_buffer: None,
         login_limiter: Arc::new(ruscker_admin::auth::LoginRateLimiter::default_policy()),
         api_limiter: Arc::new(ruscker_admin::ratelimit::ApiRateLimiter::new()),

--- a/crates/ruscker-admin/tests/health_probes.rs
+++ b/crates/ruscker-admin/tests/health_probes.rs
@@ -28,7 +28,7 @@ fn base_state() -> AppState {
         base_path: Arc::from(""),
         locales: Arc::new(locales),
         admin_auth: Default::default(),
-        admin_sessions: Default::default(),
+        admin_sessions: Arc::new(ruscker_admin::auth::InMemoryAdminSessionStore::default()),
         log_buffer: None,
         login_limiter: Arc::new(ruscker_admin::auth::LoginRateLimiter::default_policy()),
         api_limiter: Arc::new(ruscker_admin::ratelimit::ApiRateLimiter::new()),

--- a/crates/ruscker-admin/tests/landing_access.rs
+++ b/crates/ruscker-admin/tests/landing_access.rs
@@ -62,7 +62,7 @@ async fn app_state(db: ConfigDb) -> AppState {
         admin_auth: AdminAuth {
             admin: Some(Arc::from("test-token")),
         },
-        admin_sessions: Default::default(),
+        admin_sessions: Arc::new(ruscker_admin::auth::InMemoryAdminSessionStore::default()),
         log_buffer: None,
         login_limiter: Arc::new(ruscker_admin::auth::LoginRateLimiter::default_policy()),
         api_limiter: Arc::new(ruscker_admin::ratelimit::ApiRateLimiter::new()),
@@ -268,7 +268,7 @@ async fn admin_session_sees_every_spec() {
     let db = open_db().await;
     let state = app_state(db).await;
     // A break-glass token session: Admin role, no username.
-    let sid = state.admin_sessions.create(Role::Admin, None);
+    let sid = state.admin_sessions.create(Role::Admin, None).await;
     let body = landing_body(state, Some(format!("{COOKIE_NAME}={sid}"))).await;
 
     assert!(has_card(&body, "open app"));
@@ -295,7 +295,8 @@ async fn group_member_sees_their_group_spec() {
     let state = app_state(db).await;
     let sid = state
         .admin_sessions
-        .create(Role::Viewer, Some("alice".to_string()));
+        .create(Role::Viewer, Some("alice".to_string()))
+        .await;
     let body = landing_body(state, Some(format!("{COOKIE_NAME}={sid}"))).await;
 
     assert!(has_card(&body, "open app"));
@@ -320,7 +321,8 @@ async fn named_user_sees_their_user_spec() {
     let state = app_state(db).await;
     let sid = state
         .admin_sessions
-        .create(Role::Viewer, Some("carol".to_string()));
+        .create(Role::Viewer, Some("carol".to_string()))
+        .await;
     let body = landing_body(state, Some(format!("{COOKIE_NAME}={sid}"))).await;
 
     assert!(has_card(&body, "open app"));

--- a/crates/ruscker-admin/tests/landing_render.rs
+++ b/crates/ruscker-admin/tests/landing_render.rs
@@ -26,7 +26,7 @@ fn app_state() -> AppState {
         base_path: Arc::from(""),
         locales: Arc::new(locales),
         admin_auth: Default::default(),
-        admin_sessions: Default::default(),
+        admin_sessions: Arc::new(ruscker_admin::auth::InMemoryAdminSessionStore::default()),
         log_buffer: None,
         login_limiter: std::sync::Arc::new(ruscker_admin::auth::LoginRateLimiter::default_policy()),
         api_limiter: std::sync::Arc::new(ruscker_admin::ratelimit::ApiRateLimiter::new()),

--- a/crates/ruscker-admin/tests/max_body_size.rs
+++ b/crates/ruscker-admin/tests/max_body_size.rs
@@ -43,7 +43,7 @@ fn state() -> AppState {
         base_path: Arc::from(""),
         locales: Arc::new(locales),
         admin_auth: Default::default(),
-        admin_sessions: Default::default(),
+        admin_sessions: Arc::new(ruscker_admin::auth::InMemoryAdminSessionStore::default()),
         log_buffer: None,
         login_limiter: Arc::new(ruscker_admin::auth::LoginRateLimiter::default_policy()),
         api_limiter: Arc::new(ruscker_admin::ratelimit::ApiRateLimiter::new()),

--- a/crates/ruscker-admin/tests/metrics.rs
+++ b/crates/ruscker-admin/tests/metrics.rs
@@ -16,7 +16,7 @@ fn state(yaml: &str) -> AppState {
         base_path: Arc::from(""),
         locales: Arc::new(locales),
         admin_auth: Default::default(),
-        admin_sessions: Default::default(),
+        admin_sessions: Arc::new(ruscker_admin::auth::InMemoryAdminSessionStore::default()),
         log_buffer: None,
         login_limiter: Arc::new(ruscker_admin::auth::LoginRateLimiter::default_policy()),
         api_limiter: Arc::new(ruscker_admin::ratelimit::ApiRateLimiter::new()),

--- a/crates/ruscker-admin/tests/proxy_access.rs
+++ b/crates/ruscker-admin/tests/proxy_access.rs
@@ -63,7 +63,7 @@ async fn app_state(db: ConfigDb) -> AppState {
         admin_auth: AdminAuth {
             admin: Some(Arc::from("test-token")),
         },
-        admin_sessions: Default::default(),
+        admin_sessions: Arc::new(ruscker_admin::auth::InMemoryAdminSessionStore::default()),
         log_buffer: None,
         login_limiter: Arc::new(ruscker_admin::auth::LoginRateLimiter::default_policy()),
         api_limiter: Arc::new(ruscker_admin::ratelimit::ApiRateLimiter::new()),
@@ -129,7 +129,7 @@ async fn restricted_api_forbids_anonymous() {
 #[tokio::test]
 async fn admin_session_reaches_restricted_app() {
     let state = app_state(open_db().await).await;
-    let sid = state.admin_sessions.create(Role::Admin, None);
+    let sid = state.admin_sessions.create(Role::Admin, None).await;
     assert_eq!(
         get(state, "/app/analysts-app/", Some(format!("{COOKIE_NAME}={sid}"))).await,
         ALLOWED,
@@ -154,7 +154,8 @@ async fn group_member_reaches_restricted_app() {
     let state = app_state(db).await;
     let sid = state
         .admin_sessions
-        .create(Role::Viewer, Some("alice".to_string()));
+        .create(Role::Viewer, Some("alice".to_string()))
+        .await;
     assert_eq!(
         get(state, "/app/analysts-app/", Some(format!("{COOKIE_NAME}={sid}"))).await,
         ALLOWED,
@@ -179,7 +180,8 @@ async fn non_member_forbidden_from_restricted_app() {
     let state = app_state(db).await;
     let sid = state
         .admin_sessions
-        .create(Role::Viewer, Some("dave".to_string()));
+        .create(Role::Viewer, Some("dave".to_string()))
+        .await;
     // Logged in but not in the group ⇒ 403, not a login redirect.
     assert_eq!(
         get(state, "/app/analysts-app/", Some(format!("{COOKIE_NAME}={sid}"))).await,

--- a/crates/ruscker-admin/tests/rbac.rs
+++ b/crates/ruscker-admin/tests/rbac.rs
@@ -40,7 +40,7 @@ fn state() -> AppState {
         admin_auth: AdminAuth {
             admin: Some("admin-tok".into()),
         },
-        admin_sessions: Default::default(),
+        admin_sessions: Arc::new(ruscker_admin::auth::InMemoryAdminSessionStore::default()),
         log_buffer: None,
         login_limiter: Arc::new(ruscker_admin::auth::LoginRateLimiter::default_policy()),
         api_limiter: Arc::new(ruscker_admin::ratelimit::ApiRateLimiter::new()),
@@ -61,8 +61,11 @@ fn state() -> AppState {
 /// Mint a live session for `role` in the state's store and return the
 /// cookie header value to send it back. The store is behind an `Arc`
 /// shared with the router built from the same `state`.
-fn cookie_for(state: &AppState, role: Role) -> String {
-    let id = state.admin_sessions.create(role, Some("test-user".into()));
+async fn cookie_for(state: &AppState, role: Role) -> String {
+    let id = state
+        .admin_sessions
+        .create(role, Some("test-user".into()))
+        .await;
     format!("{COOKIE_NAME}={id}")
 }
 
@@ -81,7 +84,7 @@ async fn send(state: AppState, method: &str, uri: &str, cookie: Option<&str>) ->
 #[tokio::test]
 async fn viewer_can_view_dashboard() {
     let st = state();
-    let c = cookie_for(&st, Role::Viewer);
+    let c = cookie_for(&st, Role::Viewer).await;
     // No DB needed for the dashboard render, so this is a clean 200.
     assert_eq!(
         send(st, "GET", "/admin/dashboard", Some(&c)).await,
@@ -101,7 +104,7 @@ async fn viewer_cannot_reach_apps_or_admin_sections() {
         "/admin/logs",
     ] {
         let st = state();
-        let c = cookie_for(&st, Role::Viewer);
+        let c = cookie_for(&st, Role::Viewer).await;
         assert_eq!(
             send(st, "GET", uri, Some(&c)).await,
             StatusCode::FORBIDDEN,
@@ -113,7 +116,7 @@ async fn viewer_cannot_reach_apps_or_admin_sections() {
 #[tokio::test]
 async fn viewer_cannot_perform_dashboard_actions() {
     let st = state();
-    let c = cookie_for(&st, Role::Viewer);
+    let c = cookie_for(&st, Role::Viewer).await;
     let uri = "/admin/dashboard/replicas/11111111-2222-3333-4444-555555555555/stop";
     assert_eq!(
         send(st, "POST", uri, Some(&c)).await,
@@ -130,7 +133,7 @@ async fn editor_passes_guard_on_apps_and_media() {
     // no DB is attached. The point is it's NOT a 403.
     for uri in ["/admin/specs", "/admin/media"] {
         let st = state();
-        let c = cookie_for(&st, Role::Editor);
+        let c = cookie_for(&st, Role::Editor).await;
         let status = send(st, "GET", uri, Some(&c)).await;
         assert_ne!(status, StatusCode::FORBIDDEN, "editor allowed on {uri}");
         assert_eq!(
@@ -145,7 +148,7 @@ async fn editor_passes_guard_on_apps_and_media() {
 async fn editor_can_perform_dashboard_actions() {
     // RequireEditor passes; no backend ⇒ 503, but crucially not 403.
     let st = state();
-    let c = cookie_for(&st, Role::Editor);
+    let c = cookie_for(&st, Role::Editor).await;
     let uri = "/admin/dashboard/replicas/11111111-2222-3333-4444-555555555555/stop";
     let status = send(st, "POST", uri, Some(&c)).await;
     assert_ne!(status, StatusCode::FORBIDDEN, "editor may stop/restart");
@@ -161,7 +164,7 @@ async fn editor_cannot_reach_admin_only_sections() {
         "/admin/logs",
     ] {
         let st = state();
-        let c = cookie_for(&st, Role::Editor);
+        let c = cookie_for(&st, Role::Editor).await;
         assert_eq!(
             send(st, "GET", uri, Some(&c)).await,
             StatusCode::FORBIDDEN,
@@ -183,7 +186,7 @@ async fn admin_passes_guard_everywhere() {
         "/admin/audit",
     ] {
         let st = state();
-        let c = cookie_for(&st, Role::Admin);
+        let c = cookie_for(&st, Role::Admin).await;
         assert_ne!(
             send(st, "GET", uri, Some(&c)).await,
             StatusCode::FORBIDDEN,

--- a/crates/ruscker-admin/tests/user_accounts.rs
+++ b/crates/ruscker-admin/tests/user_accounts.rs
@@ -27,7 +27,7 @@ async fn state_with_db() -> (AppState, sqlx::SqlitePool) {
         base_path: Arc::from(""),
         locales: Arc::new(locales),
         admin_auth: AdminAuth::with_token("break-glass-tok"),
-        admin_sessions: Default::default(),
+        admin_sessions: Arc::new(ruscker_admin::auth::InMemoryAdminSessionStore::default()),
         log_buffer: None,
         login_limiter: Arc::new(ruscker_admin::auth::LoginRateLimiter::default_policy()),
         api_limiter: Arc::new(ruscker_admin::ratelimit::ApiRateLimiter::new()),
@@ -218,7 +218,7 @@ async fn setup_page_chrome_cluster_is_outside_the_setup_form() {
     // Twin of `login_page_chrome_cluster_is_outside_the_login_form` for
     // /admin/setup.
     let (state, _pool) = state_with_db().await;
-    let sid = state.admin_sessions.create(Role::Admin, None);
+    let sid = state.admin_sessions.create(Role::Admin, None).await;
     let cookie = format!("{COOKIE_NAME}={sid}");
     let app = router(state);
     let resp = app
@@ -263,7 +263,8 @@ async fn last_admin_cannot_be_deleted() {
     // Mint an admin session directly (the shared store the router reads).
     let sid = state
         .admin_sessions
-        .create(Role::Admin, Some("root".into()));
+        .create(Role::Admin, Some("root".into()))
+        .await;
     let cookie = format!("{COOKIE_NAME}={sid}");
 
     let (status, loc) = post(state, "/admin/users/root/delete", "", Some(&cookie)).await;

--- a/crates/ruscker-cli/src/main.rs
+++ b/crates/ruscker-cli/src/main.rs
@@ -175,6 +175,15 @@ enum Command {
         #[arg(long, env = "RUSCKER_SESSION_STORE_URL")]
         session_store_url: Option<String>,
 
+        /// Postgres DSN for the shared HA admin-session store (#185).
+        /// When set, sign-in sessions survive a load-balancer hop
+        /// between Ruscker instances — removes the need for the
+        /// sticky-upstream workaround documented for #161. A short
+        /// local TTL cache keeps the proxy hot path effectively
+        /// DB-free. Omitted → the single-node in-memory store.
+        #[arg(long, env = "RUSCKER_ADMIN_SESSION_STORE_URL")]
+        admin_session_store_url: Option<String>,
+
         /// Serve the whole portal under a base path, for mounting behind
         /// a reverse proxy at a subpath when you can't make a subdomain
         /// (e.g. `--base-path /box` ⇒ `example.org/box/`). Overrides
@@ -213,6 +222,7 @@ fn main() -> Result<()> {
             master_key,
             docker,
             session_store_url,
+            admin_session_store_url,
             base_path,
         } => cmd_serve(ServeArgs {
             config_path: config,
@@ -224,6 +234,7 @@ fn main() -> Result<()> {
             master_key,
             docker,
             session_store_url,
+            admin_session_store_url,
             base_path_override: base_path,
             log_buffer,
         }),
@@ -392,6 +403,7 @@ struct ServeArgs {
     master_key: Option<String>,
     docker: bool,
     session_store_url: Option<String>,
+    admin_session_store_url: Option<String>,
     base_path_override: Option<String>,
     log_buffer: ruscker_admin::logbuf::LogBuffer,
 }
@@ -407,6 +419,7 @@ fn cmd_serve(args: ServeArgs) -> Result<()> {
         master_key,
         docker,
         session_store_url,
+        admin_session_store_url,
         base_path_override,
         log_buffer,
     } = args;
@@ -516,6 +529,13 @@ fn cmd_serve(args: ServeArgs) -> Result<()> {
                 .await
                 .context("connect to the Postgres session store")?;
             server = server.with_session_store(std::sync::Arc::new(store));
+        }
+        if let Some(url) = admin_session_store_url {
+            tracing::info!("HA admin-session store: Postgres");
+            let store = ruscker_admin::admin_sessions_pg::PostgresAdminSessionStore::connect(&url)
+                .await
+                .context("connect to the Postgres admin-session store")?;
+            server = server.with_admin_session_store(std::sync::Arc::new(store));
         }
         server.run().await
     })

--- a/docs/SECURITY.md
+++ b/docs/SECURITY.md
@@ -75,9 +75,12 @@ Status: living document. Tracks the Phase 5 security audit
 - **[implemented]** Admin cookie is `HttpOnly` + `SameSite=Strict`
   + `Secure` (under TLS, see §7) — `routes::admin::login_submit`.
 - **[implemented]** Opaque server-side sessions (#77) — the cookie
-  carries a random 244-bit session id (`auth::AdminSessions`), never
-  the token. Logout and server restart revoke it; a stolen cookie
-  never exposes the token.
+  carries a random 244-bit session id (`auth::AdminSessionStore`),
+  never the token. Logout and server restart revoke it; a stolen
+  cookie never exposes the token. The store is in-memory by default
+  (`InMemoryAdminSessionStore`); for HA, point Ruscker at a shared
+  Postgres via `--admin-session-store-url` (#185) so sessions survive
+  a load-balancer hop.
 - **[implemented]** Role-based access control (#101/#107) — three
   roles (**Viewer** = dashboard read-only; **Editor** = apps + media +
   dashboard incl. stop/restart; **Admin** = everything, incl. user


### PR DESCRIPTION
Closes #185. Removes the sticky-upstream workaround documented for #161: sign-in sessions now survive a load-balancer hop between HA instances when the operator points Ruscker at a shared Postgres.

## What ships

### Trait + in-memory store
- \`auth::AdminSessions\` (struct) → \`auth::AdminSessionStore\` (async trait: \`create / validate / remove\`).
- Existing behavior stays as \`auth::InMemoryAdminSessionStore\`, the default.
- \`AppState.admin_sessions\` becomes \`Arc<dyn AdminSessionStore>\` so either impl drops in identically.
- All call sites updated to \`.await\` the async API: the hot-path \`auth::from_request_parts\` (every admin route + every \`MaybeSession\`), \`admin::login_submit / token_login / setup_submit / logout\`, plus eight test files (\`Default::default()\` → \`Arc::new(InMemoryAdminSessionStore::default())\`; \`rbac::cookie_for\` became async).

### Postgres-backed store with local TTL cache
New \`crates/ruscker-admin/src/admin_sessions_pg.rs\`:
- One \`admin_sessions(sid, role, actor, expires_at)\` table; idempotent \`CREATE TABLE IF NOT EXISTS + INDEX\` on connect.
- Node-local \`DashMap<sid, (Option<SessionInfo>, valid_until)>\` cache.
  - **Hit (fresh) returns immediately** — proxy hot path stays effectively DB-free.
  - Miss/stale → one \`SELECT\`, repopulate.
- \`create\` / \`remove\` write through to PG AND the cache so the local node sees its own writes instantly; cross-node staleness bounded by the cache TTL.
- Defaults: session TTL 24h (cookie Max-Age), cache TTL **5s**.
- Lazy GC of expired rows on validate; tombstone cached so repeated lookups of a stale cookie also skip the DB.

### Wiring
- New \`auth::mint_session_id()\` (crate-private) shared by both impls so the wire format stays uniform.
- New \`AdminServer::with_admin_session_store(Arc<dyn …>)\` builder.
- **New CLI flag** \`--admin-session-store-url\` (env \`RUSCKER_ADMIN_SESSION_STORE_URL\`), plumbed through \`ServeArgs\`.

### Docs
- \`book/src/deploying.md\` § HA — sticky-upstream section rewritten. Shared admin-session store is now the **recommended fix**; sticky upstream demoted to "fallback if you can't host shared Postgres". Cross-link from \`book/src/faq.md\` still resolves.

## Test plan
- [x] \`cargo test --workspace\`: green (~330 tests).
- [x] \`cargo clippy --workspace --all-targets\`: 0 warnings.
- [x] **5/5 \`postgres-it\` tests against postgres:16-alpine**, serialized via \`crate::db::pg_test_lock\`:
  - \`create_then_validate_roundtrips\` — happy path.
  - \`validate_hits_cache_after_first_lookup\` — cache shortcut survives a manual DELETE.
  - \`cross_instance_visibility_via_shared_table\` — session on A validates on B without re-login.
  - \`remove_revokes_within_cache_ttl_on_other_node\` — logout propagation bounded by TTL.
  - \`expired_session_returns_none_and_is_pruned\` — lazy GC.
- [x] Existing in-memory \`admin_sessions_*\` tests rewritten as \`#[tokio::test]\` to match the async trait.
- [x] \`mdbook build\` clean.

## Run the integration tests locally

\`\`\`bash
docker run --rm -d --name pg -e POSTGRES_PASSWORD=pg -p 5433:5432 postgres:16-alpine
RUSCKER_TEST_PG_URL=postgres://postgres:pg@127.0.0.1:5433/postgres \\
  cargo test -p ruscker-admin --features postgres-it admin_sessions_pg
\`\`\`

🤖 Generated with [Claude Code](https://claude.com/claude-code)