### PR TITLE
fix(admin): clarify the two registry-credential paths in the spec form (#351)

### DIFF
--- a/crates/ruscker-admin/assets/i18n/en/landing.ftl
+++ b/crates/ruscker-admin/assets/i18n/en/landing.ftl
@@ -492,8 +492,8 @@ spec-form-registry-password = Password
 spec-form-registry-password-keep = Blank keeps the current password
 spec-help-registry-password = Use an environment variable — never paste the password as text. Only used together with the username.
 spec-form-registry-credential = Stored credential
-spec-help-registry-credential = Name of a credential from the vault, instead of the inline username/password.
-spec-form-registry-help = For private images. Keep secrets in environment variables; the validator warns about plaintext passwords.
+spec-help-registry-credential = Pick a named credential from the store (Credentials page) to pull private images. When set, it takes precedence over the inline username/password.
+spec-form-registry-help = Two ways to pull a private image: a named credential from the store (above), or the inline domain/username/password. The named credential wins if both are set. Never paste a plaintext password — reference an environment variable instead.
 spec-form-access-section = Access
 spec-form-access-groups = Allowed groups
 spec-help-access-groups = Groups that may see and reach the app (comma-separated). Blank, with users also blank = open to everyone.

--- a/crates/ruscker-admin/assets/i18n/es/landing.ftl
+++ b/crates/ruscker-admin/assets/i18n/es/landing.ftl
@@ -492,8 +492,8 @@ spec-form-registry-password = Contraseña
 spec-form-registry-password-keep = En blanco mantiene la contraseña actual
 spec-help-registry-password = Usa una variable de entorno — nunca pegues la contraseña en texto. Solo se usa junto con el usuario.
 spec-form-registry-credential = Credencial guardada
-spec-help-registry-credential = Nombre de una credencial del almacén, en vez del usuario/contraseña en línea.
-spec-form-registry-help = Para imágenes privadas. Mantén los secretos en variables de entorno; el validador avisa de contraseñas en texto.
+spec-help-registry-credential = Elige una credencial con nombre del almacén (página Credenciales) para descargar imágenes privadas. Cuando se define, tiene prioridad sobre el usuario/contraseña en línea.
+spec-form-registry-help = Dos formas de descargar una imagen privada: una credencial con nombre del almacén (arriba) o el dominio/usuario/contraseña en línea. La credencial con nombre gana si se definen ambas. Nunca pegues una contraseña en texto plano — usa una variable de entorno.
 spec-form-access-section = Acceso
 spec-form-access-groups = Grupos permitidos
 spec-help-access-groups = Grupos que pueden ver y acceder a la app (separados por comas). Vacío, con usuarios también vacío = abierto a todos.

--- a/crates/ruscker-admin/assets/i18n/fr/landing.ftl
+++ b/crates/ruscker-admin/assets/i18n/fr/landing.ftl
@@ -492,8 +492,8 @@ spec-form-registry-password = Mot de passe
 spec-form-registry-password-keep = Vide conserve le mot de passe actuel
 spec-help-registry-password = Utilisez une variable d'environnement — ne collez jamais le mot de passe en clair. Utilisé uniquement avec l'utilisateur.
 spec-form-registry-credential = Identifiant enregistré
-spec-help-registry-credential = Nom d'un identifiant du coffre, au lieu de l'utilisateur/mot de passe en ligne.
-spec-form-registry-help = Pour les images privées. Gardez les secrets dans des variables d'environnement ; le validateur alerte sur les mots de passe en clair.
+spec-help-registry-credential = Choisissez un identifiant nommé du coffre (page Identifiants) pour tirer des images privées. S'il est défini, il prime sur l'utilisateur/mot de passe en ligne.
+spec-form-registry-help = Deux façons de tirer une image privée : un identifiant nommé du coffre (ci-dessus) ou le domaine/utilisateur/mot de passe en ligne. L'identifiant nommé l'emporte si les deux sont définis. Ne collez jamais de mot de passe en clair — référencez plutôt une variable d'environnement.
 spec-form-access-section = Accès
 spec-form-access-groups = Groupes autorisés
 spec-help-access-groups = Groupes qui peuvent voir et atteindre l'app (séparés par des virgules). Vide, avec utilisateurs aussi vide = ouvert à tous.

--- a/crates/ruscker-admin/assets/i18n/pt/landing.ftl
+++ b/crates/ruscker-admin/assets/i18n/pt/landing.ftl
@@ -496,8 +496,8 @@ spec-form-registry-password = Senha
 spec-form-registry-password-keep = Em branco mantém a senha atual
 spec-help-registry-password = Use uma variável de ambiente — nunca cole a senha em texto. Só usada junto com o usuário.
 spec-form-registry-credential = Credencial salva
-spec-help-registry-credential = Nome de uma credencial do cofre, em vez de usuário/senha inline.
-spec-form-registry-help = Para imagens privadas. Mantenha segredos em variáveis de ambiente; o validador alerta sobre senhas em texto.
+spec-help-registry-credential = Escolha uma credencial nomeada do cofre (página Credenciais) para puxar imagens privadas. Quando definida, tem precedência sobre o usuário/senha inline.
+spec-form-registry-help = Duas formas de puxar uma imagem privada: uma credencial nomeada do cofre (acima) ou o domínio/usuário/senha inline. A credencial nomeada vence se ambas estiverem definidas. Nunca cole uma senha em texto puro — use uma variável de ambiente.
 spec-form-access-section = Acesso
 spec-form-access-groups = Grupos permitidos
 spec-help-access-groups = Grupos que podem ver e acessar o app (separados por vírgula). Em branco, com usuários também em branco = aberto a todos.

--- a/crates/ruscker-admin/src/routes/admin/spec_form.rs
+++ b/crates/ruscker-admin/src/routes/admin/spec_form.rs
@@ -703,6 +703,10 @@ struct SpecFormPage<'a> {
     /// Filenames in the media library, for the logo picker. Empty
     /// when no DB is wired or the listing fails.
     logo_images: Vec<String>,
+    /// Names of stored registry credentials, for the
+    /// `docker-registry-credential` datalist (#351). Empty when no DB
+    /// is wired or the listing fails — the field stays free-text.
+    credential_names: Vec<String>,
 }
 
 impl<'a> SpecFormPage<'a> {
@@ -750,6 +754,21 @@ async fn logo_filenames(state: &AppState) -> Vec<String> {
     }
 }
 
