### PR TITLE
ux(admin): show YAML-only specs in /admin/specs as read-only (#303)

### DIFF
--- a/crates/ruscker-admin/assets/i18n/en/landing.ftl
+++ b/crates/ruscker-admin/assets/i18n/en/landing.ftl
@@ -181,6 +181,8 @@ admin-specs-filter-search = Search by id or name…
 admin-specs-filter-kind-all = All kinds
 admin-specs-filter-state-all = Active and inactive
 admin-specs-edit = Edit
+admin-specs-config-badge = config
+admin-specs-config-defined = Defined in the YAML config — read-only here; edit the file
 admin-specs-delete = Delete
 
 # Spec form (new / edit)

--- a/crates/ruscker-admin/assets/i18n/es/landing.ftl
+++ b/crates/ruscker-admin/assets/i18n/es/landing.ftl
@@ -181,6 +181,8 @@ admin-specs-filter-search = Buscar por id o nombre…
 admin-specs-filter-kind-all = Todos los tipos
 admin-specs-filter-state-all = Activos e inactivos
 admin-specs-edit = Editar
+admin-specs-config-badge = config
+admin-specs-config-defined = Definido en el YAML — solo lectura aquí; edita el archivo
 admin-specs-delete = Borrar
 
 # Spec form (new / edit)

--- a/crates/ruscker-admin/assets/i18n/fr/landing.ftl
+++ b/crates/ruscker-admin/assets/i18n/fr/landing.ftl
@@ -181,6 +181,8 @@ admin-specs-filter-search = Rechercher par id ou nom…
 admin-specs-filter-kind-all = Tous les types
 admin-specs-filter-state-all = Actifs et inactifs
 admin-specs-edit = Modifier
+admin-specs-config-badge = config
+admin-specs-config-defined = Défini dans le YAML — lecture seule ici; modifiez le fichier
 admin-specs-delete = Supprimer
 
 # Spec form (new / edit)

--- a/crates/ruscker-admin/assets/i18n/pt/landing.ftl
+++ b/crates/ruscker-admin/assets/i18n/pt/landing.ftl
@@ -185,6 +185,8 @@ admin-specs-filter-search = Buscar por id ou nome…
 admin-specs-filter-kind-all = Todos os tipos
 admin-specs-filter-state-all = Ativos e inativos
 admin-specs-edit = Editar
+admin-specs-config-badge = config
+admin-specs-config-defined = Definido no YAML — somente leitura aqui; edite o arquivo
 admin-specs-delete = Apagar
 
 # Spec form (new / edit)

--- a/crates/ruscker-admin/src/routes/admin/specs.rs
+++ b/crates/ruscker-admin/src/routes/admin/specs.rs
@@ -44,6 +44,12 @@ pub struct SpecRow {
     pub state: String,
     pub updated_at: DateTime<Utc>,
     pub version: i64,
+    /// `true` for a spec that exists only in the YAML `--config`, not the
+    /// DB (#303) — it runs + shows on the landing but is **read-only**
+    /// here (edit the file to change it). `#[sqlx(default)]` so the DB
+    /// `SELECT` (which doesn't have the column) still maps.
+    #[sqlx(default)]
+    pub config_only: bool,
 }
 
 /// Post-import flash, carried back via query params on the
@@ -152,13 +158,47 @@ async fn index(
         crate::db::ConfigDb::Sqlite(pool) => sqlx::query_as(sql).fetch_all(pool).await,
         crate::db::ConfigDb::Postgres(pool) => sqlx::query_as(sql).fetch_all(pool).await,
     };
-    let specs: Vec<SpecRow> = match loaded {
+    let mut specs: Vec<SpecRow> = match loaded {
         Ok(rows) => rows,
         Err(err) => {
             tracing::error!(error = ?err, "load specs failed");
             return (StatusCode::INTERNAL_SERVER_ERROR, "db error").into_response();
         }
     };
+
+    // Append specs that exist only in the YAML `--config` (not the DB) as
+    // read-only "config-defined" rows (#303). They run + show on the
+    // landing, so showing them here avoids the "where did my spec go?"
+    // confusion; they can't be edited/deleted from the admin (the file is
+    // their source).
+    {
+        use std::collections::HashSet;
+        let db_ids: HashSet<String> = specs.iter().map(|s| s.id.clone()).collect();
+        for s in &state.config.proxy.specs {
+            if db_ids.contains(&s.id) {
+                continue;
+            }
+            let kind = match s.kind() {
+                ruscker_config::SpecKind::Shiny => "shiny",
+                ruscker_config::SpecKind::InteractiveApp => "interactive",
+                ruscker_config::SpecKind::Api => "api",
+                ruscker_config::SpecKind::External => "external",
+            };
+            specs.push(SpecRow {
+                id: s.id.clone(),
+                display_name: s.display_name.clone(),
+                kind: kind.to_string(),
+                state: if s.template_properties.is_active() {
+                    "active".into()
+                } else {
+                    "inactive".into()
+                },
+                updated_at: Utc::now(), // not shown for config rows
+                version: 0,
+                config_only: true,
+            });
+        }
+    }
 
     let flash = build_flash(&state.locales, loc, &flash);
     let page = SpecsPage {

--- a/crates/ruscker-admin/templates/admin/specs.html
+++ b/crates/ruscker-admin/templates/admin/specs.html
@@ -101,6 +101,13 @@
           </td>
           <td><span class="pill pill-kind-{{ spec.kind }}">{{ spec.kind }}</span></td>
           <td><span class="pill pill-state-{{ spec.state }}">{{ spec.state }}</span></td>
+          {% if spec.config_only %}
+          <td class="text-[color:var(--text-faint)]">—</td>
+          <td class="text-[color:var(--text-faint)]">—</td>
+          <td class="actions-cell">
+            <span class="pill" title="{{ self.t("admin-specs-config-defined") }}">{{ self.t("admin-specs-config-badge") }}</span>
+          </td>
+          {% else %}
           <td class="text-[color:var(--text-muted)]">{{ spec.updated_at.format("%d/%m/%Y %H:%M") }}</td>
           <td class="text-[color:var(--text-muted)]">v{{ spec.version }}</td>
           <td class="actions-cell">
@@ -110,6 +117,7 @@
               <i class="ti ti-edit" aria-hidden="true"></i>
             </a>
           </td>
+          {% endif %}
         </tr>
       {% endfor %}
     </tbody>


### PR DESCRIPTION
Runtime resolves specs **DB ∪ YAML** (#271), but `/admin/specs` listed only the DB — so a spec defined only in the `--config` YAML ran + showed on the landing yet was **invisible** in the admin, and deleting a DB spec that also exists in the YAML silently reappeared.

## Fix
The list now appends config-only specs (in `proxy.specs`, not the DB) as **read-only** rows with a "config" badge — date/version render `—`, no edit/delete (the file is their source). `SpecRow` gains a `config_only` flag (`#[sqlx(default)]` so the DB `SELECT` still maps). New i18n keys ×4.

This also makes the "delete resurrects" case less confusing: the spec reappears clearly marked as config-defined.

## Smoke
Fresh DB (showcase seed) + the example YAML → 12 editable rows + 8 "config" rows; `ops-report` (YAML-only) now visible. Full admin suite + clippy + i18n green.

Closes #303
🤖 Generated with [Claude Code](https://claude.com/claude-code)