### PR TITLE
feat(showcase): R Markdown card runs the shinyproxy-rmarkdown-demo container (#354)

### DIFF
--- a/crates/ruscker-admin/src/db/showcase.rs
+++ b/crates/ruscker-admin/src/db/showcase.rs
@@ -278,18 +278,20 @@ fn showcase_specs() -> Result<Vec<Spec>> {
             rst.kind_override = Some(ruscker_config::SpecKindOverride::App);
             rst
         },
-        // R Markdown isn't a server — it's a document format. Linked to
-        // its docs rather than launching a container (the RStudio Server
-        // card above is what actually renders/previews `.Rmd` files).
+        // R Markdown demo — OpenAnalytics' `shinyproxy-rmarkdown-demo`
+        // renders an `.Rmd` document with a Shiny backend, so it routes
+        // exactly like the Shiny card (sticky + WebSocket, port 3838) and
+        // the existing `/app` rewriter handles its URLs without extra
+        // base-url flags. amd64-only image → pin the platform (#354).
         card(
             "rmarkdown",
             "R Markdown",
-            "Reproducible R documents — author and render in RStudio.",
+            "Reproducible R documents rendered live, with a Shiny backend.",
             "/assets/showcase/rmarkdown.svg",
             "https://rmarkdown.rstudio.com",
-            None,
-            None,
-            None,
+            Some("openanalytics/shinyproxy-rmarkdown-demo:latest"),
+            Some(3838),
+            Some("linux/amd64"),
         )?,
         // ── External-link cards (no public hello image) ─────────────
         card(


### PR DESCRIPTION
Parte de #354.

## Mudança
O card **R Markdown** deixa de ser link externo e passa a rodar `openanalytics/shinyproxy-rmarkdown-demo:latest` — um `.Rmd` renderizado com **backend Shiny**, então roteia igual ao card Shiny (kind Shiny, sticky + WebSocket, porta 3838) e o rewriter `/app` atual já cobre as URLs sem flags de base-url. Imagem amd64-only → `platform` pinada.

Seed continua com **12 cards** (só troca o rmarkdown de external→container); só pega em **DB fresco** (seed idempotente).

## Gate
`cargo test -p ruscker-admin showcase` 4 ✓; clippy `-D warnings` limpo.

> **Draft**: spawna container real — validar no `/box` pós-release/freshstart (abrir o card R Markdown e confirmar que renderiza).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
