### PR TITLE
fix(proxy): look up specs in the DB first (showcase + admin edits)

### DIFF
--- a/crates/ruscker-admin/src/routes/proxy.rs
+++ b/crates/ruscker-admin/src/routes/proxy.rs
@@ -181,11 +181,14 @@ async fn forward(
     // cookie we may set at the end.
     let is_https = crate::auth::request_is_https(req.headers());
 
-    // 1. Find the spec.
-    let Some(spec) = find_spec(&state.config, &spec_id) else {
+    // 1. Find the spec. DB-first when attached (covers the showcase
+    // seed + operator edits via the admin), falling back to the YAML
+    // `proxy.specs` so deployments that load specs exclusively from
+    // the config file keep working. Matches the landing handler's
+    // spec source rule.
+    let Some(spec) = find_spec(&state, &spec_id).await else {
         return (StatusCode::NOT_FOUND, format!("spec `{spec_id}` not found")).into_response();
     };
-    let spec = spec.clone();
 
     // 2. External link: bounce.
     if spec.kind() == SpecKind::External {
@@ -553,8 +556,26 @@ fn cors_preflight_response() -> Response {
     resp
 }
 
-fn find_spec<'a>(config: &'a ruscker_config::Config, id: &str) -> Option<&'a Spec> {
-    config.proxy.specs.iter().find(|s| s.id == id)
+async fn find_spec(state: &AppState, id: &str) -> Option<Spec> {
+    // DB-first — the operator-editable catalog (admin UI + showcase
+    // seed) shadows the YAML for matching ids. Cheap: single indexed
+    // SELECT by primary key.
+    if let Some(db) = state.db.as_ref() {
+        match crate::db::specs::fetch_one(db, id).await {
+            Ok(Some(spec)) => return Some(spec),
+            Ok(None) => {}
+            Err(err) => {
+                tracing::warn!(error = ?err, spec_id = id, "spec DB lookup failed; falling back to YAML");
+            }
+        }
+    }
+    state
+        .config
+        .proxy
+        .specs
+        .iter()
+        .find(|s| s.id == id)
+        .cloned()
 }
 
 /// Returns the chosen `Replica`, the session_id we'll track this


### PR DESCRIPTION
The proxy was finding specs only in \`state.config.proxy.specs\` (the YAML startup config), so clicking a card the operator added via the admin OR a card from the showcase seed (#202) returned 404 \"spec not found\". Mirrors the landing handler's DB-first rule (also from #202) so both surfaces agree on what specs exist.

## Change

\`routes::proxy::find_spec\` becomes \`async fn find_spec(&AppState, &str) -> Option<Spec>\`:

1. When a DB is attached: \`db::specs::fetch_one\` (single indexed PK SELECT, sub-ms).
2. On miss / no DB / DB error: fall back to \`config.proxy.specs\`.
3. Returns an owned \`Spec\` — the caller already cloned the result on the next line, so the change is zero-cost at the call site.

A warning is logged on DB lookup error so the YAML fallback isn't silent in production.

## Verified locally

127.0.0.1:8097 against \`--config examples/application.yml --db ...\` with the showcase-seeded DB:

- \`GET /app/jupyter/\` → 302 (proxy resolves; was 404 before).
- \`GET /app/rmarkdown/\` → 302 (same).
- \`GET /app/shiny/\` → 502 with \"no matching manifest for linux/arm64/v8\" — proxy DID find the spec; the failure is the upstream \`rocker/shiny:latest\` image not shipping an arm64 manifest. Tracked separately.

## Tests

- \`cargo test -p ruscker-admin\` green (194 lib + integration).
- \`cargo clippy --workspace --all-targets\` → 0 warnings.

🤖 Generated with [Claude Code](https://claude.com/claude-code)