### PR TITLE
feat(validate): flag unenforced scaling knobs in --strict-compat (#326, phase 1)

### DIFF
--- a/crates/ruscker-config/src/validate.rs
+++ b/crates/ruscker-config/src/validate.rs
@@ -234,6 +234,44 @@ const UNSUPPORTED_SPEC_FIELDS: &[(&str, &str)] = &[
     // NOTE: per-spec env/cmd injection IS now supported — map your
     // ShinyProxy `container-env` / `container-cmd` straight across. They
     // are intentionally absent from this ignored-fields list.
+    //
+    // Scaling/lifecycle knobs (#326): these parse, round-trip, and are
+    // editable in the admin form, but the scaler does NOT yet consume
+    // them — it scales on seat saturation (`sessions_active` vs
+    // `sessions_max`) with built-in grace ticks. Flag them so a migrating
+    // operator isn't misled into thinking a set value takes effect.
+    (
+        "scale-up-threshold",
+        "autoscaling threshold not enforced — scaler scales on seat saturation; tracked in #326",
+    ),
+    (
+        "scale-down-threshold",
+        "autoscaling threshold not enforced — scaler scales on seat saturation; tracked in #326",
+    ),
+    (
+        "scale-down-grace",
+        "scale-down grace not honoured — a fixed cooldown is used instead; tracked in #326",
+    ),
+    (
+        "drain-timeout",
+        "per-spec drain timeout not honoured — `proxy.shutdown-grace-ms` applies globally; tracked in #326",
+    ),
+    (
+        "concurrent-requests-per-replica",
+        "request-based concurrency limit not enforced — capacity is seat-based; tracked in #326",
+    ),
+    (
+        "max-lifetime",
+        "max container lifetime not enforced — replicas are reaped by idle, not age; tracked in #326",
+    ),
+    (
+        "container-lifetime",
+        "max container lifetime not enforced — replicas are reaped by idle, not age; tracked in #326",
+    ),
+    (
+        "stop-on-logout",
+        "stop-on-logout not implemented — sessions end via heartbeat-timeout; tracked in #326",
+    ),
 ];
 
 /// Top-level `proxy.*` keys that are unsupported.
@@ -935,6 +973,43 @@ proxy:
             fields.contains(&"kubernetes-pod-patches"),
             "fields: {fields:?}"
         );
+    }
+
+    #[test]
+    fn compat_scan_flags_unenforced_scaling_knobs() {
+        // #326: these parse + round-trip + are form-editable but the
+        // scaler never consumes them, so strict-compat must surface them
+        // as accepted-but-not-enforced (so a migrating operator isn't
+        // misled). A clean spec (no such knobs) stays quiet.
+        let yaml = "\
+proxy:
+  specs:
+  - id: scaled
+    container-image: rocker/shiny
+    scale-up-threshold: 0.9
+    scale-down-grace: 600
+    drain-timeout: 90
+    concurrent-requests-per-replica: 4
+    max-lifetime: 3600
+    stop-on-logout: true
+";
+        let fields: Vec<String> = compat(yaml)
+            .into_iter()
+            .filter_map(|w| match w {
+                CompatWarning::UnsupportedSpecField { field, .. } => Some(field),
+                _ => None,
+            })
+            .collect();
+        for expected in [
+            "scale-up-threshold",
+            "scale-down-grace",
+            "drain-timeout",
+            "concurrent-requests-per-replica",
+            "max-lifetime",
+            "stop-on-logout",
+        ] {
+            assert!(fields.iter().any(|f| f == expected), "missing {expected}: {fields:?}");
+        }
     }
 
     #[test]

--- a/docs/YAML_SCHEMA.md
+++ b/docs/YAML_SCHEMA.md
@@ -255,10 +255,10 @@ A spec describes one app, API, or external link. Every spec has an
                                       #   (8050), … . ShinyProxy `port:`
                                       #   is accepted as an alias.
   seats-per-container: 10             # sessions per replica
-  max-lifetime: 360                   # minutes — hard cap
-  container-lifetime: 360             # minutes — soft cap
-  heartbeat-timeout: 3600000          # ms — per-spec override
-  stop-on-logout: false               # auth-related
+  max-lifetime: 360                   # minutes — NOT yet enforced (#326)
+  container-lifetime: 360             # minutes — NOT yet enforced (#326)
+  heartbeat-timeout: 3600000          # ms — per-spec override (enforced)
+  stop-on-logout: false               # NOT yet enforced (#326)
   docker-registry-username: acme
   docker-registry-password: ${DOCKER_REGISTRY_PASSWORD}   # use env vars!
   docker-registry-domain: docker.io
