### PR TITLE
release: bump workspace version to 0.1.3

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2779,7 +2779,7 @@ dependencies = [
 
 [[package]]
 name = "ruscker-admin"
-version = "0.1.2"
+version = "0.1.3"
 dependencies = [
  "aes-gcm",
  "anyhow",
@@ -2826,7 +2826,7 @@ dependencies = [
 
 [[package]]
 name = "ruscker-cli"
-version = "0.1.2"
+version = "0.1.3"
 dependencies = [
  "anyhow",
  "clap",
@@ -2846,7 +2846,7 @@ dependencies = [
 
 [[package]]
 name = "ruscker-config"
-version = "0.1.2"
+version = "0.1.3"
 dependencies = [
  "chrono",
  "ordered-float",
@@ -2861,7 +2861,7 @@ dependencies = [
 
 [[package]]
 name = "ruscker-core"
-version = "0.1.2"
+version = "0.1.3"
 dependencies = [
  "async-trait",
  "chrono",
@@ -2874,7 +2874,7 @@ dependencies = [
 
 [[package]]
 name = "ruscker-docker"
-version = "0.1.2"
+version = "0.1.3"
 dependencies = [
  "anyhow",
  "async-stream",
@@ -2893,7 +2893,7 @@ dependencies = [
 
 [[package]]
 name = "ruscker-proxy"
-version = "0.1.2"
+version = "0.1.3"
 dependencies = [
  "anyhow",
  "axum",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -10,7 +10,7 @@ members = [
 ]
 
 [workspace.package]
-version = "0.1.2"
+version = "0.1.3"
 edition = "2021"
 rust-version = "1.85"
 license = "Apache-2.0"


### PR DESCRIPTION
Cuts **v0.1.3** with the post-v0.1.2 batch (all already on `main`):

- #207 — RStudio Server card + R Markdown logo/role fix
- #208 — `container-env` / `container-cmd` passthrough
- #210 — `/app` rewrite (`/api` + `Location`) → **Jupyter works end-to-end**
- #214 — full Advanced spec form (every param) + help popovers
- #215 — self-service card image picker + inline upload
- #216 — `ruscker import` no longer wipes `landing_blocks`
- #217 — `/admin/logs` capped initial render + full-buffer download
- #218 — scaler spawn-failure log dedup/backoff

Bumps `[workspace.package].version` 0.1.2 → 0.1.3 (+ Cargo.lock). Binary reports `ruscker 0.1.3`. Merge, then tag `v0.1.3` to trigger the release workflow (multi-arch image + .deb + musl tarballs, cosign-signed; moves `:latest`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)