### PR TITLE
fix: converge spec source-of-truth + DB-first display names (#271 #275)

### DIFF
--- a/crates/ruscker-admin/src/routes/admin/dashboard.rs
+++ b/crates/ruscker-admin/src/routes/admin/dashboard.rs
@@ -304,34 +304,21 @@ async fn build_snapshot(state: &AppState, locale: Locale) -> DashboardSnapshot {
         .len();
     let tracker_sessions = state.sessions.len();
 
-    // Resolve a display name per distinct spec_id once: the YAML config
-    // first, then the DB (showcase/admin specs live only there, #205),
-    // else the raw id. Done up front so we don't re-query per row.
+    // Resolve a display name per distinct spec_id once, DB-first
+    // (admin edits + showcase seed shadow the YAML), via the shared
+    // `find_spec` resolver — a config-first order showed the stale YAML
+    // name for a spec renamed in the admin (#275). Done up front so we
+    // don't re-resolve per row.
     let mut name_of: std::collections::HashMap<String, String> = std::collections::HashMap::new();
     for sid in snap
         .iter()
         .map(|r| r.spec_id.clone())
         .collect::<std::collections::HashSet<_>>()
     {
-        let from_config = state
-            .config
-            .proxy
-            .specs
-            .iter()
-            .find(|s| s.id == sid)
-            .and_then(|s| s.display_name.clone());
-        let name = match from_config {
-            Some(n) => n,
-            None => match state.db.as_ref() {
-                Some(db) => crate::db::specs::fetch_one(db, &sid)
-                    .await
-                    .ok()
-                    .flatten()
-                    .and_then(|s| s.display_name.clone())
-                    .unwrap_or_else(|| sid.clone()),
-                None => sid.clone(),
-            },
-        };
+        let name = crate::routes::proxy::find_spec(state, &sid)
+            .await
+            .and_then(|s| s.display_name.clone())
+            .unwrap_or_else(|| sid.clone());
         name_of.insert(sid, name);
     }
 
@@ -485,30 +472,26 @@ async fn logs(
             .into_response();
     };
 
-    // Resolve display_name + spec_id from the registry snapshot
-    // so the page heading is friendly even though logs come
-    // straight from the backend.
-    let (display_name, spec_id) = {
+    // Resolve display_name + spec_id for the heading. Read the spec id
+    // from the registry under the lock, then drop it before the DB-first
+    // name lookup (#275) so we never hold the registry lock across I/O.
+    let spec_id_of_replica = {
         let reg = state.replicas.read().await;
         let found = reg.all().find(|r| r.id == rid).map(|r| r.spec_id.clone());
-        match found {
-            Some(sid) => {
-                let dn = state
-                    .config
-                    .proxy
-                    .specs
-                    .iter()
-                    .find(|s| s.id == sid)
-                    .and_then(|s| s.display_name.clone())
-                    .unwrap_or_else(|| sid.clone());
-                (dn, sid)
-            }
-            // Replica not in registry — still try to fetch logs
-            // (it may have just been dropped from the registry
-            // but the container lingers). Heading falls back to
-            // the raw id.
-            None => (replica_id.clone(), String::new()),
+        found
+    };
+    let (display_name, spec_id) = match spec_id_of_replica {
+        Some(sid) => {
+            let dn = crate::routes::proxy::find_spec(&state, &sid)
+                .await
+                .and_then(|s| s.display_name.clone())
+                .unwrap_or_else(|| sid.clone());
+            (dn, sid)
         }
+        // Replica not in registry — still try to fetch logs (it may have
+        // just been dropped from the registry but the container lingers).
+        // Heading falls back to the raw id.
+        None => (replica_id.clone(), String::new()),
     };
 
     let lines = match backend.logs(&rid, LOGS_TAIL).await {

--- a/crates/ruscker-admin/src/routes/landing.rs
+++ b/crates/ruscker-admin/src/routes/landing.rs
@@ -119,24 +119,15 @@ async fn index(
         _ => Vec::new(),
     };
 
-    // Specs source: DB when attached AND non-empty (operator-editable
-    // catalog plus the first-install showcase seed), YAML otherwise.
-    // An empty DB falls back to YAML so deployments that load specs
-    // exclusively from `proxy.specs` keep working — only when the DB
-    // actually has rows do they take precedence. Mirrors how
-    // `landing_customization` chooses below.
-    let db_specs: Vec<ruscker_config::Spec> = match state.db.as_ref() {
-        Some(db) => crate::db::specs::list_all(db).await.unwrap_or_else(|err| {
-            tracing::warn!(error = ?err, "specs DB fetch failed; falling back to YAML");
-            Vec::new()
-        }),
-        None => Vec::new(),
-    };
-    let owned_specs: Vec<ruscker_config::Spec> = if db_specs.is_empty() {
-        state.config.proxy.specs.clone()
-    } else {
-        db_specs
-    };
+    // Specs source: the SAME effective catalog the proxy and the
+    // lifecycle loops use (#271) — DB unioned with the YAML
+    // `proxy.specs`, the DB shadowing on an id collision; YAML-only
+    // when no DB. Routing all surfaces through one resolver keeps the
+    // landing, the `/app` guard, the scaler/sweeper, and the dashboard
+    // from disagreeing on what specs exist (an earlier "DB-only when
+    // non-empty" rule here hid an admin-deleted spec from the landing
+    // while `find_spec` still resolved it from the YAML and spawned it).
+    let owned_specs = crate::catalog::effective_specs(state.db.as_ref(), &state.config).await;
     let mut cards: Vec<CardCtx<'_>> = owned_specs
         .iter()
         .filter(|spec| spec.access_allows(is_admin, username.as_deref(), &groups))


### PR DESCRIPTION
Two convergence fixes from the audit (#187).

## #271 — one spec resolver everywhere
The landing used "DB-only when non-empty"; the proxy `find_spec` used DB-first + YAML fallback; the scaler/sweeper used `catalog::effective_specs` (union). Net: deleting a spec in the admin hid it from the landing while `/app/{id}` still resolved it from the YAML and **spawned** it.

Landing now uses the same `catalog::effective_specs` (DB ∪ YAML, DB shadows on id collision) as the proxy + lifecycle loops. All surfaces agree. A YAML-defined spec still can't be deleted via the DB (the file is its source) — documented in the issue.

## #275 — DB-first display names
Dashboard `build_snapshot` resolved names YAML-first; the logs page used YAML only. A spec renamed in the admin showed its stale name (or raw id on the logs page). Both now resolve **DB-first** via the shared `proxy::find_spec`. The logs handler reads the spec id under the registry lock and drops it before the DB lookup.

Core logic is covered by `catalog::effective_specs` unit tests + `find_spec`; full admin suite + `clippy -D warnings` green.

Closes #271, #275
🤖 Generated with [Claude Code](https://claude.com/claude-code)