### PR TITLE
docs(site): show shipped versions per phase in the roadmap figure

### DIFF
--- a/book/src/images/roadmap.svg
+++ b/book/src/images/roadmap.svg
@@ -1,6 +1,10 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 720 520" width="720" height="520" font-family="Jost, Inter, system-ui, -apple-system, sans-serif" role="img" aria-label="Roadmap timeline. Phases 0 through 7 are done: 0 to 5 shipped in v0.1.0 (scaffolding, landing page, persistence and admin CRUD, proxy and Docker backend, monitoring dashboard, production polish); 6 (multi-host scheduling) and 7 (HA / multi-instance) are complete on main. Phase 8 (external auth) is planned and optional.">
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 720 520" width="720" height="520" font-family="Jost, Inter, system-ui, -apple-system, sans-serif" role="img" aria-label="Roadmap timeline. Phases 0 through 7 are done. Phases 0 to 5 shipped in v0.1.0 (scaffolding, landing page, persistence and admin CRUD, proxy and Docker backend, monitoring dashboard, production polish); phase 6 (multi-host scheduling, app visibility, sub-path mounting) shipped across v0.1.1 and v0.1.2; phase 7 (HA / multi-instance) shipped in v0.1.1. The latest release, v0.1.3, adds admin/UX and proxy polish across the shipped phases. Phase 8 (external auth) is planned and optional.">
   <title>Ruscker — roadmap</title>
+
+  <!-- latest-release pill -->
+  <rect x="520" y="14" width="120" height="22" rx="11" fill="#0F6E56"/>
+  <text x="580" y="29" text-anchor="middle" font-size="11" font-weight="700" fill="#FFFFFF">latest · v0.1.3</text>
 
   <!-- rail: solid teal through the done phases (0–7), dashed grey after -->
   <line x1="60" y1="52" x2="60" y2="420" stroke="#1D9E75" stroke-width="3"/>
@@ -44,23 +48,27 @@
     <text x="86" y="309" font-weight="700" fill="#085041">Phase 5 · Production polish</text>
     <text x="86" y="325" font-size="11" fill="#5B6B66">probes · graceful shutdown · RBAC · signed releases</text>
     <rect x="520" y="298" width="120" height="22" rx="11" fill="#0F6E56"/>
-    <text x="580" y="313" text-anchor="middle" font-size="11" font-weight="700" fill="#FFFFFF">shipped · v0.1.0</text>
-  </g>
+    <text x="580" y="313" text-anchor="middle" font-size="11" font-weight="700" fill="#FFFFFF">v0.1.0</text>
 
-  <!-- planned phases -->
-  <g font-size="13">
-    <!-- 6 (done) -->
+    <!-- 6 -->
     <circle cx="60" cy="368" r="9" fill="#0F6E56"/>
     <path d="M55.5,368 l3,3 l6,-6.5" fill="none" stroke="#FFFFFF" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"/>
     <text x="86" y="365" font-weight="700" fill="#085041">Phase 6 · Multi-host scheduling</text>
-    <text x="86" y="381" font-size="11" fill="#5B6B66">multiple Docker hosts · bin-pack / spread · anti-affinity</text>
+    <text x="86" y="381" font-size="11" fill="#5B6B66">multiple Docker hosts · app visibility · sub-path mounting</text>
+    <rect x="520" y="354" width="120" height="22" rx="11" fill="#0F6E56"/>
+    <text x="580" y="369" text-anchor="middle" font-size="11" font-weight="700" fill="#FFFFFF">v0.1.1 – v0.1.2</text>
 
-    <!-- 7 (done) -->
+    <!-- 7 -->
     <circle cx="60" cy="420" r="9" fill="#0F6E56"/>
     <path d="M55.5,420 l3,3 l6,-6.5" fill="none" stroke="#FFFFFF" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"/>
     <text x="86" y="417" font-weight="700" fill="#085041">Phase 7 · HA / multi-instance</text>
     <text x="86" y="433" font-size="11" fill="#5B6B66">Postgres session store · advisory locks · failover</text>
+    <rect x="520" y="406" width="120" height="22" rx="11" fill="#0F6E56"/>
+    <text x="580" y="421" text-anchor="middle" font-size="11" font-weight="700" fill="#FFFFFF">v0.1.1</text>
+  </g>
 
+  <!-- planned phase -->
+  <g font-size="13">
     <!-- 8 -->
     <circle cx="60" cy="472" r="8.5" fill="#FFFFFF" stroke="#B9CDC6" stroke-width="2.5"/>
     <text x="86" y="469" font-weight="700" fill="#5B6B66">Phase 8 · External auth</text>

--- a/book/src/roadmap.md
+++ b/book/src/roadmap.md
@@ -5,7 +5,7 @@ production-ready and horizontally scalable. Phase 8 (external auth) is
 the main optional, demand-driven work left. For what changed in each
 release, see the [release notes](./news.md).
 
-![Roadmap timeline: phases 0–7 are done — 0 to 5 shipped in v0.1.0 (scaffolding, landing page, persistence + admin CRUD, proxy + Docker backend, monitoring dashboard, production polish), and 6 (multi-host scheduling) and 7 (HA / multi-instance) followed in v0.1.1. Phase 8 (external auth) is planned and optional.](images/roadmap.svg)
+![Roadmap timeline: phases 0–7 are done — 0 to 5 shipped in v0.1.0 (scaffolding, landing page, persistence + admin CRUD, proxy + Docker backend, monitoring dashboard, production polish); phase 6 (multi-host scheduling, app visibility, sub-path mounting) across v0.1.1–v0.1.2; phase 7 (HA / multi-instance) in v0.1.1. The latest release v0.1.3 adds admin/UX + proxy polish. Phase 8 (external auth) is planned and optional.](images/roadmap.svg)
 
 ## Shipped
 

