### PR TITLE
perf(admin): serve small WebP thumbnails for media galleries (#283)

### DIFF
--- a/crates/ruscker-admin/src/images.rs
+++ b/crates/ruscker-admin/src/images.rs
@@ -181,6 +181,27 @@ fn encode_to_webp(bytes: &[u8]) -> Result<(Vec<u8>, u32, u32)> {
     Ok((out, w, h))
 }
 
+/// Decode `bytes`, scale to fit within `max_dim`×`max_dim` (aspect
+/// preserved, never upscaled), and re-encode as WebP. Serves small
+/// gallery thumbnails so the spec form / media page don't ship the
+/// full-size blob per `<img>` (#283). Raster formats only — the caller
+/// skips SVG (vector, already tiny).
+pub fn thumbnail_webp(bytes: &[u8], max_dim: u32) -> Result<Vec<u8>> {
+    let img = ImageReader::new(Cursor::new(bytes))
+        .with_guessed_format()
+        .context("guess format")?
+        .decode()
+        .context("decode source image")?;
+    // `thumbnail` preserves aspect ratio and never upscales, using a
+    // fast filter — fine for a small tile.
+    let thumb = img.thumbnail(max_dim, max_dim);
+    let mut out: Vec<u8> = Vec::new();
+    thumb
+        .write_to(&mut Cursor::new(&mut out), image::ImageFormat::WebP)
+        .context("write WebP thumbnail")?;
+    Ok(out)
+}
+
 fn decode_dimensions(bytes: &[u8]) -> Result<(u32, u32)> {
     let img = ImageReader::new(Cursor::new(bytes))
         .with_guessed_format()?
@@ -191,6 +212,23 @@ fn decode_dimensions(bytes: &[u8]) -> Result<(u32, u32)> {
 #[cfg(test)]
 mod tests {
     use super::*;
+
+    #[test]
+    fn thumbnail_webp_scales_within_max_dim_preserving_aspect() {
+        // 200×100 source → fits within 96×96, aspect kept (96×48).
+        let src = image::DynamicImage::ImageRgba8(image::RgbaImage::from_pixel(
+            200,
+            100,
+            image::Rgba([10, 20, 30, 255]),
+        ));
+        let mut png = Vec::new();
+        src.write_to(&mut Cursor::new(&mut png), image::ImageFormat::Png)
+            .unwrap();
+        let thumb = thumbnail_webp(&png, 96).unwrap();
+        let (w, h) = decode_dimensions(&thumb).unwrap();
+        assert_eq!((w, h), (96, 48), "scaled to fit, aspect preserved");
+        assert!(thumb.len() < 5000, "thumbnail is compact: {} bytes", thumb.len());
+    }
 
     #[test]
     fn sanitize_strips_paths_and_normalizes() {

--- a/crates/ruscker-admin/src/routes/assets.rs
+++ b/crates/ruscker-admin/src/routes/assets.rs
@@ -12,15 +12,36 @@
 //! the binary itself does), so they all carry a one-year
 //! `cache-control: immutable` header — safe to cache aggressively.
 
+use std::sync::LazyLock;
+
 use axum::{
-    extract::{Path as AxumPath, State},
+    extract::{Path as AxumPath, Query, State},
     http::{header, HeaderMap, HeaderValue, StatusCode},
     response::{IntoResponse, Response},
     routing::get,
     Router,
 };
+use dashmap::DashMap;
 
 use crate::AppState;
+
+/// Max dimension (px) for a gallery thumbnail (`/assets/img/x?thumb`).
+/// The picker tiles render at ~48 px; 96 covers HiDPI.
+const THUMB_MAX_DIM: u32 = 96;
+
+/// Process-wide cache of generated thumbnails, keyed by filename.
+/// Uploaded images are immutable per filename (a new upload gets a new
+/// name), so an entry never goes stale; the map is bounded by the size
+/// of the media library. First request for an image pays the
+/// decode+resize; the rest hit this cache.
+static THUMB_CACHE: LazyLock<DashMap<String, Vec<u8>>> = LazyLock::new(DashMap::new);
+
+/// `?thumb` query flag on `/assets/img/{filename}`.
+#[derive(serde::Deserialize)]
+struct ImgQuery {
+    #[serde(default)]
+    thumb: Option<String>,
+}
 
 // ── Embedded assets ───────────────────────────────────────────────
 
@@ -129,6 +150,7 @@ pub fn routes() -> Router<AppState> {
 async fn serve_card_image(
     State(state): State<AppState>,
     AxumPath(filename): AxumPath<String>,
+    Query(q): Query<ImgQuery>,
 ) -> Response {
     // Don't allow `../` or directory components — Axum's path
     // extractor already collapses path segments per route, but
@@ -137,27 +159,79 @@ async fn serve_card_image(
         return StatusCode::BAD_REQUEST.into_response();
     }
 
-    // 1. DB lookup
-    if let Some(pool) = state.db.as_ref() {
-        match crate::db::images::fetch_by_filename(pool, &filename).await {
-            Ok(Some((mime, bytes))) => return serve_dynamic(bytes, &mime),
-            Ok(None) => {}
+    // Thumbnail fast path: serve a cached small WebP if we've already
+    // made one for this (immutable) filename (#283).
+    let want_thumb = q.thumb.is_some();
+    if want_thumb {
+        if let Some(cached) = THUMB_CACHE.get(&filename) {
+            return serve_thumbnail_bytes(cached.clone());
+        }
+    }
+
+    // Resolve the full image bytes: DB first, then the on-disk fallback.
+    let Some((mime, bytes)) = fetch_image_bytes(&state, &filename).await else {
+        return StatusCode::NOT_FOUND.into_response();
+    };
+
+    // Vector / no resize needed → serve as-is. Raster + `?thumb` →
+    // generate a thumbnail (off the async worker), cache, and serve.
+    if want_thumb && mime != "image/svg+xml" {
+        let fname = filename.clone();
+        let src = bytes.clone();
+        match tokio::task::spawn_blocking(move || {
+            crate::images::thumbnail_webp(&src, THUMB_MAX_DIM)
+        })
+        .await
+        {
+            Ok(Ok(thumb)) => {
+                THUMB_CACHE.insert(fname, thumb.clone());
+                return serve_thumbnail_bytes(thumb);
+            }
+            Ok(Err(err)) => {
+                tracing::warn!(error = ?err, filename, "thumbnail generation failed; serving full image");
+            }
             Err(err) => {
-                tracing::error!(error = ?err, filename, "image DB lookup failed");
+                tracing::warn!(error = ?err, filename, "thumbnail task join failed; serving full image");
             }
         }
     }
 
-    // 2. Disk fallback
-    if let Some(dir) = state.images_dir.as_ref() {
-        let candidate = dir.join(&filename);
-        if let Ok(bytes) = tokio::fs::read(&candidate).await {
-            let mime = mime_from_extension(&filename);
-            return serve_dynamic(bytes, mime);
+    serve_dynamic(bytes, &mime)
+}
+
+/// Fetch an operator-uploaded image's `(mime, bytes)` — DB first, then
+/// the on-disk `images_dir` fallback. `None` if it isn't found anywhere.
+async fn fetch_image_bytes(state: &AppState, filename: &str) -> Option<(String, Vec<u8>)> {
+    if let Some(pool) = state.db.as_ref() {
+        match crate::db::images::fetch_by_filename(pool, filename).await {
+            Ok(Some((mime, bytes))) => return Some((mime, bytes)),
+            Ok(None) => {}
+            Err(err) => tracing::error!(error = ?err, filename, "image DB lookup failed"),
         }
     }
+    if let Some(dir) = state.images_dir.as_ref() {
+        let candidate = dir.join(filename);
+        if let Ok(bytes) = tokio::fs::read(&candidate).await {
+            return Some((mime_from_extension(filename).to_string(), bytes));
+        }
+    }
+    None
+}
 
-    StatusCode::NOT_FOUND.into_response()
+/// Serve a generated WebP thumbnail. Derived deterministically from an
+/// immutable filename, so it can be cached hard (a day).
+fn serve_thumbnail_bytes(body: Vec<u8>) -> Response {
+    let mut headers = HeaderMap::new();
+    headers.insert(header::CONTENT_TYPE, HeaderValue::from_static("image/webp"));
+    headers.insert(
+        header::CACHE_CONTROL,
+        HeaderValue::from_static("public, max-age=86400"),
+    );
+    headers.insert(
+        header::X_CONTENT_TYPE_OPTIONS,
+        HeaderValue::from_static("nosniff"),
+    );
+    (StatusCode::OK, headers, body).into_response()
 }
 
 fn mime_from_extension(name: &str) -> &'static str {

--- a/crates/ruscker-admin/templates/admin/images.html
+++ b/crates/ruscker-admin/templates/admin/images.html
@@ -53,7 +53,7 @@
       <div class="image-tile">
         <a href="/assets/img/{{ img.filename }}" target="_blank" class="image-tile-frame"
            title="{{ img.filename }}">
-          <img src="/assets/img/{{ img.filename }}" alt="" loading="lazy">
+          <img src="/assets/img/{{ img.filename }}?thumb" alt="" loading="lazy">
         </a>
         <div class="image-tile-meta">
           <div class="image-tile-name" title="{{ img.filename }}">{{ img.filename }}</div>

--- a/crates/ruscker-admin/templates/admin/spec_form.html
+++ b/crates/ruscker-admin/templates/admin/spec_form.html
@@ -144,7 +144,7 @@
                     @click="form.logo = '/assets/img/' + name"
                     class="w-12 h-12 rounded-md overflow-hidden border-2 transition-colors"
                     :class="form.logo === '/assets/img/' + name ? 'border-[#0f6e56]' : 'border-transparent hover:border-[color:var(--border)]'">
-              <img :src="assetUrl('/assets/img/' + name)" :alt="name" loading="lazy" class="w-full h-full object-cover">
+              <img :src="assetUrl('/assets/img/' + name) + '?thumb'" :alt="name" loading="lazy" class="w-full h-full object-cover">
             </button>
           </template>
         </div>
@@ -248,7 +248,7 @@
               <button type="button" :title="name" @click="setCoverImage(name)"
                       class="w-12 h-12 rounded-md overflow-hidden border-2 transition-colors"
                       :class="form.cover.indexOf('/assets/img/' + name) !== -1 ? 'border-[#0f6e56]' : 'border-transparent hover:border-[color:var(--border)]'">
-                <img :src="assetUrl('/assets/img/' + name)" :alt="name" loading="lazy" class="w-full h-full object-cover">
+                <img :src="assetUrl('/assets/img/' + name) + '?thumb'" :alt="name" loading="lazy" class="w-full h-full object-cover">
               </button>
             </template>
           </div>


### PR DESCRIPTION
The spec-form logo/cover pickers and the Media page rendered one `<img>` per library image, each pulling the **full-size blob from the DB** (`/assets/img/{f}`) — heavy with a large library or large images.

## Change
- New `/assets/img/{f}?thumb`: fetch the image once, resize to fit **96 px** as WebP (`images::thumbnail_webp`, run via `spawn_blocking` so the resize doesn't block the async worker), **cache** the result in-process keyed by the immutable filename, serve with `Cache-Control: public, max-age=86400`. SVGs skip resizing.
- The two spec-form galleries + the Media tiles request `?thumb`. The live card **preview** and the Media "open full image" link keep the full asset.
- No backfill needed — the thumbnail is derived on first request and cached (an upload always gets a new filename, so the cache never goes stale).

## Verification
- Unit: `thumbnail_webp` scales 200×100 → 96×48 WebP, compact.
- Smoke: upload a PNG → `/assets/img/{f}?thumb` returns a smaller `image/webp` with `max-age=86400`.
- Full admin suite + `clippy -D warnings` green.

(The galleries still render one tile per image — pagination/virtualization is a further follow-up if a library ever gets huge; the thumbnail cut is the bandwidth/DB win.)

Closes #283
🤖 Generated with [Claude Code](https://claude.com/claude-code)