### PR TITLE
fix(ui): Safari-harden the favicon links (#374)

### DIFF
--- a/crates/ruscker-admin/templates/_layout.html
+++ b/crates/ruscker-admin/templates/_layout.html
@@ -8,12 +8,11 @@
 <title>{% block title %}{{ self.t("landing-title") }}{% endblock %}</title>
 {% block head_extra %}{% endblock %}
 
-<link rel="icon" href="{{ base }}/favicon.ico" sizes="any">
+<link rel="icon" href="{{ base }}/favicon.ico">
 <link rel="icon" type="image/png" sizes="32x32" href="{{ base }}/favicon-32.png">
 <link rel="icon" type="image/svg+xml" href="{{ base }}/favicon.svg">
 <link rel="apple-touch-icon" href="{{ base }}/apple-touch-icon.png">
 <link rel="mask-icon" href="{{ base }}/assets/brand/mark.svg" color="#0f6e56">
-<link rel="apple-touch-icon" href="{{ base }}/apple-touch-icon.png">
 
 <link rel="preload" href="{{ base }}/assets/fonts/jost-latin-400-normal.woff2" as="font" type="font/woff2" crossorigin>
 <link rel="preload" href="{{ base }}/assets/fonts/jost-latin-500-normal.woff2" as="font" type="font/woff2" crossorigin>

--- a/crates/ruscker-admin/templates/admin/_layout.html
+++ b/crates/ruscker-admin/templates/admin/_layout.html
@@ -8,12 +8,11 @@
 <meta name="robots" content="noindex,nofollow">
 <title>{% block title %}Admin · Ruscker{% endblock %}</title>
 
-<link rel="icon" href="{{ base }}/favicon.ico" sizes="any">
+<link rel="icon" href="{{ base }}/favicon.ico">
 <link rel="icon" type="image/png" sizes="32x32" href="{{ base }}/favicon-32.png">
 <link rel="icon" type="image/svg+xml" href="{{ base }}/favicon.svg">
 <link rel="apple-touch-icon" href="{{ base }}/apple-touch-icon.png">
 <link rel="mask-icon" href="{{ base }}/assets/brand/mark.svg" color="#0f6e56">
-<link rel="apple-touch-icon" href="{{ base }}/apple-touch-icon.png">
 
 <link rel="preload" href="{{ base }}/assets/fonts/jost-latin-400-normal.woff2" as="font" type="font/woff2" crossorigin>
 <link rel="preload" href="{{ base }}/assets/fonts/jost-latin-500-normal.woff2" as="font" type="font/woff2" crossorigin>


### PR DESCRIPTION
Files + links verified correct on the live deploy (Firefox renders them). Two Safari irritants removed: `sizes="any"` on the raster `.ico` (Safari mishandles it) and a duplicated `apple-touch-icon`.

Most likely root cause of FF-ok/Safari-not when markup is valid: Safari's sticky favicon cache (test in a Private window). This is defensive hardening.

🤖 Generated with [Claude Code](https://claude.com/claude-code)