### PR TITLE
feat(showcase): Shiny card runs the shinyproxy-demo image (#354)

### DIFF
--- a/crates/ruscker-admin/src/db/showcase.rs
+++ b/crates/ruscker-admin/src/db/showcase.rs
@@ -198,17 +198,22 @@ fn showcase_specs() -> Result<Vec<Spec>> {
             None,
         )?,
         // ── Containerized hello-world demos ─────────────────────────
-        // `rocker/shiny` ships an amd64-only manifest; pinning the
-        // platform lets the daemon run it via emulation on arm64
-        // hosts (Apple Silicon / Graviton). The other two images
-        // ship multi-arch manifests so they don't need the override.
+        // The Shiny card runs `openanalytics/shinyproxy-demo` — a real,
+        // single-page Shiny demo that opens straight into a working app
+        // (vs `rocker/shiny`, which lands on a sample-app index). This
+        // is the image the cast lab used for its hand-written
+        // `shiny-demo` card; folding it into the showcase seed retires
+        // that duplicate CONFIG card (#354). amd64-only manifest, so pin
+        // the platform to run it via emulation on arm64 hosts (Apple
+        // Silicon / Graviton); the other two demo images ship multi-arch
+        // manifests so they don't need the override.
         card(
             "shiny",
             "Shiny",
             "Reactive web apps in R and Python.",
             "/assets/showcase/shiny.svg",
             "https://shiny.posit.co",
-            Some("rocker/shiny:latest"),
+            Some("openanalytics/shinyproxy-demo:latest"),
             Some(3838),
             Some("linux/amd64"),
         )?,


### PR DESCRIPTION
Parte de #354.

## Mudança
O card **Shiny** do seed showcase passa a rodar `openanalytics/shinyproxy-demo:latest` em vez de `rocker/shiny:latest`.

- `rocker/shiny` abre num índice de apps de exemplo; `openanalytics/shinyproxy-demo` abre direto num app Shiny funcional.
- É a mesma imagem que o cast definia à mão como card `shiny-demo` (CONFIG). Dobrando-a no seed, o `shiny-demo` redundante pode sair do config do deploy — o conjunto de demos passa a viver só no seed showcase.
- Porta 3838 e o pin de plataforma `linux/amd64` inalterados (a imagem nova também é amd64-only). `kind()` continua Shiny.

## Gate
`cargo test -p ruscker-admin showcase` 4 ✓ (12 cards, ids, kind); clippy `-D warnings` limpo.

> O seed é idempotente (marker `showcase.seeded`) — a troca só pega em **DB fresco** (freshstart) ou via re-seed/edição. **Draft** até o smoke no /box pós-freshstart.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
