### PR TITLE
docs(site): place v0.1.3 on the roadmap timeline (between phase 7 and 8)

### DIFF
--- a/book/src/images/roadmap.svg
+++ b/book/src/images/roadmap.svg
@@ -1,14 +1,11 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 720 520" width="720" height="520" font-family="Jost, Inter, system-ui, -apple-system, sans-serif" role="img" aria-label="Roadmap timeline. Phases 0 through 7 are done. Phases 0 to 5 shipped in v0.1.0 (scaffolding, landing page, persistence and admin CRUD, proxy and Docker backend, monitoring dashboard, production polish); phase 6 (multi-host scheduling, app visibility, sub-path mounting) shipped across v0.1.1 and v0.1.2; phase 7 (HA / multi-instance) shipped in v0.1.1. The latest release, v0.1.3, adds admin/UX and proxy polish across the shipped phases. Phase 8 (external auth) is planned and optional.">
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 720 520" width="720" height="520" font-family="Jost, Inter, system-ui, -apple-system, sans-serif" role="img" aria-label="Roadmap timeline. Phases 0 through 7 are done. Phases 0 to 5 shipped in v0.1.0 (scaffolding, landing page, persistence and admin CRUD, proxy and Docker backend, monitoring dashboard, production polish); phase 6 (multi-host scheduling, app visibility, sub-path mounting) shipped across v0.1.1 and v0.1.2; phase 7 (HA / multi-instance) shipped in v0.1.1. After phase 7, the latest release v0.1.3 adds admin/UX and proxy polish across the shipped phases. Phase 8 (external auth) is planned and optional.">
   <title>Ruscker — roadmap</title>
 
-  <!-- latest-release pill -->
-  <rect x="520" y="14" width="120" height="22" rx="11" fill="#0F6E56"/>
-  <text x="580" y="29" text-anchor="middle" font-size="11" font-weight="700" fill="#FFFFFF">latest · v0.1.3</text>
-
-  <!-- rail: solid teal through the done phases (0–7), dashed grey after -->
-  <line x1="60" y1="52" x2="60" y2="420" stroke="#1D9E75" stroke-width="3"/>
-  <line x1="60" y1="420" x2="60" y2="476" stroke="#B9CDC6" stroke-width="3" stroke-dasharray="3 6"/>
+  <!-- rail: solid teal through the done phases (0–7) and the v0.1.3
+       release marker, dashed grey after toward the planned phase 8 -->
+  <line x1="60" y1="52" x2="60" y2="446" stroke="#1D9E75" stroke-width="3"/>
+  <line x1="60" y1="446" x2="60" y2="476" stroke="#B9CDC6" stroke-width="3" stroke-dasharray="3 6"/>
 
   <!-- done phases -->
   <g font-size="13">
@@ -67,13 +64,21 @@
     <text x="580" y="421" text-anchor="middle" font-size="11" font-weight="700" fill="#FFFFFF">v0.1.1</text>
   </g>
 
+  <!-- v0.1.3 release marker — between phase 7 and the planned phase 8.
+       A diamond (not a phase circle): a cross-cutting release, not a
+       phase. Sits at the solid→dashed transition. -->
+  <path d="M60,439 l7,7 l-7,7 l-7,-7 z" fill="#1D9E75" stroke="#FFFFFF" stroke-width="1.5"/>
+  <text x="86" y="450" font-size="12.5">
+    <tspan font-weight="700" fill="#085041">v0.1.3</tspan><tspan fill="#5B6B66"> · latest — admin &amp; UX + proxy polish (across phases 1–7)</tspan>
+  </text>
+
   <!-- planned phase -->
   <g font-size="13">
     <!-- 8 -->
-    <circle cx="60" cy="472" r="8.5" fill="#FFFFFF" stroke="#B9CDC6" stroke-width="2.5"/>
-    <text x="86" y="469" font-weight="700" fill="#5B6B66">Phase 8 · External auth</text>
-    <text x="86" y="485" font-size="11" fill="#90A39C">OIDC · SAML · LDAP · per-app ACLs (RBAC already shipped)</text>
-    <rect x="520" y="458" width="120" height="22" rx="11" fill="#FFFFFF" stroke="#B9CDC6" stroke-width="1.5"/>
-    <text x="580" y="473" text-anchor="middle" font-size="11" font-weight="600" fill="#5B6B66">planned · optional</text>
+    <circle cx="60" cy="476" r="8.5" fill="#FFFFFF" stroke="#B9CDC6" stroke-width="2.5"/>
+    <text x="86" y="473" font-weight="700" fill="#5B6B66">Phase 8 · External auth</text>
+    <text x="86" y="489" font-size="11" fill="#90A39C">OIDC · SAML · LDAP · per-app ACLs (RBAC already shipped)</text>
+    <rect x="520" y="462" width="120" height="22" rx="11" fill="#FFFFFF" stroke="#B9CDC6" stroke-width="1.5"/>
+    <text x="580" y="477" text-anchor="middle" font-size="11" font-weight="600" fill="#5B6B66">planned · optional</text>
   </g>
 </svg>

