### PR TITLE
fix(secrets): keep ${VAR} secrets literal end-to-end, resolve at use (#260)

### DIFF
--- a/crates/ruscker-admin/assets/i18n/en/landing.ftl
+++ b/crates/ruscker-admin/assets/i18n/en/landing.ftl
@@ -485,6 +485,7 @@ spec-help-registry-domain = Registry host for private images (e.g. docker.io, gh
 spec-form-registry-username = Username
 spec-help-registry-username = Username to authenticate the pull of a private image.
 spec-form-registry-password = Password
+spec-form-registry-password-keep = Blank keeps the current password
 spec-help-registry-password = Use an environment variable — never paste the password as text. Only used together with the username.
 spec-form-registry-credential = Stored credential
 spec-help-registry-credential = Name of a credential from the vault, instead of the inline username/password.

--- a/crates/ruscker-admin/assets/i18n/es/landing.ftl
+++ b/crates/ruscker-admin/assets/i18n/es/landing.ftl
@@ -485,6 +485,7 @@ spec-help-registry-domain = Host del registro para imágenes privadas (ej.: dock
 spec-form-registry-username = Usuario
 spec-help-registry-username = Usuario para autenticar la descarga de una imagen privada.
 spec-form-registry-password = Contraseña
+spec-form-registry-password-keep = En blanco mantiene la contraseña actual
 spec-help-registry-password = Usa una variable de entorno — nunca pegues la contraseña en texto. Solo se usa junto con el usuario.
 spec-form-registry-credential = Credencial guardada
 spec-help-registry-credential = Nombre de una credencial del almacén, en vez del usuario/contraseña en línea.

--- a/crates/ruscker-admin/assets/i18n/fr/landing.ftl
+++ b/crates/ruscker-admin/assets/i18n/fr/landing.ftl
@@ -485,6 +485,7 @@ spec-help-registry-domain = Hôte du registre pour les images privées (ex. : do
 spec-form-registry-username = Utilisateur
 spec-help-registry-username = Utilisateur pour authentifier le téléchargement d'une image privée.
 spec-form-registry-password = Mot de passe
+spec-form-registry-password-keep = Vide conserve le mot de passe actuel
 spec-help-registry-password = Utilisez une variable d'environnement — ne collez jamais le mot de passe en clair. Utilisé uniquement avec l'utilisateur.
 spec-form-registry-credential = Identifiant enregistré
 spec-help-registry-credential = Nom d'un identifiant du coffre, au lieu de l'utilisateur/mot de passe en ligne.

--- a/crates/ruscker-admin/assets/i18n/pt/landing.ftl
+++ b/crates/ruscker-admin/assets/i18n/pt/landing.ftl
@@ -489,6 +489,7 @@ spec-help-registry-domain = Host do registro para imagens privadas (ex.: docker.
 spec-form-registry-username = Usuário
 spec-help-registry-username = Usuário para autenticar no pull de uma imagem privada.
 spec-form-registry-password = Senha
+spec-form-registry-password-keep = Em branco mantém a senha atual
 spec-help-registry-password = Use uma variável de ambiente — nunca cole a senha em texto. Só usada junto com o usuário.
 spec-form-registry-credential = Credencial salva
 spec-help-registry-credential = Nome de uma credencial do cofre, em vez de usuário/senha inline.

--- a/crates/ruscker-admin/src/routes/admin/spec_form.rs
+++ b/crates/ruscker-admin/src/routes/admin/spec_form.rs
@@ -265,7 +265,11 @@ impl SpecForm {
                 .unwrap_or_default(),
             docker_registry_domain: spec.docker_registry_domain.clone().unwrap_or_default(),
             docker_registry_username: spec.docker_registry_username.clone().unwrap_or_default(),
-            docker_registry_password: spec.docker_registry_password.clone().unwrap_or_default(),
+            // Never prefill the registry password (#260): the stored
+            // value is a `${VAR}` literal at best and a legacy cleartext
+            // secret at worst — neither should be rendered. Blank here +
+            // "blank ⇒ keep" in `into_spec` makes the field write-only.
+            docker_registry_password: String::new(),
             docker_registry_credential: spec.docker_registry_credential.clone().unwrap_or_default(),
             access_groups: spec.access_groups.as_ref().map(|v| v.join(", ")).unwrap_or_default(),
             access_users: spec.access_users.as_ref().map(|v| v.join(", ")).unwrap_or_default(),
@@ -408,7 +412,13 @@ impl SpecForm {
             container_cmd: lines_to_vec(&self.container_cmd),
             docker_registry_domain: empty_to_none(&self.docker_registry_domain),
             docker_registry_username: empty_to_none(&self.docker_registry_username),
-            docker_registry_password: empty_to_none(&self.docker_registry_password),
+            // Write-only (#260): a blank field keeps the existing stored
+            // value (the form never shows it), so editing a spec doesn't
+            // wipe the password; a non-blank value replaces it.
+            docker_registry_password: match empty_to_none(&self.docker_registry_password) {
+                Some(v) => Some(v),
+                None => base.and_then(|b| b.docker_registry_password.clone()),
+            },
             docker_registry_credential: empty_to_none(&self.docker_registry_credential),
             access_groups: list_to_vec(&self.access_groups),
             access_users: list_to_vec(&self.access_users),
@@ -1027,6 +1037,50 @@ proxy:
         // Form-managed advanced fields still round-trip.
         assert_eq!(merged.min_replicas, Some(1));
         assert_eq!(merged.max_replicas, Some(4));
+    }
+
+    /// #260: the registry password is write-only. The form never loads
+    /// it (`from_spec` blanks it), and a blank submit keeps the existing
+    /// stored value rather than wiping it; a typed value replaces it.
+    #[test]
+    fn registry_password_is_write_only() {
+        let yaml = r#"
+proxy:
+  specs:
+    - id: ops
+      display-name: Ops
+      container-image: registry.example.com/acme/ops:latest
+      docker-registry-username: acme
+      docker-registry-password: ${DOCKER_REGISTRY_PASSWORD}
+"#;
+        std::env::set_var("DOCKER_REGISTRY_PASSWORD", "test");
+        let cfg = Config::from_yaml(yaml).expect("parse fixture");
+        let original = &cfg.proxy.specs[0];
+        // Stored literal preserved at parse (the model from this PR).
+        assert_eq!(
+            original.docker_registry_password.as_deref(),
+            Some("${DOCKER_REGISTRY_PASSWORD}")
+        );
+
+        // The form never exposes it.
+        let form = SpecForm::from_spec(original);
+        assert_eq!(form.docker_registry_password, "");
+
+        // Blank submit ⇒ keep the stored value.
+        let kept = SpecForm::from_spec(original)
+            .into_spec(Some(original))
+            .expect("into_spec");
+        assert_eq!(
+            kept.docker_registry_password.as_deref(),
+            Some("${DOCKER_REGISTRY_PASSWORD}"),
+            "blank field must not wipe the stored password"
+        );
+
+        // A typed value replaces it.
+        let mut form = SpecForm::from_spec(original);
+        form.docker_registry_password = "${OTHER_VAR}".into();
+        let replaced = form.into_spec(Some(original)).expect("into_spec");
+        assert_eq!(replaced.docker_registry_password.as_deref(), Some("${OTHER_VAR}"));
     }
 
     /// A brand-new spec (no base) has no unmodelled fields to carry.

--- a/crates/ruscker-admin/src/routes/proxy.rs
+++ b/crates/ruscker-admin/src/routes/proxy.rs
@@ -916,9 +916,6 @@ async fn pick_or_spawn(state: &AppState, spec: &Spec) -> anyhow::Result<Replica>
 /// just reject the pull). Lives next to the proxy spawn path
 /// so the scaler can reuse it via `pub(crate)`.
 ///
-/// The password comes through already env-interpolated by
-/// `ruscker-config`'s loader — there's no `${VAR}` left to
-/// resolve here.
 /// Build [`ResourceLimits`] from a spec's `container-*-limit` /
 /// `container-*-request` fields. Returns an empty (all-`None`)
 /// `ResourceLimits` when the spec sets nothing — the backend
@@ -934,13 +931,20 @@ pub(crate) fn limits_from_spec(spec: &Spec) -> ruscker_core::ResourceLimits {
     }
 }
 
+/// The password is stored as the literal `${VAR}` (never resolved into
+/// the DB / config in memory — #260), so we interpolate it **here**, at
+/// the point of use, right before a pull. Idempotent: a value with no
+/// `${...}` (or a `docker-registry-credential` flow) is unaffected. If a
+/// referenced env var is unset we keep the literal — the backend's
+/// pull then fails with a clear "still contains `${...}`" error rather
+/// than silently pulling anonymously.
 pub(crate) fn creds_from_spec(spec: &Spec) -> Option<ruscker_core::RegistryCredentials> {
     let user = spec.docker_registry_username.as_deref().filter(|s| !s.is_empty());
     let pass = spec.docker_registry_password.as_deref().filter(|s| !s.is_empty());
     match (user, pass) {
         (Some(u), Some(p)) => Some(ruscker_core::RegistryCredentials {
             username: u.to_string(),
-            password: p.to_string(),
+            password: ruscker_config::env::interpolate_value(p).unwrap_or_else(|_| p.to_string()),
             server_address: spec
                 .docker_registry_domain
                 .as_deref()
@@ -1518,6 +1522,26 @@ docker-registry-domain: priv.io
         assert_eq!(c.username, "bot");
         assert_eq!(c.password, "hunter2");
         assert_eq!(c.server_address.as_deref(), Some("priv.io"));
+    }
+
+    #[test]
+    fn creds_from_spec_resolves_password_env_at_use() {
+        // #260: the password is stored as a `${VAR}` literal (never
+        // resolved into the DB/config); creds_from_spec resolves it at
+        // the point of use, right before the pull.
+        std::env::set_var("RUSCKER_TEST_REG_PW", "fromenv");
+        let s = spec_yaml(
+            r#"
+id: p
+display-name: P
+container-image: priv.io/app:1
+docker-registry-username: bot
+docker-registry-password: ${RUSCKER_TEST_REG_PW}
+"#,
+        );
+        let c = creds_from_spec(&s).expect("creds present");
+        assert_eq!(c.password, "fromenv", "resolved at use");
+        std::env::remove_var("RUSCKER_TEST_REG_PW");
     }
 
     #[test]

--- a/crates/ruscker-admin/templates/admin/spec_form.html
+++ b/crates/ruscker-admin/templates/admin/spec_form.html
@@ -535,8 +535,9 @@
                 <label for="f-reg-pass" class="spec-form-label">{{ self.t("spec-form-registry-password") }}</label>
                 {% call help(self.t("spec-help-registry-password")) %}{% endcall %}
               </div>
-              <input id="f-reg-pass" type="text" name="docker_registry_password"
-                     value="{{ form.docker_registry_password }}" placeholder="${DOCKER_REGISTRY_PASSWORD}"
+              <input id="f-reg-pass" type="password" name="docker_registry_password"
+                     value="" autocomplete="new-password"
+                     placeholder="{{ self.t("spec-form-registry-password-keep") }}"
                      class="spec-form-input spec-form-input--mono">
             </div>
             <div class="spec-form-field">

--- a/crates/ruscker-config/src/env.rs
+++ b/crates/ruscker-config/src/env.rs
@@ -39,6 +39,14 @@ static ENV_VAR_PATTERN: LazyLock<Regex> = LazyLock::new(|| {
 /// References inside YAML comments (lines starting with `#` after optional
 /// whitespace) are left untouched. This preserves comment-out workflows
 /// that operators use during debugging.
+/// YAML keys whose values are secrets: their `${VAR}` placeholders are
+/// **preserved verbatim** at parse and resolved only at the point of use
+/// (e.g. `creds_from_spec` right before a registry pull). This keeps the
+/// resolved secret out of the DB on `import`, out of `export` output,
+/// and off the admin form — "the DB never sees the secret in clear"
+/// (#260). The credentials store (AES-encrypted) is the other path.
+pub const SECRET_KEYS: &[&str] = &["docker-registry-password"];
+
 pub fn interpolate(input: &str) -> Result<String> {
     let mut output = String::with_capacity(input.len());
 
@@ -48,10 +56,36 @@ pub fn interpolate(input: &str) -> Result<String> {
             output.push_str(line);
             continue;
         }
+        // Leave secret-keyed lines (e.g. `docker-registry-password:
+        // ${VAR}`) untouched — resolved at use, not at parse (#260).
+        if is_secret_key_line(trimmed) {
+            output.push_str(line);
+            continue;
+        }
         output.push_str(&interpolate_line(line)?);
     }
 
     Ok(output)
+}
+
+/// Resolve `${VAR}` / `${VAR:-default}` in a single scalar value (e.g. a
+/// secret read back from the DB at use time). Idempotent: a value with
+/// no `${...}` comes back unchanged.
+pub fn interpolate_value(value: &str) -> Result<String> {
+    interpolate_line(value)
+}
+
+/// Does this (already left-trimmed) YAML line assign a [`SECRET_KEYS`]
+/// key? Matches the key before the first `:`, tolerating a leading `- `
+/// for a list-item mapping's first key.
+fn is_secret_key_line(trimmed: &str) -> bool {
+    let key = trimmed
+        .split(':')
+        .next()
+        .unwrap_or("")
+        .trim_start_matches('-')
+        .trim();
+    SECRET_KEYS.contains(&key)
 }
 
 fn interpolate_line(line: &str) -> Result<String> {
@@ -113,6 +147,32 @@ mod tests {
         with_env("RUSCKER_TEST_VAR", "hello", || {
             let result = interpolate("value: ${RUSCKER_TEST_VAR}").unwrap();
             assert_eq!(result, "value: hello");
+        });
+    }
+
+    #[test]
+    fn preserves_secret_keyed_lines() {
+        // #260: a secret-keyed line keeps its `${VAR}` verbatim (resolved
+        // only at use), while ordinary lines interpolate as usual.
+        with_env("RUSCKER_REG_PASS", "s3cret", || {
+            let yaml = "container-image: nginx:${RUSCKER_NEVER_SET:-latest}\n\
+                        docker-registry-password: ${RUSCKER_REG_PASS}\n";
+            let out = interpolate(yaml).unwrap();
+            assert!(out.contains("nginx:latest"), "non-secret line interpolated");
+            assert!(
+                out.contains("docker-registry-password: ${RUSCKER_REG_PASS}"),
+                "secret line preserved verbatim: {out}"
+            );
+            assert!(!out.contains("s3cret"), "secret never resolved at parse");
+        });
+    }
+
+    #[test]
+    fn interpolate_value_resolves_and_is_idempotent() {
+        with_env("RUSCKER_REG_PASS", "s3cret", || {
+            assert_eq!(interpolate_value("${RUSCKER_REG_PASS}").unwrap(), "s3cret");
+            // A value with no placeholder comes back unchanged.
+            assert_eq!(interpolate_value("already-plain").unwrap(), "already-plain");
         });
     }
 

--- a/crates/ruscker-config/tests/shinyproxy_compat.rs
+++ b/crates/ruscker-config/tests/shinyproxy_compat.rs
@@ -82,7 +82,7 @@ fn classifies_specs_correctly() {
 }
 
 #[test]
-fn env_interpolation_works_on_credentials() {
+fn registry_secret_is_preserved_literal_and_resolved_at_use() {
     let config = load_with_env();
     let ops = config
         .proxy
@@ -90,11 +90,22 @@ fn env_interpolation_works_on_credentials() {
         .iter()
         .find(|s| s.id == "ops-report")
         .expect("ops-report spec must exist");
+    // #260: the registry password is a *secret* key — its `${VAR}` is
+    // preserved verbatim at parse (so it never lands resolved in the DB
+    // on import or in export output) and resolved only at the point of
+    // use.
     assert_eq!(
         ops.docker_registry_password.as_deref(),
-        Some("test-pat-not-real"),
-        "${{DOCKER_REGISTRY_PASSWORD}} should have been interpolated"
+        Some("${DOCKER_REGISTRY_PASSWORD}"),
+        "the registry password stays a ${{VAR}} literal at parse"
     );
+    assert_eq!(
+        ruscker_config::env::interpolate_value(ops.docker_registry_password.as_deref().unwrap())
+            .unwrap(),
+        "test-pat-not-real",
+        "and resolves at use"
+    );
+    // Non-secret fields still interpolate at parse as before.
     assert_eq!(ops.docker_registry_username.as_deref(), Some("acme"));
 }
 

--- a/docs/SECURITY.md
+++ b/docs/SECURITY.md
@@ -110,6 +110,20 @@ Status: living document. Tracks the Phase 5 security audit
 - **[implemented]** DB credential store wired to image pulls —
   `db::credentials::resolve` decrypts only at pull time, in the
   spawn path, never echoed to the UI.
+- **[implemented]** `${VAR}` secrets stay literal end-to-end (#260) —
+  `docker-registry-password` (and any [`env::SECRET_KEYS`] key) is
+  **not** interpolated at parse: the `${VAR}` placeholder is preserved
+  through `import` into the DB and through `export` output, and resolved
+  only at the point of use (`creds_from_spec`, right before a pull). So
+  the resolved secret never lands in the config DB or an export. The
+  admin spec form treats the password as **write-only** — never
+  pre-filled or rendered; a blank field keeps the stored value.
+  `docker-registry-credential` (the AES-encrypted store) is preferred
+  for new flows.
+- **[legacy]** A spec imported by an older build may hold a *resolved*
+  password in its `config_json`. Re-import the YAML (which now preserves
+  the literal) or rotate the secret to the credentials store; the
+  `scan_raw_text` validator still flags inline cleartext in YAML.
 - **[implemented]** Plaintext secrets never logged: pull path
   logs `with_creds=<bool>` + registry host, not the password;
   audit-log inserts carry action/target, not secret values.


### PR DESCRIPTION
## Problem

`Config::from_yaml` interpolated the whole doc before deserialize, so `docker-registry-password: ${VAR}` was resolved into the in-memory `Spec`. `import` then persisted the **cleartext** secret as `config_json`, and the admin form rendered it as `type="text"` with the value. That contradicts "secrets never go to YAML/DB" the moment you `import` a config using `${DOCKER_REGISTRY_PASSWORD}`.

## Model — the DB never sees the resolved secret

- **`env`** — secret-keyed lines (`SECRET_KEYS` = `docker-registry-password`) are preserved verbatim at parse; ordinary `${VAR}` still interpolate. New `env::interpolate_value` resolves a single scalar at use.
- **`creds_from_spec`** — resolves the password `${VAR}` at the point of use (right before the pull), idempotently. Unset var ⇒ keep the literal so the pull fails loudly rather than pulling anonymously.
- **Spec form** — the password is **write-only**: `from_spec` never loads it, the input is `type="password"` with no value, and `into_spec` keeps the base value when the field is blank (a typed value replaces it). Prefer `docker-registry-credential` (AES store).
- Net: `import` persists the `${VAR}` literal, `export` emits it, and the resolved secret exists only transiently in the spawn path.

`SECURITY.md §3` documents the model + a legacy re-import note (older builds may hold a resolved password; re-import or rotate).

## Tests
- `env`: secret line preserved at parse; `interpolate_value` resolves + idempotent.
- `proxy`: `creds_from_spec` resolves a `${VAR}` password at use.
- `spec_form`: write-only — blank keeps the stored value, typed replaces it.
- `shinyproxy_compat`: now asserts literal-at-parse + resolve-at-use.
- Full `ruscker-config` + `ruscker-admin` suites + `clippy -D warnings` + `i18n-check` green.

Closes #260
🤖 Generated with [Claude Code](https://claude.com/claude-code)