### PR TITLE
fix(admin): validate username charset (#429) + mask user password fields (#430)

### DIFF
--- a/crates/ruscker-admin/src/db/users.rs
+++ b/crates/ruscker-admin/src/db/users.rs
@@ -39,6 +39,19 @@ pub fn normalize_username(raw: &str) -> String {
     raw.trim().to_lowercase()
 }
 
+/// A username is safe iff it's non-empty and made only of identifier-ish
+/// chars (letters, digits, `_ . @ -` — `@` so e-mail logins work). It
+/// lands un-encoded in the per-user admin action URLs
+/// (`/admin/users/{username}/...`), so anything else (`/`, `?`, `#`,
+/// space, …) would make the user impossible to edit/delete from the UI
+/// (#429, same class as the credential-name fix #423).
+pub fn is_valid_username(name: &str) -> bool {
+    !name.is_empty()
+        && name
+            .chars()
+            .all(|c| c.is_ascii_alphanumeric() || matches!(c, '_' | '.' | '@' | '-'))
+}
+
 /// Parse the stored comma-separated `groups` column into a clean list:
 /// trimmed, empties dropped, duplicates removed (first wins, order
 /// preserved). Group names are compared case-sensitively against a
@@ -644,6 +657,19 @@ mod tests {
         assert!(verify_password("s3cret-pw", &h));
         assert!(!verify_password("wrong", &h));
         assert!(!verify_password("s3cret-pw", "not-a-phc-string"));
+    }
+
+    #[test]
+    fn username_charset_is_restricted() {
+        assert!(is_valid_username("jane"));
+        assert!(is_valid_username("jane.doe_99"));
+        assert!(is_valid_username("ops@de.ufpe.br")); // e-mail logins
+        // Unsafe in the per-user action URL path segment (#429).
+        assert!(!is_valid_username("foo/bar"));
+        assert!(!is_valid_username("a?b"));
+        assert!(!is_valid_username("a#b"));
+        assert!(!is_valid_username("with space"));
+        assert!(!is_valid_username(""));
     }
 
     #[tokio::test]

--- a/crates/ruscker-admin/src/routes/admin/users.rs
+++ b/crates/ruscker-admin/src/routes/admin/users.rs
@@ -141,7 +141,7 @@ async fn create(
     };
     let username = db::users::normalize_username(&form.username);
     let role = Role::parse(&form.role).unwrap_or(Role::Viewer);
-    if username.is_empty() || form.password.len() < MIN_PASSWORD_LEN {
+    if !db::users::is_valid_username(&username) || form.password.len() < MIN_PASSWORD_LEN {
         return redirect_flash("bad-input");
     }
     let groups = db::users::parse_groups(&form.groups);

--- a/crates/ruscker-admin/templates/admin/users.html
+++ b/crates/ruscker-admin/templates/admin/users.html
@@ -35,7 +35,7 @@
     </label>
     <label class="admin-login-field" style="margin:0">
       <span class="admin-login-label">{{ self.t("admin-users-initial-password") }}</span>
-      <input type="text" name="password" required autocomplete="off" placeholder="••••••••">
+      <input type="password" name="password" required autocomplete="new-password" placeholder="••••••••">
     </label>
     <label class="admin-login-field" style="margin:0">
       <span class="admin-login-label">{{ self.t("admin-users-role") }}</span>
@@ -98,8 +98,8 @@
           {# Reset password — reveals a tiny inline form. #}
           <form method="post" action="{{ base }}/admin/users/{{ u.username }}/password"
                 style="display:inline-flex;gap:4px;align-items:center" autocomplete="off">
-            <input type="text" name="password" placeholder="{{ self.t("admin-users-new-password") }}"
-                   style="width:120px" autocomplete="off">
+            <input type="password" name="password" placeholder="{{ self.t("admin-users-new-password") }}"
+                   style="width:120px" autocomplete="new-password">
             <button type="submit" class="dash-action" title="{{ self.t("admin-users-reset-password") }}"><i class="ti ti-key"></i></button>
           </form>
           <form method="post" action="{{ base }}/admin/users/{{ u.username }}/delete" style="display:inline"


### PR DESCRIPTION
Closes #429, #430.

- **#429**: `is_valid_username` restricts create to `[A-Za-z0-9_.@-]` (un-encoded in the per-user action URLs, same class as #423). Helper + test.
- **#430**: user create/reset password fields `type=text` → `type=password`.