### PR TITLE
fix(admin): align users-form role <select> with the text inputs (#243)

### DIFF
--- a/crates/ruscker-admin/assets/tailwind/input.css
+++ b/crates/ruscker-admin/assets/tailwind/input.css
@@ -644,7 +644,8 @@ body {
   text-transform: uppercase;
   letter-spacing: 0.05em;
 }
-.admin-login-field input {
+.admin-login-field input,
+.admin-login-field select {
   appearance: none;
   background: var(--bg);
   border: 0.5px solid var(--border);
@@ -653,8 +654,19 @@ body {
   font-size: 13px;
   font-family: ui-monospace, SFMono-Regular, Menlo, monospace;
   color: var(--text);
+  height: 39px;            /* one consistent control height across the row */
+  box-sizing: border-box;
 }
-.admin-login-field input:focus {
+/* The <select> loses its native arrow under appearance:none — give it a
+   muted chevron so it still reads as a dropdown, matching the inputs. */
+.admin-login-field select {
+  padding-right: 30px;
+  background-image: url('data:image/svg+xml,<svg xmlns="http://www.w3.org/2000/svg" width="12" height="12" viewBox="0 0 24 24" fill="none" stroke="%235b6b66" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><path d="M6 9l6 6 6-6"/></svg>');
+  background-repeat: no-repeat;
+  background-position: right 10px center;
+}
+.admin-login-field input:focus,
+.admin-login-field select:focus {
   outline: none;
   border-color: var(--color-teal-600);
   box-shadow: 0 0 0 2px rgba(15, 110, 86, 0.15);


### PR DESCRIPTION
## Problem

In the add-user row the role `<select>` kept its native OS chrome, so it sat at a different height and visual style than the username/groups text inputs — the row looked ragged.

## Fix

`.admin-login-field select` now shares the inputs' border/radius/padding/font, a fixed **39px height + box-sizing:border-box** so every control in the row lines up, and — because `appearance:none` removes the native arrow — a muted inline-SVG chevron plus the shared focus ring.

Applies to the add-user form (the role select there is wrapped in `.admin-login-field`). `input.css` only; `build.rs` regenerates `output.css` (untracked) at compile time — verified the rule lands in the built CSS.

Closes #243

🤖 Generated with [Claude Code](https://claude.com/claude-code)