### PR TITLE
fix(admin): allow 'unsafe-eval' in CSP so Alpine.js runs (#244)

### DIFF
--- a/crates/ruscker-admin/src/lib.rs
+++ b/crates/ruscker-admin/src/lib.rs
@@ -635,8 +635,13 @@ async fn security_headers(
 /// `img-src`, `connect-src`). The landing uses this to allow an
 /// operator-configured analytics provider without loosening the
 /// policy for every other page. `'unsafe-inline'` on script/style is
-/// still required by the inline landing/dashboard scripts (a
-/// nonce-based CSP is a tracked follow-up).
+/// still required by the inline landing/dashboard scripts, and
+/// `'unsafe-eval'` by Alpine.js (its default evaluator builds
+/// functions via `new Function`, which a CSP without `'unsafe-eval'`
+/// blocks with an `EvalError` — breaking every Alpine directive:
+/// the card filters, help popovers, cover editor, spec form, etc.).
+/// The strict path (Alpine's CSP build + a nonce, dropping both
+/// `unsafe-*`) is a tracked follow-up.
 pub(crate) fn content_security_policy(extra_origins: &str) -> String {
     // Sanitize operator-supplied origins before they reach the header:
     // a stray `*`, `'unsafe-eval'`, or a `;`-smuggled directive would
@@ -649,7 +654,7 @@ pub(crate) fn content_security_policy(extra_origins: &str) -> String {
     };
     format!(
         "default-src 'self'; \
-         script-src 'self' 'unsafe-inline'{extra}; \
+         script-src 'self' 'unsafe-inline' 'unsafe-eval'{extra}; \
          style-src 'self' 'unsafe-inline'; \
          img-src 'self' data:{extra}; \
          font-src 'self'; \
@@ -712,7 +717,7 @@ mod csp_tests {
     #[test]
     fn base_policy_is_self_only() {
         let csp = content_security_policy("");
-        assert!(csp.contains("script-src 'self' 'unsafe-inline';"));
+        assert!(csp.contains("script-src 'self' 'unsafe-inline' 'unsafe-eval';"));
         assert!(csp.contains("connect-src 'self';"));
         assert!(!csp.contains("plausible"));
     }
@@ -720,7 +725,7 @@ mod csp_tests {
     #[test]
     fn extra_origins_widen_script_img_connect() {
         let csp = content_security_policy("https://plausible.io");
-        assert!(csp.contains("script-src 'self' 'unsafe-inline' https://plausible.io;"));
+        assert!(csp.contains("script-src 'self' 'unsafe-inline' 'unsafe-eval' https://plausible.io;"));
         assert!(csp.contains("img-src 'self' data: https://plausible.io;"));
         assert!(csp.contains("connect-src 'self' https://plausible.io;"));
         // Directives that must NOT be widened.
@@ -738,7 +743,10 @@ mod csp_tests {
         // Only the one clean host source survives.
         assert!(csp.contains("https://ok.example.com"));
         assert!(!csp.contains('*'));
-        assert!(!csp.contains("unsafe-eval"));
+        // The base `script-src` carries exactly one `'unsafe-eval'`
+        // (for Alpine). The operator's injected copy must be stripped,
+        // so it appears once — not duplicated into img-src/connect-src.
+        assert_eq!(csp.matches("unsafe-eval").count(), 1);
         // The `evil.com;script-src` token (directive smuggling) is gone.
         assert!(!csp.contains("evil.com"));
         // The base policy is intact.


### PR DESCRIPTION
## Problem

Browser console on the live deploy:

```
EvalError: Refused to evaluate a string as JavaScript because 'unsafe-eval'
... is not an allowed source ... "script-src 'self' 'unsafe-inline'".
```

Alpine.js compiles every directive expression through `new Function(...)` → counts as `eval`. With no `'unsafe-eval'` in our CSP, Alpine boots, removes `x-cloak`, then throws on the first `x-show`/`@click` and **silently aborts all directives**. Visible fallout: help popovers stuck open, the "Nada por aqui." empty-state flashing on a populated portal, dead card filters / live preview / editors.

Masked in local testing because `file://` pages carry no CSP.

## Fix

Add `'unsafe-eval'` to `script-src` in `content_security_policy()`. Consistent with the `'unsafe-inline'` already required for the inline landing/dashboard scripts.

The strict path (Alpine CSP build + per-request nonce, dropping both `unsafe-*`) remains the tracked `SECURITY.md` §10 follow-up — a larger refactor moving every inline expression into `Alpine.data()` objects.

## Tests

- `base_policy_is_self_only` / `extra_origins_widen_script_img_connect` updated for the new token.
- `dangerous_origins_are_dropped` now asserts the operator-injected `'unsafe-eval'` is still stripped — only the single base copy survives (`matches().count() == 1`), so it can't be smuggled into `img-src`/`connect-src`.
- Full admin suite green (212+ lib, all integration bins).

Closes #244

🤖 Generated with [Claude Code](https://claude.com/claude-code)