### PR TITLE
fix(admin): invalidate thumbnail cache on re-upload/delete (#301)

### DIFF
--- a/crates/ruscker-admin/src/db/images.rs
+++ b/crates/ruscker-admin/src/db/images.rs
@@ -194,9 +194,10 @@ pub async fn list_all(db: &ConfigDb) -> Result<Vec<ImageMeta>> {
         .collect())
 }
 
-/// Delete by id. Returns true if a row was removed. Audit row is
-/// written on either branch (an attempted delete is an event).
-pub async fn delete_one(db: &ConfigDb, id: &str, actor: Option<&str>) -> Result<bool> {
+/// Delete an image by id. Returns the deleted row's filename (so the
+/// caller can invalidate caches keyed by it, #301), or `None` if no
+/// such image existed. Audit row is written when a row was removed.
+pub async fn delete_one(db: &ConfigDb, id: &str, actor: Option<&str>) -> Result<Option<String>> {
     let now = Utc::now();
     let target = format!("image:{id}");
     match db {
@@ -229,7 +230,7 @@ pub async fn delete_one(db: &ConfigDb, id: &str, actor: Option<&str>) -> Result<
                 .context("audit image.delete")?;
             }
             tx.commit().await.context("commit image delete")?;
-            Ok(removed)
+            Ok(if removed { filename.map(|(f,)| f) } else { None })
         }
         ConfigDb::Postgres(pool) => {
             let mut tx = pool.begin().await.context("begin image delete tx")?;
@@ -259,7 +260,7 @@ pub async fn delete_one(db: &ConfigDb, id: &str, actor: Option<&str>) -> Result<
                 .context("audit image.delete")?;
             }
             tx.commit().await.context("commit image delete")?;
-            Ok(removed)
+            Ok(if removed { filename.map(|(f,)| f) } else { None })
         }
     }
 }
@@ -311,7 +312,11 @@ mod pg_tests {
         assert_eq!(metas[0].size_bytes, 4);
         assert_eq!(metas[0].width, Some(48));
 
-        assert!(delete_one(&db, &id, Some("admin")).await.unwrap());
+        // Returns the deleted filename now (#301).
+        assert_eq!(
+            delete_one(&db, &id, Some("admin")).await.unwrap().as_deref(),
+            Some("logo.webp")
+        );
         assert!(fetch_by_filename(&db, "logo.webp").await.unwrap().is_none());
     }
 }

