### PR TITLE
docs(site): add a Release notes page; refresh roadmap to v0.1.3

### DIFF
--- a/book/src/SUMMARY.md
+++ b/book/src/SUMMARY.md
@@ -19,4 +19,5 @@
 
 - [Architecture](./architecture.md)
 - [Roadmap](./roadmap.md)
+- [Release notes](./news.md)
 - [Security](./security.md)

--- a/book/src/faq.md
+++ b/book/src/faq.md
@@ -77,8 +77,9 @@ the **sign-in session** paths to a single upstream — see
 
 ### Is it production-ready?
 
-Ruscker shipped **v0.1.0** and runs in production. Releases are multi-arch
-and cosign-signed. The [Roadmap](./roadmap.md) tracks what's shipped
+Ruscker is on **v0.1.3** and runs in production. Releases are multi-arch
+and cosign-signed; see the [release notes](./news.md) for what changed
+in each version. The [Roadmap](./roadmap.md) tracks what's shipped
 (Phases 0–7) and what's planned (Phase 8: external auth).
 
 ### What platforms does it run on?

--- a/book/src/introduction.md
+++ b/book/src/introduction.md
@@ -37,7 +37,7 @@ proper admin panel, a monitoring dashboard, and load balancing.
 
 ## In production
 
-Ruscker shipped **v0.1.0** and runs in production today. Where the
+Ruscker is on **v0.1.3** and runs in production today. Where the
 JVM-based stack it replaced idled at hundreds of megabytes, Ruscker
 idles in the low tens:
 

