### PR TITLE
feat(admin): duplicate-card button on the specs list (#368)

### DIFF
--- a/crates/ruscker-admin/assets/i18n/en/landing.ftl
+++ b/crates/ruscker-admin/assets/i18n/en/landing.ftl
@@ -181,6 +181,7 @@ admin-specs-filter-search = Search by id or name…
 admin-specs-filter-kind-all = All kinds
 admin-specs-filter-state-all = Active and inactive
 admin-specs-edit = Edit
+admin-specs-duplicate = Duplicate
 admin-specs-config-badge = config
 admin-specs-config-defined = Defined in the YAML config — read-only here; edit the file
 admin-specs-delete = Delete

--- a/crates/ruscker-admin/assets/i18n/es/landing.ftl
+++ b/crates/ruscker-admin/assets/i18n/es/landing.ftl
@@ -181,6 +181,7 @@ admin-specs-filter-search = Buscar por id o nombre…
 admin-specs-filter-kind-all = Todos los tipos
 admin-specs-filter-state-all = Activos e inactivos
 admin-specs-edit = Editar
+admin-specs-duplicate = Duplicar
 admin-specs-config-badge = config
 admin-specs-config-defined = Definido en el YAML — solo lectura aquí; edita el archivo
 admin-specs-delete = Borrar

--- a/crates/ruscker-admin/assets/i18n/fr/landing.ftl
+++ b/crates/ruscker-admin/assets/i18n/fr/landing.ftl
@@ -181,6 +181,7 @@ admin-specs-filter-search = Rechercher par id ou nom…
 admin-specs-filter-kind-all = Tous les types
 admin-specs-filter-state-all = Actifs et inactifs
 admin-specs-edit = Modifier
+admin-specs-duplicate = Dupliquer
 admin-specs-config-badge = config
 admin-specs-config-defined = Défini dans le YAML — lecture seule ici; modifiez le fichier
 admin-specs-delete = Supprimer

--- a/crates/ruscker-admin/assets/i18n/pt/landing.ftl
+++ b/crates/ruscker-admin/assets/i18n/pt/landing.ftl
@@ -185,6 +185,7 @@ admin-specs-filter-search = Buscar por id ou nome…
 admin-specs-filter-kind-all = Todos os tipos
 admin-specs-filter-state-all = Ativos e inativos
 admin-specs-edit = Editar
+admin-specs-duplicate = Duplicar
 admin-specs-config-badge = config
 admin-specs-config-defined = Definido no YAML — somente leitura aqui; edite o arquivo
 admin-specs-delete = Apagar

--- a/crates/ruscker-admin/src/routes/admin/spec_form.rs
+++ b/crates/ruscker-admin/src/routes/admin/spec_form.rs
@@ -42,6 +42,7 @@ pub fn routes() -> Router<AppState> {
             "/admin/specs/{id}/edit",
             get(edit_form),
         )
+        .route("/admin/specs/{id}/duplicate", get(duplicate_form))
         .route("/admin/specs/{id}", post(update))
         .route("/admin/specs/{id}/delete", post(delete))
 }