--- a/crates/ruscker-admin/src/routes/admin/images.rs
+++ b/crates/ruscker-admin/src/routes/admin/images.rs
@@ -184,6 +184,9 @@ async fn upload(
         let stored_name = processed.filename.clone();
         match db::images::insert(pool, processed, Some(editor.actor())).await {
             Ok(_id) => {
+                // A re-upload replaced the bytes behind this filename —
+                // drop any cached thumbnail so the new image shows (#301).
+                crate::routes::assets::invalidate_thumb(&stored_name);
                 last_uploaded_name = Some(stored_name);
             }
             Err(err) => {
@@ -263,12 +266,15 @@ async fn upload_inline(
         };
         let name = processed.filename.clone();
         return match db::images::insert(pool, processed, Some(editor.actor())).await {
-            Ok(_) => Json(InlineUpload {
-                url: Some(format!("/assets/img/{name}")),
-                filename: Some(name),
-                error: None,
-            })
-            .into_response(),
+            Ok(_) => {
+                crate::routes::assets::invalidate_thumb(&name); // #301
+                Json(InlineUpload {
+                    url: Some(format!("/assets/img/{name}")),
+                    filename: Some(name),
+                    error: None,
+                })
+                .into_response()
+            }
             Err(err) => {
                 tracing::error!(error = ?err, "inline image insert failed");
                 inline_err(StatusCode::INTERNAL_SERVER_ERROR, "save failed")
@@ -287,7 +293,13 @@ async fn delete(
         return (StatusCode::SERVICE_UNAVAILABLE, "no db").into_response();
     };
     match db::images::delete_one(pool, &id, Some(editor.actor())).await {
-        Ok(_) => Redirect::to("/admin/media").into_response(),
+        Ok(filename) => {
+            // Drop the cached thumbnail of the deleted image (#301).
+            if let Some(name) = filename {
+                crate::routes::assets::invalidate_thumb(&name);
+            }
+            Redirect::to("/admin/media").into_response()
+        }
         Err(err) => {
             tracing::error!(error = ?err, id, "image delete failed");
             (StatusCode::INTERNAL_SERVER_ERROR, "delete failed").into_response()

--- a/crates/ruscker-admin/src/routes/assets.rs
+++ b/crates/ruscker-admin/src/routes/assets.rs
@@ -30,11 +30,19 @@ use crate::AppState;
 const THUMB_MAX_DIM: u32 = 96;
 
 /// Process-wide cache of generated thumbnails, keyed by filename.
-/// Uploaded images are immutable per filename (a new upload gets a new
-/// name), so an entry never goes stale; the map is bounded by the size
-/// of the media library. First request for an image pays the
-/// decode+resize; the rest hit this cache.
+/// First request for an image pays the decode+resize; the rest hit this
+/// cache. A filename's bytes CAN change (a re-upload `REPLACE`s the same
+/// name), so [`invalidate_thumb`] must be called on upload/delete — the
+/// cache is not self-invalidating (#301). Bounded by the media library.
 static THUMB_CACHE: LazyLock<DashMap<String, Vec<u8>>> = LazyLock::new(DashMap::new);
+
+/// Drop a filename's cached thumbnail. Call this whenever the bytes
+/// behind a filename change — an upload `REPLACE`s a same-named image,
+/// and a delete removes it — otherwise the gallery serves the stale
+/// thumbnail for the rest of the process's life (#301).
+pub(crate) fn invalidate_thumb(filename: &str) {
+    THUMB_CACHE.remove(filename);
+}
 
 /// `?thumb` query flag on `/assets/img/{filename}`.
 #[derive(serde::Deserialize)]
@@ -165,7 +173,7 @@ async fn serve_card_image(
     let want_thumb = q.thumb.is_some();
     if want_thumb {
         if let Some(cached) = THUMB_CACHE.get(&filename) {
-            return serve_thumbnail_bytes(cached.clone());
+            return serve_thumbnail_bytes(&req_headers, cached.clone());
         }
     }
 
@@ -186,7 +194,7 @@ async fn serve_card_image(
         {
             Ok(Ok(thumb)) => {
                 THUMB_CACHE.insert(fname, thumb.clone());
-                return serve_thumbnail_bytes(thumb);
+                return serve_thumbnail_bytes(&req_headers, thumb);
             }
             Ok(Err(err)) => {
                 tracing::warn!(error = ?err, filename, "thumbnail generation failed; serving full image");
@@ -227,13 +235,23 @@ async fn fetch_image_bytes(state: &AppState, filename: &str) -> Option<(String, 
 
 /// Serve a generated WebP thumbnail. Derived deterministically from an
 /// immutable filename, so it can be cached hard (a day).
-fn serve_thumbnail_bytes(body: Vec<u8>) -> Response {
+fn serve_thumbnail_bytes(req_headers: &HeaderMap, body: Vec<u8>) -> Response {
+    // A filename can be re-uploaded (#301), so a thumb isn't truly
+    // immutable — cache modestly and lean on the ETag to make a
+    // revalidation a cheap 304 when the bytes are unchanged.
+    let etag = etag_for(&body);
     let mut headers = HeaderMap::new();
-    headers.insert(header::CONTENT_TYPE, HeaderValue::from_static("image/webp"));
     headers.insert(
         header::CACHE_CONTROL,
-        HeaderValue::from_static("public, max-age=86400"),
+        HeaderValue::from_static("public, max-age=300"),
     );
+    if let Ok(v) = HeaderValue::from_str(&etag) {
+        headers.insert(header::ETAG, v);
+    }
+    if if_none_match(req_headers, &etag) {
+        return (StatusCode::NOT_MODIFIED, headers).into_response();
+    }
+    headers.insert(header::CONTENT_TYPE, HeaderValue::from_static("image/webp"));
     headers.insert(
         header::X_CONTENT_TYPE_OPTIONS,
         HeaderValue::from_static("nosniff"),


### PR DESCRIPTION
`THUMB_CACHE` is keyed by filename and assumed immutable, but `db::images::insert` `REPLACE`s a same-named image — so re-uploading `logo.png` left the gallery serving the **old** thumbnail for the whole process (and up to a day in the browser, `max-age=86400`).

## Fix
- `assets::invalidate_thumb(filename)` drops the cached thumb — called from the upload, inline-upload, and delete handlers. `db::images::delete_one` now returns the deleted filename so the delete handler can invalidate it.
- Thumbnails are served `max-age=300` + an `ETag` (not a day): a re-upload shows within 5 min in the browser; the ETag makes a revalidation a cheap 304 when unchanged.

## Smoke
Re-uploading the same filename with a different image now serves the new thumbnail (334→240 bytes — cache invalidated); thumb carries `max-age=300` + ETag. Full admin suite + `clippy -D warnings` green.

Closes #301
🤖 Generated with [Claude Code](https://claude.com/claude-code)