### PR TITLE
fix(base-path): prefix runtime/landing URLs left bare after the #294 rewrite drop

### DIFF
--- a/crates/ruscker-admin/src/routes/landing.rs
+++ b/crates/ruscker-admin/src/routes/landing.rs
@@ -134,7 +134,7 @@ async fn index(
     let mut cards: Vec<CardCtx<'_>> = owned_specs
         .iter()
         .filter(|spec| spec.access_allows(is_admin, username.as_deref(), &groups))
-        .map(CardCtx::from_spec)
+        .map(|spec| CardCtx::from_spec(spec, &state.base_path))
         .collect();
     sort_by_recent(&mut cards);
     let type_chips = build_type_chips(&cards);

--- a/crates/ruscker-admin/src/routes/proxy.rs
+++ b/crates/ruscker-admin/src/routes/proxy.rs
@@ -309,7 +309,13 @@ async fn forward(
             // is sent to log in; everyone else (and all API clients) get
             // a flat 403 (CORS-wrapped for the `/api/` family).
             if route_prefix == APP_PREFIX && session.is_none() {
-                return Redirect::to("/admin/login").into_response();
+                // Proxy routes are not wrapped by the chrome's
+                // `prefix_base_path` Location-rewriter, so build the
+                // base-prefixed login URL ourselves (#294) — otherwise a
+                // `/box/app/<spec>` visitor is bounced to a `/admin/login`
+                // that 404s outside the mount.
+                return Redirect::to(&format!("{}/admin/login", state.base_path))
+                    .into_response();
             }
             return with_cors(
                 (StatusCode::FORBIDDEN, "access denied\n").into_response(),

--- a/crates/ruscker-admin/src/view_model.rs
+++ b/crates/ruscker-admin/src/view_model.rs
@@ -198,7 +198,10 @@ pub struct CardCtx<'a> {
     /// verbatim from `template-properties.subject` and rendered as-is
     /// in the UI — operators choose their own taxonomy.
     pub subject: Option<&'a str>,
-    pub logo: Option<&'a str>,
+    /// Card logo URL. Stored base-agnostic; a root-absolute value
+    /// (e.g. `/assets/img/x.png`) is prefixed with the portal base
+    /// path at construction (#294) so it resolves under `--base-path`.
+    pub logo: Option<String>,
     /// Optional CSS background for the card cover, read verbatim
     /// from `template-properties.cover` (a solid color or a
     /// `linear-/radial-gradient(...)`). When `None`, the card
@@ -206,8 +209,9 @@ pub struct CardCtx<'a> {
     /// into a `style="background: …"` — the browser fail-softs on
     /// invalid CSS, and the value round-trips through YAML/export
     /// untouched. (Not server-validated, same policy as
-    /// `landing_customization.header_bg`.)
-    pub cover: Option<&'a str>,
+    /// `landing_customization.header_bg`.) Any embedded
+    /// `url(/assets/…)` is base-prefixed at construction (#294).
+    pub cover: Option<String>,
     pub updated_raw: Option<&'a str>,
     /// "DD/MM" — short form used in the meta row.
     pub updated_short: Option<String>,
@@ -220,7 +224,12 @@ pub struct CardCtx<'a> {
 }
 
 impl<'a> CardCtx<'a> {
-    pub fn from_spec(spec: &'a Spec) -> Self {
+    /// Build a card view-model. `base` is the portal base path (`""`
+    /// or e.g. `/box`); root-absolute asset URLs in `href`/`logo`/
+    /// `cover` are prefixed with it so the landing renders correct
+    /// links under `--base-path` (the per-request HTML body rewriter
+    /// was removed in #294, so prefixing happens at construction now).
+    pub fn from_spec(spec: &'a Spec, base: &str) -> Self {
         let kind = spec.kind();
         let display_type = DisplayType::from_spec(spec);
         let tp = &spec.template_properties;
@@ -230,17 +239,23 @@ impl<'a> CardCtx<'a> {
             .unwrap_or(false);
         let active = tp.is_active();
         let subject = tp.get_str("subject");
-        let logo = tp.get_str("logo");
+        let logo = tp.get_str("logo").map(|l| prefix_asset_url(l, base));
         // Empty string ⇒ treat as unset so the kind-tint fallback
         // kicks in rather than rendering `background: ;`.
-        let cover = tp.get_str("cover").filter(|s| !s.trim().is_empty());
+        let cover = tp
+            .get_str("cover")
+            .filter(|s| !s.trim().is_empty())
+            .map(|c| prefix_css_asset_urls(c, base));
         let updated_raw = tp.get_str("updated");
         let updated_date = updated_raw.and_then(parse_dmy);
         let updated_short = updated_date.map(|d| d.format("%d/%m").to_string());
         let status = compute_status(updated_date, Utc::now().date_naive());
         let href = match kind {
+            // External links are operator-authored absolute URLs — never
+            // base-prefixed. Containerized specs route under the portal,
+            // so their `/app/<id>/` path must carry the base path (#294).
             SpecKind::External => tp.get_str("link").unwrap_or("#").to_string(),
-            _ => format!("/app/{}/", spec.id),
+            _ => format!("{base}/app/{}/", spec.id),
         };
         Self {
             id: &spec.id,
@@ -259,6 +274,36 @@ impl<'a> CardCtx<'a> {
             href,
         }
     }
+}
+
+/// Prefix the portal `base` path onto a root-absolute asset URL
+/// (`/assets/img/x` → `/box/assets/img/x`). A full URL (`https://…`),
+/// an anchor, or any non-root-absolute value is returned unchanged.
+/// Mirrors the client-side `assetUrl` helper used by the admin pickers
+/// — the stored value stays base-agnostic; only the rendered URL gets
+/// the prefix (#294/#270).
+fn prefix_asset_url(value: &str, base: &str) -> String {
+    if base.is_empty() || !value.starts_with('/') {
+        value.to_string()
+    } else {
+        format!("{base}{value}")
+    }
+}
+
+/// Prefix the portal `base` path onto root-absolute `url(/assets/…)`
+/// targets embedded in a CSS value (the card `cover` may be
+/// `url('/assets/img/x.png')`). Solid colors / gradients pass through
+/// untouched. Mirrors the client-side `coverStyle` helper exactly —
+/// only `/assets/` URLs are rewritten, so a protocol-relative
+/// `url(//cdn/…)` is left alone (#294/#270).
+fn prefix_css_asset_urls(value: &str, base: &str) -> String {
+    if base.is_empty() {
+        return value.to_string();
+    }
+    value
+        .replace("url(/assets/", &format!("url({base}/assets/"))
+        .replace("url('/assets/", &format!("url('{base}/assets/"))
+        .replace("url(\"/assets/", &format!("url(\"{base}/assets/"))
 }
 
 /// Parse the operator-authored `DD/MM/YYYY` form used in the SEPE
@@ -436,14 +481,17 @@ mod tests {
     #[test]
     fn card_cover_read_from_template_properties() {
         let spec = spec_with_tp("  cover: \"linear-gradient(135deg, #0f6e56, #5dcaa5)\"\n");
-        let card = CardCtx::from_spec(&spec);
-        assert_eq!(card.cover, Some("linear-gradient(135deg, #0f6e56, #5dcaa5)"));
+        let card = CardCtx::from_spec(&spec, "");
+        assert_eq!(
+            card.cover.as_deref(),
+            Some("linear-gradient(135deg, #0f6e56, #5dcaa5)")
+        );
     }
 
     #[test]
     fn card_cover_absent_falls_back_to_tint() {
         let spec = spec_with_tp("  subject: Saúde\n");
-        let card = CardCtx::from_spec(&spec);
+        let card = CardCtx::from_spec(&spec, "");
         assert_eq!(card.cover, None);
     }
 
@@ -452,7 +500,66 @@ mod tests {
         // Empty cover must not render `background: ;` — it should
         // fall through to the kind tint.
         let spec = spec_with_tp("  cover: \"  \"\n");
-        let card = CardCtx::from_spec(&spec);
+        let card = CardCtx::from_spec(&spec, "");
         assert_eq!(card.cover, None);
+    }
+
+    #[test]
+    fn card_urls_prefixed_under_base_path() {
+        // #294: with the per-request HTML body rewriter gone, root-
+        // absolute URLs must be base-prefixed at construction. The href
+        // of a containerized spec, a root-absolute logo, and a
+        // `url(/assets/…)` cover all carry `/box`; external links and
+        // gradients are left untouched.
+        let spec = spec_with_tp(
+            "  logo: \"/assets/img/logo.png\"\n  cover: \"url('/assets/img/c.png')\"\n",
+        );
+        let card = CardCtx::from_spec(&spec, "/box");
+        assert_eq!(card.href, "/box/app/x/");
+        assert_eq!(card.logo.as_deref(), Some("/box/assets/img/logo.png"));
+        assert_eq!(card.cover.as_deref(), Some("url('/box/assets/img/c.png')"));
+
+        // Root deploy (no base) leaves everything bare.
+        let card0 = CardCtx::from_spec(&spec, "");
+        assert_eq!(card0.href, "/app/x/");
+        assert_eq!(card0.logo.as_deref(), Some("/assets/img/logo.png"));
+    }
+
+    #[test]
+    fn prefix_asset_url_only_touches_root_absolute() {
+        assert_eq!(prefix_asset_url("/assets/x.png", "/box"), "/box/assets/x.png");
+        // Full URLs and anchors pass through untouched.
+        assert_eq!(
+            prefix_asset_url("https://cdn/x.png", "/box"),
+            "https://cdn/x.png"
+        );
+        assert_eq!(prefix_asset_url("#", "/box"), "#");
+        // Empty base is a no-op (root deploy).
+        assert_eq!(prefix_asset_url("/assets/x.png", ""), "/assets/x.png");
+    }
+
+    #[test]
+    fn prefix_css_asset_urls_handles_quote_variants_and_leaves_others() {
+        assert_eq!(
+            prefix_css_asset_urls("url(/assets/a.png)", "/box"),
+            "url(/box/assets/a.png)"
+        );
+        assert_eq!(
+            prefix_css_asset_urls("url('/assets/a.png')", "/box"),
+            "url('/box/assets/a.png')"
+        );
+        assert_eq!(
+            prefix_css_asset_urls("url(\"/assets/a.png\")", "/box"),
+            "url(\"/box/assets/a.png\")"
+        );
+        // Gradients and protocol-relative CDNs are left alone.
+        assert_eq!(
+            prefix_css_asset_urls("linear-gradient(#000, #fff)", "/box"),
+            "linear-gradient(#000, #fff)"
+        );
+        assert_eq!(
+            prefix_css_asset_urls("url(//cdn/a.png)", "/box"),
+            "url(//cdn/a.png)"
+        );
     }
 }

--- a/crates/ruscker-admin/templates/admin/dashboard.html
+++ b/crates/ruscker-admin/templates/admin/dashboard.html
@@ -393,7 +393,7 @@
   } catch (_) { /* initial snapshot embedding is best-effort */ }
 
   if (!window.EventSource) return;
-  var es = new EventSource('/admin/dashboard/events');
+  var es = new EventSource((window.RUSCKER_BASE || '') + '/admin/dashboard/events');
   es.onmessage = function (e) {
     try { apply(JSON.parse(e.data)); } catch (_) { /* ignore */ }
   };

--- a/crates/ruscker-admin/templates/admin/logs.html
+++ b/crates/ruscker-admin/templates/admin/logs.html
@@ -93,7 +93,7 @@
 
   function startFollow() {
     if (!window.EventSource || es) return;
-    es = new EventSource('/admin/dashboard/logs/' + encodeURIComponent(replicaId) + '/stream');
+    es = new EventSource((window.RUSCKER_BASE || '') + '/admin/dashboard/logs/' + encodeURIComponent(replicaId) + '/stream');
     es.onmessage = function (e) { appendLine(e.data); };
     es.onerror = function () {
       // The stream closed (container stopped, or network).

--- a/crates/ruscker-admin/templates/admin/process_logs.html
+++ b/crates/ruscker-admin/templates/admin/process_logs.html
@@ -50,7 +50,7 @@
     const box = document.getElementById('proclog');
     const nearBottom = () => box.scrollHeight - box.scrollTop - box.clientHeight < 48;
     box.scrollTop = box.scrollHeight; // start pinned to the newest line
-    const es = new EventSource('/admin/logs/stream');
+    const es = new EventSource((window.RUSCKER_BASE || '') + '/admin/logs/stream');
     es.onmessage = (e) => {
       const stick = nearBottom();
       // Append as text nodes — never parse log content as HTML.


### PR DESCRIPTION
## Summary

Follow-up to #294, which removed the per-request HTML body rewriter under `--base-path`. With that gone, every internal URL must carry the base path at **render time** (templates emit `{{ base }}/…`) or at **runtime** (`window.RUSCKER_BASE`). Several paths were missed and 404 under a subpath mount (e.g. `/box`):

- **Three admin `EventSource` streams** used a root-absolute URL → dashboard live updates and the process/replica log *follow* all 404'd under a subpath. Now prefixed with `window.RUSCKER_BASE`.
  - `dashboard.html` `/admin/dashboard/events`
  - `process_logs.html` `/admin/logs/stream`
  - `logs.html` `/admin/dashboard/logs/<id>/stream`
- **Landing card links** (`/app/<spec>/`), **card logos**, and **`url(/assets/…)` covers** rendered bare → every app card and its artwork 404'd under `/box`. Now prefixed at `CardCtx` construction (owned strings), mirroring the client-side `assetUrl`/`coverStyle` helpers. External links and gradients are left untouched.
- **Proxy access-denied login redirect** (`/admin/login`) is not wrapped by the chrome's `prefix_base_path` Location-rewriter → an anonymous visitor to `/box/app/<spec>` was bounced outside the mount. Now builds the base-prefixed URL explicitly.

## Tests

New unit tests for the prefix helpers (`prefix_asset_url`, `prefix_css_asset_urls`) and a card-under-base-path case. Full `ruscker-admin` suite + `clippy -D warnings` green.

## Note

These bugs only manifest under `--base-path`, so this is the kind of thing the **manual `/box` click-through before cutting v0.1.18** is meant to catch.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
