### PR TITLE
fix(admin): spec-form preview mirrors the landing card's SVG fit rule (#359)

### DIFF
--- a/crates/ruscker-admin/templates/admin/spec_form.html
+++ b/crates/ruscker-admin/templates/admin/spec_form.html
@@ -779,7 +779,12 @@
                :class="form.cover ? '' : 'tint-' + form.display_type"
                :style="coverStyle()"></div>
           <template x-if="form.logo">
-            <img :src="assetUrl(form.logo)" alt="" class="rcover-img">
+            {# Mirror the landing card's fit rule (#359): SVG logos get
+               `rcover-img--contain` (object-fit: contain + padding) so the
+               artwork breathes; raster images stay `cover`. Without this
+               the preview cropped SVGs that the landing showed whole. #}
+            <img :src="assetUrl(form.logo)" alt="" loading="lazy"
+                 :class="(form.logo || '').toLowerCase().endsWith('.svg') ? 'rcover-img rcover-img--contain' : 'rcover-img'">
           </template>
           <template x-if="!form.logo">
             <span class="rcover-fallback" x-text="form.id || '—'"></span>

--- a/crates/ruscker-admin/tests/landing_access.rs
+++ b/crates/ruscker-admin/tests/landing_access.rs
@@ -382,3 +382,35 @@ async fn named_user_sees_their_user_spec() {
     assert!(has_card(&body, "vip user app"), "carol is the VIP user");
     assert!(!has_card(&body, "analysts app"), "carol is not in analysts");
 }
+
+#[tokio::test]
+async fn spec_form_preview_matches_landing_svg_fit() {
+    // #359: the preview's logo <img> must mirror the landing card's fit
+    // rule — an SVG logo gets `rcover-img--contain` (object-fit: contain),
+    // not the default `cover` that crops it. The binding is evaluated by
+    // Alpine client-side; this is a regression guard that the rule stays
+    // wired into the rendered preview (the landing applies the same rule
+    // server-side, so the two cards agree).
+    let state = app_state(open_db().await).await;
+    let sid = state.admin_sessions.create(Role::Admin, None).await;
+    let app = router(state);
+    let resp = app
+        .oneshot(
+            Request::builder()
+                .uri("/admin/specs/new")
+                .header(header::COOKIE, format!("{COOKIE_NAME}={sid}"))
+                .body(Body::empty())
+                .unwrap(),
+        )
+        .await
+        .unwrap();
+    assert_eq!(resp.status(), StatusCode::OK);
+    let body = String::from_utf8(
+        axum::body::to_bytes(resp.into_body(), 1 << 20).await.unwrap().to_vec(),
+    )
+    .unwrap();
+    assert!(
+        body.contains("rcover-img--contain") && body.contains(".svg')"),
+        "preview must apply the SVG contain-fit rule like the landing card"
+    );
+}


### PR DESCRIPTION
Fixes #359.

## Bug
O preview ao vivo do spec form **cortava/ampliava** logos que o card real da landing mostrava **inteiras**. A landing aplica `rcover-img--contain` (`object-fit: contain` + padding) em logos `.svg`; o espelho Alpine do preview usava sempre o `rcover-img` cru (`object-fit: cover`). Como **os 12 logos do showcase são SVG**, todos ficavam diferentes entre o preview e o card.

## Fix
Espelhar a regra no preview: `:class` liga `rcover-img--contain` quando `form.logo` termina em `.svg`, senão `rcover-img`. Também adicionei `loading="lazy"` p/ casar com a `<img>` da landing.

## Teste
`spec_form_preview_matches_landing_svg_fit` renderiza o form de novo-spec e assere que a regra de contain-fit para SVG está cabeada no preview (a avaliação do `:class` é client-side via Alpine).

## Gate
`cargo test -p ruscker-admin` 242 + integração (landing_access 10) ✓; clippy `--all-targets -D warnings` limpo.

> **Draft**: paridade visual — vale o olho no /box (abrir um card de logo SVG e comparar preview × card). A issue também sugere extrair o card num partial compartilhado p/ matar o drift de vez (follow-up maior, não incluído aqui).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
