### PR TITLE
fix(admin): CSRF defense for chrome mutations + same-origin caveat (#259)

### DIFF
--- a/crates/ruscker-admin/src/lib.rs
+++ b/crates/ruscker-admin/src/lib.rs
@@ -519,7 +519,11 @@ pub fn router_with_images(state: AppState, _images_dir: Option<&Path>) -> Router
         .merge(routes::assets::routes())
         .merge(routes::prefs::routes())
         .merge(routes::admin::routes())
-        .layer(axum::middleware::from_fn(security_headers));
+        .layer(axum::middleware::from_fn(security_headers))
+        // CSRF defense for the chrome's mutations (#259). Layered on the
+        // chrome only — NOT the proxy routes (apps legitimately take
+        // cross-origin POSTs). Safe methods pass through untouched.
+        .layer(axum::middleware::from_fn(csrf_guard));
 
     // Base-path mounting (#173): when served under a subpath, rewrite the
     // chrome's root-absolute URLs / redirects to carry the prefix. Only
@@ -634,6 +638,68 @@ async fn security_headers(
     resp
 }
 
+/// CSRF defense for the chrome's state-changing requests (#259).
+///
+/// Belt-and-suspenders with the `SameSite=Strict` session cookie:
+/// rejects POST/PUT/PATCH/DELETE that aren't same-origin. Uses **Fetch
+/// Metadata** when the browser sends it (`Sec-Fetch-Site`: only
+/// `same-origin` / `none` may mutate), falling back to an **Origin vs
+/// Host** check for clients that don't. Requests with neither header
+/// (curl, the break-glass token POST) pass — they aren't browser CSRF.
+///
+/// IMPORTANT — this does NOT isolate *untrusted apps* hosted on the same
+/// origin: a script in an app at `/app/{spec}` is genuinely same-origin
+/// with `/admin`, so it passes this check. Hosting third-party apps
+/// requires a **separate origin/hostname for the admin** (see
+/// `docs/SECURITY.md`).
+async fn csrf_guard(
+    req: axum::extract::Request,
+    next: axum::middleware::Next,
+) -> axum::response::Response {
+    use axum::http::Method;
+    use axum::response::IntoResponse;
+    let state_changing = matches!(
+        *req.method(),
+        Method::POST | Method::PUT | Method::PATCH | Method::DELETE
+    );
+    if state_changing && request_is_cross_origin(req.headers()) {
+        tracing::warn!(
+            method = %req.method(), uri = %req.uri(),
+            "CSRF guard refused a cross-origin state-changing request"
+        );
+        return (
+            axum::http::StatusCode::FORBIDDEN,
+            "cross-origin request refused",
+        )
+            .into_response();
+    }
+    next.run(req).await
+}
+
+/// `true` when a state-changing request looks cross-origin. See
+/// [`csrf_guard`] for the policy.
+fn request_is_cross_origin(h: &axum::http::HeaderMap) -> bool {
+    use axum::http::header;
+    // Modern browsers: trust Fetch Metadata.
+    if let Some(site) = h.get("sec-fetch-site").and_then(|v| v.to_str().ok()) {
+        return !matches!(site, "same-origin" | "none");
+    }
+    // Fallback: reject only when an Origin is present and disagrees with
+    // the request host. No Origin ⇒ not a browser form/fetch ⇒ allow.
+    let Some(origin) = h.get(header::ORIGIN).and_then(|v| v.to_str().ok()) else {
+        return false;
+    };
+    let host = h
+        .get("x-forwarded-host")
+        .or_else(|| h.get(header::HOST))
+        .and_then(|v| v.to_str().ok());
+    match host {
+        // Strip the scheme from the Origin and compare host[:port].
+        Some(host) => origin.split("://").nth(1).unwrap_or(origin) != host,
+        None => false,
+    }
+}
+
 /// Build the Content-Security-Policy for Ruscker's own pages.
 ///
 /// `extra_origins` (space-separated, may be empty) is appended to the
@@ -714,6 +780,57 @@ fn is_safe_csp_source(t: &str) -> bool {
             .is_some_and(|c| c.is_ascii_alphanumeric());
     // Must look like a host (has a dot or a port) — rejects bare words.
     valid && (body.contains('.') || body.contains(':'))
+}
+
+#[cfg(test)]
+mod csrf_tests {
+    use super::request_is_cross_origin;
+    use axum::http::{header, HeaderMap, HeaderValue};
+
+    fn hm(pairs: &[(&str, &str)]) -> HeaderMap {
+        let mut h = HeaderMap::new();
+        for (k, v) in pairs {
+            h.insert(
+                header::HeaderName::from_bytes(k.as_bytes()).unwrap(),
+                HeaderValue::from_str(v).unwrap(),
+            );
+        }
+        h
+    }
+
+    #[test]
+    fn fetch_metadata_decides_when_present() {
+        assert!(!request_is_cross_origin(&hm(&[("sec-fetch-site", "same-origin")])));
+        assert!(!request_is_cross_origin(&hm(&[("sec-fetch-site", "none")])));
+        assert!(request_is_cross_origin(&hm(&[("sec-fetch-site", "cross-site")])));
+        assert!(request_is_cross_origin(&hm(&[("sec-fetch-site", "same-site")])));
+    }
+
+    #[test]
+    fn no_headers_is_allowed() {
+        // curl / the break-glass token POST send neither header.
+        assert!(!request_is_cross_origin(&HeaderMap::new()));
+    }
+
+    #[test]
+    fn origin_fallback_compares_host() {
+        // Same host (scheme stripped) → allowed.
+        assert!(!request_is_cross_origin(&hm(&[
+            ("origin", "https://portal.example.org"),
+            ("host", "portal.example.org"),
+        ])));
+        // Behind a proxy, compare against X-Forwarded-Host.
+        assert!(!request_is_cross_origin(&hm(&[
+            ("origin", "https://portal.example.org"),
+            ("x-forwarded-host", "portal.example.org"),
+            ("host", "127.0.0.1:8080"),
+        ])));
+        // Different host → cross-origin.
+        assert!(request_is_cross_origin(&hm(&[
+            ("origin", "https://evil.example.com"),
+            ("host", "portal.example.org"),
+        ])));
+    }
 }
 
 #[cfg(test)]

--- a/docs/SECURITY.md
+++ b/docs/SECURITY.md
@@ -169,7 +169,28 @@ Status: living document. Tracks the Phase 5 security audit
   reduces a `Referer` to a same-origin path; used by `/__set/*`
   and the login redirect.
 - **[implemented]** CSRF defense — admin cookie is
-  `SameSite=Strict`, so a cross-site POST can't carry it.
+  `SameSite=Strict`, so a cross-site POST can't carry it, **and** a
+  server-side guard (`csrf_guard`, #259) rejects state-changing chrome
+  requests that aren't same-origin: it trusts `Sec-Fetch-Site`
+  (`same-origin`/`none` only) when present, else falls back to an
+  `Origin` vs `Host` check. Requests with neither header (curl, the
+  break-glass token POST) pass — they aren't browser CSRF.
+- **[implemented]** Ruscker cookies are stripped before forwarding
+  upstream (#258) — `strip_ruscker_cookies` removes the admin session,
+  the sticky cookie, and the theme/locale prefs from the upstream-bound
+  `Cookie` header so an app container never sees them (the admin session
+  id is a bearer).
+- **[accepted limitation — needs origin separation]** Admin and apps
+  share one origin by default. A script inside an **untrusted** app
+  served at `/app/{spec}` is genuinely *same-origin* with `/admin`, so
+  neither `SameSite=Strict` nor the same-origin CSRF guard can stop it
+  from issuing credentialed `fetch('/admin/...')` calls. The cookie
+  strip (#258) stops the app from *reading* the session, but a
+  same-origin request from the browser still carries it. **If you host
+  third-party / untrusted apps, serve the admin on a separate
+  hostname/origin** (e.g. `admin.example.org` vs `apps.example.org`) so
+  the browser's same-origin policy isolates them. Trusted, first-party
+  apps on one origin are fine.
 - **[implemented]** Sticky-cookie cross-app defense — the handler
   checks `session.spec_id == spec.id` before honoring a sticky
   cookie, even though its `Path=/` spans apps.


### PR DESCRIPTION
## P0 — admin POSTs lacked CSRF defense; admin & apps share an origin

Admin mutations were protected only by the `SameSite=Strict` cookie, with no server-side check.

## Fix

`csrf_guard` middleware, layered on the **chrome** router only (not the proxy routes — apps legitimately take cross-origin POSTs). State-changing methods (POST/PUT/PATCH/DELETE) must be same-origin:
- trusts **Fetch Metadata** when present — `Sec-Fetch-Site` ∈ {`same-origin`, `none`};
- else falls back to an **`Origin` vs `Host`** check (honors `X-Forwarded-Host`);
- requests with neither header (curl, the break-glass token POST) pass — not browser CSRF.

Defense-in-depth with the SameSite cookie; existing handler/route tests (which POST without those headers) are unaffected.

## Honest limitation (documented, SECURITY.md §6)

This does **not** isolate *untrusted* apps on the same origin: a script at `/app/{spec}` is genuinely same-origin with `/admin`, so it passes. The #258 cookie strip stops the app from *reading* the session, but a same-origin browser request still carries it. **Hosting third-party apps needs a separate admin origin/hostname** — now spelled out in the threat model.

## Tests
`fetch_metadata_decides_when_present`, `no_headers_is_allowed`, `origin_fallback_compares_host`. Full admin suite + `clippy -D warnings` green.

Closes #259
🤖 Generated with [Claude Code](https://claude.com/claude-code)