--- a/docs/images/roadmap.svg
+++ b/docs/images/roadmap.svg
@@ -1,6 +1,10 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 720 520" width="720" height="520" font-family="Jost, Inter, system-ui, -apple-system, sans-serif" role="img" aria-label="Roadmap timeline. Phases 0 through 7 are done: 0 to 5 shipped in v0.1.0 (scaffolding, landing page, persistence and admin CRUD, proxy and Docker backend, monitoring dashboard, production polish); 6 (multi-host scheduling) and 7 (HA / multi-instance) are complete on main. Phase 8 (external auth) is planned and optional.">
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 720 520" width="720" height="520" font-family="Jost, Inter, system-ui, -apple-system, sans-serif" role="img" aria-label="Roadmap timeline. Phases 0 through 7 are done. Phases 0 to 5 shipped in v0.1.0 (scaffolding, landing page, persistence and admin CRUD, proxy and Docker backend, monitoring dashboard, production polish); phase 6 (multi-host scheduling, app visibility, sub-path mounting) shipped across v0.1.1 and v0.1.2; phase 7 (HA / multi-instance) shipped in v0.1.1. The latest release, v0.1.3, adds admin/UX and proxy polish across the shipped phases. Phase 8 (external auth) is planned and optional.">
   <title>Ruscker — roadmap</title>
+
+  <!-- latest-release pill -->
+  <rect x="520" y="14" width="120" height="22" rx="11" fill="#0F6E56"/>
+  <text x="580" y="29" text-anchor="middle" font-size="11" font-weight="700" fill="#FFFFFF">latest · v0.1.3</text>
 
   <!-- rail: solid teal through the done phases (0–7), dashed grey after -->
   <line x1="60" y1="52" x2="60" y2="420" stroke="#1D9E75" stroke-width="3"/>
@@ -44,23 +48,27 @@
     <text x="86" y="309" font-weight="700" fill="#085041">Phase 5 · Production polish</text>
     <text x="86" y="325" font-size="11" fill="#5B6B66">probes · graceful shutdown · RBAC · signed releases</text>
     <rect x="520" y="298" width="120" height="22" rx="11" fill="#0F6E56"/>
-    <text x="580" y="313" text-anchor="middle" font-size="11" font-weight="700" fill="#FFFFFF">shipped · v0.1.0</text>
-  </g>
+    <text x="580" y="313" text-anchor="middle" font-size="11" font-weight="700" fill="#FFFFFF">v0.1.0</text>
 
-  <!-- planned phases -->
-  <g font-size="13">
-    <!-- 6 (done) -->
+    <!-- 6 -->
     <circle cx="60" cy="368" r="9" fill="#0F6E56"/>
     <path d="M55.5,368 l3,3 l6,-6.5" fill="none" stroke="#FFFFFF" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"/>
     <text x="86" y="365" font-weight="700" fill="#085041">Phase 6 · Multi-host scheduling</text>
-    <text x="86" y="381" font-size="11" fill="#5B6B66">multiple Docker hosts · bin-pack / spread · anti-affinity</text>
+    <text x="86" y="381" font-size="11" fill="#5B6B66">multiple Docker hosts · app visibility · sub-path mounting</text>
+    <rect x="520" y="354" width="120" height="22" rx="11" fill="#0F6E56"/>
+    <text x="580" y="369" text-anchor="middle" font-size="11" font-weight="700" fill="#FFFFFF">v0.1.1 – v0.1.2</text>
 
-    <!-- 7 (done) -->
+    <!-- 7 -->
     <circle cx="60" cy="420" r="9" fill="#0F6E56"/>
     <path d="M55.5,420 l3,3 l6,-6.5" fill="none" stroke="#FFFFFF" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"/>
     <text x="86" y="417" font-weight="700" fill="#085041">Phase 7 · HA / multi-instance</text>
     <text x="86" y="433" font-size="11" fill="#5B6B66">Postgres session store · advisory locks · failover</text>
+    <rect x="520" y="406" width="120" height="22" rx="11" fill="#0F6E56"/>
+    <text x="580" y="421" text-anchor="middle" font-size="11" font-weight="700" fill="#FFFFFF">v0.1.1</text>
+  </g>
 
+  <!-- planned phase -->
+  <g font-size="13">
     <!-- 8 -->
     <circle cx="60" cy="472" r="8.5" fill="#FFFFFF" stroke="#B9CDC6" stroke-width="2.5"/>
     <text x="86" y="469" font-weight="700" fill="#5B6B66">Phase 8 · External auth</text>


### PR DESCRIPTION
The roadmap timeline badged only **v0.1.0**. This adds release badges to every shipped phase so the figure reflects the full history:

- Phase 5 → **v0.1.0**
- Phase 6 → **v0.1.1 – v0.1.2** (multi-host + app visibility + sub-path mounting)
- Phase 7 → **v0.1.1** (HA / multi-instance)
- a **`latest · v0.1.3`** pill at the top (admin/UX + proxy polish — it spans the shipped phases rather than being a phase of its own)

Phase 8 stays the planned/optional outline pill. Both SVG copies (`book/src/images` + `docs/images`) updated in lockstep; the markdown alt text is refreshed to match.

Verified by rendering with `rsvg-convert` (librsvg respects the layout like the browser) — badges align with their phase rows, no overlaps. `mdbook build` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)