### PR TITLE
perf(metrics): bound the Docker stats fan-out + configurable interval (#288)

### DIFF
--- a/crates/ruscker-admin/src/lib.rs
+++ b/crates/ruscker-admin/src/lib.rs
@@ -396,7 +396,9 @@ impl AdminServer {
                 self.state.metrics.clone(),
                 backend,
                 self.state.replicas.clone(),
-                metrics_cache::REFRESH_INTERVAL,
+                // `proxy.metrics-interval` (seconds; 0 ⇒ 5 s default) —
+                // a busy host can poll Docker stats less often (#288).
+                std::time::Duration::from_secs(self.state.config.proxy.effective_metrics_interval_secs()),
             );
         }
 

--- a/crates/ruscker-admin/src/metrics_cache.rs
+++ b/crates/ruscker-admin/src/metrics_cache.rs
@@ -34,6 +34,11 @@ use tracing::{info, warn};
 /// CPU delta windows large enough to read sanely.
 pub const REFRESH_INTERVAL: Duration = Duration::from_secs(5);
 
+/// Max concurrent `stats` round-trips to the Docker daemon per refresh
+/// (#288). Bounds the burst on a host with many replicas; the calls
+/// still overlap, just not all at once.
+const MAX_CONCURRENT_STATS: usize = 8;
+
 /// How many recent samples to keep per replica for the dashboard
 /// sparklines. 30 × [`REFRESH_INTERVAL`] (5 s) ≈ 2.5 min of history —
 /// enough to show a trend without unbounded growth.
@@ -157,20 +162,24 @@ async fn refresh_once(
         return;
     }
 
-    // Fan out `backend.metrics_for()` calls in parallel. Each call
-    // is independent so they should overlap their Docker stats
-    // round-trips.
-    use futures_util::future::join_all;
-    let results: Vec<(ReplicaId, Result<ReplicaMetrics, _>)> = join_all(targets.into_iter().map(
-        |(id, container_id)| {
+    // Fan out `backend.metrics_for()` calls, but **bounded** — at most
+    // `MAX_CONCURRENT_STATS` in flight at once (#288). `join_all` would
+    // fire one Docker `stats` round-trip per replica simultaneously,
+    // which on a host with many replicas bursts the daemon and can drag
+    // the whole admin. `buffer_unordered` caps the burst while still
+    // overlapping the independent round-trips.
+    use futures_util::stream::{self, StreamExt};
+    let results: Vec<(ReplicaId, Result<ReplicaMetrics, _>)> =
+        stream::iter(targets.into_iter().map(|(id, container_id)| {
             let id_for_err = id.clone();
             async move {
                 let r = backend.metrics_for(&id, &container_id).await;
                 (id_for_err, r)
             }
-        },
-    ))
-    .await;
+        }))
+        .buffer_unordered(MAX_CONCURRENT_STATS)
+        .collect()
+        .await;
 
     let mut fresh = Vec::with_capacity(results.len());
     for (id, result) in results {

--- a/crates/ruscker-config/src/schema.rs
+++ b/crates/ruscker-config/src/schema.rs
@@ -180,6 +180,14 @@ pub struct Proxy {
     #[serde(rename = "shutdown-grace-ms")]
     pub shutdown_grace_ms: u64,
 
+    /// How often the dashboard metrics cache polls the backend for
+    /// per-replica CPU/memory, in **seconds**. Each poll fans out
+    /// `stats` round-trips to the Docker daemon, so a busy host may
+    /// prefer a slower cadence (10–15 s). `0` falls back to the
+    /// 5 s default. Ruscker extension — not present in ShinyProxy YAML.
+    #[serde(rename = "metrics-interval", default)]
+    pub metrics_interval_secs: u64,
+
     /// Maximum request body accepted on proxied routes (`/app/*`,
     /// `/api/*`), as a Docker-style size string (`"10m"`, `"1g"`,
     /// or plain bytes). A request whose `Content-Length` exceeds
@@ -285,6 +293,7 @@ impl Default for Proxy {
             heartbeat_timeout: 3_600_000,
             container_wait_time: 60_000,
             shutdown_grace_ms: 30_000,
+            metrics_interval_secs: 0,
             max_body_size: None,
             container_log_path: None,
             port: 8080,
@@ -299,6 +308,16 @@ impl Default for Proxy {
 }
 
 impl Proxy {
+    /// Dashboard metrics poll interval in seconds, honoring
+    /// `proxy.metrics-interval` (0 ⇒ the 5 s default).
+    pub fn effective_metrics_interval_secs(&self) -> u64 {
+        if self.metrics_interval_secs == 0 {
+            5
+        } else {
+            self.metrics_interval_secs
+        }
+    }
+
     /// Global default max request-body size in bytes, parsed from
     /// `proxy.max-body-size`. `None` (unset or malformed) means no
     /// global default; the validator flags a malformed value.
@@ -1052,6 +1071,16 @@ mod parse_memory_tests {
     #[test]
     fn whitespace_tolerated() {
         assert_eq!(parse_memory_string("  512m  "), Some(512 * 1024 * 1024));
+    }
+
+    #[test]
+    fn metrics_interval_defaults_to_5s_else_honors_config() {
+        // Unset / 0 ⇒ 5 s default.
+        assert_eq!(Proxy::default().effective_metrics_interval_secs(), 5);
+        // `proxy.metrics-interval: 12` is honored.
+        let cfg = crate::Config::from_yaml("proxy:\n  metrics-interval: 12\n").unwrap();
+        assert_eq!(cfg.proxy.metrics_interval_secs, 12);
+        assert_eq!(cfg.proxy.effective_metrics_interval_secs(), 12);
     }
 }
 

--- a/docs/YAML_SCHEMA.md
+++ b/docs/YAML_SCHEMA.md
@@ -79,6 +79,7 @@ ignored by Ruscker.
 | `shutdown-grace-ms` | ms | `30000` | Drain window on SIGTERM/Ctrl-C before forced exit; `/readyz` reports `draining` during it. Ruscker extension |
 | `max-body-size` | size | none | Global cap on proxied request bodies (`"10m"`, `"1g"`, bytes); over → `413`. Per-spec `max-body-size` overrides. Ruscker extension |
 | `metrics-enabled` | bool | `false` | Expose a Prometheus `/metrics` endpoint (**unauthenticated** when on — firewall it). Ruscker extension |
+| `metrics-interval` | s | `5` | How often the dashboard polls the backend for per-replica CPU/mem. A busy host can slow it (`10`–`15`) to ease the Docker daemon. `0` ⇒ default. Ruscker extension |
 | `hosts` | list | `[]` | Docker hosts for multi-host scheduling (Phase 6). Empty ⇒ the local daemon. Ruscker extension |
 
 ### `proxy.hosts` — multi-host scheduling (Phase 6)


### PR DESCRIPTION
The metrics cache fired one Docker `stats` round-trip per replica **simultaneously** (`join_all`) every **hardcoded 5s** — a burst on hosts with many replicas.

- **Bound** the fan-out: `buffer_unordered(8)` instead of `join_all` — still overlaps, capped at 8 in flight.
- **Configurable interval**: new `proxy.metrics-interval` (seconds; `0` ⇒ 5s default), so a busy host can poll less often (10–15s). Wired through `metrics_cache::spawn`.

Schema test (`0`→5, `12`→12) + YAML_SCHEMA entry. Full config/admin suites + `clippy -D warnings` green.

Closes #288
🤖 Generated with [Claude Code](https://claude.com/claude-code)