### PR TITLE
chore(release): bump workspace version 0.1.28 → 0.1.29

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2845,7 +2845,7 @@ dependencies = [
 
 [[package]]
 name = "ruscker-admin"
-version = "0.1.28"
+version = "0.1.29"
 dependencies = [
  "aes-gcm",
  "anyhow",
@@ -2892,7 +2892,7 @@ dependencies = [
 
 [[package]]
 name = "ruscker-cli"
-version = "0.1.28"
+version = "0.1.29"
 dependencies = [
  "anyhow",
  "clap",
@@ -2912,7 +2912,7 @@ dependencies = [
 
 [[package]]
 name = "ruscker-config"
-version = "0.1.28"
+version = "0.1.29"
 dependencies = [
  "chrono",
  "ordered-float",
@@ -2927,7 +2927,7 @@ dependencies = [
 
 [[package]]
 name = "ruscker-core"
-version = "0.1.28"
+version = "0.1.29"
 dependencies = [
  "async-trait",
  "chrono",
@@ -2940,7 +2940,7 @@ dependencies = [
 
 [[package]]
 name = "ruscker-docker"
-version = "0.1.28"
+version = "0.1.29"
 dependencies = [
  "anyhow",
  "async-stream",
@@ -2959,7 +2959,7 @@ dependencies = [
 
 [[package]]
 name = "ruscker-proxy"
-version = "0.1.28"
+version = "0.1.29"
 dependencies = [
  "anyhow",
  "axum",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -10,7 +10,7 @@ members = [
 ]
 
 [workspace.package]
-version = "0.1.28"
+version = "0.1.29"
 edition = "2021"
 rust-version = "1.85"
 license = "Apache-2.0"


### PR DESCRIPTION
Release v0.1.29 — #416 (Media page Alpine fix: drag-drop + gallery) + #417 (built-in logos picker, Option A). Tag `v0.1.29` after merge.

🤖 Generated with [Claude Code](https://claude.com/claude-code)