### PR TITLE
fix(admin): load Alpine on the media page (drag-drop + gallery were inert)

### DIFF
--- a/crates/ruscker-admin/templates/admin/images.html
+++ b/crates/ruscker-admin/templates/admin/images.html
@@ -136,4 +136,12 @@
   </script>
 {% endif %}
 
+{# Alpine powers BOTH the upload-zone drag-drop (the form near the top) and
+   the gallery filter / "show more" below. The admin layout doesn't ship
+   Alpine globally — each page includes it — and this page was missing it,
+   so those directives were inert (drag-drop dead, gallery search/paging
+   silently broken). Load it here, outside the gallery `{% if %}`, so the
+   upload form works even when the library is empty. #}
+<script src="{{ base }}/assets/js/alpine.min.js?v={{ crate::APP_VERSION }}" defer></script>
+
 {% endblock %}


### PR DESCRIPTION
**Root cause** of "drag-drop doesn't work in Media": the admin layout doesn't ship Alpine globally (each page includes it), and `images.html` was **missing the Alpine script**. So the upload `@drop` (#410) AND the gallery filter/"show more" (#319) were all inert.

Verified headless: synthetic file-drop now fires (`dragover.defaultPrevented=true`), sets the input file, and POSTs to /admin/media. Spec-form inline tiles already worked (spec_form loads Alpine).

Follow-up: consider moving Alpine into the admin layout so a page can't forget it.