### PR TITLE
perf(admin): paginate the media gallery with "show more" (#293)

### DIFF
--- a/crates/ruscker-admin/assets/i18n/en/landing.ftl
+++ b/crates/ruscker-admin/assets/i18n/en/landing.ftl
@@ -525,6 +525,7 @@ spec-form-error-threshold = Threshold must be a number between 0 and 1.
 
 # ── spec-form image picker (#213) ──────────────────────────────────
 spec-form-logo-upload = Upload image
+spec-form-gallery-more = Show more
 spec-form-logo-clear = Remove
 spec-form-logo-none = No image — a kind-based tint is used.
 spec-form-logo-path-advanced = Advanced: paste a path or URL

--- a/crates/ruscker-admin/assets/i18n/es/landing.ftl
+++ b/crates/ruscker-admin/assets/i18n/es/landing.ftl
@@ -525,6 +525,7 @@ spec-form-error-threshold = El umbral debe ser un número entre 0 y 1.
 
 # ── spec-form image picker (#213) ──────────────────────────────────
 spec-form-logo-upload = Subir imagen
+spec-form-gallery-more = Mostrar más
 spec-form-logo-clear = Quitar
 spec-form-logo-none = Sin imagen — se usa un tono según el tipo.
 spec-form-logo-path-advanced = Avanzado: pegar una ruta o URL

--- a/crates/ruscker-admin/assets/i18n/fr/landing.ftl
+++ b/crates/ruscker-admin/assets/i18n/fr/landing.ftl
@@ -525,6 +525,7 @@ spec-form-error-threshold = Le seuil doit être un nombre entre 0 et 1.
 
 # ── spec-form image picker (#213) ──────────────────────────────────
 spec-form-logo-upload = Téléverser une image
+spec-form-gallery-more = Afficher plus
 spec-form-logo-clear = Retirer
 spec-form-logo-none = Pas d'image — une teinte selon le type est utilisée.
 spec-form-logo-path-advanced = Avancé : coller un chemin ou une URL

--- a/crates/ruscker-admin/assets/i18n/pt/landing.ftl
+++ b/crates/ruscker-admin/assets/i18n/pt/landing.ftl
@@ -529,6 +529,7 @@ spec-form-error-threshold = O limiar deve ser um número entre 0 e 1.
 
 # ── spec-form image picker (#213) ──────────────────────────────────
 spec-form-logo-upload = Enviar imagem
+spec-form-gallery-more = Mostrar mais
 spec-form-logo-clear = Remover
 spec-form-logo-none = Sem imagem — usa um tom gerado pelo tipo.
 spec-form-logo-path-advanced = Avançado: colar um caminho ou URL

--- a/crates/ruscker-admin/templates/admin/spec_form.html
+++ b/crates/ruscker-admin/templates/admin/spec_form.html
@@ -138,8 +138,9 @@
                    @change="uploadImage($event, 'logo')">
             <i class="ti" :class="imgUploading ? 'ti-loader-2 animate-spin' : 'ti-upload'" aria-hidden="true"></i>
           </label>
-          {# Library thumbnails (reactive — inline uploads push here) #}
-          <template x-for="name in logoImages" :key="name">
+          {# Library thumbnails (reactive — inline uploads push here).
+             Only the first `logoShown` render initially (#293). #}
+          <template x-for="name in logoImages.slice(0, logoShown)" :key="name">
             <button type="button" :title="name"
                     @click="form.logo = '/assets/img/' + name"
                     class="w-12 h-12 rounded-md overflow-hidden border-2 transition-colors"
@@ -147,6 +148,9 @@
               <img :src="assetUrl('/assets/img/' + name) + '?thumb'" :alt="name" loading="lazy" class="w-full h-full object-cover">
             </button>
           </template>
+          <button type="button" x-show="logoImages.length > logoShown" x-cloak
+                  @click="logoShown += galleryPage" class="admin-nav-link self-center text-xs"
+                  x-text="'{{ self.t("spec-form-gallery-more") }}' + ' (' + (logoImages.length - logoShown) + ')'"></button>
         </div>
 
         {# Upload error (e.g. unsupported type / too large) #}
@@ -244,13 +248,16 @@
               <input type="file" accept="image/*" class="hidden" @change="uploadImage($event, 'cover')">
               <i class="ti" :class="imgUploading ? 'ti-loader-2 animate-spin' : 'ti-upload'" aria-hidden="true"></i>
             </label>
-            <template x-for="name in logoImages" :key="'cov-' + name">
+            <template x-for="name in logoImages.slice(0, coverShown)" :key="'cov-' + name">
               <button type="button" :title="name" @click="setCoverImage(name)"
                       class="w-12 h-12 rounded-md overflow-hidden border-2 transition-colors"
                       :class="form.cover.indexOf('/assets/img/' + name) !== -1 ? 'border-[#0f6e56]' : 'border-transparent hover:border-[color:var(--border)]'">
                 <img :src="assetUrl('/assets/img/' + name) + '?thumb'" :alt="name" loading="lazy" class="w-full h-full object-cover">
               </button>
             </template>
+            <button type="button" x-show="logoImages.length > coverShown" x-cloak
+                    @click="coverShown += galleryPage" class="admin-nav-link self-center text-xs"
+                    x-text="'{{ self.t("spec-form-gallery-more") }}' + ' (' + (logoImages.length - coverShown) + ')'"></button>
           </div>
           <div class="spec-form-help">{{ self.t("spec-form-cover-image-help") }}</div>
           <input type="text" name="cover" x-model="form.cover" readonly
@@ -826,6 +833,12 @@ window.ruscker.specForm = (initial, logoImages) => ({
   // Media-library filenames for the logo/cover pickers (#213). Inline
   // uploads unshift new names here so a fresh thumbnail appears at once.
   logoImages: Array.isArray(logoImages) ? logoImages : [],
+  // How many gallery tiles to render initially (#293) — keeps the DOM +
+  // thumbnail requests bounded on a large media library. "Show more"
+  // reveals another page.
+  logoShown: 24,
+  coverShown: 24,
+  galleryPage: 24,
   // Prefix the base path on a root-absolute asset URL (#270). These
   // <img :src> values are set by Alpine at runtime, so the base-path
   // response rewriter (which only touches static HTML) never sees them


### PR DESCRIPTION
The spec form rendered **one `<img>` per library image**, in both the logo and cover pickers — so a large media library meant a lot of DOM + a thumbnail request per tile (×2).

## Fix
The galleries now render only the first `logoShown` / `coverShown` tiles (**24**) with a "Show more (N)" button that reveals another page client-side. Bounds the initial DOM + thumbnail fetches regardless of library size; the filename list is already in memory (cheap strings), so paging is instant. New i18n key ×4 locales.

Smoke: both galleries render `logoImages.slice(0, …)`; show-more buttons present. Full admin suite + clippy + i18n green.

Closes #293
🤖 Generated with [Claude Code](https://claude.com/claude-code)