### PR TITLE
feat(admin): self-service card image picker — inline upload + picker-first (#213)

### DIFF
--- a/crates/ruscker-admin/assets/i18n/en/landing.ftl
+++ b/crates/ruscker-admin/assets/i18n/en/landing.ftl
@@ -521,3 +521,11 @@ spec-form-anti-affinity = Anti-affinity
 spec-help-anti-affinity = Prefer distinct hosts for this spec's replicas (multi-host). Off by default.
 spec-form-error-port = Port must be a number between 1 and 65535.
 spec-form-error-threshold = Threshold must be a number between 0 and 1.
+
+# ── spec-form image picker (#213) ──────────────────────────────────
+spec-form-logo-upload = Upload image
+spec-form-logo-clear = Remove
+spec-form-logo-none = No image — a kind-based tint is used.
+spec-form-logo-path-advanced = Advanced: paste a path or URL
+spec-form-cover-image = Image
+spec-form-cover-image-help = Pick a library image (or upload one) as the card background.

--- a/crates/ruscker-admin/assets/i18n/es/landing.ftl
+++ b/crates/ruscker-admin/assets/i18n/es/landing.ftl
@@ -521,3 +521,11 @@ spec-form-anti-affinity = Anti-afinidad
 spec-help-anti-affinity = Prefiere hosts distintos para las réplicas de este spec (multi-host). Desactivado por defecto.
 spec-form-error-port = El puerto debe ser un número entre 1 y 65535.
 spec-form-error-threshold = El umbral debe ser un número entre 0 y 1.
+
+# ── spec-form image picker (#213) ──────────────────────────────────
+spec-form-logo-upload = Subir imagen
+spec-form-logo-clear = Quitar
+spec-form-logo-none = Sin imagen — se usa un tono según el tipo.
+spec-form-logo-path-advanced = Avanzado: pegar una ruta o URL
+spec-form-cover-image = Imagen
+spec-form-cover-image-help = Elige una imagen de la biblioteca (o sube una) como fondo de la tarjeta.

--- a/crates/ruscker-admin/assets/i18n/fr/landing.ftl
+++ b/crates/ruscker-admin/assets/i18n/fr/landing.ftl
@@ -521,3 +521,11 @@ spec-form-anti-affinity = Anti-affinité
 spec-help-anti-affinity = Préfère des hôtes distincts pour les répliques de ce spec (multi-hôte). Désactivé par défaut.
 spec-form-error-port = Le port doit être un nombre entre 1 et 65535.
 spec-form-error-threshold = Le seuil doit être un nombre entre 0 et 1.
+
+# ── spec-form image picker (#213) ──────────────────────────────────
+spec-form-logo-upload = Téléverser une image
+spec-form-logo-clear = Retirer
+spec-form-logo-none = Pas d'image — une teinte selon le type est utilisée.
+spec-form-logo-path-advanced = Avancé : coller un chemin ou une URL
+spec-form-cover-image = Image
+spec-form-cover-image-help = Choisissez une image de la bibliothèque (ou téléversez-en une) comme fond de la carte.

--- a/crates/ruscker-admin/assets/i18n/pt/landing.ftl
+++ b/crates/ruscker-admin/assets/i18n/pt/landing.ftl
@@ -525,3 +525,11 @@ spec-form-anti-affinity = Anti-afinidade
 spec-help-anti-affinity = Prefere hosts distintos para as réplicas deste spec (multi-host). Desligado por padrão.
 spec-form-error-port = A porta deve ser um número entre 1 e 65535.
 spec-form-error-threshold = O limiar deve ser um número entre 0 e 1.
+
+# ── spec-form image picker (#213) ──────────────────────────────────
+spec-form-logo-upload = Enviar imagem
+spec-form-logo-clear = Remover
+spec-form-logo-none = Sem imagem — usa um tom gerado pelo tipo.
+spec-form-logo-path-advanced = Avançado: colar um caminho ou URL
+spec-form-cover-image = Imagem
+spec-form-cover-image-help = Escolha uma imagem da biblioteca (ou envie uma) como fundo do card.

--- a/crates/ruscker-admin/src/routes/admin/images.rs
+++ b/crates/ruscker-admin/src/routes/admin/images.rs
@@ -17,7 +17,7 @@ use axum::{
     http::StatusCode,
     response::{IntoResponse, Redirect, Response},
     routing::{get, post},
-    Router,
+    Json, Router,
 };
 
 use crate::auth::{RequireEditor, Role};
@@ -36,6 +36,10 @@ pub fn routes() -> Router<AppState> {
         // "Docker images" confusion (#9). The DB table + Rust
         // module stay `images` — that's internal and accurate.
         .route("/admin/media", get(index).post(upload))
+        // Inline upload from the spec form (#213): same pipeline, JSON
+        // response so the form can add + select the image without a
+        // full page navigation to the media library.
+        .route("/admin/media/upload-inline", post(upload_inline))
         .route("/admin/media/{id}/delete", post(delete))
         // 301 from the old path so any bookmarks / in-flight
         // links keep working.
@@ -198,6 +202,80 @@ async fn upload(
         last_error,
     )
     .await
+}
+
+/// JSON shape returned by [`upload_inline`]. On success `filename` +
+/// `url` are set; on failure `error` carries an operator-facing string.
+#[derive(serde::Serialize)]
+struct InlineUpload {
+    #[serde(skip_serializing_if = "Option::is_none")]
+    filename: Option<String>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    url: Option<String>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    error: Option<String>,
+}
+
+fn inline_err(status: StatusCode, msg: impl Into<String>) -> Response {
+    (
+        status,
+        Json(InlineUpload {
+            filename: None,
+            url: None,
+            error: Some(msg.into()),
+        }),
+    )
+        .into_response()
+}
+
+/// Upload a single image and return JSON (`{filename, url}`), used by
+/// the spec form's inline picker. Same `process_upload` + `insert`
+/// pipeline as [`upload`]; only the response shape differs.
+async fn upload_inline(
+    editor: RequireEditor,
+    State(state): State<AppState>,
+    mut multipart: Multipart,
+) -> Response {
+    let Some(pool) = state.db.as_ref() else {
+        return inline_err(StatusCode::SERVICE_UNAVAILABLE, "no database");
+    };
+    loop {
+        let field = match multipart.next_field().await {
+            Ok(Some(f)) => f,
+            Ok(None) => break,
+            Err(err) => return inline_err(StatusCode::BAD_REQUEST, format!("multipart: {err}")),
+        };
+        if field.name() != Some("file") {
+            continue;
+        }
+        let filename = field.file_name().unwrap_or("upload").to_string();
+        let mime = field.content_type().map(|s| s.to_string());
+        let bytes = match field.bytes().await {
+            Ok(b) => b.to_vec(),
+            Err(err) => return inline_err(StatusCode::BAD_REQUEST, format!("read upload: {err}")),
+        };
+        if bytes.is_empty() {
+            continue;
+        }
+        let processed = match images::process_upload(&filename, mime.as_deref(), bytes) {
+            Ok(p) => p,
+            Err(err) => return inline_err(StatusCode::UNPROCESSABLE_ENTITY, err.to_string()),
+        };
+        let name = processed.filename.clone();
+        return match db::images::insert(pool, processed, Some(editor.actor())).await {
+            Ok(_) => Json(InlineUpload {
+                url: Some(format!("/assets/img/{name}")),
+                filename: Some(name),
+                error: None,
+            })
+            .into_response(),
+            Err(err) => {
+                tracing::error!(error = ?err, "inline image insert failed");
+                inline_err(StatusCode::INTERNAL_SERVER_ERROR, "save failed")
+            }
+        };
+    }
+    inline_err(StatusCode::BAD_REQUEST, "no file field in upload")
 }
 
 async fn delete(

--- a/crates/ruscker-admin/src/routes/admin/spec_form.rs
+++ b/crates/ruscker-admin/src/routes/admin/spec_form.rs
@@ -684,6 +684,12 @@ impl<'a> SpecFormPage<'a> {
         serde_json::to_string(&self.form).unwrap_or_else(|_| "{}".into())
     }
 
+    /// Media-library filenames as a JSON array, seeding the Alpine logo
+    /// picker so an inline upload can push new thumbnails reactively.
+    fn logo_images_json(&self) -> String {
+        serde_json::to_string(&self.logo_images).unwrap_or_else(|_| "[]".into())
+    }
+
     /// Options for the kind picker: (key, label-fluent-key, tabler-icon).
     /// Order intentional — mirrors the public landing chip order.
     fn display_type_options(&self) -> &'static [(&'static str, &'static str, &'static str)] {

--- a/crates/ruscker-admin/templates/admin/spec_form.html
+++ b/crates/ruscker-admin/templates/admin/spec_form.html
@@ -17,7 +17,7 @@
 
 {% block content %}
 
-<div x-data="ruscker.specForm({{ form_initial_json() }})" x-cloak>
+<div x-data="ruscker.specForm({{ form_initial_json() }}, {{ logo_images_json() }})" x-cloak>
 
   {# ── Header ───────────────────────────────────────────────── #}
   <div class="flex items-end justify-between mb-5 pb-3 border-b border-[color:var(--border)]">
@@ -117,35 +117,57 @@
 
       <div class="spec-form-section-title">{{ self.t("spec-form-visual") }}</div>
 
+      {# ── Card logo (#213) — pick from the library, upload inline, or
+         (advanced) paste a path/URL. Picker-first: no path typing in the
+         common case. The submitted value is the hidden `logo` input. ── #}
       <div class="spec-form-field">
         <div class="spec-form-label-row">
-          <label for="f-logo" class="spec-form-label">{{ self.t("spec-form-logo") }}</label>
+          <label class="spec-form-label">{{ self.t("spec-form-logo") }}</label>
           {% call help(self.t("spec-help-logo")) %}{% endcall %}
         </div>
-        <input id="f-logo" type="text" name="logo"
-               value="{{ form.logo }}"
-               x-model="form.logo"
-               placeholder="/assets/img/myapp.png"
-               class="spec-form-input spec-form-input--mono">
-        <div class="spec-form-help">{{ self.t("spec-form-logo-help") }}</div>
+        {# The value actually submitted — driven by the picker / upload /
+           clear / advanced path field below. #}
+        <input type="hidden" name="logo" x-model="form.logo">
 
-        {# Logo picker — choose from the media library (#54). Clicking a
-           thumbnail sets form.logo; the text field still accepts manual
-           paths / external URLs. Hidden when the library is empty. #}
-        {% if !logo_images.is_empty() %}
-        <div class="flex flex-wrap gap-2 mt-2" x-cloak>
-          {% for name in logo_images %}
-          <button type="button" title="{{ name }}"
-                  @click="form.logo = '/assets/img/{{ name }}'"
-                  class="w-12 h-12 rounded-md overflow-hidden border-2 transition-colors"
-                  :class="form.logo === '/assets/img/{{ name }}' ? 'border-[#0f6e56]' : 'border-transparent hover:border-[color:var(--border)]'">
-            <img src="/assets/img/{{ name }}" alt="{{ name }}" loading="lazy"
-                 class="w-full h-full object-cover">
-          </button>
-          {% endfor %}
+        <div class="flex flex-wrap gap-2" x-cloak>
+          {# Upload tile #}
+          <label class="w-12 h-12 rounded-md border-2 border-dashed border-[color:var(--border)] flex items-center justify-center cursor-pointer hover:border-[#0f6e56] transition-colors"
+                 :class="imgUploading ? 'opacity-50 pointer-events-none' : ''"
+                 :title="'{{ self.t("spec-form-logo-upload") }}'">
+            <input type="file" accept="image/*" class="hidden"
+                   @change="uploadImage($event, 'logo')">
+            <i class="ti" :class="imgUploading ? 'ti-loader-2 animate-spin' : 'ti-upload'" aria-hidden="true"></i>
+          </label>
+          {# Library thumbnails (reactive — inline uploads push here) #}
+          <template x-for="name in logoImages" :key="name">
+            <button type="button" :title="name"
+                    @click="form.logo = '/assets/img/' + name"
+                    class="w-12 h-12 rounded-md overflow-hidden border-2 transition-colors"
+                    :class="form.logo === '/assets/img/' + name ? 'border-[#0f6e56]' : 'border-transparent hover:border-[color:var(--border)]'">
+              <img :src="'/assets/img/' + name" :alt="name" loading="lazy" class="w-full h-full object-cover">
+            </button>
+          </template>
         </div>
-        <div class="spec-form-help">{{ self.t("spec-form-logo-pick-help") }}</div>
-        {% endif %}
+
+        {# Upload error (e.g. unsupported type / too large) #}
+        <div class="spec-form-help" style="color:var(--color-lock)" x-show="imgError" x-text="imgError" x-cloak></div>
+
+        {# Current selection + clear #}
+        <div class="spec-form-help flex items-center gap-2" x-show="form.logo" x-cloak>
+          <span class="truncate" x-text="form.logo"></span>
+          <button type="button" class="admin-nav-link" @click="form.logo = ''"
+                  title="{{ self.t("spec-form-logo-clear") }}"><i class="ti ti-x" aria-hidden="true"></i></button>
+        </div>
+        <div class="spec-form-help" x-show="!form.logo" x-cloak>{{ self.t("spec-form-logo-none") }}</div>
+
+        {# Advanced: paste a path or external URL #}
+        <details class="mt-1">
+          <summary class="spec-form-help cursor-pointer">{{ self.t("spec-form-logo-path-advanced") }}</summary>
+          <input type="text" x-model="form.logo"
+                 placeholder="/assets/img/myapp.png"
+                 class="spec-form-input spec-form-input--mono mt-1">
+          <div class="spec-form-help">{{ self.t("spec-form-logo-help") }}</div>
+        </details>
       </div>
 
       {# ── Card cover (#11) — Auto tint / Solid / Gradient ───── #}
@@ -161,6 +183,8 @@
                   @click="setCoverMode('solid')">{{ self.t("admin-grad-solid") }}</button>
           <button type="button" class="grad-mode" :class="coverMode === 'gradient' ? 'is-active' : ''"
                   @click="setCoverMode('gradient')">{{ self.t("admin-grad-gradient") }}</button>
+          <button type="button" class="grad-mode" :class="coverMode === 'image' ? 'is-active' : ''"
+                  @click="setCoverMode('image')">{{ self.t("spec-form-cover-image") }}</button>
         </div>
 
         {# AUTO: nothing to configure — the kind tint is used. The
@@ -209,6 +233,29 @@
           <input type="text" name="cover" x-model="form.cover" readonly
                  :disabled="coverMode !== 'gradient'"
                  class="spec-form-input spec-form-input--mono grad-output">
+        </div>
+
+        {# IMAGE — same library + inline upload as the logo picker (#213). #}
+        <div x-show="coverMode === 'image'" x-cloak>
+          <div class="flex flex-wrap gap-2 mt-1">
+            <label class="w-12 h-12 rounded-md border-2 border-dashed border-[color:var(--border)] flex items-center justify-center cursor-pointer hover:border-[#0f6e56] transition-colors"
+                   :class="imgUploading ? 'opacity-50 pointer-events-none' : ''"
+                   :title="'{{ self.t("spec-form-logo-upload") }}'">
+              <input type="file" accept="image/*" class="hidden" @change="uploadImage($event, 'cover')">
+              <i class="ti" :class="imgUploading ? 'ti-loader-2 animate-spin' : 'ti-upload'" aria-hidden="true"></i>
+            </label>
+            <template x-for="name in logoImages" :key="'cov-' + name">
+              <button type="button" :title="name" @click="setCoverImage(name)"
+                      class="w-12 h-12 rounded-md overflow-hidden border-2 transition-colors"
+                      :class="form.cover.indexOf('/assets/img/' + name) !== -1 ? 'border-[#0f6e56]' : 'border-transparent hover:border-[color:var(--border)]'">
+                <img :src="'/assets/img/' + name" :alt="name" loading="lazy" class="w-full h-full object-cover">
+              </button>
+            </template>
+          </div>
+          <div class="spec-form-help">{{ self.t("spec-form-cover-image-help") }}</div>
+          <input type="text" name="cover" x-model="form.cover" readonly
+                 :disabled="coverMode !== 'image'"
+                 class="spec-form-input spec-form-input--mono">
         </div>
       </div>
 
@@ -768,8 +815,13 @@
 <script src="/assets/js/alpine.min.js" defer></script>
 <script>
 window.ruscker = window.ruscker || {};
-window.ruscker.specForm = (initial) => ({
+window.ruscker.specForm = (initial, logoImages) => ({
   form: initial,
+  // Media-library filenames for the logo/cover pickers (#213). Inline
+  // uploads unshift new names here so a fresh thumbnail appears at once.
+  logoImages: Array.isArray(logoImages) ? logoImages : [],
+  imgUploading: false,
+  imgError: '',
   // Open the Advanced section on load if it already carries any value,
   // so edits to existing advanced config are visible.
   advancedOpen: !!(
@@ -812,7 +864,9 @@ window.ruscker.specForm = (initial) => ({
   // existing `cover` value.
   coverMode: !((initial.cover || '').trim())
     ? 'auto'
-    : window.ruscker.bgMode(initial.cover),
+    : ((initial.cover || '').trim().indexOf('url(') === 0
+        ? 'image'
+        : window.ruscker.bgMode(initial.cover)),
   grad: window.ruscker.gradientDefault(),
   applyCoverGrad() {
     this.form.cover = window.ruscker.gradientCss(this.grad);
@@ -833,8 +887,42 @@ window.ruscker.specForm = (initial) => ({
     this.coverMode = mode;
     if (mode === 'auto') this.form.cover = '';
     else if (mode === 'gradient') this.applyCoverGrad();
-    // 'solid' keeps whatever's in form.cover (or the picker
-    // default once the operator touches it).
+    // 'solid' / 'image' keep whatever's in form.cover until the
+    // operator picks a color / image.
+  },
+  // Set the cover to a library image as a CSS background (#213).
+  setCoverImage(name) {
+    this.coverMode = 'image';
+    this.form.cover = "url('/assets/img/" + name + "') center / cover no-repeat";
+  },
+  // Inline upload to the media library, then select the result for
+  // `target` ('logo' or 'cover'). Reuses the same pipeline as the
+  // media page; no navigation. Honors RUSCKER_BASE for subpath mounts.
+  async uploadImage(event, target) {
+    const input = event.target;
+    const file = input.files && input.files[0];
+    if (!file) return;
+    this.imgError = '';
+    this.imgUploading = true;
+    try {
+      const fd = new FormData();
+      fd.append('file', file);
+      const base = (window.RUSCKER_BASE || '');
+      const resp = await fetch(base + '/admin/media/upload-inline', { method: 'POST', body: fd });
+      const data = await resp.json().catch(() => ({}));
+      if (!resp.ok || !data.filename) {
+        this.imgError = data.error || ('upload failed (' + resp.status + ')');
+        return;
+      }
+      if (this.logoImages.indexOf(data.filename) === -1) this.logoImages.unshift(data.filename);
+      if (target === 'cover') this.setCoverImage(data.filename);
+      else this.form.logo = data.url || ('/assets/img/' + data.filename);
+    } catch (e) {
+      this.imgError = String(e);
+    } finally {
+      this.imgUploading = false;
+      input.value = ''; // let the same file be chosen again
+    }
   },
   needsContainer() {
     return ['app', 'api', 'talk', 'report'].includes(this.form.display_type);

--- a/crates/ruscker-admin/tests/rbac.rs
+++ b/crates/ruscker-admin/tests/rbac.rs
@@ -205,3 +205,32 @@ async fn unauthenticated_is_redirected_to_login() {
         "no session ⇒ redirect to login, got {status}"
     );
 }
+
+// ── Inline image upload (#213) — same RequireEditor guard ───────────
+
+#[tokio::test]
+async fn inline_upload_is_editor_gated() {
+    // Viewer: forbidden before the handler runs.
+    let st = state();
+    let c = cookie_for(&st, Role::Viewer).await;
+    assert_eq!(
+        send(st, "POST", "/admin/media/upload-inline", Some(&c)).await,
+        StatusCode::FORBIDDEN,
+        "viewer cannot upload images"
+    );
+    // Editor: guard passes (empty body ⇒ a 4xx/503 from the handler,
+    // never 403).
+    let st = state();
+    let c = cookie_for(&st, Role::Editor).await;
+    assert_ne!(
+        send(st, "POST", "/admin/media/upload-inline", Some(&c)).await,
+        StatusCode::FORBIDDEN,
+        "editor may upload inline"
+    );
+    // Anonymous: redirected to login, never a public write endpoint.
+    let status = send(state(), "POST", "/admin/media/upload-inline", None).await;
+    assert!(
+        status.is_redirection(),
+        "anon upload ⇒ redirect to login, got {status}"
+    );
+}


### PR DESCRIPTION
Closes #213.

## Problem

Setting a card's logo/cover meant either knowing an `/assets/img/...` path or leaving the form to upload on the media page first.

## Change

- **Logo — picker-first**: gallery of library thumbnails + an **Upload** tile; the raw path/URL field is demoted into a collapsible *Advanced* disclosure; a clear (×) button removes the selection. Submitted via a hidden `logo` input.
- **Inline upload**: new `POST /admin/media/upload-inline` — same `process_upload` (→WebP) + `insert` pipeline as the media page, but returns JSON `{filename, url}`. The form uploads via `fetch`, unshifts the new name into the (now Alpine-reactive) gallery, and selects it — **no page navigation**. Honors `window.RUSCKER_BASE` for subpath mounts.
- **Cover** gains an **Image** mode alongside auto/solid/gradient, reusing the same gallery + upload (`cover` → `url(...) center/cover`).
- Custom path / external URL still works via the advanced field.

The gallery moved from an Askama `{% for %}` to an Alpine `x-for` over a `logoImages` array seeded by `logo_images_json()`, so inline uploads appear immediately.

## Tests
- rbac integration: the inline endpoint is `RequireEditor`-gated (viewer 403, editor passes, anon redirected).
- **Real smoke**: served the binary, `POST` a real PNG to `/admin/media/upload-inline` → `200 {"filename":"...webp","url":"/assets/img/...webp"}`; `GET /admin/specs/new` renders the upload tiles, clear button, advanced-path disclosure, and cover Image mode.
- 6 new i18n keys ×4 (parity green). Full workspace suite green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)