### PR TITLE
perf(assets): version bundled CSS/JS URLs for immutable caching (#289)

### DIFF
--- a/crates/ruscker-admin/src/routes/assets.rs
+++ b/crates/ruscker-admin/src/routes/assets.rs
@@ -91,11 +91,11 @@ pub fn routes() -> Router<AppState> {
     Router::new()
         .route(
             "/assets/styles.css",
-            get(|| serve(STYLES_CSS, "text/css; charset=utf-8")),
+            get(|q| serve_versioned(q, STYLES_CSS, "text/css; charset=utf-8")),
         )
         .route(
             "/assets/icons/tabler-icons.min.css",
-            get(|| serve(TABLER_CSS, "text/css; charset=utf-8")),
+            get(|q| serve_versioned(q, TABLER_CSS, "text/css; charset=utf-8")),
         )
         .route(
             "/assets/icons/tabler-icons.woff2",
@@ -115,7 +115,7 @@ pub fn routes() -> Router<AppState> {
         )
         .route(
             "/assets/js/alpine.min.js",
-            get(|| serve(ALPINE_JS, "application/javascript; charset=utf-8")),
+            get(|q| serve_versioned(q, ALPINE_JS, "application/javascript; charset=utf-8")),
         )
         // Tech showcase logos. URLs match the seeded specs in migration 0009.
         .route("/assets/showcase/bokeh.svg", get(|| serve(SHOWCASE_BOKEH, SVG)))
@@ -285,23 +285,44 @@ fn serve_dynamic(body: Vec<u8>, content_type: &str) -> Response {
 
 // ── Helpers ───────────────────────────────────────────────────────
 
-async fn serve(body: &'static [u8], content_type: &'static str) -> Response {
+/// `?v=<version>` cache-busting flag on a bundled asset URL (#289).
+#[derive(serde::Deserialize)]
+struct AssetVer {
+    v: Option<String>,
+}
+
+fn serve_with_cache(body: &'static [u8], content_type: &'static str, cache: &'static str) -> Response {
     let mut headers = HeaderMap::new();
     headers.insert(header::CONTENT_TYPE, HeaderValue::from_static(content_type));
+    headers.insert(header::CACHE_CONTROL, HeaderValue::from_static(cache));
+    (StatusCode::OK, headers, body).into_response()
+}
+
+async fn serve(body: &'static [u8], content_type: &'static str) -> Response {
     // Cache for a short window (no `must-revalidate`) so the admin's
     // full-page-reload navigation doesn't fire a conditional-GET
-    // round-trip for every bundled asset on every click — the main
-    // source of the "menus feel slow" jank (#269). 5 minutes is long
-    // enough to cover an active browsing session and short enough that
-    // a new binary's assets are picked up promptly (a hard reload
-    // always bypasses the cache). `immutable` would be wrong here — the
-    // bytes change across upgrades under the same URL; the proper
-    // long-term fix is hash-bearing URLs (`/assets/styles-<hash>.css`).
-    headers.insert(
-        header::CACHE_CONTROL,
-        HeaderValue::from_static("public, max-age=300"),
-    );
-    (StatusCode::OK, headers, body).into_response()
+    // round-trip for every bundled asset on every click (#269). 5 min
+    // covers an active session; a new binary's assets are picked up
+    // promptly (a hard reload always bypasses). `immutable` would be
+    // wrong for an un-versioned URL — the bytes change across upgrades.
+    serve_with_cache(body, content_type, "public, max-age=300")
+}
+
+/// Serve a bundled asset whose URL carries `?v=<version>` (#289). The
+/// version stamps the URL per release, so the bytes for a given URL are
+/// immutable — cache them hard for a year. A request without `?v`
+/// (a stale link, or a direct hit) falls back to the short cache, so we
+/// never serve stale bytes under a non-versioned URL.
+async fn serve_versioned(
+    Query(q): Query<AssetVer>,
+    body: &'static [u8],
+    content_type: &'static str,
+) -> Response {
+    if q.v.is_some() {
+        serve_with_cache(body, content_type, "public, max-age=31536000, immutable")
+    } else {
+        serve(body, content_type).await
+    }
 }
 
 #[cfg(test)]

--- a/crates/ruscker-admin/templates/_layout.html
+++ b/crates/ruscker-admin/templates/_layout.html
@@ -16,8 +16,8 @@
 <link rel="preload" href="/assets/fonts/jost-latin-500-normal.woff2" as="font" type="font/woff2" crossorigin>
 <!-- Preload the icon font (448 KB) so the table/menu glyphs don't pop in late (#269). -->
 <link rel="preload" href="/assets/icons/tabler-icons.woff2" as="font" type="font/woff2" crossorigin>
-<link rel="stylesheet" href="/assets/styles.css">
-<link rel="stylesheet" href="/assets/icons/tabler-icons.min.css">
+<link rel="stylesheet" href="/assets/styles.css?v={{ crate::APP_VERSION }}">
+<link rel="stylesheet" href="/assets/icons/tabler-icons.min.css?v={{ crate::APP_VERSION }}">
 </head>
 <body class="min-h-screen flex flex-col">
 

--- a/crates/ruscker-admin/templates/admin/_layout.html
+++ b/crates/ruscker-admin/templates/admin/_layout.html
@@ -16,8 +16,8 @@
 <link rel="preload" href="/assets/fonts/jost-latin-500-normal.woff2" as="font" type="font/woff2" crossorigin>
 <!-- Preload the icon font (448 KB) so the table/menu glyphs don't pop in late (#269). -->
 <link rel="preload" href="/assets/icons/tabler-icons.woff2" as="font" type="font/woff2" crossorigin>
-<link rel="stylesheet" href="/assets/styles.css">
-<link rel="stylesheet" href="/assets/icons/tabler-icons.min.css">
+<link rel="stylesheet" href="/assets/styles.css?v={{ crate::APP_VERSION }}">
+<link rel="stylesheet" href="/assets/icons/tabler-icons.min.css?v={{ crate::APP_VERSION }}">
 </head>
 <body class="min-h-screen flex flex-col">
 

--- a/crates/ruscker-admin/templates/admin/audit.html
+++ b/crates/ruscker-admin/templates/admin/audit.html
@@ -108,7 +108,7 @@
 
 </div>
 
-<script src="/assets/js/alpine.min.js" defer></script>
+<script src="/assets/js/alpine.min.js?v={{ crate::APP_VERSION }}" defer></script>
 <script>
 window.ruscker = window.ruscker || {};
 window.ruscker.audit = () => ({

--- a/crates/ruscker-admin/templates/admin/landing.html
+++ b/crates/ruscker-admin/templates/admin/landing.html
@@ -260,7 +260,7 @@
 {# Custom HTML blocks editor, folded in from the old standalone tab (#242). #}
 {% include "admin/_blocks_editor.html" %}
 
-<script src="/assets/js/alpine.min.js" defer></script>
+<script src="/assets/js/alpine.min.js?v={{ crate::APP_VERSION }}" defer></script>
 <script>
 // Gradient helpers (gradientCss / gradientDefault / bgMode) are
 // defined in admin/_layout.html so they're shared with the

--- a/crates/ruscker-admin/templates/admin/login.html
+++ b/crates/ruscker-admin/templates/admin/login.html
@@ -7,8 +7,8 @@
 <meta name="robots" content="noindex,nofollow">
 <title>{{ self.t("admin-login-title") }} · Ruscker</title>
 <link rel="icon" type="image/svg+xml" href="/favicon.svg">
-<link rel="stylesheet" href="/assets/styles.css">
-<link rel="stylesheet" href="/assets/icons/tabler-icons.min.css">
+<link rel="stylesheet" href="/assets/styles.css?v={{ crate::APP_VERSION }}">
+<link rel="stylesheet" href="/assets/icons/tabler-icons.min.css?v={{ crate::APP_VERSION }}">
 </head>
 <body class="min-h-screen flex flex-col items-center justify-center px-4 relative">
 

--- a/crates/ruscker-admin/templates/admin/setup.html
+++ b/crates/ruscker-admin/templates/admin/setup.html
@@ -7,8 +7,8 @@
 <meta name="robots" content="noindex,nofollow">
 <title>{{ self.t("admin-setup-title") }} · Ruscker</title>
 <link rel="icon" type="image/svg+xml" href="/favicon.svg">
-<link rel="stylesheet" href="/assets/styles.css">
-<link rel="stylesheet" href="/assets/icons/tabler-icons.min.css">
+<link rel="stylesheet" href="/assets/styles.css?v={{ crate::APP_VERSION }}">
+<link rel="stylesheet" href="/assets/icons/tabler-icons.min.css?v={{ crate::APP_VERSION }}">
 </head>
 <body class="min-h-screen flex flex-col items-center justify-center px-4 relative">
 

--- a/crates/ruscker-admin/templates/admin/spec_form.html
+++ b/crates/ruscker-admin/templates/admin/spec_form.html
@@ -813,7 +813,7 @@
   </div>
 </div>
 
-<script src="/assets/js/alpine.min.js" defer></script>
+<script src="/assets/js/alpine.min.js?v={{ crate::APP_VERSION }}" defer></script>
 <script>
 window.ruscker = window.ruscker || {};
 window.ruscker.specForm = (initial, logoImages) => ({

--- a/crates/ruscker-admin/templates/landing.html
+++ b/crates/ruscker-admin/templates/landing.html
@@ -241,7 +241,7 @@
 <section class="landing-block landing-block--bottom px-6 max-w-6xl mx-auto w-full">{{ b.html|safe }}</section>
 {% endfor %}
 
-<script src="/assets/js/alpine.min.js" defer></script>
+<script src="/assets/js/alpine.min.js?v={{ crate::APP_VERSION }}" defer></script>
 <script>
 window.ruscker = window.ruscker || {};
 window.ruscker.landing = () => ({

--- a/crates/ruscker-admin/tests/landing_render.rs
+++ b/crates/ruscker-admin/tests/landing_render.rs
@@ -113,7 +113,8 @@ async fn landing_emits_data_theme_when_set() {
 #[tokio::test]
 async fn landing_stylesheet_link_is_present() {
     let (_, body) = get_with_cookie(None).await;
-    assert!(body.contains(r#"href="/assets/styles.css""#));
+    // The URL carries a `?v=<version>` cache-buster (#289).
+    assert!(body.contains(r#"href="/assets/styles.css?v="#));
 }
 
 #[tokio::test]


### PR DESCRIPTION
Bundled CSS/JS were `max-age=300` (the #269 stopgap) — a long session still revalidates every 5 min.

## Change
- Stamp `?v={{ crate::APP_VERSION }}` onto the `styles.css` / `tabler-icons.min.css` / `alpine.min.js` refs in the templates.
- `serve_versioned`: a request carrying `?v` gets `Cache-Control: public, max-age=31536000, immutable`; without `?v` it falls back to `max-age=300` (never serve stale bytes under a non-versioned URL).
- A new release changes the version → fresh URL → fresh fetch; within a version, zero revalidation. Fonts stay un-versioned (referenced inside CSS `@font-face` + the preloads, so a `?v` mismatch would double-fetch) — they keep the short cache.

## Smoke
- `styles.css?v=<ver>` → `immutable, max-age=1y`; `styles.css` (no `?v`) → `max-age=300`; landing HTML emits `?v=<ver>`; woff2 still `max-age=300`. Works under `/box` (rewriter preserves the query).
- Test updated; full admin suite + `clippy -D warnings` + i18n green.

Closes #289
🤖 Generated with [Claude Code](https://claude.com/claude-code)