### PR TITLE
feat(admin): custom CSS in the landing editor (#232)

### DIFF
--- a/crates/ruscker-admin/assets/i18n/en/landing.ftl
+++ b/crates/ruscker-admin/assets/i18n/en/landing.ftl
@@ -533,3 +533,7 @@ admin-proclog-tail-note = Showing the most recent lines
 admin-proclog-download = Download full log
 
 landing-empty = Nothing here yet.
+
+admin-landing-style = Style (CSS)
+admin-landing-custom-css = Custom CSS
+admin-landing-custom-css-help = CSS injected at the end of the landing <head> — overrides the built-in styles. Target stable classes/variables (.rcard, .tint-*, --color-link, header vars). Admin-trusted; take care not to break the layout.

--- a/crates/ruscker-admin/assets/i18n/es/landing.ftl
+++ b/crates/ruscker-admin/assets/i18n/es/landing.ftl
@@ -533,3 +533,7 @@ admin-proclog-tail-note = Mostrando las líneas más recientes
 admin-proclog-download = Descargar log completo
 
 landing-empty = Nada por aquí.
+
+admin-landing-style = Estilo (CSS)
+admin-landing-custom-css = CSS personalizado
+admin-landing-custom-css-help = CSS inyectado al final del <head> de la landing — sobrescribe los estilos por defecto. Apunta a clases/variables estables (.rcard, .tint-*, --color-link, variables del header). De confianza (admin); cuidado con romper el diseño.

--- a/crates/ruscker-admin/assets/i18n/fr/landing.ftl
+++ b/crates/ruscker-admin/assets/i18n/fr/landing.ftl
@@ -533,3 +533,7 @@ admin-proclog-tail-note = Affichage des lignes les plus récentes
 admin-proclog-download = Télécharger le journal complet
 
 landing-empty = Rien ici pour l'instant.
+
+admin-landing-style = Style (CSS)
+admin-landing-custom-css = CSS personnalisé
+admin-landing-custom-css-help = CSS injecté à la fin du <head> de la landing — remplace les styles intégrés. Ciblez des classes/variables stables (.rcard, .tint-*, --color-link, variables d'en-tête). De confiance (admin) ; attention à ne pas casser la mise en page.

--- a/crates/ruscker-admin/assets/i18n/pt/landing.ftl
+++ b/crates/ruscker-admin/assets/i18n/pt/landing.ftl
@@ -537,3 +537,7 @@ admin-proclog-tail-note = Mostrando as linhas mais recentes
 admin-proclog-download = Baixar log completo
 
 landing-empty = Nada por aqui.
+
+admin-landing-style = Estilo (CSS)
+admin-landing-custom-css = CSS personalizado
+admin-landing-custom-css-help = CSS injetado no fim do <head> da landing — sobrescreve o estilo padrão. Mire classes/variáveis estáveis (.rcard, .tint-*, --color-link, vars do header). Admin-confiável; cuidado para não quebrar o layout.

--- a/crates/ruscker-admin/migrations-pg/0009_landing_custom_css.sql
+++ b/crates/ruscker-admin/migrations-pg/0009_landing_custom_css.sql
@@ -1,0 +1,3 @@
+-- Operator custom CSS on the landing_customization singleton (#232).
+-- Postgres twin of migrations/0009. Optional/NULL.
+ALTER TABLE landing_customization ADD COLUMN custom_css TEXT;

--- a/crates/ruscker-admin/migrations/0009_landing_custom_css.sql
+++ b/crates/ruscker-admin/migrations/0009_landing_custom_css.sql
@@ -1,0 +1,3 @@
+-- Operator custom CSS on the landing_customization singleton (#232).
+-- Injected as a <style> in the landing <head>. Optional/NULL.
+ALTER TABLE landing_customization ADD COLUMN custom_css TEXT;

--- a/crates/ruscker-admin/src/db/landing.rs
+++ b/crates/ruscker-admin/src/db/landing.rs
@@ -29,10 +29,11 @@ pub async fn fetch(db: &ConfigDb) -> Result<LandingCustomization> {
         Option<String>, // og_image
         Option<String>, // analytics_html
         Option<String>, // analytics_origins
+        Option<String>, // custom_css
     );
     let sql = "SELECT header_bg, header_fg, intro, intro_locales_json,
                 seo_title, seo_description, og_image,
-                analytics_html, analytics_origins
+                analytics_html, analytics_origins, custom_css
            FROM landing_customization WHERE id = 1";
     let row: Option<Row> = match db {
         ConfigDb::Sqlite(pool) => sqlx::query_as(sql).fetch_optional(pool).await,
@@ -51,6 +52,7 @@ pub async fn fetch(db: &ConfigDb) -> Result<LandingCustomization> {
             og_image,
             analytics_html,
             analytics_origins,
+            custom_css,
         )) => {
             let intro_locales =
                 serde_json::from_str(&locales_json).context("parse intro_locales_json")?;
@@ -64,6 +66,7 @@ pub async fn fetch(db: &ConfigDb) -> Result<LandingCustomization> {
                 og_image,
                 analytics_html,
                 analytics_origins,
+                custom_css,
                 // Blocks live in their own table; callers that render
                 // or export them load via `landing_blocks`.
                 blocks: Vec::new(),
@@ -134,7 +137,7 @@ pub(crate) async fn update_in_tx(
             SET header_bg = ?, header_fg = ?, intro = ?,
                 intro_locales_json = ?, seo_title = ?, seo_description = ?,
                 og_image = ?, analytics_html = ?, analytics_origins = ?,
-                updated_at = ?
+                custom_css = ?, updated_at = ?
           WHERE id = 1",
     )
     .bind(none_if_empty(&lc.header_bg))
@@ -146,6 +149,7 @@ pub(crate) async fn update_in_tx(
     .bind(none_if_empty(&lc.og_image))
     .bind(none_if_empty(&lc.analytics_html))
     .bind(none_if_empty(&lc.analytics_origins))
+    .bind(none_if_empty(&lc.custom_css))
     .bind(now)
     .execute(&mut **tx)
     .await
@@ -168,7 +172,7 @@ pub(crate) async fn update_in_tx_pg(
             SET header_bg = $1, header_fg = $2, intro = $3,
                 intro_locales_json = $4, seo_title = $5, seo_description = $6,
                 og_image = $7, analytics_html = $8, analytics_origins = $9,
-                updated_at = $10
+                custom_css = $10, updated_at = $11
           WHERE id = 1",
     )
     .bind(none_if_empty(&lc.header_bg))
@@ -180,6 +184,7 @@ pub(crate) async fn update_in_tx_pg(
     .bind(none_if_empty(&lc.og_image))
     .bind(none_if_empty(&lc.analytics_html))
     .bind(none_if_empty(&lc.analytics_origins))
+    .bind(none_if_empty(&lc.custom_css))
     .bind(now)
     .execute(&mut **tx)
     .await

--- a/crates/ruscker-admin/src/routes/admin/landing.rs
+++ b/crates/ruscker-admin/src/routes/admin/landing.rs
@@ -82,6 +82,7 @@ pub struct LandingForm {
     pub og_image: String,
     pub analytics_html: String,
     pub analytics_origins: String,
+    pub custom_css: String,
 }
 
 impl LandingForm {
@@ -100,6 +101,7 @@ impl LandingForm {
             og_image: lc.og_image.clone().unwrap_or_default(),
             analytics_html: lc.analytics_html.clone().unwrap_or_default(),
             analytics_origins: lc.analytics_origins.clone().unwrap_or_default(),
+            custom_css: lc.custom_css.clone().unwrap_or_default(),
         }
     }
 
@@ -126,6 +128,7 @@ impl LandingForm {
             og_image: empty_to_none(self.og_image),
             analytics_html: empty_to_none(self.analytics_html),
             analytics_origins: empty_to_none(self.analytics_origins),
+            custom_css: empty_to_none(self.custom_css),
             // The landing editor doesn't manage blocks (their own
             // screen does); `landing::update` ignores this field, so
             // an empty Vec here never clobbers stored blocks.

--- a/crates/ruscker-admin/src/routes/landing.rs
+++ b/crates/ruscker-admin/src/routes/landing.rs
@@ -58,6 +58,9 @@ struct LandingPage<'a> {
     /// Operator analytics snippet, injected verbatim into `<head>`
     /// (rendered with `|safe`). Empty ⇒ nothing injected.
     analytics_html: String,
+    /// Operator custom CSS (#232), injected as a `<style>` near the end
+    /// of `<head>` (rendered with `|safe`). Empty ⇒ nothing injected.
+    custom_css: String,
     /// Custom HTML blocks rendered after the header (`top` slot) and
     /// after the card grid (`bottom` slot), in `position` order.
     blocks_top: Vec<crate::db::landing_blocks::LandingBlock>,
@@ -184,6 +187,7 @@ async fn index(
     let seo_description = not_blank(&lc.seo_description).unwrap_or_else(|| intro.clone());
     let og_image = not_blank(&lc.og_image).unwrap_or_default();
     let analytics_html = not_blank(&lc.analytics_html).unwrap_or_default();
+    let custom_css = not_blank(&lc.custom_css).unwrap_or_default();
 
     // Custom HTML blocks (DB-only). Split into the two slots; collect
     // their CSP origins alongside the analytics ones so embedded
@@ -224,6 +228,7 @@ async fn index(
         seo_description,
         og_image,
         analytics_html,
+        custom_css,
         blocks_top,
         blocks_bottom,
         signed_in: session.is_some(),

--- a/crates/ruscker-admin/templates/admin/landing.html
+++ b/crates/ruscker-admin/templates/admin/landing.html
@@ -211,6 +211,15 @@
         <div class="spec-form-help">{{ self.t("admin-landing-analytics-origins-help") }}</div>
       </div>
 
+      <div class="spec-form-section-title">{{ self.t("admin-landing-style") }}</div>
+      <div class="spec-form-field">
+        <label class="spec-form-label">{{ self.t("admin-landing-custom-css") }}</label>
+        <textarea name="custom_css" rows="6" x-model="form.custom_css"
+                  placeholder=".rcard { border-radius: 6px } &#10;:root { --color-link: #1d9e75 }"
+                  class="spec-form-input spec-form-input--mono">{{ form.custom_css }}</textarea>
+        <div class="spec-form-help">{{ self.t("admin-landing-custom-css-help") }}</div>
+      </div>
+
       <div class="info-box">
         <i class="ti ti-info-circle" aria-hidden="true"></i>
         <div>

--- a/crates/ruscker-admin/templates/landing.html
+++ b/crates/ruscker-admin/templates/landing.html
@@ -11,6 +11,9 @@
 <meta name="twitter:card" content="{% if !og_image.is_empty() %}summary_large_image{% else %}summary{% endif %}">
 {# Operator analytics snippet — rendered verbatim (admin-trusted). #}
 {% if !analytics_html.is_empty() %}{{ analytics_html|safe }}{% endif %}
+{# Operator custom CSS (#232) — injected last so it overrides the
+   built-in styles. Admin-trusted; landing CSP allows inline styles. #}
+{% if !custom_css.is_empty() %}<style>{{ custom_css|safe }}</style>{% endif %}
 {% endblock %}
 
 {% block content %}

--- a/crates/ruscker-config/src/schema.rs
+++ b/crates/ruscker-config/src/schema.rs
@@ -377,6 +377,14 @@ pub struct LandingCustomization {
     #[serde(default, rename = "analytics-origins")]
     pub analytics_origins: Option<String>,
 
+    /// Operator-authored CSS, injected as a `<style>` near the end of
+    /// the landing `<head>` so it can override the built-in styles
+    /// (#232). Admin-managed via the landing editor. The landing CSP
+    /// already allows `style-src 'unsafe-inline'`, so no policy change.
+    /// Trusted (admin-only) — like `analytics-html`.
+    #[serde(default, rename = "custom-css")]
+    pub custom_css: Option<String>,
+
     /// Custom HTML blocks rendered in the landing slots (`top` /
     /// `bottom`). Admin-managed; this field exists so they survive
     /// `import` / `export` (YAML round-trip). Array order within a


### PR DESCRIPTION
Closes #232 (option A — the custom-CSS slice).

A "style editor" for power users: an operator **`custom-css`** field injected as a `<style>` at the **end of the landing `<head>`** so it overrides the built-in styles. Admin-only + trusted (same model as `analytics-html`); the landing CSP already allows `style-src 'unsafe-inline'`, so no policy change.

- **Schema**: `LandingCustomization.custom_css` (`custom-css`) — round-trips via import/export.
- **Migration 0009** (sqlite + pg twin): `ADD COLUMN custom_css TEXT`.
- **db::landing** fetch + update (both dialects) carry it.
- **Landing** injects `<style>{custom_css|safe}</style>` last in `<head>`; **admin landing editor** gets a "Style (CSS)" textarea (live via the existing Alpine form). i18n ×4 with stable-hook guidance.

Real smoke: set `.rcard{outline:3px solid magenta}` in the editor → the landing head renders that `<style>`. Full suite + `i18n-check` green.

Structured controls / presets (options B/C in #232) can layer on later.