### PR TITLE
refactor(proxy): generalize runtime shim (script.src/link.href); drop rewrite_voila (#372)

### DIFF
--- a/crates/ruscker-admin/src/routes/rewrite.rs
+++ b/crates/ruscker-admin/src/routes/rewrite.rs
@@ -348,6 +348,41 @@ fn build_runtime_shim(base_path: &str) -> String {
       return origOpen.apply(this, [method, prefix(url)].concat(rest));
     }};
   }} catch (_) {{}}
+  // Dynamic <script src> / <link href> — RequireJS and webpack chunk
+  // loaders build root-absolute URLs at RUNTIME and assign them to the
+  // element's .src/.href property, a path the fetch/XHR/WS wrappers
+  // above never see (it's the browser's own resource fetch). We patch
+  // the prototype accessor so the same `prefix()` is applied generically
+  // — no per-framework HTML rewrite needed. This is the Class-3 fix that
+  // makes Voilà's RequireJS bootstrap and Jupyter's webpack chunks load
+  // under the mount without bespoke `rewrite_*` passes.
+  function patchUrlProp(proto, name) {{
+    try {{
+      var d = Object.getOwnPropertyDescriptor(proto, name);
+      if (d && typeof d.set === "function" && typeof d.get === "function" && d.configurable) {{
+        Object.defineProperty(proto, name, {{
+          configurable: true,
+          enumerable: d.enumerable,
+          get: function () {{ return d.get.call(this); }},
+          set: function (v) {{ d.set.call(this, prefix(v)); }}
+        }});
+      }}
+    }} catch (_) {{}}
+  }}
+  try {{ patchUrlProp(HTMLScriptElement.prototype, "src"); }} catch (_) {{}}
+  try {{ patchUrlProp(HTMLLinkElement.prototype, "href"); }} catch (_) {{}}
+  // Some loaders set the URL via setAttribute('src'/'href') instead of
+  // the property. Catch that path too, scoped to script/link elements.
+  try {{
+    var origSetAttr = Element.prototype.setAttribute;
+    Element.prototype.setAttribute = function (name, value) {{
+      var n = (this.tagName || "").toUpperCase();
+      if ((name === "src" && n === "SCRIPT") || (name === "href" && n === "LINK")) {{
+        value = prefix(value);
+      }}
+      return origSetAttr.call(this, name, value);
+    }};
+  }} catch (_) {{}}
 }})();</script>"##,
         base = base_path
     )
@@ -442,53 +477,6 @@ fn rewrite_jupyter_config(html: &str, base_path: &str) -> Option<String> {
     Some(out)
 }
 
-/// Rewrite Voilà's inline-script `/voila/…` URLs to the mount (#372).
-///
-/// ## Why this is needed on top of the `<base href>` + shim + #348
-///
-/// Voilà is served with `--base_url=/` (so the container, behind our
-/// *stripping* proxy, serves at root — `base_url=#{publicPath}` would
-/// 404 every request, the same trap as Jupyter in #382). Its page then
-/// boots via **RequireJS**, whose bootstrap lives in an inline
-/// `<script>` (NOT an HTML attribute, so the lol_html attribute pass
-/// never sees it):
-///
-/// ```js
-/// requirejs.config({ baseUrl: '/voila/' });
-/// window.voila_js_url = "/voila/templates/lab/static/voila.js?v=…";
-/// requirejs(["/voila/templates/lab/static/main.js?v=…"]);
-/// ```
-///
-/// Plus `<body data-base-url="/voila/">`. Those root-absolute `/voila/…`
-/// URLs are requested at the host root, miss the `/box/app/voila/` mount,
-/// and 404 → a blank page with a RequireJS `Script error` (the console
-/// the operator reported). `jupyter-config-data` is already handled by
-/// [`rewrite_jupyter_config`] (Voilà ships that block too), so kernels
-/// work; this closes the static-asset gap.
-///
-/// The fix: prefix every **quoted** `/voila/` occurrence with the mount
-/// (`'/voila/` → `'/box/app/voila/voila/`). Anchoring on the quote means
-/// we only touch URL string literals; the `src`/`href` attributes that
-/// the lol_html pass already rewrites are left for it (and even if one
-/// slipped through, [`rewrite_url`] skips paths already under
-/// `base_path`, so there's no double-prefix). The browser then requests
-/// `…/voila/…` under the mount, the proxy strips it, and the container
-/// (still at `base_url=/`) serves from its own `/voila/` root.
-///
-/// `Some` only when something changed; `None` for every non-Voilà page.
-fn rewrite_voila(html: &str, base_path: &str) -> Option<String> {
-    // `/voila/` is Voilà's fixed internal static namespace (independent
-    // of the spec id), so its presence as a quoted URL is a reliable,
-    // cheap marker. Bail before allocating on every other app's page.
-    if !html.contains("\"/voila/") && !html.contains("'/voila/") {
-        return None;
-    }
-    let out = html
-        .replace("\"/voila/", &format!("\"{base_path}voila/"))
-        .replace("'/voila/", &format!("'{base_path}voila/"));
-    (out != html).then_some(out)
-}
-
 /// Rewrite the container's own internal authority to the mount path
 /// (#373). An app behind the proxy that builds absolute URLs from the
 /// `Host` it sees (e.g. Starlette/FastAPI `url_for`) emits
