### PR TITLE
feat(admin): show the Ruscker version in landing + admin footers (#241)

### DIFF
--- a/crates/ruscker-admin/src/lib.rs
+++ b/crates/ruscker-admin/src/lib.rs
@@ -42,6 +42,12 @@ pub mod view_model;
 
 use sqlx::SqlitePool;
 
+/// The running Ruscker version, from the workspace `Cargo.toml` at
+/// compile time. Surfaced in the landing + admin footers (#241) and
+/// reported by `/healthz`. Pathed (`crate::APP_VERSION`) from the
+/// templates so it never drifts from a hardcoded string.
+pub const APP_VERSION: &str = env!("CARGO_PKG_VERSION");
+
 /// Shared state injected into every request.
 #[derive(Clone)]
 pub struct AppState {

--- a/crates/ruscker-admin/templates/_layout.html
+++ b/crates/ruscker-admin/templates/_layout.html
@@ -24,7 +24,10 @@
 {# Footer slimmed down to just the "powered by" lockup (#182). Theme
    and language pickers moved into the top-right chrome cluster on every
    page. #}
-<footer class="mt-auto border-t border-[color:var(--border)] py-4 px-6 text-xs text-[color:var(--text-muted)] flex items-center justify-end">
+<footer class="mt-auto border-t border-[color:var(--border)] py-4 px-6 text-xs text-[color:var(--text-muted)] flex items-center justify-end gap-3">
+  <a class="opacity-60 hover:opacity-100 transition-opacity"
+     href="https://github.com/StrategicProjects/ruscker/releases/tag/v{{ crate::APP_VERSION }}"
+     title="Release notes">v{{ crate::APP_VERSION }}</a>
   <a class="inline-flex items-center gap-2 opacity-70 hover:opacity-100 transition-opacity"
      href="https://github.com/StrategicProjects/ruscker"
      aria-label="Ruscker">

--- a/crates/ruscker-admin/templates/admin/_layout.html
+++ b/crates/ruscker-admin/templates/admin/_layout.html
@@ -157,7 +157,10 @@ window.ruscker.bgMode = (value) =>
 
 {# Footer trimmed — theme + language pickers moved into the top-right
    chrome cluster in the navbar (#182 + #183). #}
-<footer class="mt-auto border-t border-[color:var(--border)] py-3 px-6 text-xs text-[color:var(--text-muted)] flex items-center justify-end">
+<footer class="mt-auto border-t border-[color:var(--border)] py-3 px-6 text-xs text-[color:var(--text-muted)] flex items-center justify-end gap-3">
+  <a class="opacity-60 hover:opacity-100 transition-opacity"
+     href="https://github.com/StrategicProjects/ruscker/releases/tag/v{{ crate::APP_VERSION }}"
+     title="Release notes">v{{ crate::APP_VERSION }}</a>
   <a class="inline-flex items-center gap-2 opacity-70 hover:opacity-100 transition-opacity"
      href="https://github.com/StrategicProjects/ruscker"
      aria-label="Ruscker">


### PR DESCRIPTION
## Ask (#241)

Surface the running version unobtrusively on the public landing and in the admin chrome.

## Change

- New crate-level `pub const APP_VERSION = env!("CARGO_PKG_VERSION")` in `lib.rs` (same source `/healthz` already reports).
- Both footers (`templates/_layout.html` public + `templates/admin/_layout.html`) now render a small muted **`v{version}`** next to the brand lockup, linking to `…/releases/tag/v{version}`.
- Templates reference it by path — `{{ crate::APP_VERSION }}` — so there's **no hardcoded string to drift**; it tracks the workspace version automatically (shows `v0.1.6` today).

## Acceptance

- [x] `v0.1.x` on the public landing footer.
- [x] `v0.1.x` in the admin footer chrome.
- [x] Sourced from `CARGO_PKG_VERSION`.

Build green (Askama accepts the path expression); full admin suite passes. Visual confirmation is a one-glance check on the next cast deploy.

Closes #241

🤖 Generated with [Claude Code](https://claude.com/claude-code)