### PR TITLE
perf(admin): paginate + filter the /admin/media gallery (#317)

### DIFF
--- a/crates/ruscker-admin/assets/i18n/en/landing.ftl
+++ b/crates/ruscker-admin/assets/i18n/en/landing.ftl
@@ -248,6 +248,8 @@ admin-images-uploaded = Image uploaded:
 admin-images-empty = No images yet. Upload the first one above.
 admin-images-delete = Delete
 admin-images-delete-confirm = Delete this image? Specs referencing the filename will fall back to the tinted cover.
+admin-images-search = Search images…
+admin-images-no-match = No images match your search.
 
 # Admin credentials
 admin-creds-title = Registry credentials

--- a/crates/ruscker-admin/assets/i18n/es/landing.ftl
+++ b/crates/ruscker-admin/assets/i18n/es/landing.ftl
@@ -248,6 +248,8 @@ admin-images-uploaded = Imagen subida:
 admin-images-empty = Aún no hay imágenes. Suba la primera arriba.
 admin-images-delete = Eliminar
 admin-images-delete-confirm = ¿Eliminar esta imagen? Las specs que referencian el archivo mostrarán el cover tintado.
+admin-images-search = Buscar imágenes…
+admin-images-no-match = Ninguna imagen coincide con la búsqueda.
 
 # Admin credentials
 admin-creds-title = Credenciales del registry

--- a/crates/ruscker-admin/assets/i18n/fr/landing.ftl
+++ b/crates/ruscker-admin/assets/i18n/fr/landing.ftl
@@ -248,6 +248,8 @@ admin-images-uploaded = Image envoyée :
 admin-images-empty = Aucune image. Envoyez la première ci-dessus.
 admin-images-delete = Supprimer
 admin-images-delete-confirm = Supprimer cette image ? Les specs qui référencent le fichier afficheront le cover teinté.
+admin-images-search = Rechercher des images…
+admin-images-no-match = Aucune image ne correspond à la recherche.
 
 # Admin credentials
 admin-creds-title = Identifiants registry

--- a/crates/ruscker-admin/assets/i18n/pt/landing.ftl
+++ b/crates/ruscker-admin/assets/i18n/pt/landing.ftl
@@ -252,6 +252,8 @@ admin-images-uploaded = Imagem enviada:
 admin-images-empty = Nenhuma imagem ainda. Envie a primeira acima.
 admin-images-delete = Excluir
 admin-images-delete-confirm = Excluir essa imagem? Specs que referenciam o arquivo passarão a mostrar o cover tintado.
+admin-images-search = Buscar imagens…
+admin-images-no-match = Nenhuma imagem corresponde à busca.
 
 # Admin credentials
 admin-creds-title = Credenciais do registry

--- a/crates/ruscker-admin/src/routes/admin/images.rs
+++ b/crates/ruscker-admin/src/routes/admin/images.rs
@@ -84,6 +84,36 @@ impl<'a> ImagesPage<'a> {
             format!("{:.1} MB", b as f64 / 1024.0 / 1024.0)
         }
     }
