### PR TITLE
welcome LandingBlock seeded on first install (#187 #4+#5)

### DIFF
--- a/crates/ruscker-admin/assets/tailwind/input.css
+++ b/crates/ruscker-admin/assets/tailwind/input.css
@@ -561,6 +561,59 @@ body {
   height: 0.5px; background: var(--border); margin: 4px 0;
 }
 
+/* ─── Welcome block (auto-seeded on first install) ───────────────
+ *
+ * Renders inside a `landing-block landing-block--bottom` slot — the
+ * outer wrapper comes from landing.html. These rules style the inner
+ * `<section class="ruscker-welcome">` markup the seed migration
+ * inserts. Operator can delete or edit the block via /admin/blocks.
+ *
+ * Each tech "chip" uses a `--tc` CSS var (the framework's primary
+ * brand hex) as its accent color, with the chip itself a low-opacity
+ * tint of that color and the label in the same color (full opacity).
+ * Defaults gracefully on themes the operator hasn't customized.
+ */
+.ruscker-welcome {
+  margin: 36px auto 0;
+  padding: 28px 24px 32px;
+  border-top: 0.5px solid var(--border);
+  text-align: center;
+}
+.ruscker-welcome-heading {
+  font-size: 16px; font-weight: 500;
+  margin: 0 0 6px;
+  color: var(--text);
+}
+.ruscker-welcome-sub {
+  font-size: 13px; color: var(--text-muted);
+  margin: 0 0 20px;
+}
+.ruscker-welcome-techs {
+  list-style: none; padding: 0; margin: 0 0 22px;
+  display: flex; flex-wrap: wrap; justify-content: center;
+  gap: 8px 10px;
+}
+.ruscker-welcome-tech {
+  display: inline-flex; align-items: center;
+  padding: 6px 14px;
+  border-radius: 999px;
+  border: 0.5px solid color-mix(in srgb, var(--tc) 35%, transparent);
+  background: color-mix(in srgb, var(--tc) 10%, var(--surface));
+  color: var(--tc);
+  font-size: 12px; font-weight: 500; letter-spacing: 0.02em;
+  line-height: 1;
+}
+.ruscker-welcome-docs {
+  display: inline-flex; align-items: center; gap: 6px;
+  padding: 10px 18px;
+  background: var(--text); color: var(--bg);
+  border-radius: 999px;
+  font-size: 13px; font-weight: 500;
+  text-decoration: none;
+  transition: opacity 0.15s;
+}
+.ruscker-welcome-docs:hover { opacity: 0.88; }
+
 /* ─── Admin login card ───────────────────────────────────────── */
 .admin-login-card {
   background: var(--surface);

--- a/crates/ruscker-admin/migrations-pg/0008_welcome_block.sql
+++ b/crates/ruscker-admin/migrations-pg/0008_welcome_block.sql
@@ -1,0 +1,35 @@
+-- Seed a single "welcome" landing block on fresh installs (#187 #4+#5).
+-- Postgres twin of the SQLite migration with the same number.
+-- Idempotent via `INSERT ... SELECT ... WHERE NOT EXISTS`: on a database
+-- that already has any landing_blocks row the seed is skipped.
+INSERT INTO landing_blocks (
+    id, slot, position, enabled, title, html, csp_origins,
+    created_at, updated_at
+)
+SELECT
+    'welcome-seed',
+    'bottom',
+    0,
+    TRUE,
+    'Welcome (auto-seeded on first install)',
+    '<section class="ruscker-welcome">' ||
+      '<h2 class="ruscker-welcome-heading">Welcome to Ruscker</h2>' ||
+      '<p class="ruscker-welcome-sub">Ruscker can host these and more. Add your first spec from the admin panel.</p>' ||
+      '<ul class="ruscker-welcome-techs">' ||
+        '<li class="ruscker-welcome-tech" style="--tc:#447099"><span>Shiny</span></li>' ||
+        '<li class="ruscker-welcome-tech" style="--tc:#FF4B4B"><span>Streamlit</span></li>' ||
+        '<li class="ruscker-welcome-tech" style="--tc:#3F4F75"><span>Dash</span></li>' ||
+        '<li class="ruscker-welcome-tech" style="--tc:#75AADB"><span>R Markdown</span></li>' ||
+        '<li class="ruscker-welcome-tech" style="--tc:#39729E"><span>Quarto</span></li>' ||
+        '<li class="ruscker-welcome-tech" style="--tc:#F37726"><span>Jupyter</span></li>' ||
+        '<li class="ruscker-welcome-tech" style="--tc:#B4C66F"><span>Bokeh</span></li>' ||
+        '<li class="ruscker-welcome-tech" style="--tc:#B43E58"><span>Plumber</span></li>' ||
+        '<li class="ruscker-welcome-tech" style="--tc:#009688"><span>FastAPI</span></li>' ||
+        '<li class="ruscker-welcome-tech" style="--tc:#6E40C9"><span>Voilà</span></li>' ||
+      '</ul>' ||
+      '<a class="ruscker-welcome-docs" href="https://ruscker.com" target="_blank" rel="noopener">Read the Ruscker manual →</a>' ||
+    '</section>',
+    '',
+    now(),
+    now()
+WHERE NOT EXISTS (SELECT 1 FROM landing_blocks);

--- a/crates/ruscker-admin/migrations/0008_welcome_block.sql
+++ b/crates/ruscker-admin/migrations/0008_welcome_block.sql
@@ -1,0 +1,42 @@
+-- Seed a single "welcome" landing block on fresh installs (#187 #4+#5).
+-- Idempotent via `INSERT ... SELECT ... WHERE NOT EXISTS`: on a database
+-- that already has any landing_blocks row (e.g. the operator already
+-- populated one via /admin/blocks) the seed is skipped.
+--
+-- The block sits in the `bottom` slot (after the card grid). Content is
+-- a short welcome heading + a strip of framework name chips Ruscker can
+-- host + a link out to the manual. Operators can edit or delete it via
+-- /admin/blocks like any other block; that's why the URL points at the
+-- documented Ruscker docs site (admin can swap to ruscker.com once the
+-- domain is live).
+INSERT INTO landing_blocks (
+    id, slot, position, enabled, title, html, csp_origins,
+    created_at, updated_at
+)
+SELECT
+    'welcome-seed',
+    'bottom',
+    0,
+    1,
+    'Welcome (auto-seeded on first install)',
+    '<section class="ruscker-welcome">' ||
+      '<h2 class="ruscker-welcome-heading">Welcome to Ruscker</h2>' ||
+      '<p class="ruscker-welcome-sub">Ruscker can host these and more. Add your first spec from the admin panel.</p>' ||
+      '<ul class="ruscker-welcome-techs">' ||
+        '<li class="ruscker-welcome-tech" style="--tc:#447099"><span>Shiny</span></li>' ||
+        '<li class="ruscker-welcome-tech" style="--tc:#FF4B4B"><span>Streamlit</span></li>' ||
+        '<li class="ruscker-welcome-tech" style="--tc:#3F4F75"><span>Dash</span></li>' ||
+        '<li class="ruscker-welcome-tech" style="--tc:#75AADB"><span>R Markdown</span></li>' ||
+        '<li class="ruscker-welcome-tech" style="--tc:#39729E"><span>Quarto</span></li>' ||
+        '<li class="ruscker-welcome-tech" style="--tc:#F37726"><span>Jupyter</span></li>' ||
+        '<li class="ruscker-welcome-tech" style="--tc:#B4C66F"><span>Bokeh</span></li>' ||
+        '<li class="ruscker-welcome-tech" style="--tc:#B43E58"><span>Plumber</span></li>' ||
+        '<li class="ruscker-welcome-tech" style="--tc:#009688"><span>FastAPI</span></li>' ||
+        '<li class="ruscker-welcome-tech" style="--tc:#6E40C9"><span>Voilà</span></li>' ||
+      '</ul>' ||
+      '<a class="ruscker-welcome-docs" href="https://ruscker.com" target="_blank" rel="noopener">Read the Ruscker manual →</a>' ||
+    '</section>',
+    '',
+    datetime('now'),
+    datetime('now')
+WHERE NOT EXISTS (SELECT 1 FROM landing_blocks);

--- a/crates/ruscker-admin/src/db/landing_blocks.rs
+++ b/crates/ruscker-admin/src/db/landing_blocks.rs
@@ -634,9 +634,24 @@ mod tests {
         }
     }
 
+    /// Migration 0008 seeds a welcome block on fresh DBs. These tests
+    /// assert on counts/positions that predate it; wipe the table so
+    /// each test starts from a clean slate.
+    async fn wipe(db: &ConfigDb) {
+        match db {
+            ConfigDb::Sqlite(p) => {
+                sqlx::query("DELETE FROM landing_blocks").execute(p).await.unwrap();
+            }
+            ConfigDb::Postgres(p) => {
+                sqlx::query("DELETE FROM landing_blocks").execute(p).await.unwrap();
+            }
+        }
+    }
+
     #[tokio::test]
     async fn insert_appends_position_per_slot() {
         let db = ConfigDb::Sqlite(open_memory().await.unwrap());
+        wipe(&db).await;
         insert(&db, &input("top", "a"), None).await.unwrap();
         insert(&db, &input("top", "b"), None).await.unwrap();
         insert(&db, &input("bottom", "c"), None).await.unwrap();
@@ -652,6 +667,7 @@ mod tests {
     #[tokio::test]
     async fn move_block_swaps_within_slot() {
         let db = ConfigDb::Sqlite(open_memory().await.unwrap());
+        wipe(&db).await;
         let a = insert(&db, &input("top", "a"), None).await.unwrap();
         let _b = insert(&db, &input("top", "b"), None).await.unwrap();
         let c = insert(&db, &input("top", "c"), None).await.unwrap();
@@ -678,6 +694,7 @@ mod tests {
     #[tokio::test]
     async fn list_enabled_excludes_disabled() {
         let db = ConfigDb::Sqlite(open_memory().await.unwrap());
+        wipe(&db).await;
         let id = insert(&db, &input("top", "x"), None).await.unwrap();
         let mut off = input("top", "x");
         off.enabled = false;
@@ -690,8 +707,27 @@ mod tests {
     }
 
     #[tokio::test]
+    async fn welcome_block_seeded_on_fresh_db() {
+        // Migration 0008 puts a single welcome block in `bottom` on
+        // a fresh DB so first-install operators see something useful
+        // on the landing (#187 #4+#5). It's gated `WHERE NOT EXISTS`,
+        // so a DB with any block at all skips the seed.
+        let db = ConfigDb::Sqlite(open_memory().await.unwrap());
+        let all = list_all(&db).await.unwrap();
+        assert_eq!(all.len(), 1, "fresh DB has the welcome seed");
+        assert_eq!(all[0].id, "welcome-seed");
+        assert_eq!(all[0].slot, "bottom");
+        assert!(all[0].enabled);
+        // Operator deletes it → next migration run (re-startup) does
+        // NOT re-seed, because the gate is `NOT EXISTS landing_blocks`
+        // and the operator may have inserted other blocks too. Sqlx
+        // also tracks applied migrations so 0008 only runs once.
+    }
+
+    #[tokio::test]
     async fn delete_removes() {
         let db = ConfigDb::Sqlite(open_memory().await.unwrap());
+        wipe(&db).await;
         let id = insert(&db, &input("bottom", "z"), None).await.unwrap();
         assert!(delete(&db, &id, None).await.unwrap());
         assert!(fetch_one(&db, &id).await.unwrap().is_none());


### PR DESCRIPTION
Closes the #4 + #5 asks from the #187 sweep. Fresh Ruscker installs landed on an empty card grid with no signal of what the portal is for; now the first-install landing shows a "Welcome to Ruscker" panel below the card grid with a chip per supported framework name and a CTA out to the manual.

Ships via the existing #58 landing-blocks system — the operator can edit or delete the welcome block from /admin/blocks like any other content.

## What ships

- **Migrations 0008** (SQLite + Postgres). One row into \`landing_blocks\` gated by \`WHERE NOT EXISTS (SELECT 1 FROM landing_blocks)\` so operators who already populated a block before upgrading skip the seed. Sqlx migration tracking also ensures it only runs once per DB.
- Stable id \`welcome-seed\`, title labeled "Welcome (auto-seeded on first install)" so it's recognizable in the admin list.
- HTML: a \`<section class="ruscker-welcome">\` with heading, subtitle, a \`<ul>\` of framework name chips, and an outbound link to the Ruscker manual. Each chip carries \`--tc:<color>\` for its accent; the CSS uses \`color-mix()\` to produce a low-opacity tint background + full-color border + full-color label so it reads on both light and dark surfaces.
- CSS in \`input.css\` under \`/* Welcome block */\`; the seed only ships markup so removing or editing the block via the admin still works.

## Test plan

- [x] New \`welcome_block_seeded_on_fresh_db\` asserts the seed lands on an \`open_memory()\` DB.
- [x] Existing tests get a \`wipe()\` helper so they continue to assert on clean state.
- [x] \`cargo test -p ruscker-admin\` green (191 lib + integration).
- [x] Smoked on darwin (\`127.0.0.1:8095\`, fresh \`/tmp/ruscker-clean.db\`): the panel renders at the bottom of the landing under the card grid, chips wrap on narrow widths, CTA navigates to \`ruscker.com\`.

## Known follow-up

\`db::specs\` carries a \`DELETE FROM landing_blocks\` in one reset path (the legacy bulk-import flow), so \`ruscker import\` against an existing DB wipes the seed. Pre-existing — not a regression introduced here — but the welcome-block UX is the first place a user might notice. Tracking separately.

🤖 Generated with [Claude Code](https://claude.com/claude-code)