### PR TITLE
feat(scaler): recycle replicas past max-lifetime / container-lifetime (#334)

### DIFF
--- a/crates/ruscker-admin/src/scaler.rs
+++ b/crates/ruscker-admin/src/scaler.rs
@@ -340,8 +340,39 @@ async fn tick(
 
         // Per-spec snapshot — small Vec; not worth threading
         // through the registry-wide snapshot above.
-        let snap = state.replicas.read().await.replicas_of(&spec.id).to_vec();
-        let count = snap.len();
+        let mut snap = state.replicas.read().await.replicas_of(&spec.id).to_vec();
+        let mut count = snap.len();
+
+        // --- lifetime reap (#334) ---
+        // Recycle replicas past their configured age BEFORE the scale
+        // passes, so a reap that drops us under `min` is refilled by the
+        // scale-to-min branch in this same tick. The hard `max-lifetime`
+        // cap reaps even with active sessions (those sessions are lost —
+        // that's the documented contract); the soft `container-lifetime`
+        // cap reaps only idle replicas. `stop_one` also purges the
+        // replica's sessions (#324), so no orphan counts linger.
+        let aged = lifetime_reap_candidates(
+            &snap,
+            chrono::Utc::now(),
+            spec.effective_max_lifetime_secs(),
+            spec.effective_container_lifetime_secs(),
+        );
+        if !aged.is_empty() {
+            info!(
+                spec = %spec.id,
+                reaping = aged.len(),
+                "recycling replicas past max-/container-lifetime"
+            );
+            for id in &aged {
+                if let Err(e) = stop_one(state, id, backend.as_ref()).await {
+                    warn!(spec = %spec.id, replica = ?id, error = ?e, "lifetime reap stop failed");
+                }
+                idle_ticks.remove(id);
+            }
+            // Re-read so the scale passes below see the post-reap count.
+            snap = state.replicas.read().await.replicas_of(&spec.id).to_vec();
+            count = snap.len();
+        }
 
         // --- scale-up pass ---
 
@@ -483,6 +514,33 @@ fn update_idle_ticks(
 /// "not saturated" — there's nothing TO be saturated.
 fn all_saturated(replicas: &[ruscker_core::Replica]) -> bool {
     !replicas.is_empty() && replicas.iter().all(|r| r.available_seats() == 0)
+}
+
+/// Replicas that have outlived their configured lifetime and should be
+/// recycled (#334). The **hard** cap (`max-lifetime`) reaps regardless
+/// of sessions; the **soft** cap (`container-lifetime`) reaps only idle
+/// replicas (`sessions_active == 0`), so an active session isn't killed
+/// before its time. Pure over the snapshot (`now` injected) — no I/O,
+/// easy to test. Returns an empty vec when neither cap is set.
+fn lifetime_reap_candidates(
+    replicas: &[ruscker_core::Replica],
+    now: chrono::DateTime<chrono::Utc>,
+    hard_secs: Option<i64>,
+    soft_secs: Option<i64>,
+) -> Vec<ReplicaId> {
+    if hard_secs.is_none() && soft_secs.is_none() {
+        return Vec::new();
+    }
+    replicas
+        .iter()
+        .filter(|r| {
+            let age = (now - r.started_at).num_seconds();
+            let hard = hard_secs.is_some_and(|cap| age >= cap);
+            let soft = soft_secs.is_some_and(|cap| age >= cap && r.sessions_active == 0);
+            hard || soft
+        })
+        .map(|r| r.id.clone())
+        .collect()
 }
 
 /// Stop a single replica and remove it from the registry. Used
@@ -877,6 +935,52 @@ proxy:
             sessions_max: max,
             host: None,
         }
+    }
+
+    #[test]
+    fn lifetime_reap_picks_aged_replicas_by_cap() {
+        use chrono::{Duration, Utc};
+        let now = Utc::now();
+        let mk = |active: u32, age_secs: i64| Replica {
+            id: ReplicaId(uuid::Uuid::new_v4()),
+            spec_id: "s".into(),
+            container_id: "c".into(),
+            upstream: "127.0.0.1:1".parse().unwrap(),
+            state: ReplicaState::Ready,
+            started_at: now - Duration::seconds(age_secs),
+            sessions_active: active,
+            sessions_max: 5,
+            host: None,
+        };
+        let young_idle = mk(0, 60);
+        let young_busy = mk(2, 60);
+        let old_idle = mk(0, 4000);
+        let old_busy = mk(3, 4000);
+        let snap = vec![
+            young_idle.clone(),
+            young_busy.clone(),
+            old_idle.clone(),
+            old_busy.clone(),
+        ];
+
+        // No caps → nothing reaped.
+        assert!(lifetime_reap_candidates(&snap, now, None, None).is_empty());
+
+        // Hard cap (3600s) reaps BOTH old replicas — active included.
+        let hard = lifetime_reap_candidates(&snap, now, Some(3600), None);
+        assert_eq!(hard.len(), 2);
+        assert!(hard.contains(&old_idle.id) && hard.contains(&old_busy.id));
+
+        // Soft cap (3600s) reaps only the idle old one.
+        let soft = lifetime_reap_candidates(&snap, now, None, Some(3600));
+        assert_eq!(soft, vec![old_idle.id.clone()]);
+
+        // Both set: the hard cap still reaps the busy old replica.
+        let both = lifetime_reap_candidates(&snap, now, Some(3600), Some(3600));
+        assert_eq!(both.len(), 2);
+
+        // A cap longer than any age reaps nothing.
+        assert!(lifetime_reap_candidates(&snap, now, Some(99_999), Some(99_999)).is_empty());
     }
 
     #[tokio::test]

--- a/crates/ruscker-config/src/schema.rs
+++ b/crates/ruscker-config/src/schema.rs
@@ -902,6 +902,21 @@ impl Spec {
         self.max_replicas.unwrap_or_else(|| self.effective_min_replicas())
     }
 
+    /// Hard lifetime cap in **seconds** (`max-lifetime` is authored in
+    /// minutes), or `None` when unset. A replica older than this is
+    /// recycled by the scaler even while sessions are active (#334).
+    pub fn effective_max_lifetime_secs(&self) -> Option<i64> {
+        self.max_lifetime.map(|m| (m as i64).saturating_mul(60))
+    }
+
+    /// Soft lifetime cap in **seconds** (`container-lifetime` is authored
+    /// in minutes), or `None` when unset. A replica older than this is
+    /// recycled by the scaler once it goes idle (no active sessions) —
+    /// "preferred for replacement during natural turnover" (#334).
+    pub fn effective_container_lifetime_secs(&self) -> Option<i64> {
+        self.container_lifetime.map(|m| (m as i64).saturating_mul(60))
+    }
+
     /// Multi-host placement strategy (default [`Placement::Spread`]).
     pub fn effective_placement(&self) -> Placement {
         self.placement.unwrap_or_default()
@@ -1106,6 +1121,23 @@ mod max_body_size_tests {
             s.effective_max_body_bytes(Some(1024)),
             Some(10 * 1024 * 1024)
         );
+    }
+
+    #[test]
+    fn lifetime_caps_convert_minutes_to_seconds() {
+        // #334: both fields are authored in minutes; the scaler wants
+        // seconds. Unset ⇒ None (no cap).
+        let s: Spec = serde_yaml_ng::from_str(
+            "id: x\ncontainer-image: a:1\nmax-lifetime: 60\ncontainer-lifetime: 30\n",
+        )
+        .expect("parse");
+        assert_eq!(s.effective_max_lifetime_secs(), Some(3600));
+        assert_eq!(s.effective_container_lifetime_secs(), Some(1800));
+
+        let none: Spec =
+            serde_yaml_ng::from_str("id: y\ncontainer-image: a:1\n").expect("parse");
+        assert_eq!(none.effective_max_lifetime_secs(), None);
+        assert_eq!(none.effective_container_lifetime_secs(), None);
     }
 
     #[test]

--- a/crates/ruscker-config/src/validate.rs
+++ b/crates/ruscker-config/src/validate.rs
@@ -260,14 +260,10 @@ const UNSUPPORTED_SPEC_FIELDS: &[(&str, &str)] = &[
         "concurrent-requests-per-replica",
         "request-based concurrency limit not enforced — capacity is seat-based; tracked in #326",
     ),
-    (
-        "max-lifetime",
-        "max container lifetime not enforced — replicas are reaped by idle, not age; tracked in #326",
-    ),
-    (
-        "container-lifetime",
-        "max container lifetime not enforced — replicas are reaped by idle, not age; tracked in #326",
-    ),
+    // NOTE: `max-lifetime` / `container-lifetime` ARE enforced now (#334)
+    // — the scaler recycles a replica once it outlives its age cap (hard
+    // reaps regardless of sessions, soft reaps when idle). Intentionally
+    // absent from this ignored-fields list.
     (
         "stop-on-logout",
         "stop-on-logout not implemented — sessions end via heartbeat-timeout; tracked in #326",
@@ -1021,6 +1017,7 @@ proxy:
     drain-timeout: 90
     concurrent-requests-per-replica: 4
     max-lifetime: 3600
+    container-lifetime: 1800
     stop-on-logout: true
 ";
         let fields: Vec<String> = compat(yaml)
@@ -1035,11 +1032,16 @@ proxy:
             "scale-down-grace",
             "drain-timeout",
             "concurrent-requests-per-replica",
-            "max-lifetime",
             "stop-on-logout",
         ] {
             assert!(fields.iter().any(|f| f == expected), "missing {expected}: {fields:?}");
         }
+        // #334: max-lifetime / container-lifetime ARE enforced now — they
+        // must NOT be flagged as unsupported anymore.
+        assert!(
+            !fields.iter().any(|f| f == "max-lifetime" || f == "container-lifetime"),
+            "lifetime caps are enforced now: {fields:?}"
+        );
     }
 
     #[test]

