### PR TITLE
fix(docker): resolve container-env via Result, drop residual ${ scan (#314)

### DIFF
--- a/crates/ruscker-admin/src/routes/proxy.rs
+++ b/crates/ruscker-admin/src/routes/proxy.rs
@@ -867,7 +867,7 @@ async fn pick_or_spawn(state: &AppState, spec: &Spec) -> anyhow::Result<Replica>
 
     let inner_port = spec.effective_inner_port();
 
-    let creds = resolve_creds(state, spec).await;
+    let creds = resolve_creds(state, spec).await?;
     let limits = limits_from_spec(spec);
     tracing::info!(
         spec = %spec.id,
@@ -877,10 +877,16 @@ async fn pick_or_spawn(state: &AppState, spec: &Spec) -> anyhow::Result<Replica>
         with_limits = !limits.is_empty(),
         "spawning first replica"
     );
+    // Resolve `${VAR}` in container-env here, at the point of use, and
+    // fail the spawn naming the missing var (#314) — never inject a
+    // literal `${VAR}` into the container.
+    let env = spec
+        .resolved_env_pairs()
+        .map_err(|e| anyhow::anyhow!("spec {} container-env: {e}", spec.id))?;
     let mut req = ruscker_core::SpawnRequest::new(&spec.id, image)
         .with_limits(limits)
         .with_volumes(spec.volumes.clone().unwrap_or_default())
-        .with_env(spec.resolved_env_pairs())
+        .with_env(env)
         .with_placement(spec.effective_placement())
         .with_anti_affinity(spec.effective_anti_affinity());
     if let Some(port) = inner_port {
@@ -934,24 +940,31 @@ pub(crate) fn limits_from_spec(spec: &Spec) -> ruscker_core::ResourceLimits {
 /// The password is stored as the literal `${VAR}` (never resolved into
 /// the DB / config in memory — #260), so we interpolate it **here**, at
 /// the point of use, right before a pull. Idempotent: a value with no
-/// `${...}` (or a `docker-registry-credential` flow) is unaffected. If a
-/// referenced env var is unset we keep the literal — the backend's
-/// pull then fails with a clear "still contains `${...}`" error rather
-/// than silently pulling anonymously.
-pub(crate) fn creds_from_spec(spec: &Spec) -> Option<ruscker_core::RegistryCredentials> {
+/// `${...}` (or a `docker-registry-credential` flow) is unaffected.
+///
+/// Returns `Err` with the real cause (`MissingEnvVar { name }`) when the
+/// password references an unset variable, so the spawn fails naming the
+/// missing var (#314). Previously the error was swallowed and the literal
+/// `${VAR}` was left for the backend to detect by scanning for a residual
+/// `${` — a scan that also false-rejected a legitimately-resolved value
+/// containing the literal `${`. `Ok(None)` means "anonymous pull" (no, or
+/// only partial, credentials — partial creds make no sense to Docker).
+pub(crate) fn creds_from_spec(
+    spec: &Spec,
+) -> anyhow::Result<Option<ruscker_core::RegistryCredentials>> {
     let user = spec.docker_registry_username.as_deref().filter(|s| !s.is_empty());
     let pass = spec.docker_registry_password.as_deref().filter(|s| !s.is_empty());
     match (user, pass) {
-        (Some(u), Some(p)) => Some(ruscker_core::RegistryCredentials {
+        (Some(u), Some(p)) => Ok(Some(ruscker_core::RegistryCredentials {
             username: u.to_string(),
-            password: ruscker_config::env::interpolate_value(p).unwrap_or_else(|_| p.to_string()),
+            password: ruscker_config::env::interpolate_value(p)?,
             server_address: spec
                 .docker_registry_domain
                 .as_deref()
                 .filter(|s| !s.is_empty())
                 .map(str::to_string),
-        }),
-        _ => None,
+        })),
+        _ => Ok(None),
     }
 }
 
@@ -967,10 +980,14 @@ pub(crate) fn creds_from_spec(spec: &Spec) -> Option<ruscker_core::RegistryCrede
 ///
 /// Async (unlike `creds_from_spec`) because the DB lookup +
 /// decrypt is I/O. Both spawn paths call this.
+///
+/// `Err` carries the real cause when the inline password references an
+/// unset env var (#314); a DB-store credential is already decrypted so
+/// that branch never errors here.
 pub(crate) async fn resolve_creds(
     state: &AppState,
     spec: &Spec,
-) -> Option<ruscker_core::RegistryCredentials> {
+) -> anyhow::Result<Option<ruscker_core::RegistryCredentials>> {
     if let Some(name) = spec
         .docker_registry_credential
         .as_deref()
@@ -979,7 +996,7 @@ pub(crate) async fn resolve_creds(
         match (state.db.as_ref(), state.master_key.is_configured()) {
             (Some(pool), true) => {
                 match crate::db::credentials::resolve(pool, &state.master_key, name).await {
-                    Ok(Some(c)) => return Some(c),
+                    Ok(Some(c)) => return Ok(Some(c)),
                     Ok(None) => {
                         tracing::warn!(
                             credential = name, spec = %spec.id,
@@ -1503,7 +1520,7 @@ container-image: test:latest
     #[test]
     fn creds_from_spec_returns_none_for_anonymous_spec() {
         let s = fake_spec("x");
-        assert!(creds_from_spec(&s).is_none());
+        assert!(creds_from_spec(&s).unwrap().is_none());
     }
 
     #[test]
@@ -1518,7 +1535,7 @@ docker-registry-password: hunter2
 docker-registry-domain: priv.io
 "#,
         );
-        let c = creds_from_spec(&s).expect("creds present");
+        let c = creds_from_spec(&s).unwrap().expect("creds present");
         assert_eq!(c.username, "bot");
         assert_eq!(c.password, "hunter2");
         assert_eq!(c.server_address.as_deref(), Some("priv.io"));
@@ -1539,9 +1556,29 @@ docker-registry-username: bot
 docker-registry-password: ${RUSCKER_TEST_REG_PW}
 "#,
         );
-        let c = creds_from_spec(&s).expect("creds present");
+        let c = creds_from_spec(&s).unwrap().expect("creds present");
         assert_eq!(c.password, "fromenv", "resolved at use");
         std::env::remove_var("RUSCKER_TEST_REG_PW");
+    }
+
+    #[test]
+    fn creds_from_spec_errors_when_password_env_unset() {
+        // #314: an unset password var is a hard error naming the var, not
+        // a silently-kept `${VAR}` literal for the backend to scan for.
+        let s = spec_yaml(
+            r#"
+id: p
+display-name: P
+container-image: priv.io/app:1
+docker-registry-username: bot
+docker-registry-password: ${RUSCKER_DEFINITELY_UNSET_REG_PW}
+"#,
+        );
+        let err = creds_from_spec(&s).expect_err("unset var must error");
+        assert!(
+            err.to_string().contains("RUSCKER_DEFINITELY_UNSET_REG_PW"),
+            "error names the missing var: {err}"
+        );
     }
 
     #[test]
@@ -1555,7 +1592,7 @@ docker-registry-username: bot
 "#,
         );
         assert!(
-            creds_from_spec(&s).is_none(),
+            creds_from_spec(&s).unwrap().is_none(),
             "half-credentials are no credentials"
         );
     }
@@ -1570,7 +1607,7 @@ container-image: x:1
 docker-registry-password: secret
 "#,
         );
-        assert!(creds_from_spec(&s).is_none());
+        assert!(creds_from_spec(&s).unwrap().is_none());
     }
 
     #[test]
@@ -1586,7 +1623,7 @@ docker-registry-domain: ""
 "#,
         );
         assert!(
-            creds_from_spec(&s).is_none(),
+            creds_from_spec(&s).unwrap().is_none(),
             "empty strings shouldn't authenticate"
         );
     }
@@ -1744,7 +1781,7 @@ docker-registry-username: bot
 docker-registry-password: hunter2
 "#,
         );
-        let c = creds_from_spec(&s).expect("creds present");
+        let c = creds_from_spec(&s).unwrap().expect("creds present");
         assert!(c.server_address.is_none(), "Docker Hub default");
     }
 

--- a/crates/ruscker-admin/src/scaler.rs
+++ b/crates/ruscker-admin/src/scaler.rs
@@ -546,12 +546,17 @@ async fn spawn_one(
 
     let inner_port = spec.effective_inner_port();
 
-    let creds = crate::routes::proxy::resolve_creds(state, spec).await;
+    let creds = crate::routes::proxy::resolve_creds(state, spec).await?;
     let limits = crate::routes::proxy::limits_from_spec(spec);
+    // Resolve `${VAR}` in container-env at the point of use; an unset var
+    // fails the spawn naming it (#314) rather than injecting a literal.
+    let env = spec
+        .resolved_env_pairs()
+        .map_err(|e| anyhow::anyhow!("spec {} container-env: {e}", spec.id))?;
     let mut req = ruscker_core::SpawnRequest::new(&spec.id, image)
         .with_limits(limits)
         .with_volumes(spec.volumes.clone().unwrap_or_default())
-        .with_env(spec.resolved_env_pairs())
+        .with_env(env)
         .with_placement(spec.effective_placement())
         .with_anti_affinity(spec.effective_anti_affinity());
     if let Some(port) = inner_port {

--- a/crates/ruscker-config/src/schema.rs
+++ b/crates/ruscker-config/src/schema.rs
@@ -796,19 +796,22 @@ impl Spec {
     /// `container-env` values are kept as `${VAR}` literals in the
     /// config/DB (#272) — they're only resolved here, right before the
     /// container is created, so an app secret never lands in the DB.
-    /// Idempotent: a value with no `${...}` is unchanged. An unset var
-    /// with no default keeps the literal (the operator should set it).
-    /// Use this on the spawn path; `env_pairs` (raw) is for display.
-    pub fn resolved_env_pairs(&self) -> Vec<String> {
+    /// Idempotent: a value with no `${...}` is unchanged.
+    ///
+    /// Returns the **real cause** when a referenced env var is unset
+    /// (`Error::MissingEnvVar { name }`) instead of silently keeping the
+    /// `${VAR}` literal (#314). The spawn path propagates this so the
+    /// failure names the missing variable, rather than relying on the
+    /// backend scanning the final string for a residual `${` — a scan
+    /// that would also reject a legitimately-resolved value that happens
+    /// to contain the literal `${`. Use this on the spawn path;
+    /// `env_pairs` (raw) is for display.
+    pub fn resolved_env_pairs(&self) -> crate::error::Result<Vec<String>> {
         self.env_pairs()
             .into_iter()
             .map(|kv| match kv.split_once('=') {
-                Some((k, v)) => {
-                    let resolved =
-                        crate::env::interpolate_value(v).unwrap_or_else(|_| v.to_string());
-                    format!("{k}={resolved}")
-                }
-                None => kv,
+                Some((k, v)) => Ok(format!("{k}={}", crate::env::interpolate_value(v)?)),
+                None => Ok(kv),
             })
             .collect()
     }
@@ -1610,7 +1613,7 @@ proxy:
         // the Spec (and thus never the DB on import).
         assert_eq!(spec.env_pairs(), vec!["DB_PASSWORD=${RUSCKER_TEST_DB_PASS}"]);
         // Resolved only at use.
-        assert_eq!(spec.resolved_env_pairs(), vec!["DB_PASSWORD=s3cret"]);
+        assert_eq!(spec.resolved_env_pairs().unwrap(), vec!["DB_PASSWORD=s3cret"]);
         unsafe { std::env::remove_var("RUSCKER_TEST_DB_PASS") };
     }
 

--- a/crates/ruscker-docker/src/lib.rs
+++ b/crates/ruscker-docker/src/lib.rs
@@ -169,19 +169,12 @@ impl LocalDockerBackend {
         let replica_id = ReplicaId::new();
         let inner_port = req.inner_port.unwrap_or(DEFAULT_INNER_PORT);
 
-        // A `container-env` value still carrying `${...}` means its env
-        // var wasn't set — interpolation upstream couldn't resolve it
-        // (#300). Fail clearly instead of injecting a literal `${VAR}`
-        // into the container (which would silently misconfigure the app,
-        // and for a secret would leave a placeholder where a real value
-        // should be). Mirrors the registry-password guard below.
-        if let Some(name) = first_unresolved_env(&req.env) {
-            return Err(CoreError::Backend(format!(
-                "container-env {name} for {} references an unset environment \
-                 variable (value still contains ${{...}})",
-                req.spec_id
-            )));
-        }
+        // `${VAR}` resolution (container-env + registry password) happens
+        // upstream in ruscker-admin, which now fails the spawn naming the
+        // missing variable before we get here (#314). We deliberately do
+        // NOT re-scan `req.env` for a residual `${` — that scan also
+        // false-rejected a legitimately-resolved value that happens to
+        // contain the literal `${` (e.g. a templated JSON config).
 
         // 1. Pull image (idempotent — Docker no-ops when local).
         //    Errors bubble up through the stream-of-events.
@@ -314,19 +307,10 @@ impl LocalDockerBackend {
             platform: platform.unwrap_or("").to_string(),
             ..Default::default()
         };
-        // A password still carrying `${...}` means the env var the spec
-        // referenced wasn't set — interpolation upstream couldn't resolve
-        // it (#273). Fail with a clear message instead of pulling with a
-        // literal `${VAR}` password (which would surface as a confusing
-        // registry-auth error).
-        if let Some(c) = creds {
-            if c.password.contains("${") {
-                return Err(CoreError::Backend(format!(
-                    "registry password for image {image} still contains an unresolved \
-                     ${{VAR}} — is the referenced environment variable set?"
-                )));
-            }
-        }
+        // The registry password's `${VAR}` is resolved upstream in
+        // ruscker-admin, which fails the spawn naming the missing var
+        // (#314); no residual-`${` scan here (it would false-reject a
+        // legitimately-resolved value containing the literal `${`).
         // Convert our backend-neutral creds to bollard's native
         // type only at the pull boundary. `None` keeps the pull
         // anonymous (Docker Hub public images).
@@ -850,17 +834,6 @@ fn state_from_docker(s: Option<&str>) -> ReplicaState {
     }
 }
 
-/// The NAME of the first `container-env` entry (`"NAME=value"`) whose
-/// value still contains a `${...}` placeholder — i.e. an env var that
-/// wasn't set. `None` if every value resolved. Used to fail a spawn
-/// loudly instead of injecting a literal `${VAR}` (#300).
-fn first_unresolved_env(env: &[String]) -> Option<&str> {
-    env.iter().find_map(|kv| {
-        let (name, value) = kv.split_once('=')?;
-        value.contains("${").then_some(name)
-    })
-}
-
 fn backend_err(op: &str, e: bollard::errors::Error) -> CoreError {
     CoreError::Backend(format!("{op}: {e}"))
 }
@@ -896,15 +869,6 @@ fn apply_limits(host_config: &mut HostConfig, limits: &ruscker_core::ResourceLim
 #[cfg(test)]
 mod tests {
     use super::*;
-
-    #[test]
-    fn first_unresolved_env_flags_residual_placeholder() {
-        let ok = vec!["A=1".to_string(), "B=plain".to_string()];
-        assert_eq!(first_unresolved_env(&ok), None);
-        let bad = vec!["A=1".to_string(), "DB_PASSWORD=${DB_PASSWORD}".to_string()];
-        assert_eq!(first_unresolved_env(&bad), Some("DB_PASSWORD"));
-        assert_eq!(first_unresolved_env(&[]), None);
-    }
 
     #[test]
     fn state_from_docker_maps_common_values() {


### PR DESCRIPTION
Closes #314

## Problem
`${VAR}` resolution for `container-env` and the registry password swallowed its error (`unwrap_or_else`), leaving a literal `${VAR}` that the docker backend then detected by **scanning the final string for a residual `${`**. That scan also false-rejected a legitimately-resolved value that happens to contain the literal `${` (e.g. a templated JSON config).

## Fix — propagate the real cause upstream
- `Spec::resolved_env_pairs()` returns `Result<Vec<String>>`, surfacing `MissingEnvVar { name }` instead of keeping the literal.
- `creds_from_spec` / `resolve_creds` return `Result<Option<_>>`, propagating the unset-password cause (the DB-store branch is already decrypted, so it never errors here).
- Both spawn paths (`proxy::spawn_first`, `scaler::spawn_one`) `?` these, failing the spawn with a message **naming the missing variable**.
- Drop the residual-`${` scans from `ruscker-docker`: the `first_unresolved_env` helper + its call + test, and the registry-password `${` check. They can no longer false-positive.

## Verification
- New test `creds_from_spec_errors_when_password_env_unset` asserts the error names the missing var.
- `cargo test -p ruscker-config -p ruscker-admin -p ruscker-docker` → green (226 admin + 66 config + docker).
- `cargo clippy --all-targets -- -D warnings` → clean.
- `./scripts/i18n-check.sh` → key parity OK.

🤖 Generated with [Claude Code](https://claude.com/claude-code)