### PR TITLE
docs(admin): clarify the appearance editor's scope in-product (#350)

### DIFF
--- a/crates/ruscker-admin/assets/i18n/en/landing.ftl
+++ b/crates/ruscker-admin/assets/i18n/en/landing.ftl
@@ -276,6 +276,7 @@ admin-creds-key-missing-help = The credentials store needs a 32-byte key as hex 
 admin-landing-title = Landing editor
 admin-landing-crumb = Settings · Landing page
 admin-landing-subtitle = Customize the public portal. Changes take effect on the visitor's next refresh.
+admin-landing-scope-help = These options (colors, intro texts, SEO, custom blocks) apply to the public landing live — saved here, shown on the next view, no restart. It's a fixed set of settings, not an arbitrary-CSS editor.
 admin-landing-open-portal = Open portal
 admin-landing-save = Save
 admin-landing-saved = Settings saved. Reload the public portal to see them.

--- a/crates/ruscker-admin/assets/i18n/es/landing.ftl
+++ b/crates/ruscker-admin/assets/i18n/es/landing.ftl
@@ -276,6 +276,7 @@ admin-creds-key-missing-help = El store de credenciales necesita una clave de 32
 admin-landing-title = Editor del portal
 admin-landing-crumb = Ajustes · Landing page
 admin-landing-subtitle = Personalice el portal público. Los cambios surten efecto al refrescar.
+admin-landing-scope-help = Estas opciones (colores, textos de introducción, SEO, bloques personalizados) se aplican a la portada pública en vivo — guardadas aquí, mostradas en la próxima visita, sin reinicio. Es un conjunto fijo de ajustes, no un editor de CSS arbitrario.
 admin-landing-open-portal = Abrir portal
 admin-landing-save = Guardar
 admin-landing-saved = Ajustes guardados. Recargue el portal para ver los cambios.

--- a/crates/ruscker-admin/assets/i18n/fr/landing.ftl
+++ b/crates/ruscker-admin/assets/i18n/fr/landing.ftl
@@ -276,6 +276,7 @@ admin-creds-key-missing-help = Le store d'identifiants a besoin d'une clé de 32
 admin-landing-title = Éditeur du portail
 admin-landing-crumb = Paramètres · Page d'accueil
 admin-landing-subtitle = Personnalisez le portail public. Les modifications s'appliquent au prochain rafraîchissement du visiteur.
+admin-landing-scope-help = Ces options (couleurs, textes d'intro, SEO, blocs personnalisés) s'appliquent à la page d'accueil publique en direct — enregistrées ici, affichées à la prochaine visite, sans redémarrage. C'est un ensemble fixe de réglages, pas un éditeur de CSS arbitraire.
 admin-landing-open-portal = Ouvrir le portail
 admin-landing-save = Enregistrer
 admin-landing-saved = Paramètres enregistrés. Rechargez le portail public pour voir.

--- a/crates/ruscker-admin/assets/i18n/pt/landing.ftl
+++ b/crates/ruscker-admin/assets/i18n/pt/landing.ftl
@@ -280,6 +280,7 @@ admin-creds-key-missing-help = O store de credenciais precisa de uma chave de 32
 admin-landing-title = Editor da landing
 admin-landing-crumb = Configurações · Landing page
 admin-landing-subtitle = Personalize o portal público. Mudanças entram em vigor no próximo refresh do visitante.
+admin-landing-scope-help = Estas opções (cores, textos de introdução, SEO, blocos customizados) se aplicam à landing pública ao vivo — salvas aqui, exibidas na próxima visita, sem restart. É um conjunto fixo de configurações, não um editor de CSS arbitrário.
 admin-landing-open-portal = Abrir portal
 admin-landing-save = Salvar
 admin-landing-saved = Configurações salvas. Recarregue o portal público para ver.

--- a/crates/ruscker-admin/templates/admin/landing.html
+++ b/crates/ruscker-admin/templates/admin/landing.html
@@ -47,6 +47,12 @@
     <form id="landing-form" method="post" action="{{ base }}/admin/landing"
           class="spec-form-fields" autocomplete="off">
 
+      {# Scope note (#350): everything here is applied to the public
+         landing live (saved to the DB, rendered on the next view) — no
+         restart, no rebuild. It's a fixed set of options (colors, intro
+         texts, SEO, custom blocks), NOT an arbitrary-CSS editor. #}
+      <div class="spec-form-help" style="margin-bottom:12px">{{ self.t("admin-landing-scope-help") }}</div>
+
       <div class="spec-form-section-title">{{ self.t("admin-landing-colors") }}</div>
 
       <div class="grid grid-cols-2 gap-3">


### PR DESCRIPTION
Fixes #350.

## A pergunta
Editar a aparência no admin propaga p/ a landing? Dá pra CSS arbitrário?

## Resposta (e o fix)
Sim, propaga **automaticamente**: o editor cobre um conjunto **fixo** — cores, textos de introdução, SEO/meta, snippet de analytics e blocos de HTML custom — salvo em `landing_customization`/`landing_blocks` no DB e renderizado **DB-first na próxima visita** (sem restart). **Não** há campo de CSS arbitrário (decisão #350: só esclarecer, sem feature de CSS custom agora).

Para não deixar isso como adivinhação, adicionei uma **nota de escopo** no topo do editor de aparência (`/admin/landing`) + i18n × 4 locales.

## Gate
`./scripts/i18n-check.sh` ✓; `cargo test -p ruscker-admin --test landing_render` 8 ✓; clippy `-D warnings` limpo (template admin compila).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
