### PR TITLE
feat(config): generic App kind so Jupyter/RStudio aren't 'Shiny' (#231)

### DIFF
--- a/crates/ruscker-admin/src/db/showcase.rs
+++ b/crates/ruscker-admin/src/db/showcase.rs
@@ -234,18 +234,25 @@ fn showcase_specs() -> Result<Vec<Spec>> {
                 "--ServerApp.disable_check_xsrf=True".into(),
                 "--ServerApp.base_url=/".into(),
             ]);
+            // Generic interactive app, not Shiny (#231).
+            jup.kind_override = Some(ruscker_config::SpecKindOverride::App);
             jup
         },
-        card(
-            "rstudio",
-            "RStudio Server",
-            "The RStudio IDE in your browser, served per session.",
-            "/assets/showcase/rstudio.svg",
-            "https://posit.co/products/open-source/rstudio-server/",
-            Some("rocker/rstudio:latest"),
-            Some(8787),
-            None,
-        )?,
+        {
+            let mut rst = card(
+                "rstudio",
+                "RStudio Server",
+                "The RStudio IDE in your browser, served per session.",
+                "/assets/showcase/rstudio.svg",
+                "https://posit.co/products/open-source/rstudio-server/",
+                Some("rocker/rstudio:latest"),
+                Some(8787),
+                None,
+            )?;
+            // Generic interactive app, not Shiny (#231).
+            rst.kind_override = Some(ruscker_config::SpecKindOverride::App);
+            rst
+        },
         // R Markdown isn't a server — it's a document format. Linked to
         // its docs rather than launching a container (the RStudio Server
         // card above is what actually renders/previews `.Rmd` files).
@@ -360,6 +367,17 @@ mod tests {
                 .await
                 .unwrap();
         assert_eq!(row.0, "Ruscker");
+    }
+
+    #[test]
+    fn jupyter_and_rstudio_are_interactive_apps_not_shiny() {
+        // #231: containerized non-Shiny cards default to Shiny without an
+        // explicit kind; the seed tags them `App` → InteractiveApp.
+        let specs = showcase_specs().unwrap();
+        let kind = |id: &str| specs.iter().find(|s| s.id == id).unwrap().kind();
+        assert_eq!(kind("jupyter"), ruscker_config::SpecKind::InteractiveApp);
+        assert_eq!(kind("rstudio"), ruscker_config::SpecKind::InteractiveApp);
+        assert_eq!(kind("shiny"), ruscker_config::SpecKind::Shiny, "shiny stays Shiny");
     }
 
     #[tokio::test]

--- a/crates/ruscker-admin/src/routes/admin/spec_form.rs
+++ b/crates/ruscker-admin/src/routes/admin/spec_form.rs
@@ -302,7 +302,19 @@ impl SpecForm {
         // App/API/External set an explicit kind; Talk/Report are purely
         // visual, so keep whatever run-kind override `base` carried.
         let kind_override = match dt {
-            DisplayType::App => Some(SpecKindOverride::Shiny),
+            // "App" badge covers Shiny + generic interactive apps. Preserve
+            // an existing app-family run-kind (App/Streamlit/Dash/Voilà) so
+            // editing e.g. a Jupyter card doesn't silently revert it to
+            // Shiny (#231); a brand-new "app" still defaults to Shiny.
+            DisplayType::App => match base.and_then(|b| b.kind_override) {
+                Some(
+                    k @ (SpecKindOverride::App
+                    | SpecKindOverride::Streamlit
+                    | SpecKindOverride::Dash
+                    | SpecKindOverride::Voila),
+                ) => Some(k),
+                _ => Some(SpecKindOverride::Shiny),
+            },
             DisplayType::Talk | DisplayType::Report => base.and_then(|b| b.kind_override),
             DisplayType::Package | DisplayType::Link => Some(SpecKindOverride::External),
             DisplayType::Api => Some(SpecKindOverride::Api),
@@ -1105,6 +1117,29 @@ proxy:
     }
 
     // ── #211: newly-modelled advanced fields ────────────────────
+
+    #[test]
+    fn editing_an_app_card_preserves_interactive_kind() {
+        // #231: a Jupyter/RStudio card is kind App (InteractiveApp). The
+        // form's "app" badge must keep that on save, not revert to Shiny.
+        let base: Spec = serde_yaml_ng::from_str(
+            "id: nb\ndisplay-name: Jupyter\ncontainer-image: x\ntype: app",
+        )
+        .unwrap();
+        assert_eq!(base.kind(), ruscker_config::SpecKind::InteractiveApp);
+        let mut form = SpecForm::from_spec(&base);
+        form.display_name = "Jupyter (edited)".into();
+        let merged = form.into_spec(Some(&base)).unwrap();
+        assert_eq!(merged.kind(), ruscker_config::SpecKind::InteractiveApp, "App kept, not Shiny");
+
+        // A brand-new "app" (no base) still defaults to Shiny.
+        let fresh = SpecForm {
+            id: "s".into(), display_name: "S".into(), display_type: "app".into(),
+            state: "active".into(), access: "lock".into(), container_image: "x".into(),
+            ..Default::default()
+        };
+        assert_eq!(fresh.into_spec(None).unwrap().kind(), ruscker_config::SpecKind::Shiny);
+    }
 
     #[test]
     fn new_advanced_fields_round_trip() {

--- a/crates/ruscker-config/src/schema.rs
+++ b/crates/ruscker-config/src/schema.rs
@@ -727,6 +727,9 @@ impl TemplateProperties {
 #[serde(rename_all = "lowercase")]
 pub enum SpecKindOverride {
     Shiny,
+    /// Generic interactive container app (Jupyter, RStudio, …) that
+    /// isn't Shiny specifically. Maps to [`SpecKind::InteractiveApp`].
+    App,
     Streamlit,
     Dash,
     Voila,
@@ -769,9 +772,12 @@ impl Spec {
         match self.kind_override {
             Some(SpecKindOverride::Api) => SpecKind::Api,
             Some(SpecKindOverride::Shiny) => SpecKind::Shiny,
-            Some(SpecKindOverride::Streamlit | SpecKindOverride::Dash | SpecKindOverride::Voila) => {
-                SpecKind::InteractiveApp
-            }
+            Some(
+                SpecKindOverride::App
+                | SpecKindOverride::Streamlit
+                | SpecKindOverride::Dash
+                | SpecKindOverride::Voila,
+            ) => SpecKind::InteractiveApp,
             Some(SpecKindOverride::External) => SpecKind::External,
             None => {
                 if self.container_image.is_some() {


### PR DESCRIPTION
Closes #231.

Containerized showcase cards with no explicit `type:` defaulted to `SpecKind::Shiny` — so **Jupyter / RStudio** reported as "Shiny". There was no generic interactive-app override.

- Add **`SpecKindOverride::App`** (serde `"app"`) → `SpecKind::InteractiveApp` (existing kind — runtime helpers/stats/CLI already handle it; the landing badge reads `template-properties.type` first, so it's unchanged).
- Seed Jupyter + RStudio with `kind_override = App` (Shiny stays Shiny). Seed still 12 cards.
- Spec form: the "app" badge now **preserves** an existing app-family run-kind (App/Streamlit/Dash/Voilà) on save instead of hardcoding Shiny — editing a Jupyter card won't silently revert it; a new "app" still defaults to Shiny.

Tests: seed kinds; edit-preserves-App / new-defaults-Shiny. Full suite + config green.

Note: applies to fresh seeds / re-seeds — existing DB rows keep their stored kind until re-seeded or edited.