### PR TITLE
perf(admin): cap /admin/logs initial render + full-buffer download (#200)

### DIFF
--- a/crates/ruscker-admin/assets/i18n/en/landing.ftl
+++ b/crates/ruscker-admin/assets/i18n/en/landing.ftl
@@ -529,3 +529,5 @@ spec-form-logo-none = No image — a kind-based tint is used.
 spec-form-logo-path-advanced = Advanced: paste a path or URL
 spec-form-cover-image = Image
 spec-form-cover-image-help = Pick a library image (or upload one) as the card background.
+admin-proclog-tail-note = Showing the most recent lines
+admin-proclog-download = Download full log

--- a/crates/ruscker-admin/assets/i18n/es/landing.ftl
+++ b/crates/ruscker-admin/assets/i18n/es/landing.ftl
@@ -529,3 +529,5 @@ spec-form-logo-none = Sin imagen — se usa un tono según el tipo.
 spec-form-logo-path-advanced = Avanzado: pegar una ruta o URL
 spec-form-cover-image = Imagen
 spec-form-cover-image-help = Elige una imagen de la biblioteca (o sube una) como fondo de la tarjeta.
+admin-proclog-tail-note = Mostrando las líneas más recientes
+admin-proclog-download = Descargar log completo

--- a/crates/ruscker-admin/assets/i18n/fr/landing.ftl
+++ b/crates/ruscker-admin/assets/i18n/fr/landing.ftl
@@ -529,3 +529,5 @@ spec-form-logo-none = Pas d'image — une teinte selon le type est utilisée.
 spec-form-logo-path-advanced = Avancé : coller un chemin ou une URL
 spec-form-cover-image = Image
 spec-form-cover-image-help = Choisissez une image de la bibliothèque (ou téléversez-en une) comme fond de la carte.
+admin-proclog-tail-note = Affichage des lignes les plus récentes
+admin-proclog-download = Télécharger le journal complet

--- a/crates/ruscker-admin/assets/i18n/pt/landing.ftl
+++ b/crates/ruscker-admin/assets/i18n/pt/landing.ftl
@@ -533,3 +533,5 @@ spec-form-logo-none = Sem imagem — usa um tom gerado pelo tipo.
 spec-form-logo-path-advanced = Avançado: colar um caminho ou URL
 spec-form-cover-image = Imagem
 spec-form-cover-image-help = Escolha uma imagem da biblioteca (ou envie uma) como fundo do card.
+admin-proclog-tail-note = Mostrando as linhas mais recentes
+admin-proclog-download = Baixar log completo

--- a/crates/ruscker-admin/src/logbuf.rs
+++ b/crates/ruscker-admin/src/logbuf.rs
@@ -47,10 +47,23 @@ impl LogBuffer {
         }
     }
 
-    /// Current snapshot, oldest-first — for the initial page render.
+    /// Current snapshot, oldest-first — full buffer (e.g. the download
+    /// endpoint).
     pub fn snapshot(&self) -> Vec<String> {
         let g = self.inner.lock().unwrap();
         g.lines.iter().map(|(_, l)| l.clone()).collect()
+    }
+
+    /// The last `n` lines (oldest-first within the tail) plus the total
+    /// number of buffered lines. Caps the initial `/admin/logs` render so
+    /// a long-lived buffer doesn't ship the whole ring on every load
+    /// (#200); the SSE stream then appends what's new.
+    pub fn tail(&self, n: usize) -> (Vec<String>, usize) {
+        let g = self.inner.lock().unwrap();
+        let total = g.lines.len();
+        let start = total.saturating_sub(n);
+        let lines = g.lines.iter().skip(start).map(|(_, l)| l.clone()).collect();
+        (lines, total)
     }
 
     /// The next sequence number that will be assigned — an SSE follower
@@ -86,6 +99,26 @@ mod tests {
         }
         let snap = b.snapshot();
         assert_eq!(snap, vec!["line 2", "line 3", "line 4"], "kept the last 3");
+    }
+
+    #[test]
+    fn tail_returns_recent_slice_and_total() {
+        let b = LogBuffer::new(100);
+        for i in 0..10 {
+            b.push_line(format!("line {i}"));
+        }
+        // Fewer than asked → all, total reported.
+        let (lines, total) = b.tail(3);
+        assert_eq!(lines, vec!["line 7", "line 8", "line 9"]);
+        assert_eq!(total, 10);
+        // n >= len → everything, no panic.
+        let (all, total) = b.tail(100);
+        assert_eq!(all.len(), 10);
+        assert_eq!(total, 10);
+        // Empty buffer.
+        let (none, total) = LogBuffer::new(10).tail(5);
+        assert!(none.is_empty());
+        assert_eq!(total, 0);
     }
 
     #[test]

--- a/crates/ruscker-admin/src/routes/admin/logs.rs
+++ b/crates/ruscker-admin/src/routes/admin/logs.rs
@@ -9,8 +9,9 @@ use std::time::Duration;
 
 use askama::Template;
 use axum::extract::State;
+use axum::http::header;
 use axum::response::sse::{Event, KeepAlive, Sse};
-use axum::response::Response;
+use axum::response::{IntoResponse, Response};
 use axum::routing::get;
 use axum::Router;
 use futures_util::Stream;
@@ -22,11 +23,16 @@ use crate::AppState;
 
 const TICK: Duration = Duration::from_secs(1);
 const KEEPALIVE: Duration = Duration::from_secs(15);
