### PR TITLE
fix(admin): media gallery x-data HTML-escape + built-in mark path

### DIFF
--- a/crates/ruscker-admin/src/routes/assets.rs
+++ b/crates/ruscker-admin/src/routes/assets.rs
@@ -158,7 +158,7 @@ pub const BUILTIN_LOGOS: &[&str] = &[
     "/assets/showcase/fastapi.svg",
     "/assets/showcase/plumber.svg",
     "/assets/showcase/bokeh.svg",
-    "/assets/brand/ruscker-mark.svg",
+    "/assets/brand/mark.svg",
 ];
 
 // Ruscker brand kit — see docs/BRAND.md for usage rules.

--- a/crates/ruscker-admin/templates/admin/images.html
+++ b/crates/ruscker-admin/templates/admin/images.html
@@ -61,7 +61,12 @@
      every tile (and fire a thumbnail request each) on load (#317). The
      metadata is small and already in memory; paging/filtering is instant.
      Mirrors the spec-form logo picker (#293). #}
-  <div x-data="ruscker.mediaGallery({{ self.images_json()|safe }})" x-cloak>
+  {# NOTE: no `|safe` — the JSON must be HTML-escaped so its `"` don't
+     terminate this double-quoted x-data attribute (the un-escaped version
+     produced an Alpine SyntaxError the moment the gallery had any data,
+     leaving `q`/`filtered` undefined and no tiles). The browser un-escapes
+     `&quot;` back to `"` before Alpine parses it. #}
+  <div x-data="ruscker.mediaGallery({{ self.images_json() }})" x-cloak>
     <div class="mb-4">
       <input type="search" x-model="q"
              placeholder="{{ self.t("admin-images-search") }}"


### PR DESCRIPTION
Two bugs once a real image was uploaded:
1. Gallery `x-data` used `|safe` → JSON quotes broke the attribute → Alpine SyntaxError (`q`/`filtered` undefined), no tiles. Dropped `|safe` (browser un-escapes `&quot;`). Verified: 0 console errors, tiles render.
2. `BUILTIN_LOGOS` had `/assets/brand/ruscker-mark.svg` but it's served at `/assets/brand/mark.svg` → broken image. Fixed.