### PR TITLE
release: bump workspace version to 0.1.5

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2779,7 +2779,7 @@ dependencies = [
 
 [[package]]
 name = "ruscker-admin"
-version = "0.1.4"
+version = "0.1.5"
 dependencies = [
  "aes-gcm",
  "anyhow",
@@ -2826,7 +2826,7 @@ dependencies = [
 
 [[package]]
 name = "ruscker-cli"
-version = "0.1.4"
+version = "0.1.5"
 dependencies = [
  "anyhow",
  "clap",
@@ -2846,7 +2846,7 @@ dependencies = [
 
 [[package]]
 name = "ruscker-config"
-version = "0.1.4"
+version = "0.1.5"
 dependencies = [
  "chrono",
  "ordered-float",
@@ -2861,7 +2861,7 @@ dependencies = [
 
 [[package]]
 name = "ruscker-core"
-version = "0.1.4"
+version = "0.1.5"
 dependencies = [
  "async-trait",
  "chrono",
@@ -2874,7 +2874,7 @@ dependencies = [
 
 [[package]]
 name = "ruscker-docker"
-version = "0.1.4"
+version = "0.1.5"
 dependencies = [
  "anyhow",
  "async-stream",
@@ -2893,7 +2893,7 @@ dependencies = [
 
 [[package]]
 name = "ruscker-proxy"
-version = "0.1.4"
+version = "0.1.5"
 dependencies = [
  "anyhow",
  "axum",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -10,7 +10,7 @@ members = [
 ]
 
 [workspace.package]
-version = "0.1.4"
+version = "0.1.5"
 edition = "2021"
 rust-version = "1.85"
 license = "Apache-2.0"


### PR DESCRIPTION
Cuts **v0.1.5** with the post-v0.1.4 UX/admin batch (all on `main`):
- #234 — admin **Portal** nav link, landing empty-state `x-cloak`+i18n, **light card covers**
- #235 — `.deb` auto-generates `RUSCKER_MASTER_KEY` + `RUSCKER_COOKIE_KEY`
- #236 — generic **App** kind (Jupyter no longer "Shiny")
- #237 — users create-form full-width
- #238 — RStudio showcase card → docs link (doesn't proxy behind a sub-path)
- #239 — **custom CSS** in the landing editor

Bumps `[workspace.package].version` 0.1.4 → 0.1.5 (+ Cargo.lock); binary reports `ruscker 0.1.5`. Merge, then tag `v0.1.5` (castlab auto-update picks it up).