### PR TITLE
feat(scaler): honour per-spec drain-timeout on max-lifetime recycle (#335)

### DIFF
--- a/crates/ruscker-admin/src/scaler.rs
+++ b/crates/ruscker-admin/src/scaler.rs
@@ -343,19 +343,21 @@ async fn tick(
         let mut snap = state.replicas.read().await.replicas_of(&spec.id).to_vec();
         let mut count = snap.len();
 
-        // --- lifetime reap (#334) ---
+        // --- lifetime reap (#334) + drain window (#335) ---
         // Recycle replicas past their configured age BEFORE the scale
         // passes, so a reap that drops us under `min` is refilled by the
         // scale-to-min branch in this same tick. The hard `max-lifetime`
-        // cap reaps even with active sessions (those sessions are lost —
-        // that's the documented contract); the soft `container-lifetime`
-        // cap reaps only idle replicas. `stop_one` also purges the
-        // replica's sessions (#324), so no orphan counts linger.
+        // cap force-retires busy replicas, but only after the per-spec
+        // `drain-timeout` grace (#335) — an idle one is reaped at once.
+        // The soft `container-lifetime` cap reaps only idle replicas.
+        // `stop_one` also purges the replica's sessions (#324), so no
+        // orphan counts linger.
         let aged = lifetime_reap_candidates(
             &snap,
             chrono::Utc::now(),
             spec.effective_max_lifetime_secs(),
             spec.effective_container_lifetime_secs(),
+            spec.effective_drain_timeout_secs(),
         );
         if !aged.is_empty() {
             info!(
@@ -517,16 +519,25 @@ fn all_saturated(replicas: &[ruscker_core::Replica]) -> bool {
 }
 
 /// Replicas that have outlived their configured lifetime and should be
-/// recycled (#334). The **hard** cap (`max-lifetime`) reaps regardless
-/// of sessions; the **soft** cap (`container-lifetime`) reaps only idle
-/// replicas (`sessions_active == 0`), so an active session isn't killed
-/// before its time. Pure over the snapshot (`now` injected) — no I/O,
-/// easy to test. Returns an empty vec when neither cap is set.
+/// recycled (#334), honouring the per-spec drain window (#335).
+///
+/// - **hard** cap (`max-lifetime`): an *idle* replica is reaped at once;
+///   a *busy* one is granted `drain_secs` of grace past the cap (the
+///   `drain-timeout` window) so its in-flight sessions can finish, and
+///   is force-killed once `age ≥ cap + drain_secs`. New sessions still
+///   route to it during the window (it stays `Ready`), but it can't
+///   outlive `cap + drain_secs`.
+/// - **soft** cap (`container-lifetime`): reaps only idle replicas — it
+///   waits indefinitely for the sessions to leave, never force-killing.
+///
+/// Pure over the snapshot (`now` injected) — no I/O, easy to test.
+/// Returns an empty vec when neither cap is set.
 fn lifetime_reap_candidates(
     replicas: &[ruscker_core::Replica],
     now: chrono::DateTime<chrono::Utc>,
     hard_secs: Option<i64>,
     soft_secs: Option<i64>,
+    drain_secs: i64,
 ) -> Vec<ReplicaId> {
     if hard_secs.is_none() && soft_secs.is_none() {
         return Vec::new();
@@ -535,8 +546,13 @@ fn lifetime_reap_candidates(
         .iter()
         .filter(|r| {
             let age = (now - r.started_at).num_seconds();
-            let hard = hard_secs.is_some_and(|cap| age >= cap);
-            let soft = soft_secs.is_some_and(|cap| age >= cap && r.sessions_active == 0);
+            let idle = r.sessions_active == 0;
+            let hard = hard_secs.is_some_and(|cap| {
+                // Idle ⇒ reap at the cap; busy ⇒ allow the drain window.
+                let deadline = if idle { cap } else { cap.saturating_add(drain_secs) };
+                age >= deadline
+            });
+            let soft = soft_secs.is_some_and(|cap| age >= cap && idle);
             hard || soft
         })
         .map(|r| r.id.clone())
@@ -963,24 +979,72 @@ proxy:
             old_busy.clone(),
         ];
 
+        // drain_secs = 0 here: no grace, so the hard cap behaves like a
+        // plain age check (the drain window is exercised separately).
+
         // No caps → nothing reaped.
-        assert!(lifetime_reap_candidates(&snap, now, None, None).is_empty());
+        assert!(lifetime_reap_candidates(&snap, now, None, None, 0).is_empty());
 
         // Hard cap (3600s) reaps BOTH old replicas — active included.
-        let hard = lifetime_reap_candidates(&snap, now, Some(3600), None);
+        let hard = lifetime_reap_candidates(&snap, now, Some(3600), None, 0);
         assert_eq!(hard.len(), 2);
         assert!(hard.contains(&old_idle.id) && hard.contains(&old_busy.id));
 
         // Soft cap (3600s) reaps only the idle old one.
-        let soft = lifetime_reap_candidates(&snap, now, None, Some(3600));
+        let soft = lifetime_reap_candidates(&snap, now, None, Some(3600), 0);
         assert_eq!(soft, vec![old_idle.id.clone()]);
 
         // Both set: the hard cap still reaps the busy old replica.
-        let both = lifetime_reap_candidates(&snap, now, Some(3600), Some(3600));
+        let both = lifetime_reap_candidates(&snap, now, Some(3600), Some(3600), 0);
         assert_eq!(both.len(), 2);
 
         // A cap longer than any age reaps nothing.
-        assert!(lifetime_reap_candidates(&snap, now, Some(99_999), Some(99_999)).is_empty());
+        assert!(lifetime_reap_candidates(&snap, now, Some(99_999), Some(99_999), 0).is_empty());
+    }
+
+    #[test]
+    fn drain_window_delays_force_kill_of_busy_replica() {
+        // #335: past the hard cap, an idle replica is reaped at once, but
+        // a busy one gets `drain_secs` of grace before the force-kill.
+        use chrono::{Duration, Utc};
+        let now = Utc::now();
+        let mk = |active: u32, age_secs: i64| Replica {
+            id: ReplicaId(uuid::Uuid::new_v4()),
+            spec_id: "s".into(),
+            container_id: "c".into(),
+            upstream: "127.0.0.1:1".parse().unwrap(),
+            state: ReplicaState::Ready,
+            started_at: now - Duration::seconds(age_secs),
+            sessions_active: active,
+            sessions_max: 5,
+            host: None,
+        };
+        let cap = 3600;
+        let drain = 300;
+        // Just past the cap (age 3700): idle → reaped; busy → still in
+        // its drain window (3700 < 3600+300), so NOT yet reaped.
+        let idle_past = mk(0, 3700);
+        let busy_in_window = mk(2, 3700);
+        let r1 = lifetime_reap_candidates(
+            &[idle_past.clone(), busy_in_window.clone()],
+            now,
+            Some(cap),
+            None,
+            drain,
+        );
+        assert_eq!(r1, vec![idle_past.id.clone()], "idle reaped, busy still draining");
+
+        // Once the busy replica passes cap + drain (age 4000 ≥ 3900) it's
+        // force-killed regardless of its sessions.
+        let busy_expired = mk(2, 4000);
+        let r2 = lifetime_reap_candidates(
+            std::slice::from_ref(&busy_expired),
+            now,
+            Some(cap),
+            None,
+            drain,
+        );
+        assert_eq!(r2, vec![busy_expired.id.clone()], "drain window elapsed → force-kill");
     }
 
     #[tokio::test]

--- a/crates/ruscker-config/src/schema.rs
+++ b/crates/ruscker-config/src/schema.rs
@@ -917,6 +917,15 @@ impl Spec {
         self.container_lifetime.map(|m| (m as i64).saturating_mul(60))
     }
 
+    /// Grace window, in **seconds**, granted to in-flight sessions on a
+    /// replica being force-retired (the hard `max-lifetime` recycle)
+    /// before it's killed anyway. Default 60 (#335). A busy replica past
+    /// its hard cap isn't killed until it either goes idle or this window
+    /// elapses; an idle one is reaped at once.
+    pub fn effective_drain_timeout_secs(&self) -> i64 {
+        self.drain_timeout.map(|s| s as i64).unwrap_or(60)
+    }
+
     /// Multi-host placement strategy (default [`Placement::Spread`]).
     pub fn effective_placement(&self) -> Placement {
         self.placement.unwrap_or_default()

--- a/crates/ruscker-config/src/validate.rs
+++ b/crates/ruscker-config/src/validate.rs
@@ -253,13 +253,12 @@ const UNSUPPORTED_SPEC_FIELDS: &[(&str, &str)] = &[
         "scale-down grace not honoured — a fixed cooldown is used instead; tracked in #326",
     ),
     (
-        "drain-timeout",
-        "per-spec drain timeout not honoured — `proxy.shutdown-grace-ms` applies globally; tracked in #326",
-    ),
-    (
         "concurrent-requests-per-replica",
         "request-based concurrency limit not enforced — capacity is seat-based; tracked in #326",
     ),
+    // NOTE: `drain-timeout` IS honoured now (#335) — it bounds the grace
+    // window the hard `max-lifetime` recycle grants busy replicas before
+    // the force-kill. Intentionally absent from this ignored list.
     // NOTE: `max-lifetime` / `container-lifetime` ARE enforced now (#334)
     // — the scaler recycles a replica once it outlives its age cap (hard
     // reaps regardless of sessions, soft reaps when idle). Intentionally
@@ -1030,18 +1029,19 @@ proxy:
         for expected in [
             "scale-up-threshold",
             "scale-down-grace",
-            "drain-timeout",
             "concurrent-requests-per-replica",
             "stop-on-logout",
         ] {
             assert!(fields.iter().any(|f| f == expected), "missing {expected}: {fields:?}");
         }
-        // #334: max-lifetime / container-lifetime ARE enforced now — they
-        // must NOT be flagged as unsupported anymore.
-        assert!(
-            !fields.iter().any(|f| f == "max-lifetime" || f == "container-lifetime"),
-            "lifetime caps are enforced now: {fields:?}"
-        );
+        // Enforced now — must NOT be flagged: max-lifetime / container-
+        // lifetime (#334), drain-timeout (#335).
+        for enforced in ["max-lifetime", "container-lifetime", "drain-timeout"] {
+            assert!(
+                !fields.iter().any(|f| f == enforced),
+                "{enforced} is enforced now: {fields:?}"
+            );
+        }
     }
 
     #[test]

--- a/docs/YAML_SCHEMA.md
+++ b/docs/YAML_SCHEMA.md
@@ -453,21 +453,22 @@ applied) and flagged by `ruscker validate`.
 | `scale-up-threshold` | float | `0.8` | ⚠️ parsed but **not yet enforced** (#326) |
 | `scale-down-threshold` | float | `0.3` | ⚠️ parsed but **not yet enforced** (#326) |
 | `scale-down-grace` | s | `300` | ⚠️ parsed but **not yet enforced** (#326) |
-| `drain-timeout` | s | `60` | ⚠️ parsed but **not yet enforced** (#326) |
+| `drain-timeout` | s | `60` | grace for in-flight sessions on a `max-lifetime` recycle (enforced, #335) |
 | `routing-strategy` | enum | varies | See below |
 | `concurrent-requests-per-replica` | u32 | `100` | ⚠️ parsed but **not yet enforced** (#326) |
 
 > **Some autoscaling knobs not yet enforced (#326).** The scaler scales
 > on **seat saturation** (`sessions_active` vs `sessions_max`) with
-> built-in grace ticks. `max-lifetime` / `container-lifetime` **are**
-> enforced (#334 — replicas are recycled past their age cap). The
-> remaining knobs — `scale-up-threshold` / `scale-down-threshold` /
-> `scale-down-grace` / `drain-timeout` / `concurrent-requests-per-replica`
-> / `stop-on-logout` — are accepted (and round-trip through
-> import/export + the admin form) for migration friction-free, but a set
-> value does **not** change runtime behaviour yet.
-> `ruscker validate --strict-compat` flags each still-unenforced one.
-> Wiring the rest is tracked per-knob under #326 (#333/#335/#336/#337).
+> built-in grace ticks. Enforced: `max-lifetime` / `container-lifetime`
+> (#334 — replicas recycled past their age cap) and `drain-timeout`
+> (#335 — bounds the grace a busy `max-lifetime` recycle gives in-flight
+> sessions). Still not enforced — `scale-up-threshold` /
+> `scale-down-threshold` / `scale-down-grace` /
+> `concurrent-requests-per-replica` / `stop-on-logout` — are accepted
+> (and round-trip through import/export + the admin form) for migration
+> friction-free, but a set value does **not** change runtime behaviour
+> yet. `ruscker validate --strict-compat` flags each still-unenforced
+> one. Wiring the rest is tracked per-knob under #326 (#333/#336/#337).
 
 ### Routing strategies
 


### PR DESCRIPTION
Closes #335. Phase 2 of #326, building on #334.

## Problem
The hard `max-lifetime` recycle (#334) force-killed a busy replica the instant it crossed its age cap. `drain-timeout` (default 60s) — "seconds to wait for in-flight sessions to drain before killing a replica being retired" — was parsed but ignored (flagged not-enforced by #332).

## Fix
Implemented in the pure `lifetime_reap_candidates` so the scaler tick stays **non-blocking** — no background drain task, no `Draining`-state mutation, no re-reap dedup hazard:

- **hard cap + idle** → reap at the cap (immediate).
- **hard cap + busy** → reap only once `age ≥ cap + drain-timeout`. The replica stays `Ready` and serves its in-flight sessions during the window, but cannot outlive `cap + drain-timeout`.
- **soft `container-lifetime`** → unchanged (reaps only when idle; waits indefinitely, never force-kills).

`Spec::effective_drain_timeout_secs()` (default 60).

### Why not a background drain task?
The other obvious design — mark the replica `Draining`, spawn a task that polls sessions to zero, then stop — would either block the shared scaler tick for up to `drain-timeout` or add a fair amount of new machinery (registry state mutation + re-reap dedup + idle-tick handling). The age-deadline approach gives the same guarantee (busy sessions get up to `drain-timeout`, bounded force-kill) with a one-line condition and zero new moving parts. The only nuance: new sessions can still route to the replica during its final window (it's still `Ready`) — acceptable, since `max-lifetime` is a hard cap anyway and they're bounded by the same deadline.

## Compat / docs
Drops `drain-timeout` from the `--strict-compat` not-enforced list; marks it enforced in `docs/YAML_SCHEMA.md`. Remaining knobs (`scale-*-threshold`, `scale-down-grace`, `concurrent-requests-per-replica`, `stop-on-logout`) stay flagged.

## Tests
`drain_window_delays_force_kill_of_busy_replica` (busy in-window vs elapsed), the #334 test threads `drain_secs=0`, updated strict-compat expectations, real `validate --strict-compat` smoke. `ruscker-config` + `ruscker-admin` + `clippy -D warnings` + i18n green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)