### PR TITLE
feat(scaler): implement stop-on-logout (#337)

### DIFF
--- a/crates/ruscker-admin/src/lib.rs
+++ b/crates/ruscker-admin/src/lib.rs
@@ -129,6 +129,19 @@ pub struct AppState {
     /// `proxy.heartbeat_timeout` ms.
     pub sessions: std::sync::Arc<dyn sessions::SessionStore>,
 
+    /// `stop-on-logout` index (#337): maps a signed-in username to the
+    /// sticky app-session ids it has open **on specs with
+    /// `stop-on-logout: true`**. The proxy records an entry when such a
+    /// session is first registered for a known user; the logout handler
+    /// drains the user's set and ends those sessions immediately (instead
+    /// of waiting for the heartbeat sweep), so the replica goes idle and
+    /// the scaler reaps it. Process-local — consistent with the
+    /// process-local admin-session store (HA prescribes a sticky upstream
+    /// for session-bearing paths, so a user's logout and app sessions
+    /// land on the same instance). Best-effort: stale ids are harmless
+    /// no-ops at logout.
+    pub logout_index: std::sync::Arc<dashmap::DashMap<String, std::collections::HashSet<uuid::Uuid>>>,
+
     /// Decides whether this instance runs the auto-scaler. Single-node
     /// installs use [`leader::AlwaysLeader`]; HA installs inject a
     /// [`leader::PgLeaderLock`] so exactly one instance scales. The
@@ -198,6 +211,7 @@ impl AdminServer {
                 .context("load sticky cookie key")?,
             spawn_locks: std::sync::Arc::new(dashmap::DashMap::new()),
             sessions: std::sync::Arc::new(sessions::InMemorySessionStore::new()),
+            logout_index: std::sync::Arc::new(dashmap::DashMap::new()),
             leader: std::sync::Arc::new(leader::AlwaysLeader),
             metrics: metrics_cache::MetricsCache::new(),
             draining: Arc::new(std::sync::atomic::AtomicBool::new(false)),

--- a/crates/ruscker-admin/src/routes/admin.rs
+++ b/crates/ruscker-admin/src/routes/admin.rs
@@ -649,7 +649,25 @@ async fn logout(_: MaybeAdminSession, State(state): State<AppState>, cookies: Co
     // Invalidate the session server-side so a copied cookie is dead too,
     // then clear the browser's copy.
     if let Some(c) = cookies.get(COOKIE_NAME) {
-        state.admin_sessions.remove(c.value()).await;
+        let sid = c.value().to_string();
+        // stop-on-logout (#337): resolve the user *before* invalidating,
+        // then end their indexed app sessions (on specs that opted in)
+        // right away — the replicas go idle and the scaler reaps them,
+        // instead of waiting out the heartbeat timeout.
+        if let Some(info) = state.admin_sessions.validate(&sid).await {
+            if let Some(user) = info.actor {
+                if let Some((_, session_ids)) = state.logout_index.remove(&user) {
+                    let n = session_ids.len();
+                    for app_sid in session_ids {
+                        state.sessions.end_session(&state.replicas, app_sid).await;
+                    }
+                    if n > 0 {
+                        tracing::info!(user = %user, ended = n, "stop-on-logout: ended user's app sessions");
+                    }
+                }
+            }
+        }
+        state.admin_sessions.remove(&sid).await;
     }
     let mut c = Cookie::new(COOKIE_NAME, "");
     c.set_path("/");

--- a/crates/ruscker-admin/src/routes/proxy.rs
+++ b/crates/ruscker-admin/src/routes/proxy.rs
@@ -181,6 +181,11 @@ async fn forward(
     // cookie we may set at the end.
     let is_https = crate::auth::request_is_https(req.headers());
 
+    // Signed-in username (if any), captured before the access-guard below
+    // consumes `session.0`. Used to index the session for `stop-on-logout`
+    // (#337). A borrow + clone — leaves `session` intact for the guard.
+    let acting_user: Option<String> = session.0.as_ref().and_then(|s| s.actor.clone());
+
     // 1. Find the spec. DB-first when attached (covers the showcase
     // seed + operator edits via the admin), falling back to the YAML
     // `proxy.specs` so deployments that load specs exclusively from
@@ -397,10 +402,23 @@ async fn forward(
     //     per-request, not per-session, so inflating
     //     `sessions_active` for them would mislead the scaler.
     if spec_kind_needs_sticky(spec.kind()) {
-        let _outcome = state
+        let outcome = state
             .sessions
             .touch_or_register(&state.replicas, session_id, &spec.id, &replica.id)
             .await;
+        // stop-on-logout (#337): when a *known* user first registers a
+        // session on a spec that opts in, index it so their logout can
+        // end it immediately. Only on first registration and only for
+        // such specs — no cost on the common path.
+        if outcome == crate::sessions::TouchOutcome::Registered && spec.effective_stop_on_logout() {
+            if let Some(user) = &acting_user {
+                state
+                    .logout_index
+                    .entry(user.clone())
+                    .or_default()
+                    .insert(session_id);
+            }
+        }
     }
 
     // 5. WebSocket branch hijacks the upgrade and pumps frames;
@@ -1543,6 +1561,7 @@ mod tests {
             cookie_key: CookieKey::random(),
             spawn_locks: StdArc::new(dashmap::DashMap::new()),
             sessions: StdArc::new(crate::sessions::InMemorySessionStore::new()),
+            logout_index: StdArc::new(dashmap::DashMap::new()),
             leader: StdArc::new(crate::leader::AlwaysLeader),
             metrics: crate::metrics_cache::MetricsCache::new(),
             draining: StdArc::new(std::sync::atomic::AtomicBool::new(false)),

--- a/crates/ruscker-admin/src/scaler.rs
+++ b/crates/ruscker-admin/src/scaler.rs
@@ -837,6 +837,7 @@ mod tests {
             cookie_key: ruscker_proxy::sticky::CookieKey::random(),
             spawn_locks: Arc::new(dashmap::DashMap::new()),
             sessions: Arc::new(crate::sessions::InMemorySessionStore::new()),
+            logout_index: Arc::new(dashmap::DashMap::new()),
             leader: Arc::new(crate::leader::AlwaysLeader),
             metrics: crate::metrics_cache::MetricsCache::new(),
             draining: Arc::new(std::sync::atomic::AtomicBool::new(false)),

--- a/crates/ruscker-admin/src/sessions.rs
+++ b/crates/ruscker-admin/src/sessions.rs
@@ -113,6 +113,17 @@ pub trait SessionStore: Send + Sync {
     /// around this call, so there is nothing left to decrement.
     async fn drop_replica(&self, replica_id: &ReplicaId) -> usize;
 
+    /// End one tracked session by id — remove it and decrement its
+    /// replica's `sessions_active` (the same bookkeeping the idle sweep
+    /// does, but triggered on demand). Used by `stop-on-logout` (#337) to
+    /// free a user's session the moment they sign out. Returns `true` if
+    /// a session was actually removed (a stale/unknown id is a no-op).
+    async fn end_session(
+        &self,
+        registry: &RwLock<ReplicaRegistry>,
+        session_id: Uuid,
+    ) -> bool;
+
     /// Number of tracked sessions (used by graceful-shutdown drain and
     /// the dashboard/metrics).
     fn len(&self) -> usize;
@@ -269,6 +280,24 @@ impl SessionStore for InMemorySessionStore {
         victims.len()
     }
 
+    /// End one session by id: remove it and decrement its replica's
+    /// counter (mirrors a single sweep eviction). Returns whether it
+    /// existed. The DashMap removal yields the entry's `replica_id`, so
+    /// we only take the registry write lock when there's real work.
+    async fn end_session(
+        &self,
+        registry: &RwLock<ReplicaRegistry>,
+        session_id: Uuid,
+    ) -> bool {
+        match self.sessions.remove(&session_id) {
+            Some((_, entry)) => {
+                registry.write().await.dec_sessions(&entry.replica_id);
+                true
+            }
+            None => false,
+        }
+    }
+
     /// Number of tracked sessions. For introspection / tests.
     fn len(&self) -> usize {
         self.sessions.len()
@@ -408,6 +437,33 @@ mod tests {
         // Idempotent: dropping again removes nothing.
         assert_eq!(store.drop_replica(&rid_a).await, 0);
         assert_eq!(store.len(), 1);
+    }
+
+    #[tokio::test]
+    async fn end_session_removes_one_and_decrements() {
+        // #337: stop-on-logout ends a single session by id, decrementing
+        // its replica's counter (like one sweep eviction).
+        let reg = Arc::new(RwLock::new(ReplicaRegistry::new()));
+        let r = fake_replica("alpha");
+        let rid = r.id.clone();
+        reg.write().await.add(r);
+        let store = InMemorySessionStore::new();
+
+        let s1 = Uuid::new_v4();
+        let s2 = Uuid::new_v4();
+        store.touch_or_register(&reg, s1, "alpha", &rid).await;
+        store.touch_or_register(&reg, s2, "alpha", &rid).await;
+        assert_eq!(reg.read().await.replicas_of("alpha")[0].sessions_active, 2);
+
+        // End s1: removed, counter drops to 1.
+        assert!(store.end_session(&reg, s1).await);
+        assert_eq!(store.len(), 1);
+        assert_eq!(reg.read().await.replicas_of("alpha")[0].sessions_active, 1);
+
+        // Unknown / already-ended id ⇒ no-op false, counter unchanged.
+        assert!(!store.end_session(&reg, s1).await);
+        assert!(!store.end_session(&reg, Uuid::new_v4()).await);
+        assert_eq!(reg.read().await.replicas_of("alpha")[0].sessions_active, 1);
     }
 
     #[tokio::test]

--- a/crates/ruscker-admin/src/sessions_pg.rs
+++ b/crates/ruscker-admin/src/sessions_pg.rs
@@ -399,6 +399,47 @@ impl SessionStore for PostgresSessionStore {
         removed
     }
 
+    /// End one session by id (#337). Deletes the shared row and, using
+    /// the `RETURNING` replica, reconciles that replica's count to
+    /// committed truth (consistent with the register path's
+    /// `set_session_count`, not a blind decrement) plus this node's
+    /// cached `len()`. An unknown/stale id is a no-op returning `false`.
+    async fn end_session(
+        &self,
+        registry: &RwLock<ReplicaRegistry>,
+        session_id: Uuid,
+    ) -> bool {
+        let row = sqlx::query("DELETE FROM proxy_sessions WHERE session_id = $1 RETURNING replica_id")
+            .bind(session_id)
+            .fetch_optional(&self.pool)
+            .await;
+        let replica_id = match row {
+            Ok(Some(r)) => match r.try_get::<Uuid, _>("replica_id") {
+                Ok(id) => ReplicaId(id),
+                Err(_) => return true, // deleted, but couldn't read the id
+            },
+            Ok(None) => return false, // unknown / already-gone session
+            Err(e) => {
+                error!(error = %e, "postgres end_session failed");
+                return false;
+            }
+        };
+        if let Ok(n) = self.count_for_replica(&replica_id).await {
+            registry.write().await.set_session_count(&replica_id, n);
+        }
+        if let Ok(row) =
+            sqlx::query("SELECT count(*)::bigint AS n FROM proxy_sessions WHERE instance_id = $1")
+                .bind(self.instance_id)
+                .fetch_one(&self.pool)
+                .await
+        {
+            if let Ok(mine) = row.try_get::<i64, _>("n") {
+                self.local_len.store(mine.max(0) as usize, Ordering::Relaxed);
+            }
+        }
+        true
+    }
+
     fn len(&self) -> usize {
         self.local_len.load(Ordering::Relaxed)
     }

--- a/crates/ruscker-admin/tests/api_policies.rs
+++ b/crates/ruscker-admin/tests/api_policies.rs
@@ -56,6 +56,7 @@ fn state() -> AppState {
         cookie_key: ruscker_proxy::sticky::CookieKey::random(),
         spawn_locks: Arc::new(dashmap::DashMap::new()),
         sessions: Arc::new(ruscker_admin::sessions::InMemorySessionStore::new()),
+        logout_index: Arc::new(dashmap::DashMap::new()),
         leader: Arc::new(ruscker_admin::leader::AlwaysLeader),
         metrics: ruscker_admin::metrics_cache::MetricsCache::new(),
         draining: Arc::new(std::sync::atomic::AtomicBool::new(false)),

--- a/crates/ruscker-admin/tests/health_probes.rs
+++ b/crates/ruscker-admin/tests/health_probes.rs
@@ -40,6 +40,7 @@ fn base_state() -> AppState {
         cookie_key: ruscker_proxy::sticky::CookieKey::random(),
         spawn_locks: Arc::new(dashmap::DashMap::new()),
         sessions: Arc::new(ruscker_admin::sessions::InMemorySessionStore::new()),
+        logout_index: Arc::new(dashmap::DashMap::new()),
         leader: Arc::new(ruscker_admin::leader::AlwaysLeader),
         metrics: ruscker_admin::metrics_cache::MetricsCache::new(),
         draining: Arc::new(std::sync::atomic::AtomicBool::new(false)),

--- a/crates/ruscker-admin/tests/landing_access.rs
+++ b/crates/ruscker-admin/tests/landing_access.rs
@@ -78,6 +78,7 @@ async fn app_state(db: ConfigDb) -> AppState {
         cookie_key: ruscker_proxy::sticky::CookieKey::random(),
         spawn_locks: Arc::new(dashmap::DashMap::new()),
         sessions: Arc::new(ruscker_admin::sessions::InMemorySessionStore::new()),
+        logout_index: Arc::new(dashmap::DashMap::new()),
         leader: Arc::new(ruscker_admin::leader::AlwaysLeader),
         metrics: ruscker_admin::metrics_cache::MetricsCache::new(),
         draining: Arc::new(std::sync::atomic::AtomicBool::new(false)),

--- a/crates/ruscker-admin/tests/landing_render.rs
+++ b/crates/ruscker-admin/tests/landing_render.rs
@@ -38,6 +38,7 @@ fn app_state() -> AppState {
         cookie_key: ruscker_proxy::sticky::CookieKey::random(),
         spawn_locks: std::sync::Arc::new(dashmap::DashMap::new()),
         sessions: std::sync::Arc::new(ruscker_admin::sessions::InMemorySessionStore::new()),
+        logout_index: std::sync::Arc::new(dashmap::DashMap::new()),
         leader: std::sync::Arc::new(ruscker_admin::leader::AlwaysLeader),
         metrics: ruscker_admin::metrics_cache::MetricsCache::new(),
         draining: std::sync::Arc::new(std::sync::atomic::AtomicBool::new(false)),

--- a/crates/ruscker-admin/tests/max_body_size.rs
+++ b/crates/ruscker-admin/tests/max_body_size.rs
@@ -55,6 +55,7 @@ fn state() -> AppState {
         cookie_key: ruscker_proxy::sticky::CookieKey::random(),
         spawn_locks: Arc::new(dashmap::DashMap::new()),
         sessions: Arc::new(ruscker_admin::sessions::InMemorySessionStore::new()),
+        logout_index: Arc::new(dashmap::DashMap::new()),
         leader: Arc::new(ruscker_admin::leader::AlwaysLeader),
         metrics: ruscker_admin::metrics_cache::MetricsCache::new(),
         draining: Arc::new(std::sync::atomic::AtomicBool::new(false)),

--- a/crates/ruscker-admin/tests/metrics.rs
+++ b/crates/ruscker-admin/tests/metrics.rs
@@ -28,6 +28,7 @@ fn state(yaml: &str) -> AppState {
         cookie_key: ruscker_proxy::sticky::CookieKey::random(),
         spawn_locks: Arc::new(dashmap::DashMap::new()),
         sessions: Arc::new(ruscker_admin::sessions::InMemorySessionStore::new()),
+        logout_index: Arc::new(dashmap::DashMap::new()),
         leader: Arc::new(ruscker_admin::leader::AlwaysLeader),
         metrics: ruscker_admin::metrics_cache::MetricsCache::new(),
         draining: Arc::new(std::sync::atomic::AtomicBool::new(false)),

--- a/crates/ruscker-admin/tests/proxy_access.rs
+++ b/crates/ruscker-admin/tests/proxy_access.rs
@@ -75,6 +75,7 @@ async fn app_state(db: ConfigDb) -> AppState {
         cookie_key: ruscker_proxy::sticky::CookieKey::random(),
         spawn_locks: Arc::new(dashmap::DashMap::new()),
         sessions: Arc::new(ruscker_admin::sessions::InMemorySessionStore::new()),
+        logout_index: Arc::new(dashmap::DashMap::new()),
         leader: Arc::new(ruscker_admin::leader::AlwaysLeader),
         metrics: ruscker_admin::metrics_cache::MetricsCache::new(),
         draining: Arc::new(std::sync::atomic::AtomicBool::new(false)),

--- a/crates/ruscker-admin/tests/rbac.rs
+++ b/crates/ruscker-admin/tests/rbac.rs
@@ -52,6 +52,7 @@ fn state() -> AppState {
         cookie_key: ruscker_proxy::sticky::CookieKey::random(),
         spawn_locks: Arc::new(dashmap::DashMap::new()),
         sessions: Arc::new(ruscker_admin::sessions::InMemorySessionStore::new()),
+        logout_index: Arc::new(dashmap::DashMap::new()),
         leader: Arc::new(ruscker_admin::leader::AlwaysLeader),
         metrics: ruscker_admin::metrics_cache::MetricsCache::new(),
         draining: Arc::new(std::sync::atomic::AtomicBool::new(false)),

--- a/crates/ruscker-admin/tests/user_accounts.rs
+++ b/crates/ruscker-admin/tests/user_accounts.rs
@@ -39,6 +39,7 @@ async fn state_with_db() -> (AppState, sqlx::SqlitePool) {
         cookie_key: ruscker_proxy::sticky::CookieKey::random(),
         spawn_locks: Arc::new(dashmap::DashMap::new()),
         sessions: Arc::new(ruscker_admin::sessions::InMemorySessionStore::new()),
+        logout_index: Arc::new(dashmap::DashMap::new()),
         leader: Arc::new(ruscker_admin::leader::AlwaysLeader),
         metrics: ruscker_admin::metrics_cache::MetricsCache::new(),
         draining: Arc::new(std::sync::atomic::AtomicBool::new(false)),

--- a/crates/ruscker-config/src/schema.rs
+++ b/crates/ruscker-config/src/schema.rs
@@ -943,6 +943,13 @@ impl Spec {
         self.scale_down_threshold.map(|f| f.0)
     }
 
+    /// Whether a signed-in user's sticky sessions on this spec should be
+    /// ended immediately when they log out, instead of waiting for the
+    /// heartbeat sweep (#337). Default `false`.
+    pub fn effective_stop_on_logout(&self) -> bool {
+        self.stop_on_logout.unwrap_or(false)
+    }
+
     /// Multi-host placement strategy (default [`Placement::Spread`]).
     pub fn effective_placement(&self) -> Placement {
         self.placement.unwrap_or_default()
@@ -1164,6 +1171,18 @@ mod max_body_size_tests {
             serde_yaml_ng::from_str("id: y\ncontainer-image: a:1\n").expect("parse");
         assert_eq!(none.effective_max_lifetime_secs(), None);
         assert_eq!(none.effective_container_lifetime_secs(), None);
+    }
+
+    #[test]
+    fn stop_on_logout_defaults_false() {
+        // #337: default false; explicit true honoured.
+        let off: Spec =
+            serde_yaml_ng::from_str("id: a\ncontainer-image: x:1\n").expect("parse");
+        assert!(!off.effective_stop_on_logout());
+        let on: Spec =
+            serde_yaml_ng::from_str("id: b\ncontainer-image: x:1\nstop-on-logout: true\n")
+                .expect("parse");
+        assert!(on.effective_stop_on_logout());
     }
 
     #[test]

--- a/crates/ruscker-config/src/validate.rs
+++ b/crates/ruscker-config/src/validate.rs
@@ -250,11 +250,9 @@ const UNSUPPORTED_SPEC_FIELDS: &[(&str, &str)] = &[
     //   `drain-timeout` — bounds the grace the hard `max-lifetime` recycle
     //     grants busy replicas before the force-kill (#335);
     //   `max-lifetime` / `container-lifetime` — replicas recycled past
-    //     their age cap (#334).
-    (
-        "stop-on-logout",
-        "stop-on-logout not implemented — sessions end via heartbeat-timeout; tracked in #326",
-    ),
+    //     their age cap (#334);
+    //   `stop-on-logout` — a signed-in user's sticky sessions are ended
+    //     immediately on logout (#337).
 ];
 
 /// Top-level `proxy.*` keys that are unsupported.
@@ -1014,12 +1012,14 @@ proxy:
                 _ => None,
             })
             .collect();
-        for expected in ["concurrent-requests-per-replica", "stop-on-logout"] {
-            assert!(fields.iter().any(|f| f == expected), "missing {expected}: {fields:?}");
-        }
+        // Only `concurrent-requests-per-replica` (#336) is still unwired.
+        assert!(
+            fields.iter().any(|f| f == "concurrent-requests-per-replica"),
+            "expected concurrent-requests flagged: {fields:?}"
+        );
         // Enforced now — must NOT be flagged: max-lifetime / container-
         // lifetime (#334), drain-timeout (#335), the autoscaling
-        // thresholds + scale-down-grace (#333).
+        // thresholds + scale-down-grace (#333), stop-on-logout (#337).
         for enforced in [
             "max-lifetime",
             "container-lifetime",
@@ -1027,6 +1027,7 @@ proxy:
             "scale-up-threshold",
             "scale-down-threshold",
             "scale-down-grace",
+            "stop-on-logout",
         ] {
             assert!(
                 !fields.iter().any(|f| f == enforced),

--- a/docs/YAML_SCHEMA.md
+++ b/docs/YAML_SCHEMA.md
@@ -258,7 +258,7 @@ A spec describes one app, API, or external link. Every spec has an
   max-lifetime: 360                   # minutes — hard recycle (enforced, #334)
   container-lifetime: 360             # minutes — soft recycle when idle (enforced, #334)
   heartbeat-timeout: 3600000          # ms — per-spec override (enforced)
-  stop-on-logout: false               # NOT yet enforced (#326)
+  stop-on-logout: false               # end a user's sessions on logout (enforced, #337)
   docker-registry-username: acme
   docker-registry-password: ${DOCKER_REGISTRY_PASSWORD}   # use env vars!
   docker-registry-domain: docker.io
@@ -464,13 +464,14 @@ applied) and flagged by `ruscker validate`.
 > `scale-down-grace` (#333 — pool-utilization-driven scale-up + a
 > conservative scale-down gate + per-spec idle grace; unset ⇒ the
 > default rules), `max-lifetime` / `container-lifetime` (#334 — recycle
-> past the age cap), and `drain-timeout` (#335 — grace for a busy
-> `max-lifetime` recycle). Still **not** enforced —
-> `concurrent-requests-per-replica` / `stop-on-logout` — are accepted
-> (and round-trip through import/export + the admin form) for migration
+> past the age cap), `drain-timeout` (#335 — grace for a busy
+> `max-lifetime` recycle), and `stop-on-logout` (#337 — a signed-in
+> user's sticky sessions end immediately on logout). Still **not**
+> enforced — `concurrent-requests-per-replica` — is accepted (and
+> round-trips through import/export + the admin form) for migration
 > friction-free, but a set value does **not** change runtime behaviour
-> yet. `ruscker validate --strict-compat` flags each still-unenforced
-> one. Wiring the rest is tracked per-knob under #326 (#336/#337).
+> yet. `ruscker validate --strict-compat` flags it. Wiring it is tracked
+> under #326 (#336).
 
 ### Routing strategies
 


### PR DESCRIPTION
Closes #337. Phase 2 of #326 — the last of the scaling/lifecycle knobs except `concurrent-requests-per-replica` (#336).

## Behaviour
When a spec sets `stop-on-logout: true`, a signed-in user's sticky sessions on it are ended the moment they log out — the replica goes idle and the scaler reaps it, instead of waiting out the `heartbeat-timeout`.

## How
Ruscker's session tracker keys on opaque session ids, not users, so there's no user→session link to drive this. A small **process-local index** (`AppState.logout_index`) maps `username → {app session ids}` opened on `stop-on-logout` specs:

- The proxy records an entry on **first registration**, only for a **known user** and an **opt-in spec** — no cost on the common path.
- The logout handler resolves the user from the admin session (`validate` before invalidating), drains its index entry, and ends those sessions via the new `SessionStore::end_session(session_id)`:
  - in-memory: remove the entry + `dec_sessions` (one sweep eviction's worth of bookkeeping);
  - Postgres: `DELETE … RETURNING replica_id`, then reconcile that replica's count to committed truth + refresh local `len()`.

Process-local is consistent with the process-local admin-session store (#161 prescribes a sticky upstream for session-bearing paths, so a user's logout and their app sessions land on the same instance). Best-effort: a stale id is a no-op at logout, and the heartbeat sweep remains the backstop.

## Compat / docs
Drops `stop-on-logout` from the `--strict-compat` not-enforced list; marks it enforced in `docs/YAML_SCHEMA.md`. Only `concurrent-requests-per-replica` (#336) remains flagged — after which #326 closes.

## Tests
`end_session_removes_one_and_decrements` (remove + dec + stale-id no-op), `stop_on_logout_defaults_false`, updated strict-compat expectations, a `validate --strict-compat` smoke. The `logout_index` field is threaded through every `AppState` constructor (src + the 9 integration-test builders). Full gate (config + admin + clippy `-D warnings` + i18n) green.

Note: the end-to-end logout→reap path depends on a signed-in user + a running Docker backend, so it's covered by unit tests of the `end_session` primitive + the (compile-checked) glue; a live click-through is a manual follow-up.

🤖 Generated with [Claude Code](https://claude.com/claude-code)