### PR TITLE
fix(secrets): fail spawn on unresolved ${VAR} in container-env (#300)

### DIFF
--- a/crates/ruscker-docker/src/lib.rs
+++ b/crates/ruscker-docker/src/lib.rs
@@ -169,6 +169,20 @@ impl LocalDockerBackend {
         let replica_id = ReplicaId::new();
         let inner_port = req.inner_port.unwrap_or(DEFAULT_INNER_PORT);
 
+        // A `container-env` value still carrying `${...}` means its env
+        // var wasn't set — interpolation upstream couldn't resolve it
+        // (#300). Fail clearly instead of injecting a literal `${VAR}`
+        // into the container (which would silently misconfigure the app,
+        // and for a secret would leave a placeholder where a real value
+        // should be). Mirrors the registry-password guard below.
+        if let Some(name) = first_unresolved_env(&req.env) {
+            return Err(CoreError::Backend(format!(
+                "container-env {name} for {} references an unset environment \
+                 variable (value still contains ${{...}})",
+                req.spec_id
+            )));
+        }
+
         // 1. Pull image (idempotent — Docker no-ops when local).
         //    Errors bubble up through the stream-of-events.
         self.ensure_image_pulled(&req.image, req.creds.as_ref(), req.platform.as_deref())
@@ -836,6 +850,17 @@ fn state_from_docker(s: Option<&str>) -> ReplicaState {
     }
 }
 
+/// The NAME of the first `container-env` entry (`"NAME=value"`) whose
+/// value still contains a `${...}` placeholder — i.e. an env var that
+/// wasn't set. `None` if every value resolved. Used to fail a spawn
+/// loudly instead of injecting a literal `${VAR}` (#300).
+fn first_unresolved_env(env: &[String]) -> Option<&str> {
+    env.iter().find_map(|kv| {
+        let (name, value) = kv.split_once('=')?;
+        value.contains("${").then_some(name)
+    })
+}
+
 fn backend_err(op: &str, e: bollard::errors::Error) -> CoreError {
     CoreError::Backend(format!("{op}: {e}"))
 }
@@ -871,6 +896,15 @@ fn apply_limits(host_config: &mut HostConfig, limits: &ruscker_core::ResourceLim
 #[cfg(test)]
 mod tests {
     use super::*;
+
+    #[test]
+    fn first_unresolved_env_flags_residual_placeholder() {
+        let ok = vec!["A=1".to_string(), "B=plain".to_string()];
+        assert_eq!(first_unresolved_env(&ok), None);
+        let bad = vec!["A=1".to_string(), "DB_PASSWORD=${DB_PASSWORD}".to_string()];
+        assert_eq!(first_unresolved_env(&bad), Some("DB_PASSWORD"));
+        assert_eq!(first_unresolved_env(&[]), None);
+    }
 
     #[test]
     fn state_from_docker_maps_common_values() {

--- a/docs/SECURITY.md
+++ b/docs/SECURITY.md
@@ -124,7 +124,8 @@ Status: living document. Tracks the Phase 5 security audit
   parse and resolved only at spawn (`Spec::resolved_env_pairs`), so an
   app secret passed via `${VAR}` never lands in the DB either. A missing
   env var fails the pull/spawn with a clear message rather than passing
-  a literal `${VAR}` (#273).
+  a literal `${VAR}` — both for the registry password (#273) and for
+  `container-env` values (#300).
 - **[legacy]** A spec imported by an older build may hold a *resolved*
   password in its `config_json`. Re-import the YAML (which now preserves
   the literal) or rotate the secret to the credentials store; the


### PR DESCRIPTION
`resolved_env_pairs` keeps the literal when interpolation fails (unset var), and the Docker backend only guarded the **registry password** — so `container-env: { DB_PASSWORD: ${DB_PASSWORD} }` with the var unset brought the container up with `DB_PASSWORD=${DB_PASSWORD}` literal, contradicting SECURITY.md's claim that a missing env var fails clearly.

## Fix
`spawn_request` now rejects any `container-env` value still containing `${...}` with a clear *"references an unset environment variable"* error, mirroring the registry-password guard. Extracted `first_unresolved_env` + unit test. SECURITY.md §3 updated to cite both guards (#273 registry, #300 container-env).

Closes #300
🤖 Generated with [Claude Code](https://claude.com/claude-code)