@@ -824,6 +825,72 @@ async fn edit_form(
         role: editor.role,
         mode: FormMode::Edit,
         form: SpecForm::from_spec(&spec),
+        errors: Vec::new(),
+        logo_images: logo_filenames(&state).await,
+        credential_names: credential_names(&state).await,
+    };
+    super::render(&page)
+}
+
+/// Pick a fresh `{base}-copy[-N]` id that no spec uses yet, so the
+/// duplicate doesn't collide with the source (or a previous copy).
+/// Falls back to the bare `-copy` after a sane cap — the create-time
+/// duplicate-id validation is the final backstop.
+async fn unique_copy_id(pool: &crate::db::ConfigDb, base: &str) -> String {
+    let first = format!("{base}-copy");
+    let free = |id: &str| {
+        let id = id.to_string();
+        async move { matches!(db::specs::fetch_one(pool, &id).await, Ok(None)) }
+    };
+    if free(&first).await {
+        return first;
+    }
+    for n in 2..=99 {
+        let candidate = format!("{base}-copy-{n}");
+        if free(&candidate).await {
+            return candidate;
+        }
+    }
+    first
+}
+
+/// Open the **New** spec form pre-filled from an existing spec (#368).
+/// The operator duplicates a near-identical card and edits only what
+/// differs. The form starts in `FormMode::New` with a fresh unique id,
+/// so the submit hits `POST /admin/specs` and creates a brand-new spec
+/// (the source is untouched). Works on `config`-only specs too — that's
+/// a handy way to fork a YAML-defined spec into an editable DB one. The
+/// registry password is write-only (#260), so it isn't carried over.
+async fn duplicate_form(
+    editor: RequireEditor,
+    State(state): State<AppState>,
+    loc: Locale,
+    theme: Theme,
+    Path(id): Path<String>,
+) -> Response {
+    let Some(pool) = state.db.as_ref() else {
+        return (StatusCode::SERVICE_UNAVAILABLE, "no db").into_response();
+    };
+    let spec = match db::specs::fetch_one(pool, &id).await {
+        Ok(Some(s)) => s,
+        Ok(None) => return (StatusCode::NOT_FOUND, "spec not found").into_response(),
+        Err(e) => {
+            tracing::error!(error = ?e, id, "fetch spec for duplicate failed");
+            return (StatusCode::INTERNAL_SERVER_ERROR, "db error").into_response();
+        }
+    };
+    let mut form = SpecForm::from_spec(&spec);
+    form.id = unique_copy_id(pool, &spec.id).await;
+    let page = SpecFormPage {
+        locale: loc,
+        theme,
+        locales: &state.locales,
+        locales_all: &Locale::ALL,
+        base: state.base_path.clone(),
+        nav_section: "specs",
+        role: editor.role,
+        mode: FormMode::New,
+        form,
         errors: Vec::new(),
         logo_images: logo_filenames(&state).await,
         credential_names: credential_names(&state).await,

--- a/crates/ruscker-admin/templates/admin/specs.html
+++ b/crates/ruscker-admin/templates/admin/specs.html
@@ -105,6 +105,12 @@
           <td class="text-[color:var(--text-faint)]">—</td>
           <td class="text-[color:var(--text-faint)]">—</td>
           <td class="actions-cell">
+            {# Duplicate a YAML/config spec into a new, editable DB spec. #}
+            <a href="{{ base }}/admin/specs/{{ spec.id }}/duplicate"
+               class="admin-nav-link"
+               title="{{ self.t("admin-specs-duplicate") }}">
+              <i class="ti ti-copy" aria-hidden="true"></i>
+            </a>
             <span class="pill" title="{{ self.t("admin-specs-config-defined") }}">{{ self.t("admin-specs-config-badge") }}</span>
           </td>
           {% else %}
@@ -115,6 +121,11 @@
                class="admin-nav-link"
                title="{{ self.t("admin-specs-edit") }}">
               <i class="ti ti-edit" aria-hidden="true"></i>
+            </a>
+            <a href="{{ base }}/admin/specs/{{ spec.id }}/duplicate"
+               class="admin-nav-link"
+               title="{{ self.t("admin-specs-duplicate") }}">
+              <i class="ti ti-copy" aria-hidden="true"></i>
             </a>
           </td>
           {% endif %}

--- a/crates/ruscker-admin/tests/landing_access.rs
+++ b/crates/ruscker-admin/tests/landing_access.rs
@@ -485,3 +485,41 @@ async fn spec_form_preview_matches_landing_svg_fit() {
         "preview must apply the SVG contain-fit rule like the landing card"
     );
 }
+
+#[tokio::test]
+async fn duplicate_opens_new_form_prefilled_with_fresh_id() {
+    // #368: duplicating a spec opens the *New* form pre-filled from the
+    // source, with a unique `-copy` id so the submit creates a brand-new
+    // spec (the source is untouched).
+    let db = open_db().await;
+    let cfg = Config::from_yaml(
+        "proxy:\n  specs:\n    - id: voila\n      display-name: Voila\n      container-image: img/voila:1\n",
+    )
+    .expect("parse spec yaml");
+    ruscker_admin::db::specs::upsert_one(&db, &cfg.proxy.specs[0], None)
+        .await
+        .expect("insert spec");
+    let state = app_state(db).await;
+    let sid = state.admin_sessions.create(Role::Admin, None).await;
+    let app = router(state);
+    let resp = app
+        .oneshot(
+            Request::builder()
+                .uri("/admin/specs/voila/duplicate")
+                .header(header::COOKIE, format!("{COOKIE_NAME}={sid}"))
+                .body(Body::empty())
+                .unwrap(),
+        )
+        .await
+        .unwrap();
+    assert_eq!(resp.status(), StatusCode::OK);
+    let body = String::from_utf8(
+        axum::body::to_bytes(resp.into_body(), 1 << 20).await.unwrap().to_vec(),
+    )
+    .unwrap();
+    // Fresh id + source fields carried over.
+    assert!(body.contains(r#"value="voila-copy""#), "id suffixed to -copy");
+    assert!(body.contains("img/voila:1"), "source image pre-filled");
+    // New mode → the form posts to the create endpoint (no id in action).
+    assert!(body.contains(r#"action="/admin/specs""#), "New-mode create action");
+}


### PR DESCRIPTION
Fixes #368.

## Funcionalidade
Botão **Duplicar** (ícone `ti-copy`) em cada linha de `/admin/specs`: abre o form de **novo spec já pré-preenchido** a partir do existente, pro operador clonar um card quase-igual e ajustar só o que muda.

## Como funciona
- Rota nova `GET /admin/specs/{id}/duplicate` → `duplicate_form`: busca o source, `SpecForm::from_spec`, gera um **id único** via `unique_copy_id` (`{id}-copy`, depois `-copy-2`…), e renderiza em **`FormMode::New`** → o submit cai em `POST /admin/specs` (create); o source fica intacto.
- Botão nas **duas** células de ação (spec do DB **e** spec `config`/YAML read-only) — duplicar um spec do YAML é um jeito prático de "forká-lo" num spec editável no DB. Chave i18n `admin-specs-duplicate` ×4.
- A senha de registry é write-only (#260) → não é copiada; o resto (imagem, portas, acesso, template-properties) vem junto.

## Gate
`cargo test -p ruscker-admin` 247 + integração (teste novo `duplicate_opens_new_form_prefilled_with_fresh_id`) ✓; clippy `-D warnings` limpo; i18n parity ✓.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
