### PR TITLE
feat(admin): built-in logos pickable in the spec-form logo/cover pickers (Option A)

### DIFF
--- a/crates/ruscker-admin/assets/i18n/en/landing.ftl
+++ b/crates/ruscker-admin/assets/i18n/en/landing.ftl
@@ -534,6 +534,7 @@ spec-form-logo-upload = Upload image
 spec-form-gallery-more = Show more
 spec-form-logo-clear = Remove
 spec-form-logo-none = No image — a kind-based tint is used.
+spec-form-logo-builtin = Built-in logos
 spec-form-logo-path-advanced = Advanced: paste a path or URL
 spec-form-cover-image = Image
 spec-form-cover-image-help = Pick a library image (or upload one) as the card background.

--- a/crates/ruscker-admin/assets/i18n/es/landing.ftl
+++ b/crates/ruscker-admin/assets/i18n/es/landing.ftl
@@ -534,6 +534,7 @@ spec-form-logo-upload = Subir imagen
 spec-form-gallery-more = Mostrar más
 spec-form-logo-clear = Quitar
 spec-form-logo-none = Sin imagen — se usa un tono según el tipo.
+spec-form-logo-builtin = Logos integrados
 spec-form-logo-path-advanced = Avanzado: pegar una ruta o URL
 spec-form-cover-image = Imagen
 spec-form-cover-image-help = Elige una imagen de la biblioteca (o sube una) como fondo de la tarjeta.

--- a/crates/ruscker-admin/assets/i18n/fr/landing.ftl
+++ b/crates/ruscker-admin/assets/i18n/fr/landing.ftl
@@ -534,6 +534,7 @@ spec-form-logo-upload = Téléverser une image
 spec-form-gallery-more = Afficher plus
 spec-form-logo-clear = Retirer
 spec-form-logo-none = Pas d'image — une teinte selon le type est utilisée.
+spec-form-logo-builtin = Logos intégrés
 spec-form-logo-path-advanced = Avancé : coller un chemin ou une URL
 spec-form-cover-image = Image
 spec-form-cover-image-help = Choisissez une image de la bibliothèque (ou téléversez-en une) comme fond de la carte.

--- a/crates/ruscker-admin/assets/i18n/pt/landing.ftl
+++ b/crates/ruscker-admin/assets/i18n/pt/landing.ftl
@@ -538,6 +538,7 @@ spec-form-logo-upload = Enviar imagem
 spec-form-gallery-more = Mostrar mais
 spec-form-logo-clear = Remover
 spec-form-logo-none = Sem imagem — usa um tom gerado pelo tipo.
+spec-form-logo-builtin = Logos integrados
 spec-form-logo-path-advanced = Avançado: colar um caminho ou URL
 spec-form-cover-image = Imagem
 spec-form-cover-image-help = Escolha uma imagem da biblioteca (ou envie uma) como fundo do card.

--- a/crates/ruscker-admin/src/routes/admin/spec_form.rs
+++ b/crates/ruscker-admin/src/routes/admin/spec_form.rs
@@ -724,6 +724,13 @@ impl<'a> SpecFormPage<'a> {
         serde_json::to_string(&self.logo_images).unwrap_or_else(|_| "[]".into())
     }
 