+
+    /// The gallery as a JSON array, seeding the Alpine component that
+    /// renders only a page of tiles at a time + filters by filename
+    /// (#317). Same "data in `x-data`, paginate client-side" shape as
+    /// the spec-form logo picker (#293) — the whole list is small
+    /// metadata (no blobs), so paging/filtering is instant in the
+    /// browser and the DOM + thumbnail fetches stay bounded regardless
+    /// of library size. `ImageMeta` isn't `Serialize`, so we build the
+    /// objects here; `size` is pre-formatted so the template needs no
+    /// per-row Rust helper. A `dims` string is `""` when unknown.
+    fn images_json(&self) -> String {
+        let arr: Vec<serde_json::Value> = self
+            .images
+            .iter()
+            .map(|img| {
+                let dims = match (img.width, img.height) {
+                    (Some(w), Some(h)) => format!("{w}×{h}"),
+                    _ => String::new(),
+                };
+                serde_json::json!({
+                    "id": img.id,
+                    "filename": img.filename,
+                    "mime": img.mime_type,
+                    "size": self.fmt_size(&img.size_bytes),
+                    "dims": dims,
+                })
+            })
+            .collect();
+        serde_json::to_string(&arr).unwrap_or_else(|_| "[]".into())
+    }
 }
 
 async fn index(

--- a/crates/ruscker-admin/templates/admin/images.html
+++ b/crates/ruscker-admin/templates/admin/images.html
@@ -48,33 +48,83 @@
     {{ self.t("admin-images-empty") }}
   </div>
 {% else %}
-  <section class="image-gallery">
-    {% for img in images %}
-      <div class="image-tile">
-        <a href="/assets/img/{{ img.filename }}" target="_blank" class="image-tile-frame"
-           title="{{ img.filename }}">
-          <img src="/assets/img/{{ img.filename }}?thumb" alt="" loading="lazy">
-        </a>
-        <div class="image-tile-meta">
-          <div class="image-tile-name" title="{{ img.filename }}">{{ img.filename }}</div>
-          <div class="image-tile-sub">
-            <span>{{ self.fmt_size(img.size_bytes) }}</span>
-            <span class="opacity-60">·</span>
-            <span>{{ img.mime_type }}</span>
-            {% match img.width %}{% when Some with (w) %}{% match img.height %}{% when Some with (h) %}
-              <span class="opacity-60">·</span><span>{{ w }}×{{ h }}</span>
-            {% when None %}{% endmatch %}{% when None %}{% endmatch %}
+  {# Client-side filter + "show more" so a large library doesn't render
+     every tile (and fire a thumbnail request each) on load (#317). The
+     metadata is small and already in memory; paging/filtering is instant.
+     Mirrors the spec-form logo picker (#293). #}
+  <div x-data="ruscker.mediaGallery({{ self.images_json()|safe }})" x-cloak>
+    <div class="mb-4">
+      <input type="search" x-model="q"
+             placeholder="{{ self.t("admin-images-search") }}"
+             class="admin-input w-full max-w-xs text-sm"
+             style="padding:6px 10px">
+    </div>
+
+    <section class="image-gallery">
+      <template x-for="img in filtered().slice(0, shown)" :key="img.id">
+        <div class="image-tile">
+          <a :href="assetUrl('/assets/img/' + img.filename)" target="_blank"
+             class="image-tile-frame" :title="img.filename">
+            <img :src="assetUrl('/assets/img/' + img.filename) + '?thumb'" alt="" loading="lazy">
+          </a>
+          <div class="image-tile-meta">
+            <div class="image-tile-name" :title="img.filename" x-text="img.filename"></div>
+            <div class="image-tile-sub">
+              <span x-text="img.size"></span>
+              <span class="opacity-60">·</span>
+              <span x-text="img.mime"></span>
+              <template x-if="img.dims">
+                <span><span class="opacity-60">·</span><span x-text="img.dims"></span></span>
+              </template>
+            </div>
           </div>
+          <form method="post" :action="assetUrl('/admin/media/' + img.id + '/delete')"
+                onsubmit="return confirm('{{ self.t("admin-images-delete-confirm") }}');">
+            <button type="submit" class="image-tile-delete" title="{{ self.t("admin-images-delete") }}">
+              <i class="ti ti-trash" aria-hidden="true"></i>
+            </button>
+          </form>
         </div>
-        <form method="post" action="/admin/media/{{ img.id }}/delete"
-              onsubmit="return confirm('{{ self.t("admin-images-delete-confirm") }}');">
-          <button type="submit" class="image-tile-delete" title="{{ self.t("admin-images-delete") }}">
-            <i class="ti ti-trash" aria-hidden="true"></i>
-          </button>
-        </form>
-      </div>
-    {% endfor %}
-  </section>
+      </template>
+    </section>
+
+    {# Empty filter result #}
+    <div x-show="filtered().length === 0"
+         class="card-surface rounded-lg p-8 text-center text-sm text-[color:var(--text-muted)] mt-2">
+      {{ self.t("admin-images-no-match") }}
+    </div>
+
+    {# "Show more (N)" — reveals the next page client-side #}
+    <div class="mt-4 text-center" x-show="filtered().length > shown">
+      <button type="button" @click="shown += page" class="admin-nav-link text-xs"
+              x-text="'{{ self.t("spec-form-gallery-more") }}' + ' (' + (filtered().length - shown) + ')'"></button>
+    </div>
+  </div>
+
+  <script>
+  window.ruscker = window.ruscker || {};
+  // Media gallery: filter by filename + paginate render (#317). The full
+  // metadata list (no blobs) is seeded from `x-data`; we only ever render
+  // `shown` of the filtered set, so the DOM + thumbnail fetches stay
+  // bounded regardless of library size.
+  window.ruscker.mediaGallery = (items) => ({
+    all: Array.isArray(items) ? items : [],
+    q: '',
+    shown: 24,
+    page: 24,
+    filtered() {
+      const t = this.q.trim().toLowerCase();
+      return t ? this.all.filter((i) => i.filename.toLowerCase().includes(t)) : this.all;
+    },
+    // Prefix the base path on a root-absolute asset/action URL so the
+    // gallery works under `--base-path /box` (#270) — these URLs are
+    // built at runtime, so the static-HTML response rewriter never sees
+    // them. Stored values stay base-agnostic.
+    assetUrl(p) {
+      return p && p.charAt(0) === '/' ? (window.RUSCKER_BASE || '') + p : (p || '');
+    },
+  });
+  </script>
 {% endif %}
 
 {% endblock %}


### PR DESCRIPTION
Closes #317

## Problem
`/admin/media` rendered one `<img>` (a thumbnail request) per image with no limit — a large library meant a heavy DOM and a fetch per tile on every load. The spec-form pickers were already capped with "show more" (#293), but this page was missed (`db::images::list_all` then render every tile).

## Fix — client-side page + filter (mirrors #293)
- `ImagesPage::images_json()` serializes the blob-free metadata to JSON (size pre-formatted; `ImageMeta` isn't `Serialize` so built via `serde_json::json!`).
- The gallery is now an Alpine component rendering only `filtered().slice(0, shown)` tiles (24) with a "Show more" button plus a filename search box. The metadata is small and already in memory, so filtering/paging is instant and the DOM + thumbnail fetches stay bounded regardless of library size.
- Delete actions go through `assetUrl()` (base-path safe) since they're built at runtime.

## i18n
New keys `admin-images-search` + `admin-images-no-match` across all 4 locales; the button reuses `spec-form-gallery-more`.

## Verification
- `cargo test -p ruscker-admin` -> green (225 unit + integration).
- `cargo clippy -p ruscker-admin --all-targets -- -D warnings` -> clean.
- `./scripts/i18n-check.sh` -> key parity OK.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
