### PR TITLE
feat(spec): add `platform` field for cross-arch Docker spawning

### DIFF
--- a/crates/ruscker-admin/src/db/showcase.rs
+++ b/crates/ruscker-admin/src/db/showcase.rs
@@ -140,6 +140,7 @@ fn card(
     link_url: &str,
     container_image: Option<&str>,
     container_port: Option<u16>,
+    platform: Option<&str>,
 ) -> Result<Spec> {
     let mut tp = serde_json::Map::new();
     tp.insert("logo".into(), json!(logo_path));
@@ -160,6 +161,9 @@ fn card(
     spec_json.insert("template-properties".into(), json!(tp));
     if let Some(image) = container_image {
         spec_json.insert("container-image".into(), json!(image));
+        if let Some(p) = platform {
+            spec_json.insert("platform".into(), json!(p));
+        }
     } else {
         // External link card — explicit kind so Spec::kind() doesn't
         // need to infer.
@@ -187,8 +191,13 @@ fn showcase_specs() -> Result<Vec<Spec>> {
             "https://ruscker.com",
             None,
             None,
+            None,
         )?,
         // ── Containerized hello-world demos ─────────────────────────
+        // `rocker/shiny` ships an amd64-only manifest; pinning the
+        // platform lets the daemon run it via emulation on arm64
+        // hosts (Apple Silicon / Graviton). The other two images
+        // ship multi-arch manifests so they don't need the override.
         card(
             "shiny",
             "Shiny",
@@ -197,6 +206,7 @@ fn showcase_specs() -> Result<Vec<Spec>> {
             "https://shiny.posit.co",
             Some("rocker/shiny:latest"),
             Some(3838),
+            Some("linux/amd64"),
         )?,
         card(
             "jupyter",
@@ -206,6 +216,7 @@ fn showcase_specs() -> Result<Vec<Spec>> {
             "https://jupyter.org",
             Some("quay.io/jupyter/minimal-notebook:latest"),
             Some(8888),
+            None,
         )?,
         card(
             "rmarkdown",
@@ -215,6 +226,7 @@ fn showcase_specs() -> Result<Vec<Spec>> {
             "https://rmarkdown.rstudio.com",
             Some("rocker/rstudio:latest"),
             Some(8787),
+            None,
         )?,
         // ── External-link cards (no public hello image) ─────────────
         card(
@@ -223,6 +235,7 @@ fn showcase_specs() -> Result<Vec<Spec>> {
             "Data and machine-learning apps in Python.",
             "/assets/showcase/streamlit.svg",
             "https://streamlit.io",
+            None,
             None,
             None,
         )?,
@@ -234,6 +247,7 @@ fn showcase_specs() -> Result<Vec<Spec>> {
             "https://dash.plotly.com",
             None,
             None,
+            None,
         )?,
         card(
             "quarto",
@@ -241,6 +255,7 @@ fn showcase_specs() -> Result<Vec<Spec>> {
             "Open-source publishing system for technical documents.",
             "/assets/showcase/quarto.svg",
             "https://quarto.org",
+            None,
             None,
             None,
         )?,
@@ -252,6 +267,7 @@ fn showcase_specs() -> Result<Vec<Spec>> {
             "https://bokeh.org",
             None,
             None,
+            None,
         )?,
         card(
             "plumber",
@@ -259,6 +275,7 @@ fn showcase_specs() -> Result<Vec<Spec>> {
             "Turn R functions into HTTP APIs.",
             "/assets/showcase/plumber.svg",
             "https://www.rplumber.io",
+            None,
             None,
             None,
         )?,
@@ -270,6 +287,7 @@ fn showcase_specs() -> Result<Vec<Spec>> {
             "https://fastapi.tiangolo.com",
             None,
             None,
+            None,
         )?,
         card(
             "voila",
@@ -277,6 +295,7 @@ fn showcase_specs() -> Result<Vec<Spec>> {
             "Standalone web apps from Jupyter notebooks.",
             "/assets/showcase/voila.svg",
             "https://voila.readthedocs.io",
+            None,
             None,
             None,
         )?,

--- a/crates/ruscker-admin/src/routes/admin/spec_form.rs
+++ b/crates/ruscker-admin/src/routes/admin/spec_form.rs
@@ -289,6 +289,7 @@ impl SpecForm {
             // ── Not modelled by the form: preserve from `base` so an
             //    edit never silently drops YAML-imported config. ──────
             container_port: base.and_then(|b| b.container_port),
+            platform: base.and_then(|b| b.platform.clone()),
             placement: base.and_then(|b| b.placement),
             anti_affinity: base.and_then(|b| b.anti_affinity),
             access_groups: base.and_then(|b| b.access_groups.clone()),

--- a/crates/ruscker-admin/src/routes/proxy.rs
+++ b/crates/ruscker-admin/src/routes/proxy.rs
@@ -735,6 +735,9 @@ async fn pick_or_spawn(state: &AppState, spec: &Spec) -> anyhow::Result<Replica>
     if let Some(port) = inner_port {
         req = req.with_port(port);
     }
+    if let Some(platform) = spec.platform.as_deref() {
+        req = req.with_platform(platform);
+    }
     if let Some(c) = creds {
         req = req.with_creds(c);
     }

--- a/crates/ruscker-admin/src/scaler.rs
+++ b/crates/ruscker-admin/src/scaler.rs
@@ -455,6 +455,9 @@ async fn spawn_one(
     if let Some(port) = inner_port {
         req = req.with_port(port);
     }
+    if let Some(platform) = spec.platform.as_deref() {
+        req = req.with_platform(platform);
+    }
     if let Some(c) = creds {
         req = req.with_creds(c);
     }

--- a/crates/ruscker-config/src/schema.rs
+++ b/crates/ruscker-config/src/schema.rs
@@ -475,6 +475,15 @@ pub struct Spec {
     #[serde(rename = "container-port", alias = "port")]
     pub container_port: Option<u16>,
 
+    /// Docker target platform for the pull/run, e.g. `linux/amd64` or
+    /// `linux/arm64`. Lets an operator on an arm64 host (Apple
+    /// Silicon, Graviton) force emulation of an amd64-only image —
+    /// Docker Desktop wires that through QEMU/Rosetta transparently.
+    /// `None` ⇒ the daemon picks (multi-arch manifest's host match,
+    /// otherwise pull fails with `no matching manifest`).
+    #[serde(rename = "platform")]
+    pub platform: Option<String>,
+
     /// Maximum number of concurrent sessions on a single container.
     /// When all containers in a spec's pool reach this limit, the
     /// auto-scaler spawns a new replica (if `max_replicas` allows).

--- a/crates/ruscker-core/src/lib.rs
+++ b/crates/ruscker-core/src/lib.rs
@@ -136,6 +136,11 @@ pub struct SpawnRequest {
     pub placement: ruscker_config::Placement,
     /// Prefer distinct hosts for this spec's replicas (anti-affinity).
     pub anti_affinity: bool,
+    /// Docker `--platform` target, e.g. `"linux/amd64"`. Forwarded to
+    /// the daemon on both pull and create so an operator on arm64 can
+    /// run an amd64-only image via the daemon's emulation
+    /// (QEMU / Rosetta). `None` ⇒ the daemon picks per the manifest.
+    pub platform: Option<String>,
 }
 
 impl SpawnRequest {
@@ -149,7 +154,13 @@ impl SpawnRequest {
             volumes: Vec::new(),
             placement: ruscker_config::Placement::default(),
             anti_affinity: false,
+            platform: None,
         }
+    }
+
+    pub fn with_platform(mut self, platform: impl Into<String>) -> Self {
+        self.platform = Some(platform.into());
+        self
     }
 
     pub fn with_placement(mut self, placement: ruscker_config::Placement) -> Self {

--- a/crates/ruscker-docker/src/lib.rs
+++ b/crates/ruscker-docker/src/lib.rs
@@ -171,7 +171,8 @@ impl LocalDockerBackend {
 
         // 1. Pull image (idempotent — Docker no-ops when local).
         //    Errors bubble up through the stream-of-events.
-        self.ensure_image_pulled(&req.image, req.creds.as_ref()).await?;
+        self.ensure_image_pulled(&req.image, req.creds.as_ref(), req.platform.as_deref())
+            .await?;
 
         // 2. Create container with our labels + ephemeral host port.
         let port_key = format!("{inner_port}/tcp");
@@ -217,6 +218,10 @@ impl LocalDockerBackend {
         let container_name = format!("ruscker-{}-{}", req.spec_id, &replica_id.to_string()[..8]);
         let opts = CreateContainerOptions {
             name: Some(container_name.clone()),
+            // Same `platform` as the pull so the daemon doesn't try
+            // to pick a fresh manifest match. Empty string = no
+            // override (daemon picks per the image's manifest).
+            platform: req.platform.clone().unwrap_or_default(),
             ..Default::default()
         };
         let created = self
@@ -268,6 +273,7 @@ impl LocalDockerBackend {
         &self,
         image: &str,
         creds: Option<&ruscker_core::RegistryCredentials>,
+        platform: Option<&str>,
     ) -> CoreResult<()> {
         // bollard's create_image always hits the registry for the
         // manifest — even when the layers are already local. Skip
@@ -281,6 +287,12 @@ impl LocalDockerBackend {
         }
         let opts = CreateImageOptions {
             from_image: Some(image.to_string()),
+            // `platform` defaults to empty string → bollard sends no
+            // explicit platform → daemon picks per the manifest. Only
+            // set it when the spec carries one (e.g. `linux/amd64`
+            // on an arm64 host running an amd64-only image via
+            // emulation).
+            platform: platform.unwrap_or("").to_string(),
             ..Default::default()
         };
         // Convert our backend-neutral creds to bollard's native


### PR DESCRIPTION
Lets an operator on an arm64 host (Apple Silicon, Graviton, …) run an amd64-only image via the daemon's emulation layer (QEMU / Rosetta). Without this, a card pointing at e.g. \`rocker/shiny:latest\` (amd64-only manifest) fails at pull with \`no matching manifest for linux/arm64/v8\` — already hit by the showcase Shiny card on darwin/arm64.

## Surface
- \`ruscker_config::Spec.platform: Option<String>\` — new YAML field, serialized as \`platform: linux/amd64\`. Documented near \`container-image\`.
- \`ruscker_core::SpawnRequest.platform: Option<String>\` + builder \`.with_platform(...)\`. The trait surface stays one method; new knobs live inside \`SpawnRequest\` as the crate doc prescribes.
- \`ruscker_docker::ensure_image_pulled\` and the \`create_container\` call both forward the platform to bollard (empty string → daemon picks per manifest, matching today's behavior).

## Plumbing
- \`scaler::spawn_replica\` and \`routes::proxy::spawn_replica\` set \`req.with_platform(spec.platform)\` when present.
- \`routes::admin::spec_form\` preserves the platform on edit round-trips.

## Showcase
The Shiny card in the seed (\`db::showcase\`) now ships with \`platform: "linux/amd64"\`. Verified locally on darwin/arm64: \`GET /app/shiny/\` → **200** (was 502 with \`no matching manifest\`). Jupyter and RMarkdown keep \`platform: None\` — their images ship multi-arch manifests so the daemon picks correctly on its own.

## Tests
- All 194 \`ruscker-admin\` lib + integration tests green.
- \`cargo build --workspace\` clean.
- New showcase test still asserts 11 cards seeded.

🤖 Generated with [Claude Code](https://claude.com/claude-code)