+/// Names of stored registry credentials, for the spec form's
+/// `docker-registry-credential` datalist (#351) — surfaces the names
+/// the operator created on the Credentials page so the two screens
+/// connect. Empty when no DB is wired or the query fails; the field
+/// then degrades to a plain free-text input.
+async fn credential_names(state: &AppState) -> Vec<String> {
+    match state.db.as_ref() {
+        Some(pool) => db::credentials::list_all(pool)
+            .await
+            .map(|creds| creds.into_iter().map(|c| c.name).collect())
+            .unwrap_or_default(),
+        None => Vec::new(),
+    }
+}
+
 async fn new_form(
     editor: RequireEditor,
     State(state): State<AppState>,
@@ -777,6 +796,7 @@ async fn new_form(
         },
         errors: Vec::new(),
         logo_images: logo_filenames(&state).await,
+        credential_names: credential_names(&state).await,
     };
     super::render(&page)
 }
@@ -811,6 +831,7 @@ async fn edit_form(
         form: SpecForm::from_spec(&spec),
         errors: Vec::new(),
         logo_images: logo_filenames(&state).await,
+        credential_names: credential_names(&state).await,
     };
     super::render(&page)
 }
@@ -975,6 +996,7 @@ async fn render_form_with_errors(
         form,
         errors,
         logo_images: logo_filenames(state).await,
+        credential_names: credential_names(state).await,
     };
     let body = match page.render() {
         Ok(s) => s,

--- a/crates/ruscker-admin/templates/admin/spec_form.html
+++ b/crates/ruscker-admin/templates/admin/spec_form.html
@@ -552,8 +552,16 @@
                 <label for="f-reg-cred" class="spec-form-label">{{ self.t("spec-form-registry-credential") }}</label>
                 {% call help(self.t("spec-help-registry-credential")) %}{% endcall %}
               </div>
+              {# Free-text, but a datalist surfaces the names the operator
+                 created on the Credentials page so the two screens
+                 connect (#351). A named credential takes precedence over
+                 the inline domain/username/password above. #}
               <input id="f-reg-cred" type="text" name="docker_registry_credential"
-                     value="{{ form.docker_registry_credential }}" class="spec-form-input">
+                     value="{{ form.docker_registry_credential }}"
+                     list="registry-cred-suggestions" class="spec-form-input">
+              <datalist id="registry-cred-suggestions">
+                {% for name in credential_names %}<option value="{{ name }}"></option>{% endfor %}
+              </datalist>
             </div>
           </div>
           <div class="spec-form-help">{{ self.t("spec-form-registry-help") }}</div>


### PR DESCRIPTION
Fixes #351.

## Premissa corrigida
O store `/admin/credentials` **não está órfão**: `proxy::resolve_creds` (usado pelos dois caminhos de spawn) já resolve o `docker-registry-credential` de um spec a partir do store AES no momento do pull, com **precedência** sobre os campos inline `docker-registry-*`. São **dois mecanismos complementares**, não duplicação morta — a confusão é de UX. (O known-gap do CLAUDE.md que dizia "só inline é consultado" estava obsoleto.)

## Mudança (clareza, não remoção)
- O campo `docker-registry-credential` no spec form ganha um `<datalist>` com os **nomes do store** (espelha o plumbing do logo-picker: helper `credential_names()` + `Vec<String>` no `SpecFormPage`). Assim as duas telas se conectam — você escolhe um nome que de fato criou.
- Helps reescritos (campo + seção Registry, 4 locales) explicando a **precedência** (credencial nomeada vence o inline) e que são duas formas de puxar imagem privada.
- O submit não muda (campo segue texto livre, vazio ⇒ None).

Decidi **não** remover o store nem "religar" (já está religado) — remover quebraria o fluxo de credencial nomeada que funciona.

## Gate
`cargo test -p ruscker-admin` 242 ✓; clippy `--all-targets -D warnings` limpo; i18n parity ✓.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
