### PR TITLE
fix(admin): base-path-prefix the spec & block form actions (#357)

### DIFF
--- a/crates/ruscker-admin/templates/admin/block_form.html
+++ b/crates/ruscker-admin/templates/admin/block_form.html
@@ -10,7 +10,7 @@
   </h1>
 
   <form method="post"
-        action="{% if mode == "edit" %}/admin/blocks/{{ id }}{% else %}/admin/blocks{% endif %}">
+        action="{{ base }}{% if mode == "edit" %}/admin/blocks/{{ id }}{% else %}/admin/blocks{% endif %}">
 
     <div class="spec-form-field">
       <label class="spec-form-label">{{ self.t("admin-blocks-slot") }}</label>

--- a/crates/ruscker-admin/templates/admin/spec_form.html
+++ b/crates/ruscker-admin/templates/admin/spec_form.html
@@ -53,7 +53,7 @@
 
     {# ── LEFT: form ────────────────────────────────────────── #}
     <form id="spec-form" method="post"
-          action="{% if mode.is_new() %}/admin/specs{% else %}/admin/specs/{{ form.id }}{% endif %}"
+          action="{{ base }}{% if mode.is_new() %}/admin/specs{% else %}/admin/specs/{{ form.id }}{% endif %}"
           class="spec-form-fields"
           autocomplete="off">
 

--- a/crates/ruscker-admin/tests/landing_access.rs
+++ b/crates/ruscker-admin/tests/landing_access.rs
@@ -224,6 +224,77 @@ async fn chrome_self_prefixes_under_base_path() {
 }
 
 #[tokio::test]
+async fn spec_form_action_self_prefixes_under_base_path() {
+    // #357: the spec form's `<form action>` is the create/update POST
+    // target. Under `--base-path` it must carry the prefix or the POST
+    // 404s at the reverse proxy — it lacked `{{ base }}` (a #294
+    // survivor), so editing a spec landed on `/admin/specs/{id}` (no
+    // `/box`). Covers both the Edit (update) and New (create) actions.
+    let db = open_db().await;
+    let cfg = Config::from_yaml(
+        "proxy:\n  specs:\n    - id: voila\n      display-name: Voila\n      container-image: x:1\n",
+    )
+    .expect("parse spec yaml");
+    ruscker_admin::db::specs::upsert_one(&db, &cfg.proxy.specs[0], None)
+        .await
+        .expect("insert spec");
+
+    let mut state = app_state(db).await;
+    state.base_path = Arc::from("/box");
+    let sid = state.admin_sessions.create(Role::Admin, None).await;
+    let app = router(state);
+    let cookie = format!("{COOKIE_NAME}={sid}");
+
+    async fn body_text(resp: axum::response::Response) -> String {
+        String::from_utf8(
+            axum::body::to_bytes(resp.into_body(), 1 << 20).await.unwrap().to_vec(),
+        )
+        .unwrap()
+    }
+
+    // Edit form (the reported case): action → /box/admin/specs/voila.
+    let resp = app
+        .clone()
+        .oneshot(
+            Request::builder()
+                .uri("/box/admin/specs/voila/edit")
+                .header(header::COOKIE, &cookie)
+                .body(Body::empty())
+                .unwrap(),
+        )
+        .await
+        .unwrap();
+    assert_eq!(resp.status(), StatusCode::OK);
+    let body = body_text(resp).await;
+    assert!(
+        body.contains(r#"action="/box/admin/specs/voila""#),
+        "edit form action must be base-prefixed"
+    );
+    assert!(
+        !body.contains(r#"action="/admin/specs/voila""#),
+        "no bare (un-prefixed) edit action should slip through"
+    );
+
+    // New form: action → /box/admin/specs.
+    let resp = app
+        .oneshot(
+            Request::builder()
+                .uri("/box/admin/specs/new")
+                .header(header::COOKIE, &cookie)
+                .body(Body::empty())
+                .unwrap(),
+        )
+        .await
+        .unwrap();
+    assert_eq!(resp.status(), StatusCode::OK);
+    let body = body_text(resp).await;
+    assert!(
+        body.contains(r#"action="/box/admin/specs""#),
+        "new form action must be base-prefixed"
+    );
+}
+
+#[tokio::test]
 async fn login_under_base_path_honors_admin_referer() {
     // #186 (#173 follow-up): a non-admin signing in from
     // `/box/admin/specs` should land back on `/box/admin/specs`, not


### PR DESCRIPTION
Fixes #357.

## Bug
Salvar um spec sob `--base-path /box` dava **404**: o `<form action>` de editar apontava para `/admin/specs/{id}` (**sem `/box`**), então o POST batia na raiz do reverse proxy e o nginx 404ava. O `action` de criar/editar era um **sobrevivente do #294** — constrói a URL dentro de um `{% if %}` e nunca recebeu o `{{ base }}` que o resto do chrome ganhou.

## Fix + varredura
Varri **todos** os `action=` dos templates do chrome: exatamente **um** irmão com o mesmo bug — o form de **blocos** (`block_form.html`). Os dois agora prefixam `{{ base }}`; todos os outros já prefixavam (ou usam `assetUrl()` / `base +` nos construídos por JS).

- `spec_form.html` — `action="{{ base }}{% if new %}/admin/specs{% else %}/admin/specs/{id}{% endif %}"`
- `block_form.html` — idem para `/admin/blocks`

## Teste
`spec_form_action_self_prefixes_under_base_path` renderiza os forms de edição e criação com `base="/box"` e assere que o `action` carrega o prefixo (e que nenhum `action="/admin/specs/..."` cru escapa).

## Gate
`cargo test -p ruscker-admin` 242 + integração ✓; clippy `--all-targets -D warnings` limpo.

> Deploy na raiz não é afetado (`base` vazio → URL idêntica). Corrige criar/editar spec **e** blocos no cast `/box`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