@@ -523,14 +511,12 @@ fn transform(html: &[u8], base_path: &str) -> Result<Vec<u8>, lol_html::errors::
         .ok()
         .and_then(|s| rewrite_jupyter_config(s, base_path));
     let html: &[u8] = jup.as_deref().map_or(html, str::as_bytes);
-
-    // Voilà special case (#372): prefix the RequireJS bootstrap's inline
-    // `/voila/…` static URLs to the mount. Also a cheap no-op regex-free
-    // scan for every non-Voilà app and non-UTF-8 body.
-    let voila = std::str::from_utf8(html)
-        .ok()
-        .and_then(|s| rewrite_voila(s, base_path));
-    let html: &[u8] = voila.as_deref().map_or(html, str::as_bytes);
+    // NOTE: there is no Voilà-specific pass. Voilà's RequireJS bootstrap
+    // builds its static URLs (`/voila/…`) at runtime and assigns them to
+    // `script.src` — the generalized runtime shim below (which patches the
+    // `HTMLScriptElement.prototype.src` setter) prefixes them to the mount
+    // generically, so no bespoke string-rewrite is needed (#372,
+    // validated against the real container in a headless browser).
 
     let mut out = Vec::with_capacity(html.len() + 256);
     // Track whether we've already injected the `<base>` tag —
@@ -745,41 +731,6 @@ mod tests {
         assert_eq!(rewrite_jupyter_config(html, "/box/app/shiny/"), None);
     }
 
