### PR TITLE
feat(scaler): stamp a card's date from the image's publish date (#375)

### DIFF
--- a/crates/ruscker-admin/src/db/specs.rs
+++ b/crates/ruscker-admin/src/db/specs.rs
@@ -254,6 +254,35 @@ pub async fn upsert_one(
     }
 }
 
+/// Stamp a spec's `template-properties.updated` date **only if it has
+/// none yet**, returning whether it wrote. Used to fill a card's
+/// recency date from the publish date of the image it runs (#375) — a
+/// one-time enrichment on first spawn. No-op (returns `false`) when the
+/// id isn't a DB spec (YAML-only specs aren't created here) or already
+/// carries a date, so it never clobbers an operator-set value.
+pub async fn set_updated_if_absent(
+    db: &ConfigDb,
+    id: &str,
+    date: &str,
+    actor: Option<&str>,
+) -> Result<bool> {
+    let Some(mut spec) = fetch_one(db, id).await? else {
+        return Ok(false); // not a DB spec — nothing to enrich
+    };
+    let has_date = spec
+        .template_properties
+        .get_str("updated")
+        .is_some_and(|s| !s.trim().is_empty());
+    if has_date {
+        return Ok(false);
+    }
+    spec.template_properties
+        .0
+        .insert("updated".into(), serde_yaml_ng::Value::String(date.to_string()));
+    upsert_one(db, &spec, actor).await?;
+    Ok(true)
+}
+
 /// Delete a spec and all its history. Returns `true` if a row was
 /// actually removed (false if the id didn't exist). Audit log records
 /// the action when something was deleted. `ON DELETE CASCADE` clears
@@ -627,6 +656,29 @@ mod tests {
         .await
         .unwrap();
         assert_eq!(audit_count.0, 2);
+    }
+
+    #[tokio::test]
+    async fn set_updated_if_absent_fills_once_then_no_clobber() {
+        std::env::set_var("DOCKER_REGISTRY_PASSWORD", "test");
+        let db = ConfigDb::Sqlite(open_memory().await.unwrap());
+        let cfg =
+            Config::from_yaml("proxy:\n  specs:\n    - id: appx\n      container-image: img:1\n")
+                .unwrap();
+        upsert_one(&db, &cfg.proxy.specs[0], None).await.unwrap();
+
+        // Fills when the date is absent (#375).
+        assert!(set_updated_if_absent(&db, "appx", "22/08/2025", Some("system")).await.unwrap());
+        let s = fetch_one(&db, "appx").await.unwrap().unwrap();
+        assert_eq!(s.template_properties.get_str("updated"), Some("22/08/2025"));
+
+        // No-op when a date already exists — never clobbers it.
+        assert!(!set_updated_if_absent(&db, "appx", "01/01/2099", Some("system")).await.unwrap());
+        let s2 = fetch_one(&db, "appx").await.unwrap().unwrap();
+        assert_eq!(s2.template_properties.get_str("updated"), Some("22/08/2025"));
+
+        // No-op for an id that isn't a DB spec.
+        assert!(!set_updated_if_absent(&db, "nope", "01/01/2025", None).await.unwrap());
     }
 
     // #199: import must not wipe landing_blocks. Migration 0008 seeds a

--- a/crates/ruscker-admin/src/scaler.rs
+++ b/crates/ruscker-admin/src/scaler.rs
@@ -745,7 +745,38 @@ async fn spawn_one(
     replica.sessions_max = spec.effective_seats();
 
     state.replicas.write().await.add(replica);
+
+    // Best-effort: stamp the card's recency date from the image's
+    // publish date when it has none yet (#375). One-time per spec
+    // (guarded by an absent `updated`), never clobbers an operator date,
+    // and a no-op for YAML-only specs (`set_updated_if_absent`).
+    let needs_date = spec
+        .template_properties
+        .get_str("updated")
+        .is_none_or(|s| s.trim().is_empty());
+    if needs_date {
+        if let Some(db) = state.db.as_ref() {
+            if let Some(created) = backend.image_created(image).await {
+                if let Some(date) = format_image_date(&created) {
+                    if let Err(e) =
+                        crate::db::specs::set_updated_if_absent(db, &spec.id, &date, Some("system"))
+                            .await
+                    {
+                        tracing::debug!(spec = %spec.id, error = ?e, "image-date enrich failed");
+                    }
+                }
+            }
+        }
+    }
     Ok(())
+}
+
+/// An image's RFC3339 created timestamp → the showcase `updated` display
+/// format (`DD/MM/YYYY`). `None` if it doesn't parse (#375).
+fn format_image_date(rfc3339: &str) -> Option<String> {
+    chrono::DateTime::parse_from_rfc3339(rfc3339)
+        .ok()
+        .map(|dt| dt.format("%d/%m/%Y").to_string())
 }
 
 #[cfg(test)]
