### PR TITLE
fix(sessions): purge a replica's sessions when it leaves the registry (#324)

### DIFF
--- a/crates/ruscker-admin/src/routes/admin/dashboard.rs
+++ b/crates/ruscker-admin/src/routes/admin/dashboard.rs
@@ -636,6 +636,9 @@ async fn stop_replica(
         // already gone, and we don't want a phantom row.
     }
     state.replicas.write().await.remove(&rid);
+    // Drop the replica's sessions too, or `len()` stays inflated until
+    // the idle sweep (forever under `heartbeat-timeout: -1`) (#324).
+    state.sessions.drop_replica(&rid).await;
     tracing::info!(replica = %replica_id, "replica stopped via dashboard");
     Redirect::to("/admin/dashboard").into_response()
 }
@@ -683,6 +686,9 @@ async fn restart_replica(
         tracing::warn!(replica = %replica_id, error = ?e, "restart: stop phase failed");
     }
     state.replicas.write().await.remove(&rid);
+    // The old replica's sessions are dead; purge them so the fresh
+    // replica's sticky sessions aren't shadowed by ghost counts (#324).
+    state.sessions.drop_replica(&rid).await;
 
     if let Err(e) = crate::scaler::spawn_replica(&state, &spec).await {
         tracing::error!(spec = %spec.id, error = ?e, "restart: spawn phase failed");

--- a/crates/ruscker-admin/src/scaler.rs
+++ b/crates/ruscker-admin/src/scaler.rs
@@ -500,6 +500,10 @@ async fn stop_one(
         .await
         .map_err(|e| anyhow::anyhow!("backend stop: {e}"))?;
     state.replicas.write().await.remove(replica_id);
+    // Purge the stopped replica's sessions so `len()` doesn't stay
+    // inflated until the idle sweep (and forever under
+    // `heartbeat-timeout: -1`) — see SessionStore::drop_replica (#324).
+    state.sessions.drop_replica(replica_id).await;
     Ok(())
 }
 

--- a/crates/ruscker-admin/src/sessions.rs
+++ b/crates/ruscker-admin/src/sessions.rs
@@ -99,6 +99,20 @@ pub trait SessionStore: Send + Sync {
         is_leader: bool,
     ) -> usize;
 
+    /// Purge every tracked session pointing at `replica_id`. Called when
+    /// a replica leaves the registry (operator stop/restart, scaler
+    /// scale-down). Without it the session entries linger until the idle
+    /// sweep expires them — inflating `len()` for up to one
+    /// `heartbeat-timeout`, and **forever** when a spec sets
+    /// `heartbeat-timeout: -1` (the never-expire Shiny idiom), which
+    /// stalls graceful shutdown until the watchdog `process::exit`.
+    /// Returns how many entries were removed.
+    ///
+    /// The registry counter is intentionally not touched here: the caller
+    /// removes the replica (and its `sessions_active`) from the registry
+    /// around this call, so there is nothing left to decrement.
+    async fn drop_replica(&self, replica_id: &ReplicaId) -> usize;
+
     /// Number of tracked sessions (used by graceful-shutdown drain and
     /// the dashboard/metrics).
     fn len(&self) -> usize;
@@ -238,6 +252,23 @@ impl SessionStore for InMemorySessionStore {
         n
     }
 
+    /// Purge every session entry pointing at `replica_id`. Collects the
+    /// matching keys first (so no DashMap shard guard is held across the
+    /// removals) then drops them. No registry interaction — see the trait
+    /// doc.
+    async fn drop_replica(&self, replica_id: &ReplicaId) -> usize {
+        let victims: Vec<Uuid> = self
+            .sessions
+            .iter()
+            .filter(|kv| &kv.value().replica_id == replica_id)
+            .map(|kv| *kv.key())
+            .collect();
+        for sid in &victims {
+            self.sessions.remove(sid);
+        }
+        victims.len()
+    }
+
     /// Number of tracked sessions. For introspection / tests.
     fn len(&self) -> usize {
         self.sessions.len()
@@ -346,6 +377,37 @@ mod tests {
         assert_eq!(evicted, 1);
         assert!(store.is_empty());
         assert_eq!(reg.read().await.replicas_of("alpha")[0].sessions_active, 0);
+    }
+
+    #[tokio::test]
+    async fn drop_replica_purges_only_that_replicas_sessions() {
+        // #324: stopping/restarting a replica must purge its sessions so
+        // `len()` doesn't stay inflated until the idle sweep — fatal with
+        // `heartbeat-timeout: -1`, where the sweep never runs.
+        let reg = Arc::new(RwLock::new(ReplicaRegistry::new()));
+        let ra = fake_replica("alpha");
+        let rb = fake_replica("beta");
+        let (rid_a, rid_b) = (ra.id.clone(), rb.id.clone());
+        reg.write().await.add(ra);
+        reg.write().await.add(rb);
+        let store = InMemorySessionStore::new();
+
+        // Two sessions on A, one on B.
+        for spec_rid in [("alpha", &rid_a), ("alpha", &rid_a), ("beta", &rid_b)] {
+            store
+                .touch_or_register(&reg, Uuid::new_v4(), spec_rid.0, spec_rid.1)
+                .await;
+        }
+        assert_eq!(store.len(), 3);
+
+        // Drop A: its two sessions go, B's one stays.
+        let removed = store.drop_replica(&rid_a).await;
+        assert_eq!(removed, 2);
+        assert_eq!(store.len(), 1);
+
+        // Idempotent: dropping again removes nothing.
+        assert_eq!(store.drop_replica(&rid_a).await, 0);
+        assert_eq!(store.len(), 1);
     }
 
     #[tokio::test]

--- a/crates/ruscker-admin/src/sessions_pg.rs
+++ b/crates/ruscker-admin/src/sessions_pg.rs
@@ -366,6 +366,39 @@ impl SessionStore for PostgresSessionStore {
         }
     }
 
+    /// Delete every shared row for `replica_id`. A stopped replica's
+    /// container is gone, so its sessions are dead cluster-wide — this is
+    /// a definitive removal, not the idle-sweep race that #159 leader-
+    /// gates, so any node may run it. Refreshes this node's cached
+    /// `len()` from the table afterwards (the deleted rows may belong to
+    /// any instance, so we re-derive rather than guess a delta).
+    async fn drop_replica(&self, replica_id: &ReplicaId) -> usize {
+        let res = sqlx::query("DELETE FROM proxy_sessions WHERE replica_id = $1")
+            .bind(replica_id.0)
+            .execute(&self.pool)
+            .await;
+        let removed = match res {
+            Ok(r) => r.rows_affected() as usize,
+            Err(e) => {
+                error!(error = %e, "postgres drop_replica failed");
+                return 0;
+            }
+        };
+        // Best-effort refresh of this node's cached count; a transient
+        // failure just leaves the next sweep to reconcile it.
+        if let Ok(row) =
+            sqlx::query("SELECT count(*)::bigint AS n FROM proxy_sessions WHERE instance_id = $1")
+                .bind(self.instance_id)
+                .fetch_one(&self.pool)
+                .await
+        {
+            if let Ok(mine) = row.try_get::<i64, _>("n") {
+                self.local_len.store(mine.max(0) as usize, Ordering::Relaxed);
+            }
+        }
+        removed
+    }
+
     fn len(&self) -> usize {
         self.local_len.load(Ordering::Relaxed)
     }


### PR DESCRIPTION
Closes #324.

## Problem

Stopping or restarting a replica (operator action, or scaler scale-down) removed it from the `ReplicaRegistry` but left its entries in the `SessionStore`. They lingered until the idle sweep expired them, so `SessionTracker::len()` — which drives the **graceful-shutdown drain** and the dashboard "tracked sessions" — overcounted for up to one `heartbeat-timeout` after every stop.

With `heartbeat-timeout: -1` (the never-expire Shiny idiom) the orphans were **never** swept, so graceful shutdown could only ever end via the `grace + 5s` watchdog `process::exit`.

## Fix

- New trait method `SessionStore::drop_replica(&ReplicaId) -> usize`, called right after the registry `remove` in:
  - `scaler::stop_one` (scale-down)
  - dashboard `stop_replica`
  - dashboard `restart_replica`
- **In-memory store**: purges the matching DashMap entries (collects keys first, no shard guard held across removals).
- **Postgres store**: `DELETE … WHERE replica_id = $1` — *not* leader-gated, because a stopped container's rows are dead cluster-wide (this is a definitive removal, unlike the idle-sweep race #159 leader-gates) — then re-derives this node's cached `len()`.
- The registry counter is intentionally not touched: the caller already removed the replica and its `sessions_active`.

## Tests

`drop_replica_purges_only_that_replicas_sessions` — two sessions on replica A, one on B; dropping A removes exactly its two and is idempotent. Full `ruscker-admin` suite + `clippy -D warnings` green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
