### PR TITLE
feat(admin): spec form Registry → saved-credential picker only (#351, slice 2)

### DIFF
--- a/crates/ruscker-admin/assets/i18n/en/landing.ftl
+++ b/crates/ruscker-admin/assets/i18n/en/landing.ftl
@@ -496,7 +496,8 @@ spec-form-registry-password-keep = Blank keeps the current password
 spec-help-registry-password = Use an environment variable — never paste the password as text. Only used together with the username.
 spec-form-registry-credential = Stored credential
 spec-help-registry-credential = Pick a named credential from the store (Credentials page) to pull private images. When set, it takes precedence over the inline username/password.
-spec-form-registry-help = Two ways to pull a private image: a named credential from the store (above), or the inline domain/username/password. The named credential wins if both are set. Never paste a plaintext password — reference an environment variable instead.
+spec-form-registry-help = Pull a private image by selecting a saved credential. Create and manage credentials on the Credentials page — the password can be a literal (encrypted) or an environment-variable reference.
+spec-form-registry-inline-note = This app carries inline registry credentials from imported YAML. They're preserved, but prefer a saved credential above.
 spec-form-access-section = Access
 spec-form-access-groups = Allowed groups
 spec-help-access-groups = Groups that may see and reach the app (comma-separated). Blank, with users also blank = open to everyone.

--- a/crates/ruscker-admin/assets/i18n/es/landing.ftl
+++ b/crates/ruscker-admin/assets/i18n/es/landing.ftl
@@ -496,7 +496,8 @@ spec-form-registry-password-keep = En blanco mantiene la contraseña actual
 spec-help-registry-password = Usa una variable de entorno — nunca pegues la contraseña en texto. Solo se usa junto con el usuario.
 spec-form-registry-credential = Credencial guardada
 spec-help-registry-credential = Elige una credencial con nombre del almacén (página Credenciales) para descargar imágenes privadas. Cuando se define, tiene prioridad sobre el usuario/contraseña en línea.
-spec-form-registry-help = Dos formas de descargar una imagen privada: una credencial con nombre del almacén (arriba) o el dominio/usuario/contraseña en línea. La credencial con nombre gana si se definen ambas. Nunca pegues una contraseña en texto plano — usa una variable de entorno.
+spec-form-registry-help = Descarga una imagen privada seleccionando una credencial guardada. Crea y gestiona credenciales en la página Credenciales — la contraseña puede ser literal (cifrada) o una referencia a variable de entorno.
+spec-form-registry-inline-note = Esta app tiene credenciales de registry en línea (YAML importado). Se conservan, pero prefiera una credencial guardada arriba.
 spec-form-access-section = Acceso
 spec-form-access-groups = Grupos permitidos
 spec-help-access-groups = Grupos que pueden ver y acceder a la app (separados por comas). Vacío, con usuarios también vacío = abierto a todos.

--- a/crates/ruscker-admin/assets/i18n/fr/landing.ftl
+++ b/crates/ruscker-admin/assets/i18n/fr/landing.ftl
@@ -496,7 +496,8 @@ spec-form-registry-password-keep = Vide conserve le mot de passe actuel
 spec-help-registry-password = Utilisez une variable d'environnement — ne collez jamais le mot de passe en clair. Utilisé uniquement avec l'utilisateur.
 spec-form-registry-credential = Identifiant enregistré
 spec-help-registry-credential = Choisissez un identifiant nommé du coffre (page Identifiants) pour tirer des images privées. S'il est défini, il prime sur l'utilisateur/mot de passe en ligne.
-spec-form-registry-help = Deux façons de tirer une image privée : un identifiant nommé du coffre (ci-dessus) ou le domaine/utilisateur/mot de passe en ligne. L'identifiant nommé l'emporte si les deux sont définis. Ne collez jamais de mot de passe en clair — référencez plutôt une variable d'environnement.
+spec-form-registry-help = Tirez une image privée en sélectionnant un identifiant enregistré. Créez et gérez les identifiants sur la page Identifiants — le mot de passe peut être littéral (chiffré) ou une référence de variable d'environnement.
+spec-form-registry-inline-note = Cette app a des identifiants de registre en ligne (YAML importé). Ils sont conservés, mais préférez un identifiant enregistré ci-dessus.
 spec-form-access-section = Accès
 spec-form-access-groups = Groupes autorisés
 spec-help-access-groups = Groupes qui peuvent voir et atteindre l'app (séparés par des virgules). Vide, avec utilisateurs aussi vide = ouvert à tous.

--- a/crates/ruscker-admin/assets/i18n/pt/landing.ftl
+++ b/crates/ruscker-admin/assets/i18n/pt/landing.ftl
@@ -500,7 +500,8 @@ spec-form-registry-password-keep = Em branco mantém a senha atual
 spec-help-registry-password = Use uma variável de ambiente — nunca cole a senha em texto. Só usada junto com o usuário.
 spec-form-registry-credential = Credencial salva
 spec-help-registry-credential = Escolha uma credencial nomeada do cofre (página Credenciais) para puxar imagens privadas. Quando definida, tem precedência sobre o usuário/senha inline.
-spec-form-registry-help = Duas formas de puxar uma imagem privada: uma credencial nomeada do cofre (acima) ou o domínio/usuário/senha inline. A credencial nomeada vence se ambas estiverem definidas. Nunca cole uma senha em texto puro — use uma variável de ambiente.
+spec-form-registry-help = Puxe uma imagem privada selecionando uma credencial salva. Crie e gerencie credenciais na página Credenciais — a senha pode ser literal (criptografada) ou uma referência a variável de ambiente.
+spec-form-registry-inline-note = Este app tem credenciais de registry inline (YAML importado). Elas são preservadas, mas prefira uma credencial salva acima.
 spec-form-access-section = Acesso
 spec-form-access-groups = Grupos permitidos
 spec-help-access-groups = Grupos que podem ver e acessar o app (separados por vírgula). Em branco, com usuários também em branco = aberto a todos.

--- a/crates/ruscker-admin/templates/admin/spec_form.html
+++ b/crates/ruscker-admin/templates/admin/spec_form.html
@@ -512,54 +512,44 @@
             <div class="spec-form-help">{{ self.t("spec-form-container-cmd-help") }}</div>
           </div>
 
-          {# Registry — pulling private images #}
+          {# Registry — pulling private images. Unified on the credential
+             store (#351): pick a SAVED credential here; create/manage them
+             on the Credentials page (where the password can be a literal —
+             AES-encrypted — or a `${VAR}` env-ref). The inline
+             domain/username/password from imported ShinyProxy YAML are
+             preserved as hidden fields (back-compat, no data loss on save)
+             but no longer edited here — a named credential takes
+             precedence anyway. #}
           <div class="spec-form-subsection">{{ self.t("spec-form-registry-section") }}</div>
-          <div class="grid grid-cols-2 gap-3">
-            <div class="spec-form-field">
-              <div class="spec-form-label-row">
-                <label for="f-reg-domain" class="spec-form-label">{{ self.t("spec-form-registry-domain") }}</label>
-                {% call help(self.t("spec-help-registry-domain")) %}{% endcall %}
-              </div>
-              <input id="f-reg-domain" type="text" name="docker_registry_domain"
-                     value="{{ form.docker_registry_domain }}" placeholder="docker.io"
-                     class="spec-form-input spec-form-input--mono">
+          <div class="spec-form-field">
+            <div class="spec-form-label-row">
+              <label for="f-reg-cred" class="spec-form-label">{{ self.t("spec-form-registry-credential") }}</label>
+              {% call help(self.t("spec-help-registry-credential")) %}{% endcall %}
             </div>
-            <div class="spec-form-field">
-              <div class="spec-form-label-row">
-                <label for="f-reg-user" class="spec-form-label">{{ self.t("spec-form-registry-username") }}</label>
-                {% call help(self.t("spec-help-registry-username")) %}{% endcall %}
-              </div>
-              <input id="f-reg-user" type="text" name="docker_registry_username"
-                     value="{{ form.docker_registry_username }}" class="spec-form-input">
-            </div>
-            <div class="spec-form-field">
-              <div class="spec-form-label-row">
-                <label for="f-reg-pass" class="spec-form-label">{{ self.t("spec-form-registry-password") }}</label>
-                {% call help(self.t("spec-help-registry-password")) %}{% endcall %}
-              </div>
-              <input id="f-reg-pass" type="password" name="docker_registry_password"
-                     value="" autocomplete="new-password"
-                     placeholder="{{ self.t("spec-form-registry-password-keep") }}"
-                     class="spec-form-input spec-form-input--mono">
-            </div>
-            <div class="spec-form-field">
-              <div class="spec-form-label-row">
-                <label for="f-reg-cred" class="spec-form-label">{{ self.t("spec-form-registry-credential") }}</label>
-                {% call help(self.t("spec-help-registry-credential")) %}{% endcall %}
-              </div>
-              {# Free-text, but a datalist surfaces the names the operator
-                 created on the Credentials page so the two screens
-                 connect (#351). A named credential takes precedence over
-                 the inline domain/username/password above. #}
-              <input id="f-reg-cred" type="text" name="docker_registry_credential"
-                     value="{{ form.docker_registry_credential }}"
-                     list="registry-cred-suggestions" class="spec-form-input">
-              <datalist id="registry-cred-suggestions">
-                {% for name in credential_names %}<option value="{{ name }}"></option>{% endfor %}
-              </datalist>
+            <input id="f-reg-cred" type="text" name="docker_registry_credential"
+                   value="{{ form.docker_registry_credential }}"
+                   list="registry-cred-suggestions" class="spec-form-input">
+            <datalist id="registry-cred-suggestions">
+              {% for name in credential_names %}<option value="{{ name }}"></option>{% endfor %}
+            </datalist>
+            <div class="spec-form-help">
+              {{ self.t("spec-form-registry-help") }}
+              <a href="{{ base }}/admin/credentials" target="_blank" rel="noopener" class="hover:underline">
+                {{ self.t("admin-nav-credentials") }}
+                <i class="ti ti-external-link" aria-hidden="true" style="font-size:11px"></i>
+              </a>
             </div>
           </div>
-          <div class="spec-form-help">{{ self.t("spec-form-registry-help") }}</div>
+          {# Back-compat: keep inline registry creds from imported YAML so a
+             save doesn't drop them (domain/username preserved verbatim;
+             blank password keeps the stored one, #260). No longer editable
+             here — migrate to a saved credential above. #}
+          <input type="hidden" name="docker_registry_domain" value="{{ form.docker_registry_domain }}">
+          <input type="hidden" name="docker_registry_username" value="{{ form.docker_registry_username }}">
+          <input type="hidden" name="docker_registry_password" value="">
+          {% if !form.docker_registry_domain.is_empty() || !form.docker_registry_username.is_empty() %}
+          <div class="spec-form-help" style="color:var(--color-lock)">{{ self.t("spec-form-registry-inline-note") }}</div>
+          {% endif %}
 
           {# Access — who may see + reach this app (#155) #}
           <div class="spec-form-subsection">{{ self.t("spec-form-access-section") }}</div>


### PR DESCRIPTION
Completes the credentials unification (the chosen UX). The spec form's Registry section is now a **single** control — the saved-credential picker — + a "Credentials →" manage link. Slice 1 (#411) made the store accept `${VAR}`, so the picker covers both models (encrypted literal **or** env-only).

Inline domain/username/password are removed from the visible form but kept as **hidden inputs** (no data loss for imported YAML specs; blank password keeps the stored one per #260). A note nudges migration when a spec still carries inline creds. Render-verified.

Closes the #351 UX (two-places confusion).

🤖 Generated with [Claude Code](https://claude.com/claude-code)