@@ -450,12 +450,23 @@ applied) and flagged by `ruscker validate`.
 |---|---|---|---|
 | `min-replicas` | u32 | `1` | Always running |
 | `max-replicas` | u32 | = `min-replicas` | Set higher to enable auto-scale |
-| `scale-up-threshold` | float | `0.8` | Spawn when utilization > this |
-| `scale-down-threshold` | float | `0.3` | Retire when < this for grace |
-| `scale-down-grace` | s | `300` | Seconds below threshold before retiring |
-| `drain-timeout` | s | `60` | Seconds to wait for sessions to end |
+| `scale-up-threshold` | float | `0.8` | ⚠️ parsed but **not yet enforced** (#326) |
+| `scale-down-threshold` | float | `0.3` | ⚠️ parsed but **not yet enforced** (#326) |
+| `scale-down-grace` | s | `300` | ⚠️ parsed but **not yet enforced** (#326) |
+| `drain-timeout` | s | `60` | ⚠️ parsed but **not yet enforced** (#326) |
 | `routing-strategy` | enum | varies | See below |
-| `concurrent-requests-per-replica` | u32 | `100` | API-only |
+| `concurrent-requests-per-replica` | u32 | `100` | ⚠️ parsed but **not yet enforced** (#326) |
+
+> **Autoscaling knobs not yet enforced (#326).** The scaler currently
+> scales on **seat saturation** (`sessions_active` vs `sessions_max`)
+> with built-in grace ticks, and reaps replicas by **idle**, not age. So
+> `scale-up-threshold` / `scale-down-threshold` / `scale-down-grace` /
+> `drain-timeout` / `concurrent-requests-per-replica` / `max-lifetime` /
+> `container-lifetime` / `stop-on-logout` are accepted (and round-trip
+> through import/export + the admin form) for migration friction-free,
+> but a set value does **not** change runtime behaviour yet.
+> `ruscker validate --strict-compat` flags each one. Wiring them into
+> the scaler is tracked per-knob under #326.
 
 ### Routing strategies
 


### PR DESCRIPTION
Part of #326 (phase 1 of the agreed phased approach).

## Background

The per-spec scaling/lifecycle knobs — `scale-up-threshold`, `scale-down-threshold`, `scale-down-grace`, `drain-timeout`, `concurrent-requests-per-replica`, `max-lifetime`, `container-lifetime`, `stop-on-logout` — parse, round-trip through import/export, and are editable in the admin form. But the scaler **never consumes them**: it scales on seat saturation (`sessions_active` vs `sessions_max`) with built-in grace ticks and reaps replicas by idle, not age (confirmed: zero runtime consumers outside schema/validate/form).

So a ShinyProxy operator migrating a config with `scale-down-grace: 600` saw it accepted (and `InvalidScaleThreshold` even implied the thresholds mattered) yet silently ignored.

## Phase 1 — make it honest (no behaviour change)

- Add the eight knobs to the `--strict-compat` accepted-but-ignored list (`UNSUPPORTED_SPEC_FIELDS`), each with a note pointing at #326.
- Mark them in `docs/YAML_SCHEMA.md` (table + example + a callout).

Runtime behaviour is unchanged. `ruscker validate --strict-compat` now exits 2 and prints e.g.:

```
⚠ unsupported feature(s):
  - spec scaled: `scale-down-grace` — scale-down grace not honoured — a fixed cooldown is used instead; tracked in #326
  - spec scaled: `drain-timeout` — per-spec drain timeout not honoured — `proxy.shutdown-grace-ms` applies globally; tracked in #326
  - spec scaled: `stop-on-logout` — stop-on-logout not implemented — sessions end via heartbeat-timeout; tracked in #326
```

## Phase 2 (separate sub-issues)

Wiring each knob into the scaler — a deliberate, per-knob behaviour change with its own tests/smoke — is tracked in sub-issues filed off #326.

## Tests

`compat_scan_flags_unenforced_scaling_knobs` + a real `validate --strict-compat` smoke (flags the knobs, exits 2). `ruscker-config` suite + `clippy -D warnings` green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)