@@ -760,6 +791,16 @@ mod tests {
     use std::net::SocketAddr;
     use std::sync::atomic::{AtomicU32, Ordering};
     use std::sync::Arc;
+
+    #[test]
+    fn format_image_date_rfc3339_to_dmy() {
+        // #375: image `.created` (RFC3339) → showcase `updated` format.
+        assert_eq!(
+            format_image_date("2025-08-22T13:51:37.357298Z").as_deref(),
+            Some("22/08/2025")
+        );
+        assert_eq!(format_image_date("not-a-date"), None);
+    }
 
     // ── #204: spawn-failure log dedup/backoff state machine ─────────
 

--- a/crates/ruscker-core/src/lib.rs
+++ b/crates/ruscker-core/src/lib.rs
@@ -327,6 +327,15 @@ pub trait ContainerBackend: Send + Sync {
     async fn logs_follow(&self, _replica_id: &ReplicaId, _tail: usize) -> CoreResult<LogStream> {
         Ok(Box::pin(futures_util::stream::empty()))
     }
+
+    /// Creation/publish timestamp of an image as an RFC3339 string, if
+    /// the backend can read it (Docker: `inspect_image().created`).
+    /// Used to stamp a card's "updated" date from the image it runs
+    /// (#375). Default `None` so non-Docker backends don't break the
+    /// caller — it just leaves the date unset.
+    async fn image_created(&self, _image: &str) -> Option<String> {
+        None
+    }
 }
 
 #[derive(Debug, Clone, serde::Serialize, serde::Deserialize)]

--- a/crates/ruscker-docker/src/lib.rs
+++ b/crates/ruscker-docker/src/lib.rs
@@ -387,6 +387,17 @@ impl ContainerBackend for LocalDockerBackend {
         Self::spawn_with_port(self, spec_id, image, DEFAULT_INNER_PORT).await
     }
 
+    /// The image's creation/publish timestamp (RFC3339), read from a
+    /// local `docker inspect`. `None` if the image isn't present or has
+    /// no timestamp — the caller leaves the date unset (#375).
+    async fn image_created(&self, image: &str) -> Option<String> {
+        self.docker
+            .inspect_image(image)
+            .await
+            .ok()
+            .and_then(|info| info.created)
+    }
+
     /// Trait override: routes through the inherent method that
     /// already does the bollard work.
     async fn spawn_with_port(


### PR DESCRIPTION
Fixes #375. Cards de container ficavam sem `updated` → bolinha de recência cinza + "—" (#349). Agora preenche a partir da própria imagem:
- `ContainerBackend::image_created(image) -> Option<String>` (RFC3339; default None; docker lê `inspect_image().created`).
- `db::specs::set_updated_if_absent` — seta `template-properties.updated` só se ausente (uma vez, sem clobber; no-op p/ spec só-YAML).
- `scaler::spawn_replica`, best-effort pós-spawn: se o spec não tem data, lê a data da imagem e grava como `DD/MM/YYYY` (serializado pelo mutex de spawn → sem double-write).

Resultado: a bolinha vira azul/verde com data real + tooltip (#349) em vez do placeholder cinza.

Gate: admin 252 ✓ (testes novos: format_image_date, set_updated_if_absent), clippy `-D warnings` limpo.

> Só pega efeito com `--docker` (a imagem precisa estar presente p/ inspecionar) e em specs no DB; valida no /box após release.

🤖 Generated with [Claude Code](https://claude.com/claude-code)