### PR TITLE
fix(import): don't wipe landing_blocks on `ruscker import` (#199)

### DIFF
--- a/crates/ruscker-admin/src/db/specs.rs
+++ b/crates/ruscker-admin/src/db/specs.rs
@@ -51,7 +51,15 @@ pub async fn import_all(db: &ConfigDb, config: &Config) -> Result<ImportReport> 
                 tally(&mut report, upsert_in_tx(&mut tx, spec, now).await?);
             }
             super::landing::update_in_tx(&mut tx, lc, now).await?;
-            super::landing_blocks::replace_all_in_tx(&mut tx, &lc.blocks, now).await?;
+            // #199: only replace landing_blocks when the imported YAML
+            // actually carries a `blocks:` list. The parser ignores
+            // `blocks` today (DB-only — see YAML_SCHEMA.md), so this is
+            // always skipped on import and the welcome seed / operator-
+            // authored blocks survive. An unconditional replace here
+            // wiped the table with an empty list.
+            if !lc.blocks.is_empty() {
+                super::landing_blocks::replace_all_in_tx(&mut tx, &lc.blocks, now).await?;
+            }
             upsert_meta(&mut tx, "proxy", &proxy_meta, now).await?;
             upsert_meta(&mut tx, "server", &server_meta, now).await?;
             upsert_meta(&mut tx, "logging", &logging_meta, now).await?;
@@ -74,7 +82,11 @@ pub async fn import_all(db: &ConfigDb, config: &Config) -> Result<ImportReport> 
                 tally(&mut report, upsert_in_tx_pg(&mut tx, spec, now).await?);
             }
             super::landing::update_in_tx_pg(&mut tx, lc, now).await?;
-            super::landing_blocks::replace_all_in_tx_pg(&mut tx, &lc.blocks, now).await?;
+            // #199: see the SQLite arm — only replace when the import
+            // carries a non-empty `blocks:` list (never, today).
+            if !lc.blocks.is_empty() {
+                super::landing_blocks::replace_all_in_tx_pg(&mut tx, &lc.blocks, now).await?;
+            }
             upsert_meta_pg(&mut tx, "proxy", &proxy_meta, now).await?;
             upsert_meta_pg(&mut tx, "server", &server_meta, now).await?;
             upsert_meta_pg(&mut tx, "logging", &logging_meta, now).await?;
@@ -615,6 +627,33 @@ mod tests {
         .await
         .unwrap();
         assert_eq!(audit_count.0, 2);
+    }
+
+    // #199: import must not wipe landing_blocks. Migration 0008 seeds a
+    // `welcome-seed` block on a fresh DB; importing a YAML that carries
+    // no `blocks:` (the parser ignores it — DB-only) must leave it be.
+    #[tokio::test]
+    async fn import_preserves_existing_landing_blocks() {
+        let pool = open_memory().await.unwrap();
+        let db = ConfigDb::Sqlite(pool.clone());
+        let count = |p: sqlx::SqlitePool| async move {
+            let n: (i64,) =
+                sqlx::query_as("SELECT COUNT(*) FROM landing_blocks WHERE id = 'welcome-seed'")
+                    .fetch_one(&p)
+                    .await
+                    .unwrap();
+            n.0
+        };
+        assert_eq!(count(pool.clone()).await, 1, "welcome-seed present before import");
+
+        let cfg = Config::from_yaml(&fixture_yaml()).unwrap();
+        import_all(&db, &cfg).await.unwrap();
+
+        assert_eq!(
+            count(pool.clone()).await,
+            1,
+            "import must not delete pre-existing landing_blocks"
+        );
     }
 
     #[tokio::test]


### PR DESCRIPTION
Closes #199.

## Bug

`import_all` called `landing_blocks::replace_all_in_tx(&lc.blocks)` unconditionally — a `DELETE FROM landing_blocks` followed by re-inserting the list. But the YAML parser **ignores `blocks:`** (DB-only — see YAML_SCHEMA.md), so the list is always empty on import. Result: every `ruscker import` silently wiped the table, deleting operator-authored blocks (and, before #202 dropped it, the welcome seed).

## Fix

Guard the replace so it only runs when the imported YAML carries a **non-empty** `blocks:` list — never today, and correct if/when blocks ever round-trip through YAML. Applied to both the SQLite and Postgres arms.

## Tests
- `import_preserves_existing_landing_blocks`: migration 0008's `welcome-seed` survives an import carrying no blocks (the exact code path).
- **Real CLI smoke**: authored an `op-block` row, ran `ruscker import examples/application.yml --db …` → block **intact**, 20 specs imported.

Note: the original repro mentioned the welcome seed, which #202 (showcase) now drops on first install — but the wipe still hit any operator-authored block, which this fixes.

YAML_SCHEMA.md unchanged (blocks remain DB-only).

🤖 Generated with [Claude Code](https://claude.com/claude-code)