### PR TITLE
feat(scaler): wire autoscaling thresholds + scale-down-grace (#333)

### DIFF
--- a/crates/ruscker-admin/src/scaler.rs
+++ b/crates/ruscker-admin/src/scaler.rs
@@ -399,7 +399,9 @@ async fn tick(
         // (2) Saturation hysteresis: track consecutive saturated
         //     ticks. Only spawn once the counter crosses the
         //     threshold; reset on any non-saturated observation.
-        if count < max && all_saturated(&snap) {
+        //     The trigger is utilization > `scale-up-threshold` when set,
+        //     else the original all-saturated rule (#333).
+        if count < max && scale_up_triggered(&snap, spec.effective_scale_up_threshold()) {
             // Post-drop cooldown: a spec we just scaled down is
             // very likely still saturated (the long-lived
             // session that pinned it never left). Holding off
@@ -446,23 +448,41 @@ async fn tick(
         //     stop them. Cap the drop at `count - min` to never
         //     go below min.
         if count > min {
+            // Per-spec scale-down grace (#333): a `scale-down-grace`
+            // (seconds) overrides the global tick-based grace, converted
+            // against the scaler's fixed cadence. Unset ⇒ the default.
+            let drop_after = spec
+                .scale_down_grace
+                .map(|s| grace_secs_to_ticks(s, DEFAULT_INTERVAL))
+                .unwrap_or(drop_after_ticks);
+            // Optional underutilization gate (#333): with an explicit
+            // `scale-down-threshold`, only scale down while the pool sits
+            // below it — holds idle replicas during moderate load. Unset
+            // ⇒ no gate (the original "retire any idle replica" rule).
+            let underutilized = match spec.effective_scale_down_threshold() {
+                Some(t) => pool_utilization(&snap) < t,
+                None => true,
+            };
             let allowed_to_drop = count - min;
-            let drop_candidates: Vec<_> = snap
-                .iter()
-                .filter(|r| {
-                    r.sessions_active == 0
-                        && idle_ticks.get(&r.id).copied().unwrap_or(0) >= drop_after_ticks
-                })
-                .take(allowed_to_drop)
-                .cloned()
-                .collect();
+            let drop_candidates: Vec<_> = if underutilized {
+                snap.iter()
+                    .filter(|r| {
+                        r.sessions_active == 0
+                            && idle_ticks.get(&r.id).copied().unwrap_or(0) >= drop_after
+                    })
+                    .take(allowed_to_drop)
+                    .cloned()
+                    .collect()
+            } else {
+                Vec::new()
+            };
             if !drop_candidates.is_empty() {
                 info!(
                     spec = %spec.id,
                     count,
                     min,
                     dropping = drop_candidates.len(),
-                    grace_ticks = drop_after_ticks,
+                    grace_ticks = drop_after,
                     "idle replicas past grace — scaling down"
                 );
                 for r in drop_candidates {
@@ -516,6 +536,37 @@ fn update_idle_ticks(
 /// "not saturated" — there's nothing TO be saturated.
 fn all_saturated(replicas: &[ruscker_core::Replica]) -> bool {
     !replicas.is_empty() && replicas.iter().all(|r| r.available_seats() == 0)
+}
+
+/// Pool utilization: total active sessions / total seats across the
+/// snapshot. `0.0` when there are no seats (empty pool, or only
+/// `Starting` replicas with `sessions_max == 0`). (#333)
+fn pool_utilization(replicas: &[ruscker_core::Replica]) -> f64 {
+    let seats: u64 = replicas.iter().map(|r| r.sessions_max as u64).sum();
+    if seats == 0 {
+        return 0.0;
+    }
+    let active: u64 = replicas.iter().map(|r| r.sessions_active as u64).sum();
+    active as f64 / seats as f64
+}
+
+/// Whether the spec's pool is hot enough to add a replica (#333). With
+/// an explicit `scale-up-threshold`, scale up once utilization exceeds
+/// it; otherwise fall back to the original "every replica saturated"
+/// rule (which for `seats: 1` specs is the same as utilization `1.0`).
+fn scale_up_triggered(replicas: &[ruscker_core::Replica], up_threshold: Option<f64>) -> bool {
+    match up_threshold {
+        Some(t) => !replicas.is_empty() && pool_utilization(replicas) > t,
+        None => all_saturated(replicas),
+    }
+}
+
+/// Convert a grace window in seconds to whole scaler ticks at the given
+/// interval, rounded up, floored at 1 (#333). Used to honour a per-spec
+/// `scale-down-grace` against the scaler's fixed tick cadence.
+fn grace_secs_to_ticks(secs: u64, interval: Duration) -> u32 {
+    let iv = interval.as_secs().max(1);
+    secs.div_ceil(iv).max(1) as u32
 }
 
 /// Replicas that have outlived their configured lifetime and should be
@@ -1045,6 +1096,72 @@ proxy:
             drain,
         );
         assert_eq!(r2, vec![busy_expired.id.clone()], "drain window elapsed → force-kill");
+    }
+
+    #[test]
+    fn pool_utilization_and_scale_up_trigger() {
+        let r = |a, m| replica_with_sessions("s", a, m);
+        // 3 active across 10 seats = 0.3.
+        let snap = [r(1, 5), r(2, 5)];
+        assert!((pool_utilization(&snap) - 0.3).abs() < 1e-9);
+        // No seats ⇒ 0.0 (empty pool, or Starting-only).
+        assert_eq!(pool_utilization(&[]), 0.0);
+
+        // With a threshold: 0.3 is not > 0.8, but 0.9 is.
+        assert!(!scale_up_triggered(&snap, Some(0.8)));
+        assert!(scale_up_triggered(&[r(9, 10)], Some(0.8)));
+        // Without a threshold: falls back to all-saturated.
+        assert!(scale_up_triggered(&[r(5, 5), r(5, 5)], None));
+        assert!(!scale_up_triggered(&snap, None));
+        // seats=1 with a threshold behaves like saturation.
+        assert!(scale_up_triggered(&[r(1, 1)], Some(0.8)));
+        assert!(!scale_up_triggered(&[r(0, 1)], Some(0.8)));
+    }
+
+    #[test]
+    fn grace_secs_to_ticks_rounds_up_and_floors_at_one() {
+        let iv = Duration::from_secs(10);
+        assert_eq!(grace_secs_to_ticks(300, iv), 30);
+        assert_eq!(grace_secs_to_ticks(25, iv), 3); // ceil(2.5)
+        assert_eq!(grace_secs_to_ticks(5, iv), 1); // round up
+        assert_eq!(grace_secs_to_ticks(0, iv), 1); // floor at 1
+    }
+
+    #[tokio::test]
+    async fn scale_up_threshold_spawns_before_full_saturation() {
+        // #333: a multi-seat spec over its `scale-up-threshold` scales up
+        // even though it isn't fully saturated (the old all-saturated
+        // rule would not have).
+        let backend = Arc::new(CountingBackend {
+            spawns: AtomicU32::new(0),
+        });
+        let state = state_with_yaml(
+            r#"
+proxy:
+  specs:
+  - id: multi
+    display-name: Multi
+    container-image: nginx:alpine
+    min-replicas: 1
+    max-replicas: 3
+    seats-per-container: 10
+    scale-up-threshold: 0.5
+"#,
+            backend.clone(),
+        );
+        // One replica at 6/10 = 0.6 util — NOT saturated, but over 0.5.
+        state
+            .replicas
+            .write()
+            .await
+            .add(replica_with_sessions("multi", 6, 10));
+        // Saturation grace = 1 ⇒ act on the first observation.
+        tick(&state, &mut HashMap::new(), &mut HashMap::new(), &mut HashMap::new(), 1, 1, 0).await;
+        assert_eq!(
+            backend.spawns.load(Ordering::SeqCst),
+            1,
+            "util 0.6 > threshold 0.5 → scale up before saturation"
+        );
     }
 
     #[tokio::test]

--- a/crates/ruscker-config/src/schema.rs
+++ b/crates/ruscker-config/src/schema.rs
@@ -926,6 +926,23 @@ impl Spec {
         self.drain_timeout.map(|s| s as i64).unwrap_or(60)
     }
 
+    /// Pool-utilization fraction above which the scaler adds a replica,
+    /// or `None` to keep the default "scale up only when every replica is
+    /// fully saturated" rule (#333). Opt-in: setting it makes scale-up
+    /// react before the pool is 100% full (useful for multi-seat specs).
+    pub fn effective_scale_up_threshold(&self) -> Option<f64> {
+        self.scale_up_threshold.map(|f| f.0)
+    }
+
+    /// Pool-utilization fraction below which the scaler is allowed to
+    /// retire an idle replica, or `None` to keep the default "retire any
+    /// idle replica past its grace" rule (#333). Opt-in: setting it makes
+    /// scale-down more conservative — it holds idle replicas while the
+    /// pool is still moderately utilized.
+    pub fn effective_scale_down_threshold(&self) -> Option<f64> {
+        self.scale_down_threshold.map(|f| f.0)
+    }
+
     /// Multi-host placement strategy (default [`Placement::Spread`]).
     pub fn effective_placement(&self) -> Placement {
         self.placement.unwrap_or_default()

--- a/crates/ruscker-config/src/validate.rs
+++ b/crates/ruscker-config/src/validate.rs
@@ -237,32 +237,20 @@ const UNSUPPORTED_SPEC_FIELDS: &[(&str, &str)] = &[
     //
     // Scaling/lifecycle knobs (#326): these parse, round-trip, and are
     // editable in the admin form, but the scaler does NOT yet consume
-    // them — it scales on seat saturation (`sessions_active` vs
-    // `sessions_max`) with built-in grace ticks. Flag them so a migrating
-    // operator isn't misled into thinking a set value takes effect.
-    (
-        "scale-up-threshold",
-        "autoscaling threshold not enforced — scaler scales on seat saturation; tracked in #326",
-    ),
-    (
-        "scale-down-threshold",
-        "autoscaling threshold not enforced — scaler scales on seat saturation; tracked in #326",
-    ),
-    (
-        "scale-down-grace",
-        "scale-down grace not honoured — a fixed cooldown is used instead; tracked in #326",
-    ),
+    // them. Flag them so a migrating operator isn't misled into thinking
+    // a set value takes effect.
     (
         "concurrent-requests-per-replica",
         "request-based concurrency limit not enforced — capacity is seat-based; tracked in #326",
     ),
-    // NOTE: `drain-timeout` IS honoured now (#335) — it bounds the grace
-    // window the hard `max-lifetime` recycle grants busy replicas before
-    // the force-kill. Intentionally absent from this ignored list.
-    // NOTE: `max-lifetime` / `container-lifetime` ARE enforced now (#334)
-    // — the scaler recycles a replica once it outlives its age cap (hard
-    // reaps regardless of sessions, soft reaps when idle). Intentionally
-    // absent from this ignored-fields list.
+    // NOTE: enforced now, intentionally absent from this ignored list:
+    //   `scale-up-threshold` / `scale-down-threshold` / `scale-down-grace`
+    //     — the scaler scales on pool utilization vs the thresholds, with
+    //     a per-spec scale-down grace (#333);
+    //   `drain-timeout` — bounds the grace the hard `max-lifetime` recycle
+    //     grants busy replicas before the force-kill (#335);
+    //   `max-lifetime` / `container-lifetime` — replicas recycled past
+    //     their age cap (#334).
     (
         "stop-on-logout",
         "stop-on-logout not implemented — sessions end via heartbeat-timeout; tracked in #326",
@@ -1026,17 +1014,20 @@ proxy:
                 _ => None,
             })
             .collect();
-        for expected in [
-            "scale-up-threshold",
-            "scale-down-grace",
-            "concurrent-requests-per-replica",
-            "stop-on-logout",
-        ] {
+        for expected in ["concurrent-requests-per-replica", "stop-on-logout"] {
             assert!(fields.iter().any(|f| f == expected), "missing {expected}: {fields:?}");
         }
         // Enforced now — must NOT be flagged: max-lifetime / container-
-        // lifetime (#334), drain-timeout (#335).
-        for enforced in ["max-lifetime", "container-lifetime", "drain-timeout"] {
+        // lifetime (#334), drain-timeout (#335), the autoscaling
+        // thresholds + scale-down-grace (#333).
+        for enforced in [
+            "max-lifetime",
+            "container-lifetime",
+            "drain-timeout",
+            "scale-up-threshold",
+            "scale-down-threshold",
+            "scale-down-grace",
+        ] {
             assert!(
                 !fields.iter().any(|f| f == enforced),
                 "{enforced} is enforced now: {fields:?}"

--- a/docs/YAML_SCHEMA.md
+++ b/docs/YAML_SCHEMA.md
@@ -450,25 +450,27 @@ applied) and flagged by `ruscker validate`.
 |---|---|---|---|
 | `min-replicas` | u32 | `1` | Always running |
 | `max-replicas` | u32 | = `min-replicas` | Set higher to enable auto-scale |
-| `scale-up-threshold` | float | `0.8` | ⚠️ parsed but **not yet enforced** (#326) |
-| `scale-down-threshold` | float | `0.3` | ⚠️ parsed but **not yet enforced** (#326) |
-| `scale-down-grace` | s | `300` | ⚠️ parsed but **not yet enforced** (#326) |
+| `scale-up-threshold` | float | `0.8` | scale up when pool utilization exceeds this (enforced, #333) |
+| `scale-down-threshold` | float | `0.3` | only retire idle replicas while utilization is below this (enforced, #333) |
+| `scale-down-grace` | s | `300` | idle-grace before retiring a replica (enforced, #333) |
 | `drain-timeout` | s | `60` | grace for in-flight sessions on a `max-lifetime` recycle (enforced, #335) |
 | `routing-strategy` | enum | varies | See below |
 | `concurrent-requests-per-replica` | u32 | `100` | ⚠️ parsed but **not yet enforced** (#326) |
 
-> **Some autoscaling knobs not yet enforced (#326).** The scaler scales
-> on **seat saturation** (`sessions_active` vs `sessions_max`) with
-> built-in grace ticks. Enforced: `max-lifetime` / `container-lifetime`
-> (#334 — replicas recycled past their age cap) and `drain-timeout`
-> (#335 — bounds the grace a busy `max-lifetime` recycle gives in-flight
-> sessions). Still not enforced — `scale-up-threshold` /
-> `scale-down-threshold` / `scale-down-grace` /
+> **Some autoscaling knobs not yet enforced (#326).** By default the
+> scaler scales on **seat saturation** (`sessions_active` vs
+> `sessions_max`) with built-in grace ticks. Now enforced (opt-in where
+> noted): `scale-up-threshold` / `scale-down-threshold` /
+> `scale-down-grace` (#333 — pool-utilization-driven scale-up + a
+> conservative scale-down gate + per-spec idle grace; unset ⇒ the
+> default rules), `max-lifetime` / `container-lifetime` (#334 — recycle
+> past the age cap), and `drain-timeout` (#335 — grace for a busy
+> `max-lifetime` recycle). Still **not** enforced —
 > `concurrent-requests-per-replica` / `stop-on-logout` — are accepted
 > (and round-trip through import/export + the admin form) for migration
 > friction-free, but a set value does **not** change runtime behaviour
 > yet. `ruscker validate --strict-compat` flags each still-unenforced
-> one. Wiring the rest is tracked per-knob under #326 (#333/#336/#337).
+> one. Wiring the rest is tracked per-knob under #326 (#336/#337).
 
 ### Routing strategies
 


### PR DESCRIPTION
Closes #333. Phase 2 of #326 — the autoscaling thresholds.

## Problem
The scaler scaled **up** only on full seat saturation and **down** on any idle replica past a global tick grace, ignoring the per-spec `scale-up-threshold` / `scale-down-threshold` / `scale-down-grace` (flagged not-enforced by #332).

## Fix (opt-in — existing configs unchanged)
- **scale-up**: with `scale-up-threshold` set, spawn once **pool utilization** (Σ `sessions_active` / Σ `sessions_max`) exceeds it; unset ⇒ the original all-saturated rule. For `seats: 1` specs the two coincide (utilization is `1.0` exactly when saturated), so the delicate seats-1 anti-flap path is unchanged.
- **scale-down**: with `scale-down-threshold` set, only retire idle replicas **while utilization is below it** — more conservative, holds idle replicas during moderate load; unset ⇒ the original "retire any idle replica past grace".
- **`scale-down-grace`** (seconds) overrides the global idle grace, converted to ticks at the fixed scaler cadence (`DEFAULT_INTERVAL` = 10s).

The saturation/idle hysteresis counters and the post-drop cooldown (the hard-won flap-prevention) are **untouched** — only the trigger conditions and the grace source change.

New pure helpers `pool_utilization` / `scale_up_triggered` / `grace_secs_to_ticks` and schema `effective_scale_up_threshold` / `effective_scale_down_threshold`.

## Design note
`scale-down-grace` is converted against the module `DEFAULT_INTERVAL` constant rather than threading the live interval through `tick` (which has ~30 call sites). The production scaler always runs at `DEFAULT_INTERVAL`, so the conversion is exact; tests drive grace via the existing tick-count args.

## Compat / docs
Drops the three knobs from the `--strict-compat` not-enforced list; marks them enforced in `docs/YAML_SCHEMA.md`. Only `concurrent-requests-per-replica` (#336) and `stop-on-logout` (#337) remain flagged.

## Tests
Pure-helper math (`pool_utilization_and_scale_up_trigger`, `grace_secs_to_ticks_rounds_up_and_floors_at_one`), a tick test (`scale_up_threshold_spawns_before_full_saturation`) proving a multi-seat spec at 0.6 util scales up under threshold 0.5 where the old rule wouldn't, the existing scaler tests (unchanged behaviour with knobs unset), updated strict-compat expectations, and a real `validate --strict-compat` smoke. Full gate green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)