### PR TITLE
feat(proxy): X-RStudio-Root-Path — host RStudio Server behind the proxy (#230)

### DIFF
--- a/crates/ruscker-admin/src/db/showcase.rs
+++ b/crates/ruscker-admin/src/db/showcase.rs
@@ -238,22 +238,31 @@ fn showcase_specs() -> Result<Vec<Spec>> {
             jup.kind_override = Some(ruscker_config::SpecKindOverride::App);
             jup
         },
-        // RStudio Server is a docs link, not a containerized card (#230):
-        // RStudio doesn't reverse-proxy cleanly behind a prefix-stripped
-        // sub-path — it needs `www-root-path` and the prefix preserved,
-        // so the session WebSocket/RPC never connects ("unable to connect
-        // to the RStudio server"). Run it as your own spec if you need it
-        // (with the right `www-root-path`); the showcase just links out.
-        card(
-            "rstudio",
-            "RStudio Server",
-            "The RStudio IDE for R and Python — Posit's open-source server.",
-            "/assets/showcase/rstudio.svg",
-            "https://posit.co/products/open-source/rstudio-server/",
-            None,
-            None,
-            None,
-        )?,
+        {
+            // RStudio Server works behind the proxy via the
+            // `X-RStudio-Root-Path` header (set in
+            // `apply_smart_routing_headers`) — RStudio's official
+            // "behind a path-rewriting proxy" mechanism, the same one
+            // ShinyProxy uses (#230). The demo runs auth-less so it opens
+            // without rocker's random password; set a PASSWORD / real
+            // auth for anything sensitive.
+            let mut rst = card(
+                "rstudio",
+                "RStudio Server",
+                "The RStudio IDE in your browser, served per session.",
+                "/assets/showcase/rstudio.svg",
+                "https://posit.co/products/open-source/rstudio-server/",
+                Some("rocker/rstudio:latest"),
+                Some(8787),
+                None,
+            )?;
+            rst.container_env = Some(std::collections::BTreeMap::from([(
+                "DISABLE_AUTH".to_string(),
+                "true".to_string(),
+            )]));
+            rst.kind_override = Some(ruscker_config::SpecKindOverride::App);
+            rst
+        },
         // R Markdown isn't a server — it's a document format. Linked to
         // its docs rather than launching a container (the RStudio Server
         // card above is what actually renders/previews `.Rmd` files).
@@ -372,14 +381,15 @@ mod tests {
 
     #[test]
     fn showcase_card_kinds() {
-        // #231: a containerized non-Shiny card (Jupyter) is tagged `App`
-        // → InteractiveApp, not the Shiny default. Shiny stays Shiny.
-        // #230: RStudio is a docs link (External), not containerized.
+        // #231: containerized non-Shiny cards (Jupyter, RStudio) are
+        // tagged `App` → InteractiveApp, not the Shiny default. Shiny
+        // stays Shiny. (#230: RStudio works behind the proxy via the
+        // X-RStudio-Root-Path header, so it's a real container again.)
         let specs = showcase_specs().unwrap();
         let kind = |id: &str| specs.iter().find(|s| s.id == id).unwrap().kind();
         assert_eq!(kind("jupyter"), ruscker_config::SpecKind::InteractiveApp);
+        assert_eq!(kind("rstudio"), ruscker_config::SpecKind::InteractiveApp);
         assert_eq!(kind("shiny"), ruscker_config::SpecKind::Shiny, "shiny stays Shiny");
-        assert_eq!(kind("rstudio"), ruscker_config::SpecKind::External, "rstudio is a docs link");
     }
 
     #[tokio::test]

--- a/crates/ruscker-admin/src/routes/proxy.rs
+++ b/crates/ruscker-admin/src/routes/proxy.rs
@@ -1058,7 +1058,13 @@ fn apply_smart_routing_headers(
 ) {
     if let Ok(v) = HeaderValue::from_str(forwarded_prefix) {
         headers.insert("x-forwarded-prefix", v.clone());
-        headers.insert("x-script-name", v);
+        headers.insert("x-script-name", v.clone());
+        // RStudio Server's official "behind a path-rewriting proxy"
+        // mechanism: we strip `/app/{spec}/` on the way in and tell
+        // RStudio its public root via this header, so it rewrites its
+        // own URLs / redirects / session WebSocket with the prefix
+        // (#230). Harmless for apps that don't read it.
+        headers.insert("x-rstudio-root-path", v);
     }
     headers.insert(
         "x-forwarded-proto",


### PR DESCRIPTION
## Problem

RStudio built its own absolute URLs (assets + the session WebSocket) rooted at `/`, ignoring `X-Forwarded-Prefix` / `X-Script-Name`. Behind our prefix-stripping `/app/{spec}/` forward the session WebSocket failed — the user saw the splash, then *"não conseguiu conectar com o servidor RStudio"*, and no container in the dashboard.

## Fix

RStudio's official hook for path-rewriting proxies is the **`X-RStudio-Root-Path`** header: hand it the external prefix and it rewrites its own URLs / redirects / WebSocket to match. This is exactly how ShinyProxy hosts RStudio out of the box.

- `apply_smart_routing_headers` now sets `X-RStudio-Root-Path` next to the forwarded-prefix headers. Confirmed: RStudio then emits **prefixed 302 redirects**.
- Re-instate the RStudio showcase card as a real containerized app — `rocker/rstudio:latest`, port 8787, `DISABLE_AUTH=true`, `kind_override = App` (InteractiveApp defaults, not Shiny). Seed back to 12 cards; `showcase_card_kinds` updated.

## Verification status

- ✅ Header set; RStudio honors it (prefixed redirect observed).
- ✅ Container spawns/serves; WS upgrade returns 101 through Ruscker.
- ✅ Full admin test suite green.
- ⏳ **Draft until** a real-browser IDE session is smoked on cast under `--base-path /box` — headless Chrome can't settle on RStudio's continuous-polling SPA, so this needs a human click-through after the cast re-seed (existing rstudio row still shows kind Shiny — see #246).

Refs #230 #246

🤖 Generated with [Claude Code](https://claude.com/claude-code)