--- a/docs/YAML_SCHEMA.md
+++ b/docs/YAML_SCHEMA.md
@@ -255,8 +255,8 @@ A spec describes one app, API, or external link. Every spec has an
                                       #   (8050), … . ShinyProxy `port:`
                                       #   is accepted as an alias.
   seats-per-container: 10             # sessions per replica
-  max-lifetime: 360                   # minutes — NOT yet enforced (#326)
-  container-lifetime: 360             # minutes — NOT yet enforced (#326)
+  max-lifetime: 360                   # minutes — hard recycle (enforced, #334)
+  container-lifetime: 360             # minutes — soft recycle when idle (enforced, #334)
   heartbeat-timeout: 3600000          # ms — per-spec override (enforced)
   stop-on-logout: false               # NOT yet enforced (#326)
   docker-registry-username: acme
@@ -457,16 +457,17 @@ applied) and flagged by `ruscker validate`.
 | `routing-strategy` | enum | varies | See below |
 | `concurrent-requests-per-replica` | u32 | `100` | ⚠️ parsed but **not yet enforced** (#326) |
 
-> **Autoscaling knobs not yet enforced (#326).** The scaler currently
-> scales on **seat saturation** (`sessions_active` vs `sessions_max`)
-> with built-in grace ticks, and reaps replicas by **idle**, not age. So
-> `scale-up-threshold` / `scale-down-threshold` / `scale-down-grace` /
-> `drain-timeout` / `concurrent-requests-per-replica` / `max-lifetime` /
-> `container-lifetime` / `stop-on-logout` are accepted (and round-trip
-> through import/export + the admin form) for migration friction-free,
-> but a set value does **not** change runtime behaviour yet.
-> `ruscker validate --strict-compat` flags each one. Wiring them into
-> the scaler is tracked per-knob under #326.
+> **Some autoscaling knobs not yet enforced (#326).** The scaler scales
+> on **seat saturation** (`sessions_active` vs `sessions_max`) with
+> built-in grace ticks. `max-lifetime` / `container-lifetime` **are**
+> enforced (#334 — replicas are recycled past their age cap). The
+> remaining knobs — `scale-up-threshold` / `scale-down-threshold` /
+> `scale-down-grace` / `drain-timeout` / `concurrent-requests-per-replica`
+> / `stop-on-logout` — are accepted (and round-trip through
+> import/export + the admin form) for migration friction-free, but a set
+> value does **not** change runtime behaviour yet.
+> `ruscker validate --strict-compat` flags each still-unenforced one.
+> Wiring the rest is tracked per-knob under #326 (#333/#335/#336/#337).
 
 ### Routing strategies
 


### PR DESCRIPTION
Closes #334. Phase 2 of #326 — the first knob wired into the scaler.

## Problem
The scaler reaped replicas only by **idle**, never by **age**, so `max-lifetime` (hard) and `container-lifetime` (soft) parsed and round-tripped but did nothing (flagged not-enforced by #332).

## Fix
- **Schema helpers** `Spec::effective_max_lifetime_secs()` / `effective_container_lifetime_secs()` — convert the minute-authored caps to seconds; `None` when unset (no cap).
- **Pure selector** `lifetime_reap_candidates(snap, now, hard, soft)`:
  - **hard** (`max-lifetime`): reap once `age ≥ cap` **regardless of sessions** (the documented "recycled even if sessions are active" contract).
  - **soft** (`container-lifetime`): reap once `age ≥ cap` **and** `sessions_active == 0` ("preferred for replacement during natural turnover").
- **Scaler `tick`** runs a reap pass *before* the scale passes, so a reap that drops below `min-replicas` is refilled by the scale-to-min branch in the same tick (recycling). `stop_one` already purges the replica's sessions (#324), so a hard reap of an active replica leaves no orphan counts.

## Compat / docs
Drops `max-lifetime` / `container-lifetime` from the `--strict-compat` not-enforced list and marks them enforced in `docs/YAML_SCHEMA.md`. The remaining #326 knobs (`scale-*-threshold`, `scale-down-grace`, `drain-timeout`, `concurrent-requests-per-replica`, `stop-on-logout`) stay flagged.

## Tradeoff
Reaps all qualifying replicas in a tick; a spec whose whole pool ages out together gets refilled by scale-to-min next, so there can be a brief capacity dip during recycle — same model as ShinyProxy.

## Tests
`lifetime_reap_picks_aged_replicas_by_cap` (hard vs soft vs unset vs boundary), `lifetime_caps_convert_minutes_to_seconds`, updated strict-compat expectations, and a real `validate --strict-compat` smoke (lifetime no longer flagged; `drain-timeout` still is). `ruscker-config` + `ruscker-admin` suites + `clippy -D warnings` + i18n green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)