### PR TITLE
perf(docker): metrics refresh skips per-replica list_containers (#282)

### DIFF
--- a/crates/ruscker-admin/src/metrics_cache.rs
+++ b/crates/ruscker-admin/src/metrics_cache.rs
@@ -144,28 +144,32 @@ async fn refresh_once(
     backend: &dyn ContainerBackend,
     replicas: &RwLock<ruscker_core::ReplicaRegistry>,
 ) {
-    // Snapshot replica ids under the read lock, then release it
-    // before issuing any I/O.
-    let ids: Vec<ReplicaId> = {
+    // Snapshot (replica id, container id) under the read lock, then
+    // release it before issuing any I/O. Passing the container id the
+    // registry already knows lets the backend skip a per-replica
+    // `list_containers` lookup on each refresh (#282).
+    let targets: Vec<(ReplicaId, String)> = {
         let reg = replicas.read().await;
-        reg.all().map(|r| r.id.clone()).collect()
+        reg.all().map(|r| (r.id.clone(), r.container_id.clone())).collect()
     };
-    if ids.is_empty() {
+    if targets.is_empty() {
         cache.replace(Vec::new());
         return;
     }
 
-    // Fan out `backend.metrics()` calls in parallel. Each call
+    // Fan out `backend.metrics_for()` calls in parallel. Each call
     // is independent so they should overlap their Docker stats
     // round-trips.
     use futures_util::future::join_all;
-    let results: Vec<(ReplicaId, Result<ReplicaMetrics, _>)> = join_all(ids.into_iter().map(|id| {
-        let id_for_err = id.clone();
-        async move {
-            let r = backend.metrics(&id).await;
-            (id_for_err, r)
-        }
-    }))
+    let results: Vec<(ReplicaId, Result<ReplicaMetrics, _>)> = join_all(targets.into_iter().map(
+        |(id, container_id)| {
+            let id_for_err = id.clone();
+            async move {
+                let r = backend.metrics_for(&id, &container_id).await;
+                (id_for_err, r)
+            }
+        },
+    ))
     .await;
 
     let mut fresh = Vec::with_capacity(results.len());

--- a/crates/ruscker-core/src/lib.rs
+++ b/crates/ruscker-core/src/lib.rs
@@ -294,6 +294,20 @@ pub trait ContainerBackend: Send + Sync {
     /// Per-replica metrics (CPU, memory, network I/O).
     async fn metrics(&self, replica_id: &ReplicaId) -> CoreResult<ReplicaMetrics>;
 
+    /// Like [`metrics`](Self::metrics) but the caller passes the
+    /// `container_id` it already holds (from the registry), so the
+    /// backend can skip resolving the replica → container mapping.
+    /// The default ignores the hint and delegates to `metrics`; the
+    /// local Docker backend overrides it to avoid a per-call
+    /// `list_containers` on every metrics refresh (#282).
+    async fn metrics_for(
+        &self,
+        replica_id: &ReplicaId,
+        _container_id: &str,
+    ) -> CoreResult<ReplicaMetrics> {
+        self.metrics(replica_id).await
+    }
+
     /// Fetch the last `tail` lines of a replica's combined
     /// stdout+stderr. A one-shot snapshot (no follow) — the
     /// dashboard logs page uses it for "why did this container

--- a/crates/ruscker-docker/src/lib.rs
+++ b/crates/ruscker-docker/src/lib.rs
@@ -535,6 +535,22 @@ impl ContainerBackend for LocalDockerBackend {
         self.metrics_for_container(&container_id).await
     }
 
+    /// Use the caller-supplied `container_id` (from the registry) and
+    /// skip the `container_id_for_replica` `list_containers` lookup —
+    /// the metrics cache calls this for every replica every refresh, so
+    /// dropping that round-trip halves the per-refresh daemon traffic
+    /// (#282). Falls back to the label lookup if the id is empty.
+    async fn metrics_for(
+        &self,
+        replica_id: &ReplicaId,
+        container_id: &str,
+    ) -> CoreResult<ReplicaMetrics> {
+        if container_id.is_empty() {
+            return self.metrics(replica_id).await;
+        }
+        self.metrics_for_container(container_id).await
+    }
+
     async fn logs(&self, replica_id: &ReplicaId, tail: usize) -> CoreResult<Vec<String>> {
         let container_id = self.container_id_for_replica(replica_id).await?;
         self.logs_for_container(&container_id, tail).await


### PR DESCRIPTION
The metrics cache fans `backend.metrics()` over every replica each 5s, and the local Docker backend resolved each replica → container with a `list_containers` label query before `stats` — so a refresh was N × (`list_containers` + `stats`) daemon round-trips.

New `ContainerBackend::metrics_for(replica_id, container_id)`:
- default delegates to `metrics` (mock + multi-host backends unchanged — correct, just unoptimized);
- `LocalDockerBackend` overrides it to call `metrics_for_container` directly with the id the registry already carries, dropping the `list_containers` (falls back to the label lookup if the id is empty).

The metrics cache now snapshots `(replica_id, container_id)` and calls `metrics_for`. No per-replica `list_containers` on the refresh path → ~half the daemon calls per tick.

Core + docker + admin build, full suites + `clippy -D warnings` green. (Real-daemon behavior is exercised by the existing `docker-it` metrics path; the override is a thin wrapper.)

Closes #282
🤖 Generated with [Claude Code](https://claude.com/claude-code)