+    /// Built-in framework + brand logo paths as a JSON array (Option A),
+    /// seeding the picker's "built-in logos" group so an operator can reuse
+    /// a bundled logo without typing a path. Single source: [`BUILTIN_LOGOS`].
+    fn builtin_logos_json(&self) -> String {
+        serde_json::to_string(crate::routes::assets::BUILTIN_LOGOS).unwrap_or_else(|_| "[]".into())
+    }
+
     /// Options for the kind picker: (key, label-fluent-key, tabler-icon).
     /// Order intentional — mirrors the public landing chip order.
     fn display_type_options(&self) -> &'static [(&'static str, &'static str, &'static str)] {

--- a/crates/ruscker-admin/src/routes/assets.rs
+++ b/crates/ruscker-admin/src/routes/assets.rs
@@ -140,6 +140,27 @@ const SHOWCASE_SHINY_FOR_PYTHON: &[u8] =
 const SHOWCASE_STREAMLIT: &[u8] = include_bytes!("../../assets/showcase/streamlit.svg");
 const SHOWCASE_VOILA: &[u8] = include_bytes!("../../assets/showcase/voila.svg");
 
+/// Built-in logo paths offered in the spec-form logo/cover pickers
+/// (Option A, #351-follow-up): the bundled framework + brand SVGs, so a
+/// new card can reuse a curated logo without typing a path. Served by the
+/// `/assets/showcase/*` + `/assets/brand/*` handlers above; stored on a
+/// spec by this exact (base-agnostic) path.
+pub const BUILTIN_LOGOS: &[&str] = &[
+    "/assets/showcase/shiny.svg",
+    "/assets/showcase/shiny-for-python.svg",
+    "/assets/showcase/streamlit.svg",
+    "/assets/showcase/dash.svg",
+    "/assets/showcase/voila.svg",
+    "/assets/showcase/jupyter.svg",
+    "/assets/showcase/rstudio.svg",
+    "/assets/showcase/rmarkdown.svg",
+    "/assets/showcase/quarto.svg",
+    "/assets/showcase/fastapi.svg",
+    "/assets/showcase/plumber.svg",
+    "/assets/showcase/bokeh.svg",
+    "/assets/brand/ruscker-mark.svg",
+];
+
 // Ruscker brand kit — see docs/BRAND.md for usage rules.
 const BRAND_MARK: &[u8] = include_bytes!("../../assets/brand/ruscker-mark.svg");
 const BRAND_MARK_FLAT: &[u8] = include_bytes!("../../assets/brand/ruscker-mark-flat.svg");

--- a/crates/ruscker-admin/templates/admin/spec_form.html
+++ b/crates/ruscker-admin/templates/admin/spec_form.html
@@ -17,7 +17,7 @@
 
 {% block content %}
 
-<div x-data="ruscker.specForm({{ form_initial_json() }}, {{ logo_images_json() }})" x-cloak>
+<div x-data="ruscker.specForm({{ form_initial_json() }}, {{ logo_images_json() }}, {{ builtin_logos_json() }})" x-cloak>
 
   {# ── Header ───────────────────────────────────────────────── #}
   <div class="flex items-end justify-between mb-5 pb-3 border-b border-[color:var(--border)]">
@@ -158,6 +158,21 @@
                   x-text="'{{ self.t("spec-form-gallery-more") }}' + ' (' + (logoImages.length - logoShown) + ')'"></button>
         </div>
 
+        {# Built-in logos (Option A): the framework + brand SVGs bundled in
+           the binary, pickable like uploads so a new card can reuse them
+           without typing a path. Stored by their full `/assets/...` path. #}
+        <div class="spec-form-help mt-2" x-show="builtinLogos.length" x-cloak>{{ self.t("spec-form-logo-builtin") }}</div>
+        <div class="flex flex-wrap gap-2" x-show="builtinLogos.length" x-cloak>
+          <template x-for="path in builtinLogos" :key="path">
+            <button type="button" :title="path.split('/').pop()"
+                    @click="form.logo = path"
+                    class="w-12 h-12 rounded-md overflow-hidden border-2 transition-colors p-1 bg-[color:var(--surface-soft)]"
+                    :class="form.logo === path ? 'border-[#0f6e56]' : 'border-transparent hover:border-[color:var(--border)]'">
+              <img :src="assetUrl(path)" :alt="path" loading="lazy" class="w-full h-full object-contain">
+            </button>
+          </template>
+        </div>
+
         {# Upload error (e.g. unsupported type / too large) #}
         <div class="spec-form-help" style="color:var(--color-lock)" x-show="imgError" x-text="imgError" x-cloak></div>
 
@@ -266,6 +281,14 @@
             <button type="button" x-show="logoImages.length > coverShown" x-cloak
                     @click="coverShown += galleryPage" class="admin-nav-link self-center text-xs"
                     x-text="'{{ self.t("spec-form-gallery-more") }}' + ' (' + (logoImages.length - coverShown) + ')'"></button>
+            {# Built-in logos as a cover too (Option A). #}
+            <template x-for="path in builtinLogos" :key="'cov-' + path">
+              <button type="button" :title="path.split('/').pop()" @click="setCoverPath(path)"
+                      class="w-12 h-12 rounded-md overflow-hidden border-2 transition-colors p-1 bg-[color:var(--surface-soft)]"
+                      :class="form.cover.indexOf(path) !== -1 ? 'border-[#0f6e56]' : 'border-transparent hover:border-[color:var(--border)]'">
+                <img :src="assetUrl(path)" :alt="path" loading="lazy" class="w-full h-full object-contain">
+              </button>
+            </template>
           </div>
           <div class="spec-form-help">{{ self.t("spec-form-cover-image-help") }}</div>
           <input type="text" name="cover" x-model="form.cover" readonly
@@ -832,11 +855,14 @@
 <script src="{{ base }}/assets/js/alpine.min.js?v={{ crate::APP_VERSION }}" defer></script>
 <script>
 window.ruscker = window.ruscker || {};
-window.ruscker.specForm = (initial, logoImages) => ({
+window.ruscker.specForm = (initial, logoImages, builtinLogos) => ({
   form: initial,
   // Media-library filenames for the logo/cover pickers (#213). Inline
   // uploads unshift new names here so a fresh thumbnail appears at once.
   logoImages: Array.isArray(logoImages) ? logoImages : [],
+  // Built-in framework + brand logo PATHS bundled in the binary (Option A),
+  // pickable in the logo/cover pickers so a new card can reuse them.
+  builtinLogos: Array.isArray(builtinLogos) ? builtinLogos : [],
   // How many gallery tiles to render initially (#293) — keeps the DOM +
   // thumbnail requests bounded on a large media library. "Show more"
   // reveals another page.
@@ -917,8 +943,13 @@ window.ruscker.specForm = (initial, logoImages) => ({
   },
   // Set the cover to a library image as a CSS background (#213).
   setCoverImage(name) {
+    this.setCoverPath('/assets/img/' + name);
+  },
+  // Set the cover from a full asset path (a Media image or a built-in
+  // logo, Option A) as a CSS background.
+  setCoverPath(path) {
     this.coverMode = 'image';
-    this.form.cover = "url('/assets/img/" + name + "') center / cover no-repeat";
+    this.form.cover = "url('" + path + "') center / cover no-repeat";
   },
   // Inline upload to the media library, then select the result for
   // `target` ('logo' or 'cover'). Reuses the same pipeline as the


### PR DESCRIPTION
Closes the "Media is empty / where do card images come from" gap. The showcase cards use framework+brand SVGs bundled in the binary, which weren't pickable (only typeable by path). Now the logo + cover pickers show a **"Built-in logos"** group (12 framework logos + Ruscker mark) next to the uploaded Media images.

- `assets::BUILTIN_LOGOS` = single source of the path list; exposed via `builtin_logos_json()` as a 3rd Alpine-factory arg. No DB duplication, no delete-risk.
- `setCoverPath` generalizes `setCoverImage` so a built-in works as a cover too. New i18n key (4 locales). Render-verified.

Media stays "your uploads"; the picker = "your uploads + built-in logos".