### PR TITLE
feat(spec): pass container-env / container-cmd through to the backend

### DIFF
--- a/crates/ruscker-admin/src/routes/admin/spec_form.rs
+++ b/crates/ruscker-admin/src/routes/admin/spec_form.rs
@@ -279,6 +279,11 @@ impl SpecForm {
             max_replicas: parse_opt(&self.max_replicas),
             concurrent_requests_per_replica: parse_opt(&self.concurrent_requests_per_replica),
             volumes: lines_to_vec(&self.volumes),
+            // Not modelled by the form yet — preserve from `base` so a
+            // YAML-imported `container-env` / `container-cmd` survives
+            // an admin edit instead of being silently dropped.
+            container_env: base.and_then(|b| b.container_env.clone()),
+            container_cmd: base.and_then(|b| b.container_cmd.clone()),
             // Checked ⇒ leave unset (the `true` default keeps the
             // exported YAML clean); unchecked ⇒ explicit `false`.
             inject_base_href: if self.inject_base_href.trim().is_empty() {

--- a/crates/ruscker-admin/src/routes/proxy.rs
+++ b/crates/ruscker-admin/src/routes/proxy.rs
@@ -730,6 +730,7 @@ async fn pick_or_spawn(state: &AppState, spec: &Spec) -> anyhow::Result<Replica>
     let mut req = ruscker_core::SpawnRequest::new(&spec.id, image)
         .with_limits(limits)
         .with_volumes(spec.volumes.clone().unwrap_or_default())
+        .with_env(spec.env_pairs())
         .with_placement(spec.effective_placement())
         .with_anti_affinity(spec.effective_anti_affinity());
     if let Some(port) = inner_port {
@@ -737,6 +738,9 @@ async fn pick_or_spawn(state: &AppState, spec: &Spec) -> anyhow::Result<Replica>
     }
     if let Some(platform) = spec.platform.as_deref() {
         req = req.with_platform(platform);
+    }
+    if let Some(cmd) = spec.container_cmd.clone() {
+        req = req.with_cmd(cmd);
     }
     if let Some(c) = creds {
         req = req.with_creds(c);

--- a/crates/ruscker-admin/src/scaler.rs
+++ b/crates/ruscker-admin/src/scaler.rs
@@ -450,6 +450,7 @@ async fn spawn_one(
     let mut req = ruscker_core::SpawnRequest::new(&spec.id, image)
         .with_limits(limits)
         .with_volumes(spec.volumes.clone().unwrap_or_default())
+        .with_env(spec.env_pairs())
         .with_placement(spec.effective_placement())
         .with_anti_affinity(spec.effective_anti_affinity());
     if let Some(port) = inner_port {
@@ -457,6 +458,9 @@ async fn spawn_one(
     }
     if let Some(platform) = spec.platform.as_deref() {
         req = req.with_platform(platform);
+    }
+    if let Some(cmd) = spec.container_cmd.clone() {
+        req = req.with_cmd(cmd);
     }
     if let Some(c) = creds {
         req = req.with_creds(c);

--- a/crates/ruscker-config/src/schema.rs
+++ b/crates/ruscker-config/src/schema.rs
@@ -17,7 +17,7 @@
 
 use ordered_float::OrderedFloat;
 use serde::{Deserialize, Serialize};
-use std::collections::HashMap;
+use std::collections::{BTreeMap, HashMap};
 use std::path::PathBuf;
 
 /// Root of the configuration tree, equivalent to the top of `application.yml`.
@@ -575,6 +575,22 @@ pub struct Spec {
     #[serde(default)]
     pub volumes: Option<Vec<String>>,
 
+    /// Environment variables injected into the container, as a map of
+    /// `NAME: value` (ShinyProxy `container-env`). Values flow through
+    /// the same `${VAR}` interpolation as the rest of the YAML, so
+    /// secrets stay out of the file (`container-env: { DB_PASS:
+    /// "${DB_PASSWORD}" }`). The local Docker backend passes these as
+    /// `Config.Env` (`NAME=value`). A `BTreeMap` so the resulting env
+    /// list is deterministically ordered.
+    #[serde(rename = "container-env", default)]
+    pub container_env: Option<BTreeMap<String, String>>,
+
+    /// Override the container's command (ShinyProxy `container-cmd`),
+    /// as an argv list (`["R", "-e", "..."]`). Maps to Docker
+    /// `Config.Cmd`. `None` ⇒ the image's baked `CMD` is used.
+    #[serde(rename = "container-cmd", default)]
+    pub container_cmd: Option<Vec<String>>,
+
     /// Groups allowed to see and reach this app (ShinyProxy
     /// `access-groups`). A spec with neither `access-groups` nor
     /// `access-users` is **open** (visible to everyone, including
@@ -734,6 +750,16 @@ pub enum SpecKind {
 }
 
 impl Spec {
+    /// Container environment as Docker `NAME=value` strings, sorted for
+    /// determinism (the field is a `BTreeMap`). Empty when no
+    /// `container-env` is set. Consumed by the backend at spawn time.
+    pub fn env_pairs(&self) -> Vec<String> {
+        self.container_env
+            .as_ref()
+            .map(|m| m.iter().map(|(k, v)| format!("{k}={v}")).collect())
+            .unwrap_or_default()
+    }
+
     /// Compute the effective [`SpecKind`].
     ///
     /// Priority:
@@ -1339,6 +1365,8 @@ proxy:
             container_memory_request: None,
             max_body_size: None,
             volumes: None,
+            container_env: None,
+            container_cmd: None,
             access_groups: None,
             access_users: None,
             template_properties: TemplateProperties::default(),
@@ -1356,6 +1384,7 @@ proxy:
             placement: None,
             anti_affinity: None,
             concurrent_requests_per_replica: None,
+            platform: None,
         };
         assert_eq!(spec.kind(), SpecKind::External);
         assert!(!spec.needs_sticky_sessions());
@@ -1383,6 +1412,8 @@ proxy:
             container_memory_request: None,
             max_body_size: None,
             volumes: None,
+            container_env: None,
+            container_cmd: None,
             access_groups: None,
             access_users: None,
             template_properties: TemplateProperties::default(),
@@ -1400,6 +1431,7 @@ proxy:
             placement: None,
             anti_affinity: None,
             concurrent_requests_per_replica: None,
+            platform: None,
         };
         assert_eq!(spec.kind(), SpecKind::Shiny);
         assert!(spec.needs_sticky_sessions());
@@ -1427,6 +1459,8 @@ proxy:
             container_memory_request: None,
             max_body_size: None,
             volumes: None,
+            container_env: None,
+            container_cmd: None,
             access_groups: None,
             access_users: None,
             template_properties: TemplateProperties::default(),
@@ -1444,6 +1478,7 @@ proxy:
             placement: None,
             anti_affinity: None,
             concurrent_requests_per_replica: None,
+            platform: None,
         };
         spec.kind_override = Some(SpecKindOverride::Api);
         assert_eq!(spec.kind(), SpecKind::Api);
@@ -1453,6 +1488,59 @@ proxy:
 
     fn parse_spec(yaml: &str) -> Spec {
         serde_yaml_ng::from_str(yaml).expect("parse spec")
+    }
+
+    #[test]
+    fn parses_container_env_and_cmd() {
+        let s = parse_spec(
+            "\
+id: nb
+container-image: jupyter/minimal-notebook
+container-env:
+  JUPYTER_TOKEN: ''
+  GRANT_SUDO: 'yes'
+container-cmd:
+- start-notebook.sh
+- --ServerApp.base_url=/
+",
+        );
+        // BTreeMap ⇒ env_pairs() is sorted (G before J), deterministic.
+        assert_eq!(s.env_pairs(), vec!["GRANT_SUDO=yes", "JUPYTER_TOKEN="]);
+        assert_eq!(
+            s.container_cmd.as_deref(),
+            Some(&["start-notebook.sh".to_string(), "--ServerApp.base_url=/".to_string()][..])
+        );
+    }
+
+    #[test]
+    fn env_pairs_empty_when_unset() {
+        let s = parse_spec("id: a\ncontainer-image: x");
+        assert!(s.env_pairs().is_empty());
+        assert!(s.container_cmd.is_none());
+    }
+
+    #[test]
+    fn container_env_values_are_env_interpolated() {
+        // `${VAR}` in a container-env value resolves via the same
+        // whole-document interpolation the rest of the YAML uses, so
+        // secrets never sit in the file. Guard the env var so the test
+        // is hermetic regardless of the host environment.
+        // SAFETY: single-threaded test; we set and unset around use.
+        unsafe { std::env::set_var("RUSCKER_TEST_DB_PASS", "s3cret") };
+        let cfg = crate::Config::from_yaml(
+            "\
+proxy:
+  specs:
+  - id: db
+    container-image: x
+    container-env:
+      DB_PASSWORD: ${RUSCKER_TEST_DB_PASS}
+",
+        )
+        .expect("parse config");
+        unsafe { std::env::remove_var("RUSCKER_TEST_DB_PASS") };
+        let spec = &cfg.proxy.specs[0];
+        assert_eq!(spec.env_pairs(), vec!["DB_PASSWORD=s3cret"]);
     }
 
     #[test]

--- a/crates/ruscker-config/src/validate.rs
+++ b/crates/ruscker-config/src/validate.rs
@@ -231,10 +231,9 @@ const UNSUPPORTED_SPEC_FIELDS: &[(&str, &str)] = &[
         "network-connections",
         "container network wiring is not implemented (phase 3.5)",
     ),
-    (
-        "environment",
-        "per-spec environment injection is not implemented (phase 3)",
-    ),
+    // NOTE: per-spec env/cmd injection IS now supported — map your
+    // ShinyProxy `container-env` / `container-cmd` straight across. They
+    // are intentionally absent from this ignored-fields list.
 ];
 
 /// Top-level `proxy.*` keys that are unsupported.

--- a/crates/ruscker-core/src/lib.rs
+++ b/crates/ruscker-core/src/lib.rs
@@ -141,6 +141,16 @@ pub struct SpawnRequest {
     /// run an amd64-only image via the daemon's emulation
     /// (QEMU / Rosetta). `None` ⇒ the daemon picks per the manifest.
     pub platform: Option<String>,
+
+    /// Environment variables for the container as Docker `NAME=value`
+    /// strings (from the spec's `container-env`). Empty ⇒ none injected;
+    /// the local backend maps these to `Config.Env`.
+    pub env: Vec<String>,
+
+    /// Command override (the spec's `container-cmd`), as an argv list.
+    /// `None` ⇒ the image's baked `CMD` is used; the local backend maps
+    /// this to `Config.Cmd`.
+    pub cmd: Option<Vec<String>>,
 }
 
 impl SpawnRequest {
@@ -155,6 +165,8 @@ impl SpawnRequest {
             placement: ruscker_config::Placement::default(),
             anti_affinity: false,
             platform: None,
+            env: Vec::new(),
+            cmd: None,
         }
     }
 
@@ -186,6 +198,14 @@ impl SpawnRequest {
     }
     pub fn with_volumes(mut self, volumes: Vec<String>) -> Self {
         self.volumes = volumes;
+        self
+    }
+    pub fn with_env(mut self, env: Vec<String>) -> Self {
+        self.env = env;
+        self
+    }
+    pub fn with_cmd(mut self, cmd: Vec<String>) -> Self {
+        self.cmd = Some(cmd);
         self
     }
 }
@@ -452,6 +472,20 @@ mod registry_tests {
             sessions_max: 5,
             host: None,
         }
+    }
+
+    #[test]
+    fn spawn_request_carries_env_and_cmd() {
+        let req = SpawnRequest::new("nb", "jupyter")
+            .with_env(vec!["JUPYTER_TOKEN=".into(), "GRANT_SUDO=yes".into()])
+            .with_cmd(vec!["start-notebook.sh".into()]);
+        assert_eq!(req.env, vec!["JUPYTER_TOKEN=", "GRANT_SUDO=yes"]);
+        assert_eq!(req.cmd.as_deref(), Some(&["start-notebook.sh".to_string()][..]));
+
+        // Defaults: no env, no cmd override (image's baked CMD wins).
+        let bare = SpawnRequest::new("a", "img");
+        assert!(bare.env.is_empty());
+        assert!(bare.cmd.is_none());
     }
 
     #[test]

--- a/crates/ruscker-docker/src/lib.rs
+++ b/crates/ruscker-docker/src/lib.rs
@@ -212,6 +212,12 @@ impl LocalDockerBackend {
             exposed_ports: Some(vec![port_key.clone()]),
             labels: Some(labels),
             host_config: Some(host_config),
+            // `container-env` → `Config.Env` ("NAME=value"); `None`
+            // (not an empty Vec) when unset so we don't override the
+            // image's own env with nothing. `container-cmd` →
+            // `Config.Cmd`; `None` keeps the image's baked `CMD`.
+            env: (!req.env.is_empty()).then(|| req.env.clone()),
+            cmd: req.cmd.clone(),
             ..Default::default()
         };
 
@@ -983,5 +989,38 @@ mod tests {
         backend.stop(&replica.id).await.expect("stop");
         let after = backend.list().await.expect("list after stop");
         assert!(!after.iter().any(|r| r.id == replica.id));
+    }
+
+    /// `container-env` / `container-cmd` smoke: spawn with both set and
+    /// assert the real container's `Config.Env` / `Config.Cmd` carry
+    /// them (via `docker inspect`). Uses nginx's own argv as the cmd so
+    /// the container still listens on :80 and passes readiness.
+    #[cfg(feature = "docker-it")]
+    #[tokio::test]
+    async fn spawn_injects_env_and_cmd() {
+        let image = std::env::var("RUSCKER_IT_IMAGE")
+            .unwrap_or_else(|_| "nginx:1.29-alpine".into());
+        let backend = LocalDockerBackend::local().expect("connect docker");
+        let cmd = vec!["nginx".to_string(), "-g".to_string(), "daemon off;".to_string()];
+        let req = ruscker_core::SpawnRequest::new("itest-envcmd", &image)
+            .with_port(80)
+            .with_env(vec!["RUSCKER_SMOKE=hello".to_string()])
+            .with_cmd(cmd.clone());
+        let replica = backend.spawn_request(&req).await.expect("spawn");
+
+        let info = backend
+            .docker
+            .inspect_container(&replica.container_id, None)
+            .await
+            .expect("inspect");
+        let cfg = info.config.expect("container config");
+        let env = cfg.env.unwrap_or_default();
+        assert!(
+            env.iter().any(|e| e == "RUSCKER_SMOKE=hello"),
+            "injected env missing from inspect: {env:?}"
+        );
+        assert_eq!(cfg.cmd, Some(cmd), "cmd override not applied");
+
+        backend.stop(&replica.id).await.expect("stop");
     }
 }

--- a/docs/YAML_SCHEMA.md
+++ b/docs/YAML_SCHEMA.md
@@ -264,6 +264,13 @@ A spec describes one app, API, or external link. Every spec has an
   volumes:                            # bind mounts (ShinyProxy-compatible)
     - /srv/myapp/data:/data           #   persistent data
     - /srv/myapp/www:/www:ro          #   static assets, read-only
+  container-env:                      # env vars injected into the container
+    DB_HOST: db.internal              #   (ShinyProxy-compatible)
+    DB_PASSWORD: ${DB_PASSWORD}       #   ${VAR} interpolated — keep secrets out
+  container-cmd:                      # override the image's CMD (argv list)
+    - R
+    - -e
+    - shiny::runApp('/app', port=3838, host='0.0.0.0')
   access-groups: [staff, ops]         # who may see/reach this app
   access-users: [alice]               #   (ShinyProxy-compatible)
 ```
@@ -273,6 +280,14 @@ A spec describes one app, API, or external link. Every spec has an
 as needed; editable in the admin **Advanced** form (one per line).
 **Bind-mounting host paths is root-equivalent and admin-only** — see
 `SECURITY.md`.
+
+`container-env` is a `NAME: value` map injected into the container as
+environment variables (Docker `Config.Env`). Values flow through the
+same `${VAR}` / `${VAR:-default}` interpolation as the rest of the YAML,
+so secrets stay in the environment and out of the file. `container-cmd`
+is an argv list that overrides the image's baked `CMD` (Docker
+`Config.Cmd`); omit it to keep the image default. Both are
+ShinyProxy-compatible and editable per spec.
 
 `access-groups` / `access-users` (ShinyProxy-compatible) scope who can
 **see** an app on the landing and **reach** it at `/app` / `/api`. A spec
@@ -521,8 +536,10 @@ ignored:
 - `proxy.specs[*].minimum-seats-available` — pre-warm pool (planned)
 - `proxy.specs[*].labels`, `proxy.specs[*].network-connections` — phase
   3.5
-- `proxy.specs[*].volumes`, `proxy.specs[*].environment` — phase 3
 - `proxy.docker.*` — global docker config (use defaults or env vars)
+
+(`proxy.specs[*].volumes` and `container-env` / `container-cmd` are now
+supported — see "Containerized specs" above.)
 
 Setting any of these will produce a startup warning but not an error.
 Run `ruscker validate --strict-compat <config>` to list every


### PR DESCRIPTION
Slice **(A)** of the Jupyter investigation: per-spec **environment + command** injection — the reusable prerequisite for any app that needs runtime config.

## Problem

ShinyProxy's `container-env` (map) and `container-cmd` (argv) were parsed then **dropped**: `SpawnRequest` and the Docker backend had no env/cmd, and `validate --strict-compat` flagged `environment` as "not implemented (phase 3)". So you couldn't set e.g. Jupyter's `base_url`/token/allow-origin, or DB creds for an API.

## Change

- **schema** — `Spec::{container_env: BTreeMap, container_cmd: Vec}` (kebab renames) + `Spec::env_pairs()` → sorted `NAME=value`. Values flow through the existing whole-document `${VAR}` interpolation, so secrets stay out of the YAML.
- **core** — `SpawnRequest::{env, cmd}` + `with_env` / `with_cmd`.
- **docker** — `spawn_request` sets `Config.Env` (`None` when empty → image env not clobbered) and `Config.Cmd`.
- **wiring** — both spawn sites (scaler + proxy first-spawn) populate from the spec; the admin spec-form preserves YAML-imported values across edits (not yet a form field).
- **compat** — drop `environment` from the strict-compat ignore list.
- **docs** — `YAML_SCHEMA.md` documents both; removed from "Not supported".

## Also (drive-by)

Fixes a **pre-existing compile break**: #206 added `Spec.platform` but left it off three test-literal `Spec { .. }` initializers, so `cargo test -p ruscker-config` didn't build on `main`. Added `platform: None`.

## Tests

- config: parse `container-env`/`container-cmd`, `${VAR}` interpolation, `env_pairs()` ordering.
- core: `SpawnRequest` builder carries env/cmd.
- **real smoke** (`docker-it`): `spawn_injects_env_and_cmd` spawns a real container and asserts `Env` + `Cmd` via `docker inspect` — passing locally against Docker 29.4.3.
- Full default suite green; `-p ruscker-docker --features docker-it` → 24 green.

## Not in this slice

Jupyter end-to-end still needs the follow-up: the `/app` runtime shim skips `/api/` (reserved for Ruscker API specs), which collides with Jupyter's own `/api/` + kernel-WS namespace, and `/app` responses don't rewrite the `Location` header. That's a separate PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)