### PR TITLE
fix(admin): gate logs behind Editor+, 404 on update of missing spec (#261)

### DIFF
--- a/crates/ruscker-admin/src/routes/admin/dashboard.rs
+++ b/crates/ruscker-admin/src/routes/admin/dashboard.rs
@@ -464,7 +464,9 @@ async fn events(
 /// that no longer maps to a container → the backend returns an
 /// error which we surface as 404.
 async fn logs(
-    session: AdminSession,
+    // Container logs can carry sensitive data — gate behind Editor+
+    // (Viewers can see the dashboard, not the logs). #261
+    editor: RequireEditor,
     State(state): State<AppState>,
     loc: Locale,
     theme: Theme,
@@ -527,7 +529,7 @@ async fn logs(
         locales: &state.locales,
         locales_all: &Locale::ALL,
         nav_section: "dashboard",
-        role: session.role,
+        role: editor.role,
         display_name,
         spec_id,
         replica_id,
@@ -546,7 +548,7 @@ async fn logs(
 /// Seeded with the last 100 lines so turning Live on shows
 /// recent context, not just lines that arrive after connect.
 async fn logs_stream(
-    _: AdminSession,
+    _: RequireEditor,
     State(state): State<AppState>,
     Path(replica_id): Path<String>,
 ) -> Response {

--- a/crates/ruscker-admin/src/routes/admin/spec_form.rs
+++ b/crates/ruscker-admin/src/routes/admin/spec_form.rs
@@ -890,6 +890,13 @@ async fn update(
             return (StatusCode::INTERNAL_SERVER_ERROR, "db error").into_response();
         }
     };
+    // This is the *edit* path — the spec must already exist. Without
+    // this guard `into_spec(None)` + `upsert_one` would silently
+    // (re)create a spec at this id (e.g. a stale tab POSTing to a
+    // since-deleted spec). #261
+    if base.is_none() {
+        return (StatusCode::NOT_FOUND, format!("spec `{id}` not found")).into_response();
+    }
 
     let spec = match form.into_spec(base.as_ref()) {
         Ok(s) => s,

--- a/crates/ruscker-admin/templates/admin/dashboard.html
+++ b/crates/ruscker-admin/templates/admin/dashboard.html
@@ -196,11 +196,12 @@
           <td>{% if row.host.is_empty() %}<span style="color:var(--text-faint)">local</span>{% else %}{{ row.host }}{% endif %}</td>
           <td class="dash-mono">{{ row.container_short }}</td>
           <td style="white-space: nowrap;">
+            {# logs + stop/restart are all Editor/Admin only (matched by
+               the RequireEditor route guards) — logs can carry sensitive
+               data (#261). #}
+            {% if role.can_manage() %}
             <a href="/admin/dashboard/logs/{{ row.replica_id }}" title="{{ self.t("admin-logs-title") }}"
                class="dash-action" style="color: var(--text-muted)"><i class="ti ti-file-text"></i></a>
-            {# stop/restart are operational actions — Editor and Admin
-               only (matched by the RequireEditor route guard). #}
-            {% if role.can_manage() %}
             <form method="post" action="/admin/dashboard/replicas/{{ row.replica_id }}/restart"
                   style="display:inline" onsubmit="return confirm('{{ self.t("admin-dashboard-confirm-restart") }}')">
               <button type="submit" class="dash-action" title="{{ self.t("admin-dashboard-action-restart") }}"><i class="ti ti-refresh"></i></button>
@@ -276,6 +277,9 @@
       ? escapeHtml(row.memory_display)
       : '<span style="color: var(--text-faint)" title="' + escapeHtml(pendingLabel) + '">—</span>';
     var actions = !canManage ? '' : ''
+      + '<a href="' + (window.RUSCKER_BASE || '') + '/admin/dashboard/logs/' + encodeURIComponent(row.replica_id)
+        + '" title="' + escapeHtml(logsTitle)
+        + '" class="dash-action" style="color: var(--text-muted)"><i class="ti ti-file-text"></i></a>'
       + '<form method="post" action="' + (window.RUSCKER_BASE || '') + '/admin/dashboard/replicas/' + encodeURIComponent(row.replica_id)
         + '/restart" style="display:inline" onsubmit="return confirm(' + JSON.stringify(confirmRestart) + ')">'
         + '<button type="submit" class="dash-action" title="' + escapeHtml(restartLabel) + '"><i class="ti ti-refresh"></i></button>'
@@ -300,9 +304,6 @@
       + '<td>' + (row.host ? escapeHtml(row.host) : '<span style="color:var(--text-faint)">local</span>') + '</td>'
       + '<td class="dash-mono">' + escapeHtml(row.container_short) + '</td>'
       + '<td style="white-space: nowrap;">'
-        + '<a href="' + (window.RUSCKER_BASE || '') + '/admin/dashboard/logs/' + encodeURIComponent(row.replica_id)
-          + '" title="' + escapeHtml(logsTitle)
-          + '" class="dash-action" style="color: var(--text-muted)"><i class="ti ti-file-text"></i></a>'
         + actions
       + '</td>';
   }


### PR DESCRIPTION
Two small admin-route hardening fixes from the audit (#187).

## Logs → Editor+
The dashboard logs page and its SSE follow stream took any `AdminSession` (incl. **Viewer**); now `RequireEditor`. The logs link moves inside the `can_manage()` gate in both the server render and the SSE patcher (previously shown to everyone, while stop/restart were already gated). `can_manage()` (Editor+Admin) matches the `RequireEditor` route guard.

## Update of a missing spec → 404
The spec-form **edit** path loaded `base = fetch_one(id)` (which can be `Ok(None)`) and proceeded with `into_spec(None)` + `upsert_one`, silently re-creating the spec. Now returns 404 when `base` is `None`.

Tests green. Note: `clippy --all-targets -- -D warnings` on this branch still trips the pre-existing `showcase::card` `too_many_arguments` lint — that's fixed in #262; this branch adds no new warnings.

Closes #261
🤖 Generated with [Claude Code](https://claude.com/claude-code)