### PR TITLE
fix(docker): forget a container's metrics baseline on stop (#325)

### DIFF
--- a/crates/ruscker-docker/src/lib.rs
+++ b/crates/ruscker-docker/src/lib.rs
@@ -447,6 +447,10 @@ impl ContainerBackend for LocalDockerBackend {
             )
             .await
             .map_err(|e| backend_err("remove container", e))?;
+        // Drop the container's CPU-delta baseline so `prev_stats` doesn't
+        // accumulate a dead entry per recycled container over a long-
+        // lived deployment (#325). The hook existed but was never called.
+        self.forget_metrics(&container_id);
         Ok(())
     }
 
@@ -1011,10 +1015,26 @@ mod tests {
         let listed = backend.list().await.expect("list");
         assert!(listed.iter().any(|r| r.id == replica.id));
 
+        // Record a metrics sample so the CPU-delta baseline lands in
+        // `prev_stats`, then assert `stop()` clears it (#325) — otherwise
+        // the map grows by one dead entry per recycled container.
+        let _ = backend
+            .metrics_for_container(&replica.container_id)
+            .await
+            .expect("metrics");
+        assert!(
+            backend.prev_stats.contains_key(&replica.container_id),
+            "metrics_for_container should seed prev_stats"
+        );
+
         // Clean up.
         backend.stop(&replica.id).await.expect("stop");
         let after = backend.list().await.expect("list after stop");
         assert!(!after.iter().any(|r| r.id == replica.id));
+        assert!(
+            !backend.prev_stats.contains_key(&replica.container_id),
+            "stop() must forget the container's metrics baseline (#325)"
+        );
     }
 
     /// `container-env` / `container-cmd` smoke: spawn with both set and


### PR DESCRIPTION
Closes #325.

## Problem

`LocalDockerBackend::forget_metrics(container_id)` exists specifically so the `prev_stats` CPU-delta `DashMap` "doesn't grow without bound across long-lived deployments" (its own doc) — but **nothing ever called it**. `stop()` removed the container without clearing its entry.

A `min-replicas: 1` spec whose container is recycled every few minutes (scaler scale-down/up, operator restart) accumulated one dead `prev_stats` entry per recycle, forever.

## Fix

Call `self.forget_metrics(&container_id)` at the end of `stop()`. This also covers `MultiHostDockerBackend`, whose `stop` routes to the owning host's `LocalDockerBackend::stop`.

The admin-side `MetricsCache` already self-prunes each tick (`replace` retains only ids present in the current registry snapshot), so only the backend map needed wiring.

## Tests

Extended the `docker-it` `spawn_list_stop_against_real_docker` test to seed `prev_stats` via `metrics_for_container`, then assert `stop()` clears it. **Ran for real against a local Docker daemon — green.** Standard (non-docker) suite + `clippy -D warnings` (incl. `--features docker-it`) also green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)