### PR TITLE
packaging: auto-generate RUSCKER_MASTER_KEY + RUSCKER_COOKIE_KEY on install (#226)

### DIFF
--- a/packaging/README.Debian
+++ b/packaging/README.Debian
@@ -16,13 +16,21 @@ the admin panel, and the proxy on 0.0.0.0:8080.
   systemctl status ruscker
   curl http://localhost:8080/healthz
 
-Admin token
------------
-On first install the package generates a strong, unique admin token
-and prints it ONCE in the install output (there is no default
-password). It is stored in /etc/ruscker/ruscker.env as
-RUSCKER_ADMIN_TOKEN. Log in at /admin/login with it. To see it again
-or rotate it:
+Generated secrets
+-----------------
+On install the package generates three strong, unique secrets into
+/etc/ruscker/ruscker.env (root:ruscker 0640), so the box works out of
+the box with no default credentials:
+
+  RUSCKER_ADMIN_TOKEN   break-glass admin login — printed ONCE in the
+                        install output (first install only).
+  RUSCKER_MASTER_KEY    enables the encrypted credentials store.
+  RUSCKER_COOKIE_KEY    signs sticky-session cookies (stable across
+                        restarts / HA replicas).
+
+None are ever regenerated once set; the master/cookie keys are also
+filled in on upgrade if an older install was missing them. Log in at
+/admin/login with the admin token. To see it again or rotate it:
 
   sudo grep RUSCKER_ADMIN_TOKEN /etc/ruscker/ruscker.env
   # to rotate: edit the value, then  sudo systemctl restart ruscker

--- a/packaging/debian/postinst
+++ b/packaging/debian/postinst
@@ -3,6 +3,21 @@
 # cargo-deb injects the systemd enable/start logic at the marker below.
 set -e
 
+# Write VAR=<32-byte hex> to $ENVF if it isn't set yet (placeholder or
+# absent). Idempotent and upgrade-safe: never overwrites a value the
+# operator already set. Uses /dev/urandom + od (coreutils) — no openssl
+# dependency. Caller fixes ownership/permissions afterwards.
+gen_key() {
+    var="$1"
+    grep -qE "^${var}=." "$ENVF" 2>/dev/null && return 0
+    val=$(head -c 32 /dev/urandom | od -An -tx1 | tr -d ' \n')
+    if grep -qE "^#*${var}=" "$ENVF" 2>/dev/null; then
+        sed -i "s|^#*${var}=.*|${var}=${val}|" "$ENVF"
+    else
+        printf '\n%s=%s\n' "$var" "$val" >> "$ENVF"
+    fi
+}
+
 case "$1" in
     configure)
         # System group + user the unit runs as. No login, no home dir
@@ -24,6 +39,14 @@ case "$1" in
         # The secrets file must not be world-readable.
         ENVF=/etc/ruscker/ruscker.env
         if [ -f "$ENVF" ]; then
+            # Infra keys: the credentials store needs RUSCKER_MASTER_KEY,
+            # and RUSCKER_COOKIE_KEY keeps sticky-session cookies valid
+            # across restarts (and signable cross-instance in HA) instead
+            # of a fresh random key per process. Generate them if missing
+            # — on first install AND self-healing an older box that never
+            # had them. Never regenerated once set.
+            gen_key RUSCKER_MASTER_KEY
+            gen_key RUSCKER_COOKIE_KEY
             chown root:ruscker "$ENVF" || true
             chmod 640 "$ENVF" || true
         fi

--- a/packaging/ruscker.env.example
+++ b/packaging/ruscker.env.example
@@ -16,12 +16,14 @@
 #RUSCKER_ADMIN_TOKEN=
 
 # Master key for the encrypted credentials store (AES-256-GCM).
-# Required only if you use the admin credentials store. Hex (64 chars)
-# or base64 (44 chars):  openssl rand -hex 32
+# Auto-generated on .deb install (like the admin token). Needed for the
+# admin credentials store. Hex (64 chars) or base64 (44 chars):
+#   openssl rand -hex 32
 #RUSCKER_MASTER_KEY=
 
-# Key used to sign sticky-session cookies. Auto-generated per process
-# if unset — set it to keep sessions valid across restarts / replicas:
+# Key used to sign sticky-session cookies. Auto-generated on .deb
+# install so sessions stay valid across restarts and are signable
+# across HA replicas (otherwise a fresh random key is used per process).
 #   openssl rand -hex 32
 #RUSCKER_COOKIE_KEY=
 


### PR DESCRIPTION
Closes #226.

A fresh `.deb` left `RUSCKER_MASTER_KEY` / `RUSCKER_COOKIE_KEY` unset → the credentials store was disabled (the *"RUSCKER_MASTER_KEY não está configurada"* warning) and sticky cookies were re-keyed every restart (unsignable cross-instance in HA).

The postinst already generates `RUSCKER_ADMIN_TOKEN`; this factors it into a `gen_key` helper (same `/dev/urandom | od` pattern, no openssl dep) and also generates the master + cookie keys.

- **Idempotent + upgrade-safe**: never overwrites a set value.
- Master/cookie keys generate on first install **and self-heal** an older box that never had them; the admin token stays first-install-only + printed once.
- `ruscker.env.example` + `README.Debian` updated.

Verified the append path + idempotency locally; the sed-fill path mirrors the proven admin-token block (GNU sed on the Debian/Ubuntu target). Acceptance: install the `.deb` on a clean box → all three keys non-empty, Admin → Credentials works, cookies survive a restart.