### PR TITLE
fix(showcase): stop advertising public path; Quarto prerendered; favicon order (#372, #374)

### DIFF
--- a/crates/ruscker-admin/src/db/showcase.rs
+++ b/crates/ruscker-admin/src/db/showcase.rs
@@ -368,16 +368,19 @@ fn showcase_specs() -> Result<Vec<Spec>> {
             s
         },
         {
-            // Quarto demo serves rendered docs on :8080. No dedicated
-            // kind — treat as a generic interactive app (sticky+WS is
-            // harmless if the content is static).
+            // Quarto demo on :8080. Use the `:prerendered` tag (#372):
+            // the `:latest` image renders the docs on startup, which took
+            // >60s — the container accepted TCP but never answered HTTP
+            // inside the readiness window, so it never went Ready and the
+            // splash hung. The prerendered variant serves a pre-built site
+            // immediately. No dedicated kind — generic interactive app.
             let mut s = card(
                 "quarto",
                 "Quarto",
                 "Open-source publishing system for technical documents.",
                 "/assets/showcase/quarto.svg",
                 "https://quarto.org",
-                Some("openanalytics/shinyproxy-quarto-demo:latest"),
+                Some("openanalytics/shinyproxy-quarto-demo:prerendered"),
                 Some(8080),
                 Some("linux/amd64"),
             )?;

--- a/crates/ruscker-admin/src/routes/proxy.rs
+++ b/crates/ruscker-admin/src/routes/proxy.rs
@@ -712,12 +712,20 @@ pub(crate) fn public_path(base_path: &str, spec: &Spec) -> String {
 }
 
 /// Resolve the [`PUBLIC_PATH_TOKEN`] in a spec's env (`NAME=value`) and
-/// cmd argv at spawn, and inject `SHINYPROXY_PUBLIC_PATH=<path>` unless
-/// the spec already set it — so both flag-based apps (Jupyter/Voilà/
-/// Streamlit via the cmd token) and env-based ones (FastAPI `SCRIPT_NAME`,
-/// any framework reading the env) can self-route behind a base path
-/// (#371). Pure; both spawn paths call it before building the request.
-pub(crate) fn apply_public_path(env: &mut Vec<String>, cmd: &mut Option<Vec<String>>, path: &str) {
+/// cmd argv at spawn — an **explicit opt-in** for an operator who needs
+/// to feed the public mount path to an app.
+///
+/// It deliberately does **NOT** auto-inject `SHINYPROXY_PUBLIC_PATH`:
+/// Ruscker **strips** the mount prefix before forwarding (the container
+/// receives `/lab/...`, not `/box/app/jupyter/...` — proven live), the
+/// opposite of ShinyProxy's no-strip model. Advertising the public path
+/// to a ShinyProxy-style demo (which reads `SHINYPROXY_PUBLIC_PATH` to
+/// self-prefix) made it configure the WRONG prefix and 404/500 every
+/// request (Jupyter #371, Dash #372). Apps should serve at root; the
+/// `/app` rewriter + the #348 jupyter-config rewrite handle the
+/// browser-side prefixing. The token stays for the rare case an operator
+/// genuinely wants it.
+pub(crate) fn apply_public_path(env: &mut [String], cmd: &mut Option<Vec<String>>, path: &str) {
     for e in env.iter_mut() {
         if e.contains(PUBLIC_PATH_TOKEN) {
             *e = e.replace(PUBLIC_PATH_TOKEN, path);
@@ -729,9 +737,6 @@ pub(crate) fn apply_public_path(env: &mut Vec<String>, cmd: &mut Option<Vec<Stri
                 *a = a.replace(PUBLIC_PATH_TOKEN, path);
             }
         }
-    }
-    if !env.iter().any(|e| e.starts_with("SHINYPROXY_PUBLIC_PATH=")) {
-        env.push(format!("SHINYPROXY_PUBLIC_PATH={path}"));
     }
 }
 
@@ -1861,7 +1866,7 @@ container-cpu-limit: 1.5
     }
 
     #[test]
-    fn apply_public_path_substitutes_token_and_injects_env() {
+    fn apply_public_path_substitutes_token_only() {
         let path = "/box/app/jupyter/";
         let mut env = vec!["FOO=bar".to_string(), "BASE=#{publicPath}".to_string()];
         let mut cmd = Some(vec![
@@ -1876,23 +1881,16 @@ container-cpu-limit: 1.5
             .contains(&"--ServerApp.base_url=/box/app/jupyter/".to_string()));
         assert!(env.contains(&"BASE=/box/app/jupyter/".to_string()));
         assert!(env.contains(&"FOO=bar".to_string()), "untouched entries survive");
-        // The compat env var is injected.
-        assert!(env
-            .iter()
-            .any(|e| e == "SHINYPROXY_PUBLIC_PATH=/box/app/jupyter/"));
-    }
-
-    #[test]
-    fn apply_public_path_keeps_operator_set_env() {
-        // Don't clobber an explicit SHINYPROXY_PUBLIC_PATH from the spec.
-        let mut env = vec!["SHINYPROXY_PUBLIC_PATH=/custom/".to_string()];
-        let mut cmd = None;
-        apply_public_path(&mut env, &mut cmd, "/box/app/x/");
-        assert_eq!(
-            env.iter().filter(|e| e.starts_with("SHINYPROXY_PUBLIC_PATH=")).count(),
-            1
+        // Does NOT auto-inject SHINYPROXY_PUBLIC_PATH — Ruscker strips the
+        // prefix, so advertising it would mis-prefix ShinyProxy-style apps
+        // (#372). No token → no change.
+        assert!(
+            !env.iter().any(|e| e.starts_with("SHINYPROXY_PUBLIC_PATH=")),
+            "must not inject SHINYPROXY_PUBLIC_PATH"
         );
-        assert!(env.contains(&"SHINYPROXY_PUBLIC_PATH=/custom/".to_string()));
+        let mut env2 = vec!["A=1".to_string()];
+        apply_public_path(&mut env2, &mut None, path);
+        assert_eq!(env2, vec!["A=1".to_string()], "no token ⇒ env untouched");
     }
 
     #[test]

--- a/crates/ruscker-admin/templates/_layout.html
+++ b/crates/ruscker-admin/templates/_layout.html
@@ -8,9 +8,9 @@
 <title>{% block title %}{{ self.t("landing-title") }}{% endblock %}</title>
 {% block head_extra %}{% endblock %}
 
-<link rel="icon" type="image/svg+xml" href="{{ base }}/favicon.svg">
+<link rel="icon" href="{{ base }}/favicon.ico" sizes="any">
 <link rel="icon" type="image/png" sizes="32x32" href="{{ base }}/favicon-32.png">
-<link rel="alternate icon" href="{{ base }}/favicon.ico">
+<link rel="icon" type="image/svg+xml" href="{{ base }}/favicon.svg">
 <link rel="apple-touch-icon" href="{{ base }}/apple-touch-icon.png">
 <link rel="mask-icon" href="{{ base }}/assets/brand/mark.svg" color="#0f6e56">
 <link rel="apple-touch-icon" href="{{ base }}/apple-touch-icon.png">

--- a/crates/ruscker-admin/templates/admin/_layout.html
+++ b/crates/ruscker-admin/templates/admin/_layout.html
@@ -8,9 +8,9 @@
 <meta name="robots" content="noindex,nofollow">
 <title>{% block title %}Admin · Ruscker{% endblock %}</title>
 
-<link rel="icon" type="image/svg+xml" href="{{ base }}/favicon.svg">
+<link rel="icon" href="{{ base }}/favicon.ico" sizes="any">
 <link rel="icon" type="image/png" sizes="32x32" href="{{ base }}/favicon-32.png">
-<link rel="alternate icon" href="{{ base }}/favicon.ico">
+<link rel="icon" type="image/svg+xml" href="{{ base }}/favicon.svg">
 <link rel="apple-touch-icon" href="{{ base }}/apple-touch-icon.png">
 <link rel="mask-icon" href="{{ base }}/assets/brand/mark.svg" color="#0f6e56">
 <link rel="apple-touch-icon" href="{{ base }}/apple-touch-icon.png">


### PR DESCRIPTION
Follow-ups da validação ao vivo no /box.

- **Não injetar mais `SHINYPROXY_PUBLIC_PATH` (#372/Dash):** o Ruscker faz STRIP do prefixo (provado no #371) — oposto do ShinyProxy. Os demos OpenAnalytics leem essa env p/ se auto-prefixar → configuravam o prefixo errado → 404/500. `apply_public_path` agora só resolve o token explícito `#{publicPath}` (opt-in). Apps servem em root; o rewriter /app + #348 cuidam do lado browser.
- **Quarto → `:prerendered` (#372):** o `:latest` renderiza no boot (>60s) → container aceitava TCP mas não respondia HTTP na janela de readiness → nunca Ready (splash travado). O prerendered serve site pré-buildado na hora.
- **Ordem dos `<link>` de favicon (#374):** `.ico` (sizes=any) primeiro, depois png, depois svg — Safari pega o raster em vez de cair no placeholder preto.

Gate: admin 251 ✓ (single-thread), clippy -D warnings limpo, favicon route test ok.

> **Validar no próximo freshstart.** #373 (FastAPI host:porta leak) NÃO é resolvido aqui (é vazamento de Host via url_for — precisa de tratamento à parte; comentado no #373). Tudo é hipótese aterrada nos configs upstream + no comportamento de strip; confirmar ao vivo.

🤖 Generated with [Claude Code](https://claude.com/claude-code)