+/// How many of the most recent lines the initial page renders. The SSE
+/// stream appends anything newer; the full buffer is a download away.
+/// Matches the per-replica logs viewer's tail (#200).
+const INITIAL_TAIL: usize = 500;
 
 pub fn routes() -> Router<AppState> {
     Router::new()
         .route("/admin/logs", get(index))
         .route("/admin/logs/stream", get(stream))
+        .route("/admin/logs/download", get(download))
 }
 
 #[derive(Template)]
@@ -39,11 +45,22 @@ struct LogsPage<'a> {
     nav_section: &'static str,
     /// Current session role (always Admin here) - drives nav gating.
     role: Role,
-    /// Current buffered lines, oldest-first. Empty when no buffer is
-    /// wired (e.g. started without the CLI's tracing layer).
+    /// The most recent buffered lines (capped at [`INITIAL_TAIL`]),
+    /// oldest-first. Empty when no buffer is wired (e.g. started without
+    /// the CLI's tracing layer).
     lines: Vec<String>,
+    /// Total lines currently buffered — drives the "showing last N of M"
+    /// notice + download affordance when the render is truncated.
+    total: usize,
     /// Whether a log buffer is actually wired.
     available: bool,
+}
+
+impl LogsPage<'_> {
+    /// Whether the render is a truncated tail of a larger buffer.
+    fn truncated(&self) -> bool {
+        self.total > self.lines.len()
+    }
 }
 
 impl LogsPage<'_> {
@@ -58,9 +75,14 @@ async fn index(
     loc: Locale,
     theme: Theme,
 ) -> Response {
-    let (lines, available) = match &state.log_buffer {
-        Some(b) => (b.snapshot(), true),
-        None => (Vec::new(), false),
+    let (lines, total, available) = match &state.log_buffer {
+        // Only the most recent slice — the SSE stream appends what's
+        // newer, and the full buffer is one download away (#200).
+        Some(b) => {
+            let (lines, total) = b.tail(INITIAL_TAIL);
+            (lines, total, true)
+        }
+        None => (Vec::new(), 0, false),
     };
     super::render(&LogsPage {
         locale: loc,
@@ -70,8 +92,29 @@ async fn index(
         nav_section: "logs",
         role: Role::Admin,
         lines,
+        total,
         available,
     })
+}
+
+/// Full buffer as a `text/plain` attachment — for forensics, since the
+/// page renders only the recent tail. Admin-gated like the rest.
+async fn download(_: RequireAdmin, State(state): State<AppState>) -> Response {
+    let body = match &state.log_buffer {
+        Some(b) => b.snapshot().join("\n"),
+        None => String::new(),
+    };
+    (
+        [
+            (header::CONTENT_TYPE, "text/plain; charset=utf-8"),
+            (
+                header::CONTENT_DISPOSITION,
+                "attachment; filename=\"ruscker.log\"",
+            ),
+        ],
+        body,
+    )
+        .into_response()
 }
 
 /// SSE feed of lines appended since the client connected. The page

--- a/crates/ruscker-admin/templates/admin/process_logs.html
+++ b/crates/ruscker-admin/templates/admin/process_logs.html
@@ -27,6 +27,16 @@
     <h1 class="text-xl font-medium tracking-tight">{{ self.t("admin-proclog-title") }}</h1>
     <p class="text-xs text-[color:var(--text-muted)] mt-1">{{ self.t("admin-proclog-subtitle") }}</p>
   </div>
+  {% if available %}
+  <div class="text-xs text-[color:var(--text-muted)] flex items-center gap-3">
+    {% if self.truncated() %}
+    <span>{{ self.t("admin-proclog-tail-note") }} ({{ lines.len() }}/{{ total }})</span>
+    {% endif %}
+    <a href="/admin/logs/download" class="admin-nav-link" download>
+      <i class="ti ti-download" aria-hidden="true"></i> {{ self.t("admin-proclog-download") }}
+    </a>
+  </div>
+  {% endif %}
 </div>
 
 {% if !available %}


### PR DESCRIPTION
Closes #200.

## Problem

`GET /admin/logs` serialized the **entire** in-memory ring buffer into one `<pre>` on every load — ~300 KB after an hour, 1 MB+ with a noisy scaler. The SSE follow stream (`/admin/logs/stream`) already existed and the page already auto-follows, so the full snapshot was pure waste.

## Change

- Render only the most recent **500** lines (`INITIAL_TAIL`) via a new `LogBuffer::tail(n) -> (lines, total)`. The page is now bounded by line count regardless of buffer age; the SSE stream still appends everything newer.
- "Showing recent lines (N/total)" notice when truncated.
- `GET /admin/logs/download` — full buffer as a `text/plain` attachment (forensics). Admin-gated.

## Real smoke

Drove the buffer to **897 lines**, then `GET /admin/logs` rendered exactly **500** (notice `…(500/897)`); `GET /admin/logs/download` returned all **897** as `text/plain; charset=utf-8` / `attachment; filename="ruscker.log"`.

Note on the "<30 KB" acceptance figure: 500 lines of `RUST_LOG=trace` output measured ~45 KB (worst case — verbose long lines); at normal `info`/`warn` levels it's well under. The substantive fix is that the page no longer grows **unbounded** — it's capped at 500 lines no matter how full the buffer is.

## Tests
- `LogBuffer::tail` (recent slice + total; n≥len; empty buffer).
- 2 new i18n keys ×4 (parity green). Full workspace suite green. Role gating + auto-follow unchanged.

🤖 Generated with [Claude Code](https://claude.com/claude-code)