### PR TITLE
fix: unify runtime spec catalog (DB-first) across scaler/sweeper/restart (#257)

### DIFF
--- a/crates/ruscker-admin/src/catalog.rs
+++ b/crates/ruscker-admin/src/catalog.rs
@@ -1,0 +1,99 @@
+//! The effective runtime spec catalog (DB-first, YAML fallback).
+//!
+//! The landing and proxy resolve specs **DB-first** (#202 / #205), but
+//! the lifecycle loops (auto-scaler, heartbeat sweeper) and the
+//! dashboard restart historically read only the YAML `proxy.specs`.
+//! That split meant specs created/edited in the admin — or seeded into
+//! the showcase — ran on demand (the proxy spawns them) yet got no
+//! min/max-replicas, no per-spec `heartbeat-timeout` override, and
+//! couldn't be restarted from the dashboard (#257). This module is the
+//! one DB-first resolver every lifecycle consumer shares, mirroring
+//! `proxy::find_spec`'s per-id rule for the whole catalog.
+
+use std::collections::HashSet;
+
+use ruscker_config::{Config, Spec};
+
+use crate::db::{self, ConfigDb};
+
+/// Every spec the runtime should act on.
+///
+/// With a config DB attached, that's the DB catalog (admin edits +
+/// showcase seed) **unioned** with the YAML `proxy.specs`, the DB
+/// shadowing the YAML on an id collision (same rule as
+/// `proxy::find_spec`). With no DB, it's just the YAML. On a DB error
+/// it falls back to the YAML so a transient blip can't stall the
+/// scaler.
+///
+/// Takes the pool + config directly (not `AppState`) so the heartbeat
+/// sweeper — which only holds an `Arc<Config>` + an optional pool — can
+/// share it.
+pub(crate) async fn effective_specs(db: Option<&ConfigDb>, config: &Config) -> Vec<Spec> {
+    let Some(db) = db else {
+        return config.proxy.specs.clone();
+    };
+    match db::specs::list_all(db).await {
+        Ok(db_specs) => {
+            let db_ids: HashSet<String> = db_specs.iter().map(|s| s.id.clone()).collect();
+            let mut out = db_specs;
+            for s in &config.proxy.specs {
+                if !db_ids.contains(&s.id) {
+                    out.push(s.clone());
+                }
+            }
+            out
+        }
+        Err(e) => {
+            tracing::warn!(
+                error = ?e,
+                "spec catalog DB list failed; falling back to YAML proxy.specs"
+            );
+            config.proxy.specs.clone()
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::db::open_memory;
+
+    fn yaml_config(body: &str) -> Config {
+        std::env::set_var("DOCKER_REGISTRY_PASSWORD", "test");
+        Config::from_yaml(body).expect("parse config")
+    }
+
+    #[tokio::test]
+    async fn no_db_returns_yaml_specs() {
+        let cfg = yaml_config("proxy:\n  specs:\n    - id: a\n      container-image: nginx\n");
+        let specs = effective_specs(None, &cfg).await;
+        assert_eq!(specs.len(), 1);
+        assert_eq!(specs[0].id, "a");
+    }
+
+    #[tokio::test]
+    async fn unions_db_and_yaml_with_db_shadowing() {
+        let cdb = ConfigDb::Sqlite(open_memory().await.unwrap());
+        // DB carries a DB-only spec + one that collides with a YAML id.
+        let db_only: Spec = serde_yaml_ng::from_str("id: db-only\ncontainer-image: nginx").unwrap();
+        let shared_db: Spec =
+            serde_yaml_ng::from_str("id: shared\ncontainer-image: nginx\ndisplay-name: from-db")
+                .unwrap();
+        db::specs::upsert_one(&cdb, &db_only, None).await.unwrap();
+        db::specs::upsert_one(&cdb, &shared_db, None).await.unwrap();
+
+        let cfg = yaml_config(
+            "proxy:\n  specs:\n    - id: yaml-only\n      container-image: nginx\n    - id: shared\n      container-image: nginx\n      display-name: from-yaml\n",
+        );
+
+        let specs = effective_specs(Some(&cdb), &cfg).await;
+        let ids: HashSet<&str> = specs.iter().map(|s| s.id.as_str()).collect();
+        // DB-only + YAML-only both present, the shared id once.
+        assert!(ids.contains("db-only"));
+        assert!(ids.contains("yaml-only"));
+        assert_eq!(specs.iter().filter(|s| s.id == "shared").count(), 1);
+        // DB shadows YAML on the collision.
+        let shared = specs.iter().find(|s| s.id == "shared").unwrap();
+        assert_eq!(shared.display_name.as_deref(), Some("from-db"));
+    }
+}

--- a/crates/ruscker-admin/src/lib.rs
+++ b/crates/ruscker-admin/src/lib.rs
@@ -24,6 +24,7 @@ use tower_cookies::CookieManagerLayer;
 use tracing::info;
 
 pub mod auth;
+pub mod catalog;
 pub mod crypto;
 pub mod db;
 pub mod i18n;
@@ -385,6 +386,7 @@ impl AdminServer {
                 self.state.replicas.clone(),
                 self.state.config.clone(),
                 self.state.leader.clone(),
+                self.state.db.clone(),
             );
             // Dashboard metrics: keep `state.metrics` fresh in
             // the background so dashboard renders are read-only

--- a/crates/ruscker-admin/src/routes/admin/dashboard.rs
+++ b/crates/ruscker-admin/src/routes/admin/dashboard.rs
@@ -649,17 +649,12 @@ async fn restart_replica(
     let Some(spec_id) = spec_id else {
         return (StatusCode::NOT_FOUND, "replica not found").into_response();
     };
-    let spec = state
-        .config
-        .proxy
-        .specs
-        .iter()
-        .find(|s| s.id == spec_id)
-        .cloned();
-    let Some(spec) = spec else {
+    // DB-first (admin edits + showcase seed), not just the YAML config —
+    // otherwise a DB-only spec's replica couldn't be restarted (#257).
+    let Some(spec) = crate::routes::proxy::find_spec(&state, &spec_id).await else {
         return (
             StatusCode::CONFLICT,
-            format!("spec `{spec_id}` no longer in config; cannot restart"),
+            format!("spec `{spec_id}` no longer exists; cannot restart"),
         )
             .into_response();
     };

--- a/crates/ruscker-admin/src/routes/proxy.rs
+++ b/crates/ruscker-admin/src/routes/proxy.rs
@@ -614,7 +614,7 @@ fn mount_prefix(base_path: &str, route_prefix: &str, spec_id: &str) -> String {
     format!("{base_path}{route_prefix}{spec_id}")
 }
 
-async fn find_spec(state: &AppState, id: &str) -> Option<Spec> {
+pub(crate) async fn find_spec(state: &AppState, id: &str) -> Option<Spec> {
     // DB-first — the operator-editable catalog (admin UI + showcase
     // seed) shadows the YAML for matching ids. Cheap: single indexed
     // SELECT by primary key.

--- a/crates/ruscker-admin/src/scaler.rs
+++ b/crates/ruscker-admin/src/scaler.rs
@@ -283,7 +283,10 @@ async fn tick(
     let Some(backend) = state.backend.clone() else {
         return;
     };
-    let specs = state.config.proxy.specs.clone();
+    // DB-first catalog (admin edits + showcase seed), not just the YAML
+    // config — otherwise DB-only specs get no min/max-replicas or idle
+    // reaping (#257).
+    let specs = crate::catalog::effective_specs(state.db.as_ref(), &state.config).await;
 
     // Build a snapshot of every replica across every spec in one
     // read-lock acquisition. We use it for the idle-tick
@@ -291,10 +294,7 @@ async fn tick(
     // the registry (stopped, crashed, reconciled out).
     let registry_snap: Vec<ruscker_core::Replica> = {
         let reg = state.replicas.read().await;
-        state
-            .config
-            .proxy
-            .specs
+        specs
             .iter()
             .flat_map(|s| reg.replicas_of(&s.id).to_vec())
             .collect()
@@ -737,6 +737,32 @@ proxy:
         // Second tick: already at min, no more spawns.
         tick(&state, &mut HashMap::new(), &mut HashMap::new(), &mut HashMap::new(), 1, 1, 0).await;
         assert_eq!(backend.spawns.load(Ordering::SeqCst), 3, "no extra spawns");
+    }
+
+    #[tokio::test]
+    async fn tick_scales_db_only_spec_to_min() {
+        // #257: a spec that lives only in the DB (admin-added / showcase
+        // seed), absent from the YAML config, must still get its
+        // min-replicas from the background scaler.
+        let backend = Arc::new(CountingBackend {
+            spawns: AtomicU32::new(0),
+        });
+        let mut state = state_with_yaml("proxy:\n  specs: []\n", backend.clone());
+        let pool = crate::db::open_memory().await.unwrap();
+        let cdb = crate::db::ConfigDb::Sqlite(pool);
+        let spec: ruscker_config::Spec =
+            serde_yaml_ng::from_str("id: dbonly\ncontainer-image: nginx:alpine\nmin-replicas: 2")
+                .unwrap();
+        crate::db::specs::upsert_one(&cdb, &spec, None).await.unwrap();
+        state.db = Some(cdb);
+
+        tick(&state, &mut HashMap::new(), &mut HashMap::new(), &mut HashMap::new(), 1, 1, 0).await;
+        assert_eq!(
+            backend.spawns.load(Ordering::SeqCst),
+            2,
+            "DB-only spec scaled to its min-replicas"
+        );
+        assert_eq!(state.replicas.read().await.replicas_of("dbonly").len(), 2);
     }
 
     #[tokio::test]

--- a/crates/ruscker-admin/src/sessions.rs
+++ b/crates/ruscker-admin/src/sessions.rs
@@ -264,18 +264,12 @@ pub fn spawn(
     registry: Arc<RwLock<ReplicaRegistry>>,
     config: Arc<ruscker_config::Config>,
     leader: Arc<dyn crate::leader::LeaderElector>,
+    db: Option<crate::db::ConfigDb>,
 ) -> JoinHandle<()> {
     let global_ms = config.proxy.heartbeat_timeout;
-    let overrides: std::collections::HashMap<String, i64> = config
-        .proxy
-        .specs
-        .iter()
-        .filter_map(|s| s.heartbeat_timeout.map(|t| (s.id.clone(), t)))
-        .collect();
     tokio::spawn(async move {
         info!(
             global_ms,
-            per_spec_overrides = overrides.len(),
             interval = ?SWEEPER_INTERVAL,
             "session sweeper started"
         );
@@ -283,6 +277,16 @@ pub fn spawn(
         ticker.set_missed_tick_behavior(tokio::time::MissedTickBehavior::Skip);
         loop {
             ticker.tick().await;
+            // Per-spec `heartbeat-timeout` overrides, rebuilt each tick
+            // from the effective (DB-first) catalog — so DB-only specs'
+            // overrides apply and a runtime edit takes effect without a
+            // restart (#257). One cheap `list` query per tick.
+            let overrides: std::collections::HashMap<String, i64> =
+                crate::catalog::effective_specs(db.as_ref(), &config)
+                    .await
+                    .iter()
+                    .filter_map(|s| s.heartbeat_timeout.map(|t| (s.id.clone(), t)))
+                    .collect();
             // Only the leader issues the idle-eviction DELETEs in a
             // shared (HA) store; the reconcile runs regardless (#159 C3).
             // `AlwaysLeader` (single-node) is always true.


### PR DESCRIPTION
## Problem

Landing + proxy resolve specs **DB-first** (#205), but the lifecycle loops didn't: the scaler (`scaler.rs:286`), heartbeat sweeper (`sessions.rs`), and dashboard restart (`dashboard.rs`) all read only the YAML `proxy.specs`. So admin-added / showcase-seeded specs ran on demand but got **no min/max-replicas, no per-spec heartbeat override, and failed to restart** (409).

## Fix

New `catalog::effective_specs(db, config)` — the one DB-first resolver: DB catalog ∪ YAML, DB shadowing on id collision (same rule as `proxy::find_spec`); YAML-only when no DB or on a DB error (so a blip can't stall the scaler). Wired into:
- **scaler** — `tick` iterates the effective catalog; the registry snapshot follows it.
- **sweeper** — `sessions::spawn` now takes the pool and rebuilds the per-spec `heartbeat-timeout` overrides from the catalog **each tick** (one cheap `list`), so DB-only overrides apply and runtime edits land without a restart.
- **restart** — resolves via the DB-first `proxy::find_spec` (now `pub(crate)`).

## Tests
- `catalog`: union + DB-shadows-YAML; no-DB → YAML.
- `scaler`: a DB-only spec with `min-replicas: 2` scales to 2.
- Full admin suite + `clippy -D warnings` green.

Closes #257
🤖 Generated with [Claude Code](https://claude.com/claude-code)