### PR TITLE
chore(release): bump workspace version 0.1.23 → 0.1.24

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2845,7 +2845,7 @@ dependencies = [
 
 [[package]]
 name = "ruscker-admin"
-version = "0.1.23"
+version = "0.1.24"
 dependencies = [
  "aes-gcm",
  "anyhow",
@@ -2892,7 +2892,7 @@ dependencies = [
 
 [[package]]
 name = "ruscker-cli"
-version = "0.1.23"
+version = "0.1.24"
 dependencies = [
  "anyhow",
  "clap",
@@ -2912,7 +2912,7 @@ dependencies = [
 
 [[package]]
 name = "ruscker-config"
-version = "0.1.23"
+version = "0.1.24"
 dependencies = [
  "chrono",
  "ordered-float",
@@ -2927,7 +2927,7 @@ dependencies = [
 
 [[package]]
 name = "ruscker-core"
-version = "0.1.23"
+version = "0.1.24"
 dependencies = [
  "async-trait",
  "chrono",
@@ -2940,7 +2940,7 @@ dependencies = [
 
 [[package]]
 name = "ruscker-docker"
-version = "0.1.23"
+version = "0.1.24"
 dependencies = [
  "anyhow",
  "async-stream",
@@ -2959,7 +2959,7 @@ dependencies = [
 
 [[package]]
 name = "ruscker-proxy"
-version = "0.1.23"
+version = "0.1.24"
 dependencies = [
  "anyhow",
  "axum",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -10,7 +10,7 @@ members = [
 ]
 
 [workspace.package]
-version = "0.1.23"
+version = "0.1.24"
 edition = "2021"
 rust-version = "1.85"
 license = "Apache-2.0"


### PR DESCRIPTION
Release v0.1.24 — bundles #399 (Quarto :latest), #400 (Dash SHINYPROXY_PUBLIC_PATH=/), #401 (Voilà RequireJS mount).

After merge: tag `v0.1.24` to trigger the release workflow.

🤖 Generated with [Claude Code](https://claude.com/claude-code)