### PR TITLE
feat(scaler): meter API capacity by in-flight requests (#336)

### DIFF
--- a/crates/ruscker-admin/src/routes/proxy.rs
+++ b/crates/ruscker-admin/src/routes/proxy.rs
@@ -112,6 +112,46 @@ fn http_client() -> &'static Client<HttpConnector, Body> {
 const APP_PREFIX: &str = "/app/";
 const API_PREFIX: &str = "/api/";
 
+/// In-flight request count per replica (#336). API specs have no sticky
+/// sessions, so their capacity is request-based, not seat-based: this
+/// gauge lets the scaler treat concurrent in-flight requests the way it
+/// treats sessions for interactive apps. A process-global (like the
+/// scaler's failure log) so the proxy hot path and the scaler share it
+/// without threading a new field through `AppState`; keyed by replica
+/// id, each op takes only that shard's lock.
+static INFLIGHT: std::sync::LazyLock<dashmap::DashMap<ruscker_core::ReplicaId, u32>> =
+    std::sync::LazyLock::new(dashmap::DashMap::new);
+
+/// RAII guard: bumps a replica's in-flight count on creation and drops
+/// it on `Drop`, covering every return/error path of the forward.
+pub(crate) struct InflightGuard(ruscker_core::ReplicaId);
+
+impl InflightGuard {
+    pub(crate) fn new(replica_id: ruscker_core::ReplicaId) -> Self {
+        *INFLIGHT.entry(replica_id.clone()).or_insert(0) += 1;
+        Self(replica_id)
+    }
+}
+
+impl Drop for InflightGuard {
+    fn drop(&mut self) {
+        if let Some(mut v) = INFLIGHT.get_mut(&self.0) {
+            *v = v.saturating_sub(1);
+        }
+    }
+}
+
+/// Current in-flight request count for a replica (0 if untracked).
+pub(crate) fn inflight_count(replica_id: &ruscker_core::ReplicaId) -> u32 {
+    INFLIGHT.get(replica_id).map(|v| *v).unwrap_or(0)
+}
+
+/// Forget in-flight entries for replicas that have left the registry —
+/// called by the scaler's per-tick GC so the map can't grow unbounded.
+pub(crate) fn inflight_gc(alive: &std::collections::HashSet<ruscker_core::ReplicaId>) {
+    INFLIGHT.retain(|rid, _| alive.contains(rid));
+}
+
 // Each handler extracts `Option<ConnectInfo<SocketAddr>>`: it's
 // `Some` in production (the listener is served with connect-info)
 // and `None` under `Router::oneshot` tests, where there's no socket
@@ -471,6 +511,12 @@ async fn forward(
         prefix = %forwarded_prefix,
         "forwarding"
     );
+    // API capacity is request-based, not session-based (#336): count this
+    // request as in-flight on the replica for the duration of the forward
+    // (the guard decs on drop, covering every path below). Only API
+    // specs — interactive apps already meter capacity via sticky sessions.
+    let _inflight =
+        (route_prefix == API_PREFIX).then(|| InflightGuard::new(replica.id.clone()));
     let resp = match do_forward(
         &replica,
         upstream_path,
@@ -1358,6 +1404,28 @@ mod tests {
         // Only-ours ⇒ None, so the WS branch sends no Cookie header.
         let only_ours = format!("{}=sid", crate::auth::COOKIE_NAME);
         assert!(filter_ruscker_cookies(&only_ours).is_none());
+    }
+
+    #[test]
+    fn inflight_guard_counts_and_gc_prunes() {
+        // #336: the RAII guard bumps the count and drops it on scope exit;
+        // GC forgets replicas no longer alive. Fresh uuids keep this test
+        // isolated from the process-global map.
+        let rid = ruscker_core::ReplicaId(uuid::Uuid::new_v4());
+        assert_eq!(inflight_count(&rid), 0);
+        {
+            let _g1 = InflightGuard::new(rid.clone());
+            let _g2 = InflightGuard::new(rid.clone());
+            assert_eq!(inflight_count(&rid), 2);
+        }
+        // Both guards dropped → back to zero.
+        assert_eq!(inflight_count(&rid), 0);
+
+        // GC drops the (now-zero) entry when the replica isn't alive.
+        let _g = InflightGuard::new(rid.clone());
+        assert_eq!(inflight_count(&rid), 1);
+        inflight_gc(&std::collections::HashSet::new());
+        assert_eq!(inflight_count(&rid), 0);
     }
 
     #[test]

--- a/crates/ruscker-admin/src/scaler.rs
+++ b/crates/ruscker-admin/src/scaler.rs
@@ -301,6 +301,12 @@ async fn tick(
     };
     update_idle_ticks(idle_ticks, &registry_snap);
 
+    // GC the in-flight request gauge (#336) for replicas that have left
+    // the registry, so the process-global map can't grow unbounded.
+    let alive_replicas: std::collections::HashSet<ReplicaId> =
+        registry_snap.iter().map(|r| r.id.clone()).collect();
+    crate::routes::proxy::inflight_gc(&alive_replicas);
+
     // Spec ids present in this tick's config — used to GC
     // stale per-spec counters for deleted/renamed specs.
     let known_spec_ids: std::collections::HashSet<&str> =
@@ -341,6 +347,9 @@ async fn tick(
         // Per-spec snapshot — small Vec; not worth threading
         // through the registry-wide snapshot above.
         let mut snap = state.replicas.read().await.replicas_of(&spec.id).to_vec();
+        // API capacity is request-based: overlay in-flight requests as
+        // seats so all the seat logic below works for APIs too (#336).
+        overlay_request_capacity(&mut snap, spec);
         let mut count = snap.len();
 
         // --- lifetime reap (#334) + drain window (#335) ---
@@ -373,6 +382,7 @@ async fn tick(
             }
             // Re-read so the scale passes below see the post-reap count.
             snap = state.replicas.read().await.replicas_of(&spec.id).to_vec();
+            overlay_request_capacity(&mut snap, spec);
             count = snap.len();
         }
 
@@ -567,6 +577,25 @@ fn scale_up_triggered(replicas: &[ruscker_core::Replica], up_threshold: Option<f
 fn grace_secs_to_ticks(secs: u64, interval: Duration) -> u32 {
     let iv = interval.as_secs().max(1);
     secs.div_ceil(iv).max(1) as u32
+}
+
+/// For API specs, overlay request-based capacity onto the snapshot so the
+/// seat-based scale logic applies unchanged (#336): a replica's in-flight
+/// request count stands in for `sessions_active`, and
+/// `concurrent-requests-per-replica` for `sessions_max`. API replicas
+/// carry no sticky sessions, so their registry `sessions_active` is
+/// always 0 — without this they'd look permanently idle and never scale
+/// on load. No-op for non-API specs. Mutates the scaler's local snapshot
+/// only, never the registry.
+fn overlay_request_capacity(snap: &mut [ruscker_core::Replica], spec: &Spec) {
+    if !matches!(spec.kind(), SpecKind::Api) {
+        return;
+    }
+    let cap = spec.effective_concurrent_requests_per_replica();
+    for r in snap.iter_mut() {
+        r.sessions_active = crate::routes::proxy::inflight_count(&r.id);
+        r.sessions_max = cap;
+    }
 }
 
 /// Replicas that have outlived their configured lifetime and should be
@@ -1126,6 +1155,38 @@ proxy:
         assert_eq!(grace_secs_to_ticks(25, iv), 3); // ceil(2.5)
         assert_eq!(grace_secs_to_ticks(5, iv), 1); // round up
         assert_eq!(grace_secs_to_ticks(0, iv), 1); // floor at 1
+    }
+
+    #[test]
+    fn overlay_request_capacity_maps_inflight_for_api_only() {
+        let api: Spec = serde_yaml_ng::from_str(
+            "id: api1\ncontainer-image: a:1\ntype: api\nconcurrent-requests-per-replica: 50\n",
+        )
+        .expect("parse api spec");
+        let shiny: Spec =
+            serde_yaml_ng::from_str("id: app1\ncontainer-image: a:1\n").expect("parse shiny spec");
+
+        // API, no in-flight yet → (0, cap).
+        let mut snap = vec![replica_with_sessions("api1", 0, 5)];
+        let rid = snap[0].id.clone();
+        overlay_request_capacity(&mut snap, &api);
+        assert_eq!(snap[0].sessions_active, 0);
+        assert_eq!(snap[0].sessions_max, 50, "cap overlaid as seats");
+
+        // Two in-flight requests on that replica → overlay reflects them.
+        let _g1 = crate::routes::proxy::InflightGuard::new(rid.clone());
+        let _g2 = crate::routes::proxy::InflightGuard::new(rid.clone());
+        let mut snap2 = vec![replica_with_sessions("api1", 0, 5)];
+        snap2[0].id = rid.clone();
+        overlay_request_capacity(&mut snap2, &api);
+        assert_eq!(snap2[0].sessions_active, 2, "in-flight overlaid as active");
+        assert_eq!(snap2[0].sessions_max, 50);
+
+        // Non-API spec → untouched (real seats kept).
+        let mut snap3 = vec![replica_with_sessions("app1", 3, 5)];
+        overlay_request_capacity(&mut snap3, &shiny);
+        assert_eq!(snap3[0].sessions_active, 3);
+        assert_eq!(snap3[0].sessions_max, 5);
     }
 
     #[tokio::test]

--- a/crates/ruscker-config/src/schema.rs
+++ b/crates/ruscker-config/src/schema.rs
@@ -950,6 +950,14 @@ impl Spec {
         self.stop_on_logout.unwrap_or(false)
     }
 
+    /// Per-replica concurrent-request cap for API specs (#336). API
+    /// replicas have no sticky sessions, so the scaler meters their
+    /// capacity by in-flight requests against this cap instead of seats.
+    /// Default 100 (matches the API `seats-per-container` default).
+    pub fn effective_concurrent_requests_per_replica(&self) -> u32 {
+        self.concurrent_requests_per_replica.unwrap_or(100)
+    }
+
     /// Multi-host placement strategy (default [`Placement::Spread`]).
     pub fn effective_placement(&self) -> Placement {
         self.placement.unwrap_or_default()

--- a/crates/ruscker-config/src/validate.rs
+++ b/crates/ruscker-config/src/validate.rs
@@ -235,24 +235,17 @@ const UNSUPPORTED_SPEC_FIELDS: &[(&str, &str)] = &[
     // ShinyProxy `container-env` / `container-cmd` straight across. They
     // are intentionally absent from this ignored-fields list.
     //
-    // Scaling/lifecycle knobs (#326): these parse, round-trip, and are
-    // editable in the admin form, but the scaler does NOT yet consume
-    // them. Flag them so a migrating operator isn't misled into thinking
-    // a set value takes effect.
-    (
-        "concurrent-requests-per-replica",
-        "request-based concurrency limit not enforced — capacity is seat-based; tracked in #326",
-    ),
-    // NOTE: enforced now, intentionally absent from this ignored list:
+    // NOTE: the whole #326 family of scaling/lifecycle knobs is enforced
+    // now and is intentionally absent from this list:
     //   `scale-up-threshold` / `scale-down-threshold` / `scale-down-grace`
-    //     — the scaler scales on pool utilization vs the thresholds, with
-    //     a per-spec scale-down grace (#333);
-    //   `drain-timeout` — bounds the grace the hard `max-lifetime` recycle
-    //     grants busy replicas before the force-kill (#335);
-    //   `max-lifetime` / `container-lifetime` — replicas recycled past
-    //     their age cap (#334);
-    //   `stop-on-logout` — a signed-in user's sticky sessions are ended
-    //     immediately on logout (#337).
+    //     — scale on pool utilization vs the thresholds, per-spec grace
+    //       (#333);
+    //   `max-lifetime` / `container-lifetime` — recycle past the age cap
+    //     (#334);
+    //   `drain-timeout` — grace for a busy `max-lifetime` recycle (#335);
+    //   `stop-on-logout` — end a user's sticky sessions on logout (#337);
+    //   `concurrent-requests-per-replica` — API capacity metered by
+    //     in-flight requests (#336).
 ];
 
 /// Top-level `proxy.*` keys that are unsupported.
@@ -987,17 +980,16 @@ proxy:
     }
 
     #[test]
-    fn compat_scan_flags_unenforced_scaling_knobs() {
-        // #326: these parse + round-trip + are form-editable but the
-        // scaler never consumes them, so strict-compat must surface them
-        // as accepted-but-not-enforced (so a migrating operator isn't
-        // misled). A clean spec (no such knobs) stays quiet.
+    fn compat_scan_no_longer_flags_scaling_knobs() {
+        // The whole #326 family is enforced now (#333/#334/#335/#336/#337),
+        // so strict-compat must NOT flag any of them anymore.
         let yaml = "\
 proxy:
   specs:
   - id: scaled
     container-image: rocker/shiny
     scale-up-threshold: 0.9
+    scale-down-threshold: 0.2
     scale-down-grace: 600
     drain-timeout: 90
     concurrent-requests-per-replica: 4
@@ -1012,21 +1004,14 @@ proxy:
                 _ => None,
             })
             .collect();
-        // Only `concurrent-requests-per-replica` (#336) is still unwired.
-        assert!(
-            fields.iter().any(|f| f == "concurrent-requests-per-replica"),
-            "expected concurrent-requests flagged: {fields:?}"
-        );
-        // Enforced now — must NOT be flagged: max-lifetime / container-
-        // lifetime (#334), drain-timeout (#335), the autoscaling
-        // thresholds + scale-down-grace (#333), stop-on-logout (#337).
         for enforced in [
-            "max-lifetime",
-            "container-lifetime",
-            "drain-timeout",
             "scale-up-threshold",
             "scale-down-threshold",
             "scale-down-grace",
+            "drain-timeout",
+            "concurrent-requests-per-replica",
+            "max-lifetime",
+            "container-lifetime",
             "stop-on-logout",
         ] {
             assert!(

--- a/docs/YAML_SCHEMA.md
+++ b/docs/YAML_SCHEMA.md
@@ -455,23 +455,22 @@ applied) and flagged by `ruscker validate`.
 | `scale-down-grace` | s | `300` | idle-grace before retiring a replica (enforced, #333) |
 | `drain-timeout` | s | `60` | grace for in-flight sessions on a `max-lifetime` recycle (enforced, #335) |
 | `routing-strategy` | enum | varies | See below |
-| `concurrent-requests-per-replica` | u32 | `100` | ⚠️ parsed but **not yet enforced** (#326) |
+| `concurrent-requests-per-replica` | u32 | `100` | API-only — per-replica in-flight cap the scaler scales on (enforced, #336) |
 
-> **Some autoscaling knobs not yet enforced (#326).** By default the
-> scaler scales on **seat saturation** (`sessions_active` vs
-> `sessions_max`) with built-in grace ticks. Now enforced (opt-in where
-> noted): `scale-up-threshold` / `scale-down-threshold` /
+> **Autoscaling knobs (#326).** By default the scaler scales on **seat
+> saturation** (`sessions_active` vs `sessions_max`) with built-in grace
+> ticks. All the per-spec scaling/lifecycle knobs are now enforced
+> (opt-in where noted): `scale-up-threshold` / `scale-down-threshold` /
 > `scale-down-grace` (#333 — pool-utilization-driven scale-up + a
 > conservative scale-down gate + per-spec idle grace; unset ⇒ the
 > default rules), `max-lifetime` / `container-lifetime` (#334 — recycle
 > past the age cap), `drain-timeout` (#335 — grace for a busy
-> `max-lifetime` recycle), and `stop-on-logout` (#337 — a signed-in
-> user's sticky sessions end immediately on logout). Still **not**
-> enforced — `concurrent-requests-per-replica` — is accepted (and
-> round-trips through import/export + the admin form) for migration
-> friction-free, but a set value does **not** change runtime behaviour
-> yet. `ruscker validate --strict-compat` flags it. Wiring it is tracked
-> under #326 (#336).
+> `max-lifetime` recycle), `stop-on-logout` (#337 — a signed-in user's
+> sticky sessions end immediately on logout), and
+> `concurrent-requests-per-replica` (#336 — API specs have no sticky
+> sessions, so the scaler meters their capacity by in-flight requests
+> against this per-replica cap). `ruscker validate --strict-compat` no
+> longer flags any of them.
 
 ### Routing strategies
 


### PR DESCRIPTION
Closes #336. The **last** knob of #326 phase 2 — after this, the whole #326 family is enforced.

## Problem
API specs carry no sticky sessions, so their registry `sessions_active` is always 0. The seat-based scaler therefore saw API replicas as permanently idle: they never scaled up under load (only to `min`). `concurrent-requests-per-replica` (default 100) was parsed but ignored.

## Fix
- **In-flight gauge**: a process-global `INFLIGHT: DashMap<ReplicaId, u32>` (mirrors the scaler's failure-log singleton, so no new `AppState` field and no constructor ripple). An `InflightGuard` RAII increments it before the API forward and decrements on `Drop`, covering every return/error path. Tracked for **API specs only** — interactive apps already meter capacity via sessions.
- **Scaler overlay**: `overlay_request_capacity` maps, for API specs, the replica's in-flight count → `sessions_active` and the cap → `sessions_max` in the scaler's local snapshot. All the existing seat-based logic (saturation scale-up incl. the #333 thresholds, idle scale-down, lifetime reap) then applies to APIs **unchanged**. A per-tick GC forgets entries for departed replicas.

### Scope note
Routing still round-robins API requests across `Ready` replicas (unchanged). This PR is the **scaling signal**, not request-level admission control (rejecting at the cap) — that would be a separate feature.

### Why a process-global, not an `AppState` field?
The proxy (writer) and scaler (reader) both need it; a global avoids threading a field through ~12 `AppState` constructors, exactly as the existing `SPAWN_FAILURES` singleton does. Keyed by replica id; each op takes only that shard's lock.

## Compat / docs
Drops `concurrent-requests-per-replica` from the `--strict-compat` not-enforced list — **none of the #326 knobs are flagged anymore**. `docs/YAML_SCHEMA.md` updated; the callout now lists the full family as enforced.

## Tests
`inflight_guard_counts_and_gc_prunes` (inc/dec/GC), `overlay_request_capacity_maps_inflight_for_api_only` (in-flight→seats for API, no-op otherwise + cap), the rewritten `compat_scan_no_longer_flags_scaling_knobs`, and a `validate --strict-compat` smoke (a knob-laden config reports *no unsupported features*, exit 0). Full gate green.

Completes #326 (phase 2). 🎉