### PR TITLE
chore(release): bump to v0.1.18

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2845,7 +2845,7 @@ dependencies = [
 
 [[package]]
 name = "ruscker-admin"
-version = "0.1.17"
+version = "0.1.18"
 dependencies = [
  "aes-gcm",
  "anyhow",
@@ -2892,7 +2892,7 @@ dependencies = [
 
 [[package]]
 name = "ruscker-cli"
-version = "0.1.17"
+version = "0.1.18"
 dependencies = [
  "anyhow",
  "clap",
@@ -2912,7 +2912,7 @@ dependencies = [
 
 [[package]]
 name = "ruscker-config"
-version = "0.1.17"
+version = "0.1.18"
 dependencies = [
  "chrono",
  "ordered-float",
@@ -2927,7 +2927,7 @@ dependencies = [
 
 [[package]]
 name = "ruscker-core"
-version = "0.1.17"
+version = "0.1.18"
 dependencies = [
  "async-trait",
  "chrono",
@@ -2940,7 +2940,7 @@ dependencies = [
 
 [[package]]
 name = "ruscker-docker"
-version = "0.1.17"
+version = "0.1.18"
 dependencies = [
  "anyhow",
  "async-stream",
@@ -2959,7 +2959,7 @@ dependencies = [
 
 [[package]]
 name = "ruscker-proxy"
-version = "0.1.17"
+version = "0.1.18"
 dependencies = [
  "anyhow",
  "axum",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -10,7 +10,7 @@ members = [
 ]
 
 [workspace.package]
-version = "0.1.17"
+version = "0.1.18"
 edition = "2021"
 rust-version = "1.85"
 license = "Apache-2.0"


### PR DESCRIPTION
Bumps the workspace version 0.1.17 → 0.1.18 (Cargo.toml + Cargo.lock).

Merging this puts `main` at v0.1.18, ready to tag. **The tag (which fires `release.yml` and publishes the GitHub release + ghcr image) is intentionally NOT pushed yet** — it should wait for the manual `/box` base-path click-through (#294/#322 touch every admin URL under a subpath, and the #326 scaler changes are best confirmed live).

### Changelog since v0.1.17 (17 merges)
- **base-path #294 follow-up** (#322): SSE streams + landing card href/logo/cover + proxy login redirect carry the base path.
- **security** (#323): strip Ruscker cookies on the WebSocket upgrade.
- **lifecycle/perf**: session-store orphan purge (#329/#324), `forget_metrics` on stop (#331/#325), CLI `truncate` panic (#330/#327).
- **P3 hardening** (#338/#328): CSRF XFH gating, login-limiter no-DB, volume-bind parser, og:image base-path.
- **#326 phase 2 — scaling/lifecycle knobs enforced**: thresholds + scale-down-grace (#341/#333), max-/container-lifetime recycle (#339/#334), drain-timeout (#340/#335), stop-on-logout (#342/#337), concurrent-requests-per-replica for APIs (#343/#336).

🤖 Generated with [Claude Code](https://claude.com/claude-code)