### PR TITLE
Landing polish (#187 sweep): language badge / 'Sign in' / broken-img / brand mark on custom header

### DIFF
--- a/crates/ruscker-admin/assets/i18n/en/landing.ftl
+++ b/crates/ruscker-admin/assets/i18n/en/landing.ftl
@@ -157,7 +157,7 @@ admin-dashboard-state-failed = failed
 admin-dashboard-backend-missing = Docker backend is not connected — start the server with `--docker` to see containers here.
 
 # Admin login
-admin-login-title = Admin sign in
+admin-login-title = Sign in
 admin-login-help = Enter the admin token defined in RUSCKER_ADMIN_TOKEN.
 admin-login-token-label = Token
 admin-login-token-placeholder = Paste the token here

--- a/crates/ruscker-admin/assets/i18n/es/landing.ftl
+++ b/crates/ruscker-admin/assets/i18n/es/landing.ftl
@@ -157,7 +157,7 @@ admin-dashboard-state-failed = falló
 admin-dashboard-backend-missing = El backend de Docker no está conectado — inicie el servidor con `--docker` para ver contenedores aquí.
 
 # Admin login
-admin-login-title = Acceso admin
+admin-login-title = Iniciar sesión
 admin-login-help = Ingrese el token de admin definido en RUSCKER_ADMIN_TOKEN.
 admin-login-token-label = Token
 admin-login-token-placeholder = Pegue el token aquí

--- a/crates/ruscker-admin/assets/i18n/fr/landing.ftl
+++ b/crates/ruscker-admin/assets/i18n/fr/landing.ftl
@@ -157,7 +157,7 @@ admin-dashboard-state-failed = échec
 admin-dashboard-backend-missing = Le backend Docker n'est pas connecté — démarrez le serveur avec `--docker` pour voir les conteneurs ici.
 
 # Admin login
-admin-login-title = Accès admin
+admin-login-title = Se connecter
 admin-login-help = Saisissez le jeton admin défini dans RUSCKER_ADMIN_TOKEN.
 admin-login-token-label = Jeton
 admin-login-token-placeholder = Collez le jeton ici

--- a/crates/ruscker-admin/assets/i18n/pt/landing.ftl
+++ b/crates/ruscker-admin/assets/i18n/pt/landing.ftl
@@ -161,7 +161,7 @@ admin-dashboard-state-failed = falhou
 admin-dashboard-backend-missing = O backend Docker não está conectado — inicie o servidor com `--docker` para ver containers aqui.
 
 # Admin login
-admin-login-title = Acesso ao admin
+admin-login-title = Entrar
 admin-login-help = Digite o token de admin definido em RUSCKER_ADMIN_TOKEN.
 admin-login-token-label = Token
 admin-login-token-placeholder = Cole o token aqui

--- a/crates/ruscker-admin/assets/tailwind/input.css
+++ b/crates/ruscker-admin/assets/tailwind/input.css
@@ -495,17 +495,17 @@ body {
   background: var(--text); color: var(--bg); border-color: var(--text);
 }
 
-.chrome-icon-badge {
-  position: absolute; bottom: 3px; right: 3px;
-  font-size: 9px; font-weight: 600; letter-spacing: 0.04em;
-  padding: 0 3px;
-  background: var(--surface);
-  border: 0.5px solid var(--border);
-  border-radius: 4px;
-  line-height: 1.3;
-}
-.chrome-disclosure[open] > .chrome-icon .chrome-icon-badge {
-  background: var(--bg); color: var(--text); border-color: var(--bg);
+/* Language slot of the cluster: bold 2-letter locale code that fills
+   the entire icon button. Replaces the older globe+tiny-badge combo
+   (#187 finding F4) — the badge was unreadable on dark operator-set
+   header backgrounds. Uses `currentColor` so contrast comes from the
+   surrounding chrome (white on dark headers, dark on light surfaces). */
+.chrome-icon-lang {
+  font-family: inherit;
+  font-size: 11px; font-weight: 600;
+  letter-spacing: 0.06em;
+  line-height: 1;
+  color: inherit;
 }
 
 /* Anonymous sign-in CTA — textual variant of the icon-button. */

--- a/crates/ruscker-admin/templates/_chrome_cluster.html
+++ b/crates/ruscker-admin/templates/_chrome_cluster.html
@@ -41,8 +41,7 @@
   {# ── Language ───────────────────────────────────────────────── #}
   <details class="chrome-disclosure" name="chrome-cluster">
     <summary class="chrome-icon" aria-label="{{ self.t("chrome-language-label") }}" title="{{ self.t("chrome-language-label") }}">
-      <i class="ti ti-world" aria-hidden="true"></i>
-      <span class="chrome-icon-badge">{{ locale.code()|upper }}</span>
+      <span class="chrome-icon-lang">{{ locale.code()|upper }}</span>
     </summary>
     <form method="post" action="/__set/locale" class="chrome-popover">
       {% for loc in locales_all %}

--- a/crates/ruscker-admin/templates/_chrome_cluster_admin.html
+++ b/crates/ruscker-admin/templates/_chrome_cluster_admin.html
@@ -38,8 +38,7 @@
   {# ── Language ───────────────────────────────────────────────── #}
   <details class="chrome-disclosure" name="chrome-cluster">
     <summary class="chrome-icon" aria-label="{{ self.t("chrome-language-label") }}" title="{{ self.t("chrome-language-label") }}">
-      <i class="ti ti-world" aria-hidden="true"></i>
-      <span class="chrome-icon-badge">{{ locale.code()|upper }}</span>
+      <span class="chrome-icon-lang">{{ locale.code()|upper }}</span>
     </summary>
     <form method="post" action="/__set/locale" class="chrome-popover">
       {% for loc in locales_all %}

--- a/crates/ruscker-admin/templates/_chrome_cluster_anon.html
+++ b/crates/ruscker-admin/templates/_chrome_cluster_anon.html
@@ -38,8 +38,7 @@
 
   <details class="chrome-disclosure" name="chrome-cluster">
     <summary class="chrome-icon" aria-label="{{ self.t("chrome-language-label") }}" title="{{ self.t("chrome-language-label") }}">
-      <i class="ti ti-world" aria-hidden="true"></i>
-      <span class="chrome-icon-badge">{{ locale.code()|upper }}</span>
+      <span class="chrome-icon-lang">{{ locale.code()|upper }}</span>
     </summary>
     <form method="post" action="/__set/locale" class="chrome-popover">
       {% for loc in locales_all %}

--- a/crates/ruscker-admin/templates/admin/login.html
+++ b/crates/ruscker-admin/templates/admin/login.html
@@ -28,7 +28,7 @@
       <polygon points="14,40 40,28 66,40 40,52" fill="#1D9E75"/>
       <polygon points="14,28 40,16 66,28 40,40" fill="#5DCAA5"/>
     </svg>
-    <div class="brand-wordmark text-base">ruscker · admin</div>
+    <div class="brand-wordmark text-base">ruscker</div>
   </div>
 
   <h1 class="text-lg font-medium tracking-tight">{{ self.t("admin-login-title") }}</h1>

--- a/crates/ruscker-admin/templates/landing.html
+++ b/crates/ruscker-admin/templates/landing.html
@@ -20,12 +20,28 @@
   <div class="max-w-6xl mx-auto px-6 py-5 flex items-center justify-between gap-6">
     <div class="flex items-center gap-3">
       {# Small Ruscker mark left of the operator-provided title (#182).
-         Future: operators can override with `landing-customization.logo`. #}
-      <svg viewBox="0 0 80 80" width="28" height="28" aria-hidden="true" class="flex-none">
-        <polygon points="14,52 40,40 66,52 40,64" fill="#0F6E56"/>
-        <polygon points="14,40 40,28 66,40 40,52" fill="#1D9E75"/>
-        <polygon points="14,28 40,16 66,28 40,40" fill="#5DCAA5"/>
-      </svg>
+         When the operator hasn't set a custom `header-bg`, we render
+         in the brand teal palette — that works against the default
+         surface in both light and dark themes. When a custom header
+         is in play (`header_style` non-empty), one of the brand
+         polygons can collide with the chosen background (e.g. teal
+         on teal disappears) — so we drop to a monochrome `currentColor`
+         mark that inherits the header's text color and stays
+         high-contrast at zero cost. Future: operators can override
+         with `landing-customization.logo`. #}
+      {% if header_style.is_empty() %}
+        <svg viewBox="0 0 80 80" width="28" height="28" aria-hidden="true" class="flex-none">
+          <polygon points="14,52 40,40 66,52 40,64" fill="#0F6E56"/>
+          <polygon points="14,40 40,28 66,40 40,52" fill="#1D9E75"/>
+          <polygon points="14,28 40,16 66,28 40,40" fill="#5DCAA5"/>
+        </svg>
+      {% else %}
+        <svg viewBox="0 0 80 80" width="28" height="28" aria-hidden="true" class="flex-none">
+          <polygon points="14,52 40,40 66,52 40,64" fill="currentColor" opacity="0.45"/>
+          <polygon points="14,40 40,28 66,40 40,52" fill="currentColor" opacity="0.7"/>
+          <polygon points="14,28 40,16 66,28 40,40" fill="currentColor" opacity="1"/>
+        </svg>
+      {% endif %}
       <div>
         <h1 class="text-xl font-medium tracking-tight">{{ self.t("landing-title") }}</h1>
         <p class="text-xs opacity-70 mt-1">{{ self.t("landing-subtitle") }}</p>
@@ -164,9 +180,14 @@
               <div class="rcover-bg tint-{{ card.display_type.key() }}"></div>
           {% endmatch %}
           {% match card.logo %}{% when Some with (logo) %}
+            {# #187 finding F2: hide the <img> if the referenced asset
+               doesn't load — the tinted cover behind shows through
+               cleanly instead of the broken-image glyph. Operators
+               with bad paths see a clean card, not a jarring icon. #}
             <img src="{{ logo }}"
                  alt=""
                  loading="lazy"
+                 onerror="this.style.display='none'"
                  class="rcover-img{% if logo.ends_with(".svg") %} rcover-img--contain{% endif %}">
           {% when None %}
             <span class="rcover-fallback">{{ card.id }}</span>


### PR DESCRIPTION
Four small fixes surfaced by the local frontend sweep on #187. No new issues opened — bundling them here so the next deploy gets cleaner cards + a more inclusive sign-in.

## What ships

1. **Cluster language slot** — the `<i ti-world> + tiny <span> badge` stack put white-on-white inside a teal-on-teal box on operator-customized headers (visible in the audit screenshot). Replace with a single bold 2-letter code (`EN`/`PT`/...) that fills the icon and inherits \`currentColor\` from the surrounding chrome.

2. **"Admin sign in" title was misleading for non-admin roles** — with #155 we have Admin/Editor/Viewer all using the same sign-in form; the title shouldn't preselect a role.
   - en: "Admin sign in" → "Sign in"
   - pt: "Acesso ao admin" → "Entrar"
   - es: "Acceso admin" → "Iniciar sesión"
   - fr: "Accès admin" → "Se connecter"
   Also drop "· admin" from the login card's brand wordmark. The setup page keeps "· admin" because that screen IS specifically the first-admin bootstrap.

3. **Broken-image glyphs on cards when a spec's \`logo:\` points at a missing asset** — the browser's default broken-img icon was rendering over the tinted cover (clearly visible on every card in the audit landing screenshot). Added an \`onerror\` handler on the cover \`<img>\` that hides the element so the tinted cover behind shows clean.

4. **Brand mark vanished on customized header backgrounds** — the hardcoded \`fill="#0F6E56"\` polygon was identical to \`examples/application.yml\` \`header-bg: #0f6e56\`, so the dark polygon disappeared and only fragments showed. When \`header_style\` is non-empty, the template now renders a monochrome variant with \`fill="currentColor"\` + opacity steps (1 / 0.7 / 0.45) so the mark inherits the operator-set text color and keeps its layered look. Default (no override) still renders the brand teal palette.

## Test plan
- [x] \`cargo test -p ruscker-admin\` green (250+).
- [x] \`scripts/i18n-check.sh\` green.
- [x] Smoked on darwin (127.0.0.1:8092 against \`examples/application.yml\`): badge "EN" pops cleanly; brand mark visible in 3 opacity layers on the teal header; sales-dashboard etc. cards render flat tinted covers; /admin/login reads "Sign in" with brand "ruscker".

🤖 Generated with [Claude Code](https://claude.com/claude-code)