### PR TITLE
chore: fix clippy -D warnings + de-drift versions (#262)

### DIFF
--- a/README.md
+++ b/README.md
@@ -73,8 +73,10 @@ tool" cases) is in
 
 ## Status
 
-**v0.1.2 — production-ready and running in production.** Releases are
-multi-arch (amd64 + arm64) and [cosign-signed]. Where the JVM-based
+**Production-ready and running in production.** Releases are
+multi-arch (amd64 + arm64) and [cosign-signed]; the
+[releases page](https://github.com/StrategicProjects/ruscker/releases)
+has the current version. Where the JVM-based
 stack it replaced idled at hundreds of megabytes, Ruscker idles in the
 low tens:
 
@@ -124,7 +126,8 @@ curl -fsSL https://raw.githubusercontent.com/StrategicProjects/ruscker/main/inst
 Picks the right artifact from the latest release: the `.deb` (with the
 `systemd` unit + an auto-generated admin token) on Debian/Ubuntu, or the
 static binary into `/usr/local/bin` elsewhere. Pin a version or target
-dir with `./install.sh v0.1.2` or `PREFIX=~/.local/bin ./install.sh`.
+dir with `./install.sh vX.Y.Z` (any tag from the releases page) or
+`PREFIX=~/.local/bin ./install.sh`.
 
 ### Homebrew (macOS / Linux)
 

--- a/book/src/faq.md
+++ b/book/src/faq.md
@@ -77,9 +77,9 @@ the **sign-in session** paths to a single upstream — see
 
 ### Is it production-ready?
 
-Ruscker is on **v0.1.3** and runs in production. Releases are multi-arch
-and cosign-signed; see the [release notes](./news.md) for what changed
-in each version. The [Roadmap](./roadmap.md) tracks what's shipped
+Ruscker runs in production. Releases are multi-arch
+and cosign-signed; see the [release notes](./news.md) for the current
+version and what changed in each. The [Roadmap](./roadmap.md) tracks what's shipped
 (Phases 0–7) and what's planned (Phase 8: external auth).
 
 ### What platforms does it run on?

--- a/crates/ruscker-admin/src/db/showcase.rs
+++ b/crates/ruscker-admin/src/db/showcase.rs
@@ -132,6 +132,10 @@ async fn drop_old_welcome_block(db: &ConfigDb) -> Result<()> {
 /// would be all noise. Serde reads exactly what we set and fills the
 /// rest with `None` / defaults via the `#[serde(default)]` on each
 /// field.
+// Internal seed-only helper with self-documenting positional args
+// (id, name, description, logo, link, image, port, platform). Bundling
+// them into a struct buys nothing for 12 fixed call sites in one file.
+#[allow(clippy::too_many_arguments)]
 fn card(
     id: &str,
     display_name: &str,

--- a/crates/ruscker-docker/src/lib.rs
+++ b/crates/ruscker-docker/src/lib.rs
@@ -228,7 +228,6 @@ impl LocalDockerBackend {
             // to pick a fresh manifest match. Empty string = no
             // override (daemon picks per the image's manifest).
             platform: req.platform.clone().unwrap_or_default(),
-            ..Default::default()
         };
         let created = self
             .docker

--- a/packaging/homebrew/ruscker.rb
+++ b/packaging/homebrew/ruscker.rb
@@ -18,11 +18,11 @@ class Ruscker < Formula
   desc "Lightweight Rust proxy for containerized apps (Shiny/Streamlit/Dash) and APIs"
   homepage "https://strategicprojects.github.io/ruscker/"
   license "Apache-2.0"
-  version "0.1.0"
+  version "0.1.8"
 
   on_macos do
     url "https://github.com/StrategicProjects/ruscker/archive/refs/tags/v#{version}.tar.gz"
-    sha256 "cfdceafaf5bdb5affe08d1e4269b44dd3f78ccc2b0a563b9dda4f719541161c4"
+    sha256 "3bb8ba3ad40c8d84052970434083004c4be08127d64c38fdbb2a46c2144e672a"
     depends_on "rust" => :build
 
     def install
@@ -33,11 +33,11 @@ class Ruscker < Formula
   on_linux do
     on_arm do
       url "https://github.com/StrategicProjects/ruscker/releases/download/v#{version}/ruscker-#{version}-linux-arm64.tar.gz"
-      sha256 "6d493fbbf406e32ae0342cd672600e1695b1ba878d0ccac97f4c8d23f5a3fe75"
+      sha256 "ab8a2ba26cbd5806f2b844def5f586c8159ac8fcc49beb55e32c67d7b55fb9d5"
     end
     on_intel do
       url "https://github.com/StrategicProjects/ruscker/releases/download/v#{version}/ruscker-#{version}-linux-amd64.tar.gz"
-      sha256 "aafa72c38c480be2756bde9dacd3bbf4d7aa3e0d18c353d0f929d8ee6c4c7379"
+      sha256 "5d4ad236b348b266a6ce711124b1bf13ad09162595179a5139de862d88c69c09"
     end
 
     def install


### PR DESCRIPTION
## clippy `--all-targets -- -D warnings` now passes
- **ruscker-docker** — dropped the redundant `..Default::default()` on `CreateContainerOptions` (only `name`+`platform` fields) → `needless_update`.
- **ruscker-admin** — `#[allow(clippy::too_many_arguments)]` on the internal seed-only `showcase::card()` (8 self-documenting positional args, 12 fixed call sites; a struct buys nothing here).

Verified: `cargo clippy --all-targets --workspace -- -D warnings` is clean.

## Version de-drift
Was: Cargo `0.1.8`, README `v0.1.2`, FAQ `v0.1.3`, Homebrew `0.1.0`.
- **README + FAQ** no longer hard-code a version in prose — they point at the releases page / release notes, so they **can't drift again**.
- **Homebrew** formula bumped `0.1.0 → 0.1.8` with the real v0.1.8 sha256s (macOS source archive + linux amd64/arm64 musl tarballs, fetched from the release assets).

Per [[project-fmt-drift]] this does **not** run `cargo fmt`; gates used: `cargo test`, `cargo clippy --all-targets -- -D warnings`, `mdbook build`, `./scripts/i18n-check.sh` — all green.

## Recommended follow-up
Automate the Homebrew formula bump from the release tag (stamp version + sha256s in `release.yml` and open a tap PR) so it stops needing a manual update each release.

Closes #262
🤖 Generated with [Claude Code](https://claude.com/claude-code)