### PR TITLE
chore: bump Rust toolchain to 1.96.0 (#345)

### DIFF
--- a/rust-toolchain.toml
+++ b/rust-toolchain.toml
@@ -1,3 +1,3 @@
 [toolchain]
-channel = "1.95.0"
+channel = "1.96.0"
 components = ["rustfmt", "clippy"]


### PR DESCRIPTION
Closes #345 (toolchain bump part; 2024-edition evaluation deferred).

## Mudança
`rust-toolchain.toml` channel `1.95.0` → **`1.96.0`** (lançada 2026-05-25). MSRV (`rust-version = "1.85"`) **inalterada** — nenhuma feature exclusiva da 1.96 é usada; só move o compilador canônico de build/CI.

A migração para a **edition 2024** fica adiada de propósito (mudança maior, com churn de idioma) — segue rastreada no #345/follow-up.

## Verificação
Sob 1.96.0 (via `rustup run 1.96.0`, pois o `cargo` default local é um Homebrew 1.95 que ignora o toolchain file — o rustup/CI honra o pin):
- `cargo clippy --all-targets -- -D warnings` — limpo (zero lints novos da 1.96)
- `cargo test --workspace` — verde (23 suítes)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
