### PR TITLE
perf(admin): gzip/br compression for chrome text responses (#287)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -71,6 +71,21 @@ dependencies = [
 ]
 
 [[package]]
+name = "alloc-no-stdlib"
+version = "2.0.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cc7bb162ec39d46ab1ca8c77bf72e890535becd1751bb45f64c597edb4c8c6b3"
+
+[[package]]
+name = "alloc-stdlib"
+version = "0.2.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "94fb8275041c72129eb51b7d0322c29b8387a0386127718b096429201a5d6ece"
+dependencies = [
+ "alloc-no-stdlib",
+]
+
+[[package]]
 name = "allocator-api2"
 version = "0.2.21"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -236,6 +251,18 @@ dependencies = [
  "serde_derive",
  "unicode-ident",
  "winnow",
+]
+
+[[package]]
+name = "async-compression"
+version = "0.4.42"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e79b3f8a79cccc2898f31920fc69f304859b3bd567490f75ebf51ae1c792a9ac"
+dependencies = [
+ "compression-codecs",
+ "compression-core",
+ "pin-project-lite",
+ "tokio",
 ]
 
 [[package]]
@@ -547,6 +574,27 @@ dependencies = [
 ]
 
 [[package]]
+name = "brotli"
+version = "8.0.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8119e4516436f5708bbc474a9d395bf12f1b5395e93a92a56e647ac3388c8610"
+dependencies = [
+ "alloc-no-stdlib",
+ "alloc-stdlib",
+ "brotli-decompressor",
+]
+
+[[package]]
+name = "brotli-decompressor"
+version = "5.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5962523e1b92ce1b5e793d9169b9943eece10d39f62550bc04bb605d75b94924"
+dependencies = [
+ "alloc-no-stdlib",
+ "alloc-stdlib",
+]
+
+[[package]]
 name = "bstr"
 version = "1.12.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -707,6 +755,24 @@ name = "colorchoice"
 version = "1.0.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1d07550c9036bf2ae0c684c4297d503f838287c83c53686d05370d0e139ae570"
+
+[[package]]
+name = "compression-codecs"
+version = "0.4.38"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ce2548391e9c1929c21bf6aa2680af86fe4c1b33e6cea9ac1cfeec0bd11218cf"
+dependencies = [
+ "brotli",
+ "compression-core",
+ "flate2",
+ "memchr",
+]
+
+[[package]]
+name = "compression-core"
+version = "0.4.32"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cc14f565cf027a105f7a44ccf9e5b424348421a1d8952a8fc9d499d313107789"
 
 [[package]]
 name = "concurrent-queue"
@@ -3758,6 +3824,7 @@ version = "0.6.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4cfcf7e2740e6fc6d4d688b4ef00650406bb94adf4731e43c096c3a19fe40840"
 dependencies = [
+ "async-compression",
  "bitflags",
  "bytes",
  "futures-core",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -31,7 +31,7 @@ async-trait = "0.1.89"
 axum = { version = "0.8", features = ["ws", "macros", "multipart"] }
 axum-extra = { version = "0.12", features = ["cookie"] }
 tower = "0.5"
-tower-http = { version = "0.6", features = ["trace", "fs", "cors"] }
+tower-http = { version = "0.6", features = ["trace", "fs", "cors", "compression-gzip", "compression-br"] }
 tower-cookies = "0.11"
 hyper = "1.9"
 hyper-util = { version = "0.1", features = ["client", "client-legacy", "http1", "tokio"] }

--- a/crates/ruscker-admin/src/lib.rs
+++ b/crates/ruscker-admin/src/lib.rs
@@ -546,6 +546,20 @@ pub fn router_with_images(state: AppState, _images_dir: Option<&Path>) -> Router
         }
     };
 
+    // gzip/br compression for the chrome's text responses (HTML + the
+    // bundled CSS/JS) (#287). Outermost layer, so it compresses the
+    // final body — after the base-path rewrite has read it uncompressed,
+    // and only for the chrome routes (the proxy forwards upstream bodies
+    // verbatim and must not be re-compressed). Honors `Accept-Encoding`.
+    // The default predicate already skips images and tiny responses; we
+    // also skip `font/*` — woff2 is already compressed, so re-encoding it
+    // only burns CPU.
+    use tower_http::compression::predicate::{DefaultPredicate, NotForContentType, Predicate};
+    let own = own.layer(
+        tower_http::compression::CompressionLayer::new()
+            .compress_when(DefaultPredicate::new().and(NotForContentType::const_new("font/"))),
+    );
+
     // Health probes (`/healthz`, `/readyz`) sit outside the
     // `security_headers` layer: they return JSON for orchestrators,
     // not HTML for browsers, so CSP / X-Frame-Options are


### PR DESCRIPTION
`tower-http` was already a dep but no compression was wired — the admin/landing HTML + bundled CSS/JS shipped uncompressed (Tabler icon CSS alone is **209 KB**).

## Change
- Enable the `compression-gzip` + `compression-br` features on `tower-http`.
- Add a `CompressionLayer` as the **outermost** layer on the chrome router: compresses the final body *after* the base-path rewrite reads it uncompressed, and only the chrome routes (the proxy forwards upstream bodies verbatim, must not be re-compressed). Skips `font/*` (woff2 is already compressed) on top of the default image/tiny skips. Honors `Accept-Encoding`.

## Smoke
- Tabler CSS **209 KB → 36 KB** (br); landing HTML gzip'd.
- woff2 not re-encoded; no `Accept-Encoding` → no encoding.
- Under `--base-path /box`: HTML is **both rewritten and compressed** (verified the decompressed body carries the `/box` prefix).
- Full admin suite + `clippy -D warnings` green.

Closes #287
🤖 Generated with [Claude Code](https://claude.com/claude-code)