### PR TITLE
docs: drop the cargo fmt mandate from README + PLAN (#274)

### DIFF
--- a/PLAN.md
+++ b/PLAN.md
@@ -463,5 +463,5 @@ git checkout -b phase-1/landing-page
 Cada PR deve:
 - Referenciar a issue da fase (`refs #N`).
 - Ter pelo menos 1 teste (snapshot, unit ou integração).
-- Passar `cargo fmt --check && cargo clippy --all-targets`.
+- Passar `cargo test`, `cargo clippy --all-targets -- -D warnings` e `./scripts/i18n-check.sh`. (NÃO rodar `cargo fmt` crate-wide — `main` não é fmt-clean sob o rustfmt atual; formatar à mão só as linhas tocadas. `cargo fmt --check` não faz parte do gate.)
 - Ser pequeno o suficiente para revisar em <30 min.

--- a/README.md
+++ b/README.md
@@ -256,9 +256,14 @@ cargo build
 cargo test                                   # 300+ tests, no Docker needed
 cargo test -p ruscker-docker --features docker-it   # + real Docker daemon
 cargo test -p ruscker-cli --features e2e            # + full proxy/WS e2e
-cargo fmt && cargo clippy --all-targets
+cargo clippy --all-targets -- -D warnings
 ./scripts/i18n-check.sh                      # enforce locale key parity
 ```
+
+> Hand-format only the lines you touch — don't run `cargo fmt`
+> crate-wide. `main` isn't fmt-clean under the current rustfmt, so a
+> workspace `cargo fmt` produces a large unrelated diff; `cargo fmt
+> --check` is intentionally **not** part of the gate.
 
 ## License
 


### PR DESCRIPTION
`main` isn't fmt-clean under the current rustfmt, and the project decided **not** to run `cargo fmt` crate-wide (it produces a large unrelated diff). But the docs still told contributors to:
- `README.md` — `cargo fmt && cargo clippy --all-targets`
- `PLAN.md` — gate on `cargo fmt --check && cargo clippy --all-targets`

Both updated to the real gate — `cargo test` + `cargo clippy --all-targets -- -D warnings` + `./scripts/i18n-check.sh` — with a note to **hand-format only the lines you touch** and that `cargo fmt --check` is intentionally not part of the gate.

Closes #274
🤖 Generated with [Claude Code](https://claude.com/claude-code)