### PR TITLE
feat(proxy): inject public mount path into containers (SHINYPROXY_PUBLIC_PATH) (#371)

### DIFF
--- a/crates/ruscker-admin/src/db/showcase.rs
+++ b/crates/ruscker-admin/src/db/showcase.rs
@@ -250,6 +250,15 @@ fn showcase_specs() -> Result<Vec<Spec>> {
             // origin so the showcase card opens out of the box. (Demo
             // posture — the card is open; tighten with a token/auth for
             // anything real.)
+            //
+            // `--ServerApp.base_url=#{publicPath}` (#371): the proxy
+            // substitutes the spec's public mount path (e.g.
+            // `/box/app/jupyter/`) at spawn, so Jupyter serves its Lab
+            // page, REST API (`lab/api/settings|workspaces`), and kernel
+            // WebSocket under the SAME prefix the browser uses — fixing
+            // the blank Lab where `base_url=/` 404'd the REST calls. The
+            // #348 jupyter-config rewrite becomes a no-op (the config's
+            // baseUrl already matches), kept as a belt-and-suspenders.
             let mut jup = card(
                 "jupyter",
                 "Jupyter",
@@ -266,7 +275,7 @@ fn showcase_specs() -> Result<Vec<Spec>> {
                 "--ServerApp.allow_origin=*".into(),
                 "--ServerApp.allow_remote_access=True".into(),
                 "--ServerApp.disable_check_xsrf=True".into(),
-                "--ServerApp.base_url=/".into(),
+                "--ServerApp.base_url=#{publicPath}".into(),
             ]);
             // Generic interactive app, not Shiny (#231).
             jup.kind_override = Some(ruscker_config::SpecKindOverride::App);

--- a/crates/ruscker-admin/src/routes/proxy.rs
+++ b/crates/ruscker-admin/src/routes/proxy.rs
@@ -689,6 +689,52 @@ fn mount_prefix(base_path: &str, route_prefix: &str, spec_id: &str) -> String {
     format!("{base_path}{route_prefix}{spec_id}")
 }
 
+/// Token, substituted at spawn with the spec's [`public_path`], that an
+/// operator (or the showcase seed) can drop into `container-cmd` /
+/// `container-env` so a path-sensitive app can self-route behind
+/// `--base-path` (#371). Ruscker's analog of ShinyProxy's
+/// `#{proxy.getRuntimeValue('SHINYPROXY_PUBLIC_PATH')}`. Distinct from the
+/// parse-time `${VAR}` env interpolation, which never sees this runtime
+/// value. Example: Jupyter `--ServerApp.base_url=#{publicPath}`.
+pub(crate) const PUBLIC_PATH_TOKEN: &str = "#{publicPath}";
+
+/// The public mount path a spec is reachable at, **with** a trailing
+/// slash (e.g. `/box/app/jupyter/`) — what an app should use as its
+/// base-url so the URLs it emits and the paths it receives line up with
+/// what the proxy forwards. Derived from [`mount_prefix`] + the spec's
+/// route family (`/api/` for APIs, else `/app/`).
+pub(crate) fn public_path(base_path: &str, spec: &Spec) -> String {
+    let route_prefix = match spec.kind() {
+        ruscker_config::SpecKind::Api => API_PREFIX,
+        _ => APP_PREFIX,
+    };
+    format!("{}/", mount_prefix(base_path, route_prefix, &spec.id))
+}
+
+/// Resolve the [`PUBLIC_PATH_TOKEN`] in a spec's env (`NAME=value`) and
+/// cmd argv at spawn, and inject `SHINYPROXY_PUBLIC_PATH=<path>` unless
+/// the spec already set it — so both flag-based apps (Jupyter/Voilà/
+/// Streamlit via the cmd token) and env-based ones (FastAPI `SCRIPT_NAME`,
+/// any framework reading the env) can self-route behind a base path
+/// (#371). Pure; both spawn paths call it before building the request.
+pub(crate) fn apply_public_path(env: &mut Vec<String>, cmd: &mut Option<Vec<String>>, path: &str) {
+    for e in env.iter_mut() {
+        if e.contains(PUBLIC_PATH_TOKEN) {
+            *e = e.replace(PUBLIC_PATH_TOKEN, path);
+        }
+    }
+    if let Some(args) = cmd {
+        for a in args.iter_mut() {
+            if a.contains(PUBLIC_PATH_TOKEN) {
+                *a = a.replace(PUBLIC_PATH_TOKEN, path);
+            }
+        }
+    }
+    if !env.iter().any(|e| e.starts_with("SHINYPROXY_PUBLIC_PATH=")) {
+        env.push(format!("SHINYPROXY_PUBLIC_PATH={path}"));
+    }
+}
+
 pub(crate) async fn find_spec(state: &AppState, id: &str) -> Option<Spec> {
     // DB-first — the operator-editable catalog (admin UI + showcase
     // seed) shadows the YAML for matching ids. Cheap: single indexed
@@ -1801,6 +1847,52 @@ container-cpu-limit: 1.5
         // slash — `route_prefix` already has one.
         assert_eq!(mount_prefix("/box", "/app/", "rstudio"), "/box/app/rstudio");
         assert_eq!(mount_prefix("/box", "/api/", "data-api"), "/box/api/data-api");
+    }
+
+    #[test]
+    fn public_path_carries_base_and_route_family() {
+        // App/Shiny specs route under `/app/`, with a trailing slash and
+        // the base path baked in (#371).
+        assert_eq!(public_path("/box", &fake_spec("jupyter")), "/box/app/jupyter/");
+        assert_eq!(public_path("", &fake_spec("jupyter")), "/app/jupyter/");
+        // API specs route under `/api/`.
+        let api = spec_yaml("id: data\ntype: api\ncontainer-image: x:1\n");
+        assert_eq!(public_path("/box", &api), "/box/api/data/");
+    }
+
+    #[test]
+    fn apply_public_path_substitutes_token_and_injects_env() {
+        let path = "/box/app/jupyter/";
+        let mut env = vec!["FOO=bar".to_string(), "BASE=#{publicPath}".to_string()];
+        let mut cmd = Some(vec![
+            "start.py".to_string(),
+            "--ServerApp.base_url=#{publicPath}".to_string(),
+        ]);
+        apply_public_path(&mut env, &mut cmd, path);
+        // Token resolved in both the cmd argv and an env value.
+        assert!(cmd
+            .as_ref()
+            .unwrap()
+            .contains(&"--ServerApp.base_url=/box/app/jupyter/".to_string()));
+        assert!(env.contains(&"BASE=/box/app/jupyter/".to_string()));
+        assert!(env.contains(&"FOO=bar".to_string()), "untouched entries survive");
+        // The compat env var is injected.
+        assert!(env
+            .iter()
+            .any(|e| e == "SHINYPROXY_PUBLIC_PATH=/box/app/jupyter/"));
+    }
+
+    #[test]
+    fn apply_public_path_keeps_operator_set_env() {
+        // Don't clobber an explicit SHINYPROXY_PUBLIC_PATH from the spec.
+        let mut env = vec!["SHINYPROXY_PUBLIC_PATH=/custom/".to_string()];
+        let mut cmd = None;
+        apply_public_path(&mut env, &mut cmd, "/box/app/x/");
+        assert_eq!(
+            env.iter().filter(|e| e.starts_with("SHINYPROXY_PUBLIC_PATH=")).count(),
+            1
+        );
+        assert!(env.contains(&"SHINYPROXY_PUBLIC_PATH=/custom/".to_string()));
     }
 
     #[test]

--- a/crates/ruscker-admin/src/scaler.rs
+++ b/crates/ruscker-admin/src/scaler.rs
@@ -708,9 +708,15 @@ async fn spawn_one(
     let limits = crate::routes::proxy::limits_from_spec(spec);
     // Resolve `${VAR}` in container-env at the point of use; an unset var
     // fails the spawn naming it (#314) rather than injecting a literal.
-    let env = spec
+    let mut env = spec
         .resolved_env_pairs()
         .map_err(|e| anyhow::anyhow!("spec {} container-env: {e}", spec.id))?;
+    let mut cmd = spec.container_cmd.clone();
+    // Resolve the public-path token + inject `SHINYPROXY_PUBLIC_PATH` so a
+    // path-sensitive app (Jupyter `--ServerApp.base_url`, Voilà, Streamlit,
+    // FastAPI `SCRIPT_NAME`) can self-route behind `--base-path` (#371).
+    let public_path = crate::routes::proxy::public_path(&state.base_path, spec);
+    crate::routes::proxy::apply_public_path(&mut env, &mut cmd, &public_path);
     let mut req = ruscker_core::SpawnRequest::new(&spec.id, image)
         .with_limits(limits)
         .with_volumes(spec.volumes.clone().unwrap_or_default())
@@ -723,7 +729,7 @@ async fn spawn_one(
     if let Some(platform) = spec.platform.as_deref() {
         req = req.with_platform(platform);
     }
-    if let Some(cmd) = spec.container_cmd.clone() {
+    if let Some(cmd) = cmd {
         req = req.with_cmd(cmd);
     }
     if let Some(c) = creds {


### PR DESCRIPTION
Fixes #371.

## Causa
JupyterLab abria em branco sob `--base-path`: a página carregava mas as chamadas REST (`lab/api/settings|workspaces`) davam **404 no container**, porque o container rodava `base_url=/` enquanto o browser (e o path que o proxy encaminha) usavam o prefixo completo `/box/app/jupyter/...`. O #348 só consertou os chunks estáticos (webpack), não a API REST.

O Ruscker não tinha o equivalente ao `SHINYPROXY_PUBLIC_PATH` do ShinyProxy, então não dava pra dizer ao app qual é o seu caminho público.

## Mecanismo (novo)
- `proxy::public_path(base, spec)` → caminho público do spec **com barra final** (`/box/app/jupyter/`, `/box/api/data/`).
- `proxy::apply_public_path(env, cmd, path)` → no spawn, substitui o token **`#{publicPath}`** no `container-cmd` (argv) e nos valores de `container-env`, e injeta **`SHINYPROXY_PUBLIC_PATH=<path>`** (compat de migração ShinyProxy) se o spec não setou. Chamado no ponto único de spawn (`scaler::spawn_replica`).
- Seed do **Jupyter** passa a rodar `--ServerApp.base_url=#{publicPath}` (em vez de `=/`) → o container serve a página Lab, a API REST e o WS de kernel sob o **mesmo prefixo** que o browser usa. O rewrite do #348 vira no-op (config baseUrl já bate), mantido como cinto-e-suspensório.

Esse é o mecanismo geral que a família precisa: **Voilà/Streamlit/Dash/FastAPI** (#372/#373) podem adotar `#{publicPath}`/`SHINYPROXY_PUBLIC_PATH` do mesmo jeito (follow-ups, validados individualmente).

## Gate
`cargo test -p ruscker-admin` 250 ✓ (testes novos: public_path por família/base/barra, substituição do token em cmd/env, injeção do env + não-clobber); clippy `-D warnings` limpo.

> **Draft — precisa smoke ao vivo no /box** (não dá pra validar daqui; templates embutidos → só chega ao cast via release+freshstart). Ponto de atenção registrado na investigação: houve uma divergência código×runtime sobre se o proxy faz strip do prefixo ao encaminhar; este fix segue a **evidência do log do container** (recebeu o path completo → base_url=public_path faz bater). Se no smoke o deploy-raiz quebrar ou o /box ainda 404, reconciliar o comportamento de strip do forward é o próximo passo.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
