### PR TITLE
fix(credentials): only keep a password verbatim if it's a PURE env-ref (#422)

### DIFF
--- a/crates/ruscker-admin/src/db/credentials.rs
+++ b/crates/ruscker-admin/src/db/credentials.rs
@@ -44,11 +44,17 @@ pub async fn upsert(
     //     plaintext never lands in the DB at all — preserving the "DB never
     //     sees the cleartext" model now that the spec form points only at
     //     the store.
-    let (ciphertext, nonce): (Vec<u8>, Vec<u8>) = if password.contains("${") {
-        (password.as_bytes().to_vec(), Vec::new())
-    } else {
-        key.encrypt(password.as_bytes())?
-    };
+    //
+    // The env-ref branch requires the password to be ENTIRELY valid env-ref
+    // tokens (#422): a loose `contains("${")` would store a literal like
+    // `abc${def` (no valid token) verbatim — i.e. cleartext at rest. Anything
+    // that isn't a pure env-ref is encrypted.
+    let (ciphertext, nonce): (Vec<u8>, Vec<u8>) =
+        if ruscker_config::env::is_pure_env_ref(password) {
+            (password.as_bytes().to_vec(), Vec::new())
+        } else {
+            key.encrypt(password.as_bytes())?
+        };
     // Metadata-only audit diff — never the password (see the
     // `audit_log_never_records_the_password` test).
     let diff = serde_json::to_string(&serde_json::json!({
@@ -464,6 +470,28 @@ mod tests {
         assert_eq!(
             c2.password, "resolved-pw",
             "verbatim env-ref ignores the master key (not encrypted)"
+        );
+    }
+
+    #[tokio::test]
+    async fn literal_password_containing_dollar_brace_is_encrypted_not_verbatim() {
+        // #422: a literal password that merely CONTAINS `${` (not a valid
+        // env-ref) must be AES-encrypted, never stored verbatim.
+        let pool = open_memory().await.unwrap();
+        let db = ConfigDb::Sqlite(pool.clone());
+        let key = fixed_key();
+        upsert(&db, &key, "lit", "registry.example.com", "bot", "abc${def", None)
+            .await
+            .unwrap();
+        // Same key round-trips the literal verbatim.
+        let c = resolve(&db, &key, "lit").await.unwrap().expect("resolved");
+        assert_eq!(c.password, "abc${def");
+        // A DIFFERENT key fails to decrypt — proof it was encrypted, not
+        // stored in cleartext (a verbatim value would resolve regardless).
+        let other = MasterKey::parse(&"cd".repeat(32)).unwrap();
+        assert!(
+            resolve(&db, &other, "lit").await.is_err(),
+            "literal with `${{` must be AES-encrypted, not verbatim"
         );
     }
 

--- a/crates/ruscker-config/src/env.rs
+++ b/crates/ruscker-config/src/env.rs
@@ -107,6 +107,22 @@ pub fn interpolate_value(value: &str) -> Result<String> {
     interpolate_line(value)
 }
 
+/// `true` when `value` (trimmed) consists ONLY of valid `${VAR}` /
+/// `${VAR:-default}` tokens (plus inter-token whitespace) — i.e. nothing
+/// literal remains that would be stored or leak.
+///
+/// Used to decide whether a value is safe to keep VERBATIM (resolved from
+/// the environment at use time) vs. must be treated as a literal secret.
+/// A loose `contains("${")` is unsafe: a literal password like `abc${def`
+/// or `p@ss${word` has no valid token, so keeping it verbatim would store
+/// the cleartext (see the credential-store regression #422).
+pub fn is_pure_env_ref(value: &str) -> bool {
+    let t = value.trim();
+    // Strip every valid token; if only whitespace is left, the whole value
+    // was env-refs. Empty (no token at all) ⇒ not an env-ref.
+    !t.is_empty() && ENV_VAR_PATTERN.replace_all(t, "").trim().is_empty()
+}
+
 fn interpolate_line(line: &str) -> Result<String> {
     let mut result = String::with_capacity(line.len());
     let mut last_end = 0;
@@ -290,5 +306,22 @@ proxy:
             let result = interpolate("greeting: hello ${RUSCKER_NAME}!").unwrap();
             assert_eq!(result, "greeting: hello world!");
         });
+    }
+
+    #[test]
+    fn is_pure_env_ref_only_for_whole_token_values() {
+        // Pure env-refs (kept verbatim by the credential store, #422).
+        assert!(is_pure_env_ref("${VAR}"));
+        assert!(is_pure_env_ref("  ${VAR}  "));
+        assert!(is_pure_env_ref("${VAR:-default}"));
+        assert!(is_pure_env_ref("${A} ${B}"));
+        // NOT pure — literal text that would be stored / leak.
+        assert!(!is_pure_env_ref("abc${def")); // malformed, no token
+        assert!(!is_pure_env_ref("p@ss${word")); // no closing brace
+        assert!(!is_pure_env_ref("prefix${VAR}")); // literal prefix
+        assert!(!is_pure_env_ref("${VAR}suffix"));
+        assert!(!is_pure_env_ref("plainsecret"));
+        assert!(!is_pure_env_ref(""));
+        assert!(!is_pure_env_ref("${}")); // empty braces, no valid name
     }
 }


### PR DESCRIPTION
Closes #422. The store used `password.contains("${")` to decide verbatim-vs-encrypt — too loose: a literal like `abc${def` (no valid token) was stored in **cleartext**. New `is_pure_env_ref` keeps verbatim only when the whole value is valid `${VAR}`/`${VAR:-default}` tokens; everything else is AES-encrypted. Tests added (literal-with-`${` is encrypted).