-    // ── rewrite_voila: the #372 fix ──────────────────────────
-    #[test]
-    fn voila_inline_requirejs_urls_prefixed_to_mount() {
-        // The RequireJS bootstrap Voilà emits (with --base_url=/), as
-        // captured from the real container.
-        let html = r#"<body data-base-url="/voila/"><script>
-  requirejs.config({ baseUrl: '/voila/', waitSeconds: 30});
-  window.voila_js_url = "/voila/templates/lab/static/voila.js?v=abc";
-  requirejs(["/voila/templates/lab/static/main.js?v=def"]);
-</script></body>"#;
-        let out = rewrite_voila(html, "/box/app/voila/").expect("should rewrite");
-        assert!(out.contains(r#"baseUrl: '/box/app/voila/voila/'"#), "requirejs baseUrl: {out}");
-        assert!(out.contains(r#""/box/app/voila/voila/templates/lab/static/main.js?v=def""#), "main.js: {out}");
-        assert!(out.contains(r#"data-base-url="/box/app/voila/voila/""#), "data-base-url: {out}");
-        // No bare `/voila/` URL string survives.
-        assert!(!out.contains(r#""/voila/"#) && !out.contains(r#"'/voila/"#), "leftover: {out}");
-    }
-
-    #[test]
-    fn voila_absent_is_noop() {
-        // A non-Voilà page (no quoted /voila/ URL) is left untouched.
-        let html = r#"<html><head><script src="/lib/x.js"></script></head></html>"#;
-        assert_eq!(rewrite_voila(html, "/box/app/shiny/"), None);
-    }
-
-    #[test]
-    fn voila_does_not_touch_mounted_attrs_so_lol_html_skips_them() {
-        // A src already under the mount (as the lol_html pass would leave
-        // it) must NOT be re-prefixed by us — and rewrite_url skips it too.
-        let html = r#"<script src="/box/app/voila/voila/static/require.min.js"></script>"#;
-        // Our quote-anchored replace doesn't match `"/box/...`, only `"/voila/`.
-        assert_eq!(rewrite_voila(html, "/box/app/voila/"), None);
-        assert_eq!(rewrite_url("/box/app/voila/voila/static/require.min.js", "/box/app/voila/"), None);
-    }
-
     #[tokio::test]
     async fn inject_base_href_rewrites_jupyter_config_end_to_end() {
         // Through the full HTML transform: the config URLs are prefixed
@@ -964,21 +915,30 @@ mod tests {
     }
 
     #[test]
-    fn build_runtime_shim_patches_three_globals() {
+    fn build_runtime_shim_patches_the_runtime_url_surface() {
         let shim = build_runtime_shim("/app/x/");
+        // Network APIs the page calls directly.
         assert!(shim.contains("window.WebSocket"));
         assert!(shim.contains("window.fetch"));
         assert!(shim.contains("XMLHttpRequest.prototype.open"));
+        // Dynamic resource loading — the Class-3 fix (#372) that lets the
+        // generalized shim subsume per-framework rewrites: RequireJS /
+        // webpack assign root-absolute URLs to script.src / link.href.
+        assert!(shim.contains("HTMLScriptElement.prototype"));
+        assert!(shim.contains("HTMLLinkElement.prototype"));
+        assert!(shim.contains("Element.prototype.setAttribute"));
     }
 
     #[test]
     fn build_runtime_shim_wraps_each_patch_in_try_catch() {
-        // A single browser quirk shouldn't break the others.
+        // A single browser quirk shouldn't break the others — every patch
+        // (WS, fetch, XHR, the patchUrlProp helper, its two call sites, and
+        // setAttribute) is independently guarded.
         let shim = build_runtime_shim("/app/x/");
         assert_eq!(
             shim.matches("} catch (_) {}").count(),
-            3,
-            "expected one try/catch per patched global"
+            7,
+            "expected one try/catch per patched global / call site"
         );
     }
 


### PR DESCRIPTION
## Contexto

Modernização do modelo de reescrita de URL (path A da discussão "strip vs
no-strip"). Em vez de um adapter de proxy por framework, **generaliza o
runtime shim** para fechar a classe "URL construída em runtime e atribuída
a `script.src`/`link.href`" — RequireJS e chunks do webpack.

## O que muda

- **Shim genérico:** patcheia os setters de `HTMLScriptElement.prototype.src`
  e `HTMLLinkElement.prototype.href` + `Element.setAttribute`. URLs
  root-absolutas que o requirejs/webpack montam em runtime ganham o prefixo
  do mount genericamente (o único caminho da Classe-3 que os wrappers de
  `fetch`/`XHR`/`WS` não enxergam).
- **`rewrite_voila` (#401) DELETADO:** o bootstrap RequireJS do Voilà usa
  `script.src` root-relativo → o shim genérico agora prefixa. **−1 adapter
  frágil**; o proxy faz menos trabalho por-resposta (reescrita virou
  client-side estática).
- **`rewrite_jupyter_config` (#348) MANTIDO.**

## Validação (Chrome headless, Playwright, container real)

Testei os dois adapters desligados contra os containers reais:

| | `rewrite_voila` off | `rewrite_jupyter_config` off |
|---|---|---|
| Resultado | ✅ main.js/require/css/voila.js sob o mount, notebook renderiza, **zero** vazamento `/voila/` | ❌ API vai pra raiz (`/api/…` 404) |
| Motivo | requirejs usa `script.src` root-relativo → shim pega | Jupyter monta URL de API **absoluta** (`http://host/api/…`) do `PageConfig.baseUrl` → shim root-relativo não pega |

Conclusão: o shim aposenta o `rewrite_voila`, mas **não** o `jupyter_config`
— setar o `baseUrl` na fonte é o fix correto/completo (padrão "conte ao app
seu prefixo"), não substituível por interceptação client-side sem uma
reescrita de URL absoluta sempre-ligada e mais arriscada.

## Gate

436 testes verdes, clippy `-D warnings` limpo, i18n OK. Net −40 linhas.

> ⚠️ Validar Voilà no browser no cast após release (o shim roda no cliente).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
