### PR TITLE
fix(showcase): ~25% transparent margin around the Shiny-for-Python logo (#376)

### DIFF
--- a/crates/ruscker-admin/assets/showcase/shiny-for-python.svg
+++ b/crates/ruscker-admin/assets/showcase/shiny-for-python.svg
@@ -6,10 +6,10 @@
    id="Layer_1"
    x="0px"
    y="0px"
-   viewBox="0 0 66.892441 44.284122"
+   viewBox="-16.723 -11.071 100.339 66.426"
    xml:space="preserve"
-   width="66.892441"
-   height="44.284122"
+   width="100.339"
+   height="66.426"
    xmlns="http://www.w3.org/2000/svg"
    xmlns:svg="http://www.w3.org/2000/svg"><defs
    id="defs12" />


### PR DESCRIPTION
Fixes #376. O wordmark branco preenchia o SVG de borda a borda. Expandi o viewBox (e width/height) 25% por lado — `0 0 66.89 44.28` → `-16.723 -11.071 100.339 66.426` — **sem mover os paths**, centralizando a arte em ~66% da largura com margem transparente. Só o arquivo SVG bundlado; atualiza no próximo release (independe de re-seed).

🤖 Generated with [Claude Code](https://claude.com/claude-code)