### PR TITLE
fix(showcase): Plumber card → plumber2.posit.co (#253)

### DIFF
--- a/crates/ruscker-admin/src/db/showcase.rs
+++ b/crates/ruscker-admin/src/db/showcase.rs
@@ -322,7 +322,7 @@ fn showcase_specs() -> Result<Vec<Spec>> {
             "Plumber",
             "Turn R functions into HTTP APIs.",
             "/assets/showcase/plumber.svg",
-            "https://www.rplumber.io",
+            "https://plumber2.posit.co",
             None,
             None,
             None,


### PR DESCRIPTION
Updates the seeded Plumber showcase card link from `https://www.rplumber.io` to `https://plumber2.posit.co`. Seed-only (fresh installs); existing DBs update via the admin spec form or a re-seed.

Closes #253

🤖 Generated with [Claude Code](https://claude.com/claude-code)