--- a/docs/images/roadmap.svg
+++ b/docs/images/roadmap.svg
@@ -1,14 +1,11 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 720 520" width="720" height="520" font-family="Jost, Inter, system-ui, -apple-system, sans-serif" role="img" aria-label="Roadmap timeline. Phases 0 through 7 are done. Phases 0 to 5 shipped in v0.1.0 (scaffolding, landing page, persistence and admin CRUD, proxy and Docker backend, monitoring dashboard, production polish); phase 6 (multi-host scheduling, app visibility, sub-path mounting) shipped across v0.1.1 and v0.1.2; phase 7 (HA / multi-instance) shipped in v0.1.1. The latest release, v0.1.3, adds admin/UX and proxy polish across the shipped phases. Phase 8 (external auth) is planned and optional.">
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 720 520" width="720" height="520" font-family="Jost, Inter, system-ui, -apple-system, sans-serif" role="img" aria-label="Roadmap timeline. Phases 0 through 7 are done. Phases 0 to 5 shipped in v0.1.0 (scaffolding, landing page, persistence and admin CRUD, proxy and Docker backend, monitoring dashboard, production polish); phase 6 (multi-host scheduling, app visibility, sub-path mounting) shipped across v0.1.1 and v0.1.2; phase 7 (HA / multi-instance) shipped in v0.1.1. After phase 7, the latest release v0.1.3 adds admin/UX and proxy polish across the shipped phases. Phase 8 (external auth) is planned and optional.">
   <title>Ruscker — roadmap</title>
 
-  <!-- latest-release pill -->
-  <rect x="520" y="14" width="120" height="22" rx="11" fill="#0F6E56"/>
-  <text x="580" y="29" text-anchor="middle" font-size="11" font-weight="700" fill="#FFFFFF">latest · v0.1.3</text>
-
-  <!-- rail: solid teal through the done phases (0–7), dashed grey after -->
-  <line x1="60" y1="52" x2="60" y2="420" stroke="#1D9E75" stroke-width="3"/>
-  <line x1="60" y1="420" x2="60" y2="476" stroke="#B9CDC6" stroke-width="3" stroke-dasharray="3 6"/>
+  <!-- rail: solid teal through the done phases (0–7) and the v0.1.3
+       release marker, dashed grey after toward the planned phase 8 -->
+  <line x1="60" y1="52" x2="60" y2="446" stroke="#1D9E75" stroke-width="3"/>
+  <line x1="60" y1="446" x2="60" y2="476" stroke="#B9CDC6" stroke-width="3" stroke-dasharray="3 6"/>
 
   <!-- done phases -->
   <g font-size="13">
@@ -67,13 +64,21 @@
     <text x="580" y="421" text-anchor="middle" font-size="11" font-weight="700" fill="#FFFFFF">v0.1.1</text>
   </g>
 
+  <!-- v0.1.3 release marker — between phase 7 and the planned phase 8.
+       A diamond (not a phase circle): a cross-cutting release, not a
+       phase. Sits at the solid→dashed transition. -->
+  <path d="M60,439 l7,7 l-7,7 l-7,-7 z" fill="#1D9E75" stroke="#FFFFFF" stroke-width="1.5"/>
+  <text x="86" y="450" font-size="12.5">
+    <tspan font-weight="700" fill="#085041">v0.1.3</tspan><tspan fill="#5B6B66"> · latest — admin &amp; UX + proxy polish (across phases 1–7)</tspan>
+  </text>
+
   <!-- planned phase -->
   <g font-size="13">
     <!-- 8 -->
-    <circle cx="60" cy="472" r="8.5" fill="#FFFFFF" stroke="#B9CDC6" stroke-width="2.5"/>
-    <text x="86" y="469" font-weight="700" fill="#5B6B66">Phase 8 · External auth</text>
-    <text x="86" y="485" font-size="11" fill="#90A39C">OIDC · SAML · LDAP · per-app ACLs (RBAC already shipped)</text>
-    <rect x="520" y="458" width="120" height="22" rx="11" fill="#FFFFFF" stroke="#B9CDC6" stroke-width="1.5"/>
-    <text x="580" y="473" text-anchor="middle" font-size="11" font-weight="600" fill="#5B6B66">planned · optional</text>
+    <circle cx="60" cy="476" r="8.5" fill="#FFFFFF" stroke="#B9CDC6" stroke-width="2.5"/>
+    <text x="86" y="473" font-weight="700" fill="#5B6B66">Phase 8 · External auth</text>
+    <text x="86" y="489" font-size="11" fill="#90A39C">OIDC · SAML · LDAP · per-app ACLs (RBAC already shipped)</text>
+    <rect x="520" y="462" width="120" height="22" rx="11" fill="#FFFFFF" stroke="#B9CDC6" stroke-width="1.5"/>
+    <text x="580" y="477" text-anchor="middle" font-size="11" font-weight="600" fill="#5B6B66">planned · optional</text>
   </g>
 </svg>


### PR DESCRIPTION
Follow-up to the roadmap-figure update. v0.1.3 is a cross-cutting release (admin/UX + proxy polish), not a phase — the floating `latest · v0.1.3` pill at the top read as confusing.

This puts v0.1.3 **on the timeline itself**, in its chronological slot **after phase 7 (v0.1.1) and before the planned phase 8** — a diamond marker (distinct from the phase circles) at the solid→dashed transition, labelled *"v0.1.3 · latest — admin & UX + proxy polish (across phases 1–7)"*.

Phase 8 nudged down slightly for room. Both SVG copies (`book/src/images` + `docs/images`) synced; verified with `rsvg-convert`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)