--- a/book/src/news.md
+++ b/book/src/news.md
@@ -1,0 +1,103 @@
+# Release notes
+
+What changed in each release. Ruscker follows semantic versioning; while
+on `0.x` the API and YAML schema stay backward-compatible (new fields are
+optional), and breaking changes are called out here.
+
+Downloads (binaries, `.deb`, container image — all cosign-signed) are on
+the [GitHub releases page](https://github.com/StrategicProjects/ruscker/releases).
+
+---
+
+## v0.1.3 — 2026-05-29
+
+Admin & UX polish, plus proxy fixes that unlock notebook-style apps.
+
+**Admin**
+- **The spec form now edits every container option.** The *Advanced*
+  section gained inner port, platform, environment variables and command
+  override, registry credentials, per-app access groups/users, CPU/memory
+  requests, max body size, scaling thresholds, routing strategy,
+  placement, and anti-affinity — each with a `?` help bubble that states
+  the default a blank field inherits.
+- **Self-service card images.** Pick a logo (or cover) from the media
+  library or **upload one inline**, right in the spec form — no need to
+  leave for the media page or type an `/assets/img/...` path. Pasting a
+  custom path or external URL still works.
+
+**Apps & proxy**
+- **Per-app environment and command.** `container-env` (a `NAME: value`
+  map) and `container-cmd` (an argument list) are honored, ShinyProxy-
+  compatible. Values flow through `${VAR}` interpolation, so secrets stay
+  in the environment. This is what lets you configure notebook servers.
+- **Jupyter (and similar) now work behind the proxy.** The `/app/{id}`
+  URL rewriter handles apps that own the `/api/` namespace — Jupyter's
+  REST API and kernel WebSocket — and rewrites redirect `Location`
+  headers, so a notebook loads and connects end-to-end under the mount.
+- New **RStudio Server** showcase card; **R Markdown** is now a
+  documentation link with a corrected logo.
+
+**Fixes**
+- `ruscker import` no longer deletes custom landing blocks.
+- The admin **Logs** page renders only the most recent lines (fast on a
+  long-lived server) with a **download-full-log** link; live follow is
+  unchanged.
+- A spec that keeps failing to start (typo'd image, registry down) is now
+  logged **once**, then quieted, then re-surfaced if it persists —
+  instead of one warning on every scaler tick.
+
+## v0.1.2 — 2026-05-27
+
+High-availability / multi-host hardening and sub-path mounting.
+
+- **Mount under a sub-path.** `server.context-path` (ShinyProxy-
+  compatible) or the `--base-path /box` flag serves the whole portal
+  under a prefix, for reverse proxies that can't give Ruscker its own
+  subdomain. Health probes stay at the root for load balancers.
+- **Fully-public portals** can hide the sign-in entrance with
+  `landing-customization.show-admin-link: false`.
+- **Multi-host robustness**: authoritative placement pruning, idempotent
+  stop, bracketed IPv6 host literals, and a degraded start when a Docker
+  host is unreachable (fails only if none connect).
+- **HA leader hardening**: timeouts on every step of the Postgres
+  advisory-lock leader path so a degraded database can't freeze a scaler
+  tick; idle-session eviction is leader-gated.
+- **HA sign-in**: the deploy guide prescribes a sticky upstream for the
+  session-bearing paths.
+
+## v0.1.1 — 2026-05-26
+
+Per-user visibility and HA session accounting.
+
+- **Per-group / per-user app visibility.** `access-groups` and
+  `access-users` (ShinyProxy-compatible) scope who can see and reach an
+  app. The landing shows each viewer only the apps they may use, and
+  `/app` + `/api` **enforce** it (an anonymous visitor is redirected to
+  sign in; a restricted API returns 403) — not just hide the card. Users
+  and their group memberships are managed in the admin panel.
+- **HA Postgres session accounting** fixes so a load-balancer failover
+  counts active sessions correctly and a graceful drain can complete.
+
+## v0.1.0 — 2026-05-26
+
+First stable release.
+
+- **Public landing page** rendered from your config — cards with filters,
+  search, theming, custom branding/SEO/analytics, custom HTML blocks, and
+  full **i18n** (pt-BR / en-US / es-ES / fr-FR).
+- **Admin panel**: spec CRUD with a live card preview, an image library
+  (upload → WebP), an encrypted credentials store, a landing editor, and
+  an audit log.
+- **Reverse proxy + Docker backend**: on-demand container spawn, sticky
+  sessions, WebSocket proxying, per-spec CPU/memory limits, auto-scaling
+  with two-sided hysteresis, and session-heartbeat reaping.
+- **Monitoring dashboard** with live (SSE) per-replica CPU/memory and
+  sparklines, a logs viewer, and per-replica stop/restart.
+- **Accounts & security**: user accounts with roles (Viewer / Editor /
+  Admin), login rate-limiting, security headers, `/healthz` + `/readyz`
+  probes, and graceful shutdown.
+- **Migration-friendly**: ShinyProxy-compatible YAML with a
+  `validate --strict-compat` pre-flight, and `import` / `export` that
+  round-trip YAML ↔ the database.
+- **Distribution**: multi-arch container image, `.deb` packages, and
+  static musl tarballs — all **cosign-signed**.

--- a/book/src/roadmap.md
+++ b/book/src/roadmap.md
@@ -1,9 +1,11 @@
 # Roadmap
 
-Ruscker shipped **v0.1.0** — Phases 0 through 5 are done and the proxy
-is production-ready. Phases 6–8 are optional and demand-driven.
+Ruscker is at **v0.1.3** — Phases 0 through 7 are done and the proxy is
+production-ready and horizontally scalable. Phase 8 (external auth) is
+the main optional, demand-driven work left. For what changed in each
+release, see the [release notes](./news.md).
 
-![Roadmap timeline: phases 0–5 are shipped (scaffolding, landing page, persistence + admin CRUD, proxy + Docker backend, monitoring dashboard, production polish — v0.1.0). Phases 6–8 are planned and optional: multi-host scheduling, high availability, and external auth.](images/roadmap.svg)
+![Roadmap timeline: phases 0–7 are done — 0 to 5 shipped in v0.1.0 (scaffolding, landing page, persistence + admin CRUD, proxy + Docker backend, monitoring dashboard, production polish), and 6 (multi-host scheduling) and 7 (HA / multi-instance) followed in v0.1.1. Phase 8 (external auth) is planned and optional.](images/roadmap.svg)
 
 ## Shipped
 
@@ -54,21 +56,24 @@ installer, a **Homebrew tap**, and **cosign-signed** release artifacts.
 > **~540 MB to ~16 MB** (~30×). A real 31-spec config migrated with no
 > unsupported features.
 
-## Planned (optional)
-
-These are demand-driven — Ruscker is complete and useful without them.
-
-### Phase 6 — Multi-host scheduling
+### Phase 6 — Multi-host scheduling → **v0.1.1 / v0.1.2**
 A `MultiHostDockerBackend` that talks to several Docker hosts, with
 bin-pack vs spread placement and per-spec anti-affinity ("replicas on
-different hosts"). Slots in behind the existing `ContainerBackend`
-trait — no proxy changes.
+different hosts") — behind the existing `ContainerBackend` trait, no
+proxy changes. Shipped alongside per-group / per-user **app visibility**
+(`access-groups` / `access-users`) and **sub-path mounting**
+(`server.context-path` / `--base-path`).
 
-### Phase 7 — HA / multi-instance
-A Postgres `SessionStore` so two Ruscker instances behind an L4 load
-balancer can share session state and either can serve any session;
-coordination via Postgres advisory locks; failover testing. See
-[Deployment shapes](./architecture.md#deployment-shapes).
+### Phase 7 — HA / multi-instance → **v0.1.1**
+A Postgres `SessionStore` and a shared config catalog so several Ruscker
+instances behind an L4 load balancer can share state and any instance
+can serve any session; one scaler leader via Postgres advisory locks,
+with failover. A runnable 2-instance compose harness lives in
+`examples/ha/`. See [Deployment shapes](./architecture.md#deployment-shapes).
+
+## Planned (optional)
+
+Demand-driven — Ruscker is complete and useful without it.
 
 ### Phase 8 — External auth
 OIDC (Keycloak / Auth0 / Google), SAML, and LDAP, plus per-app access
@@ -93,6 +98,6 @@ After Phase 5, Ruscker can drop in where ShinyProxy runs today:
 3. Start Ruscker on the same port.
 4. Verify with the same browser URL.
 
-Phases 6+ are for organisations with more demanding scale or
-identity needs. Progress is tracked in the GitHub issues and
-`docs/ROADMAP.md`.
+Phase 8 is for organisations with federated-identity or
+fine-grained per-app access needs. Progress is tracked in the
+GitHub issues.

--- a/docs/adr/0001-rust-as-language.md
+++ b/docs/adr/0001-rust-as-language.md
@@ -41,7 +41,7 @@ Rust.
 - **Smaller talent pool** in R/data-science world. The target users
   (Brazilian government IT teams, data scientists at universities) are
   unlikely to have Rust experience. Mitigated by:
-  - Heavy documentation (CLAUDE.md per crate, mockups, ADRs)
+  - Heavy documentation (per-crate developer guides, mockups, ADRs)
   - Conservative use of language features (no macros heavy magic, no
     fancy generic constraints)
   - Clear separation between domain code (pure Rust) and I/O
@@ -83,6 +83,6 @@ with the JVM.
 - Several transitive deps need pinning (`getrandom 0.2.15`,
   `indexmap 2.7.0`, `clap 4.5.20`, `uuid 1.10.0`) because their
   newer versions require Edition 2024. This is documented in the
-  root `CLAUDE.md`.
+  workspace developer notes.
 
 If MSRV ever bumps, we can lift the pins.


### PR DESCRIPTION
## What

- **New Release notes page** (`book/src/news.md`) — a user-facing changelog with what changed per release (**v0.1.3 → v0.1.0**), linked from the front matter and the Reference section.
- **Roadmap refreshed**: Phases 6 (multi-host) and 7 (HA) moved from *Planned* to *Shipped* with release tags; intro + closing bumped to v0.1.3 (the timeline SVG already showed 0–7 done). Phase 8 stays planned.
- **Version mentions** in the intro + FAQ bumped v0.1.0 → v0.1.3, pointing at the release notes.
- **Removed `CLAUDE.md` references** from the public docs: the two mentions in ADR 0001 are rephrased to "per-crate developer guides" / "workspace developer notes". The mdBook (`book/`) had none. (`CLAUDE.md` is a gitignored, local-only project-memory file.)

## Verified
- `mdbook build` (0.5.3 — matches CI) is clean; `news.html` renders and appears in the sidebar `toc`.
- No remaining `CLAUDE.md` references in `book/` or `docs/`.

Merging deploys the site via the Pages workflow.

🤖 Generated with [Claude Code](https://claude.com/claude-code)