### PR TITLE
feat(admin): unify built-in logos into the Media library; deletable + in-use warning (#433)

### DIFF
--- a/crates/ruscker-admin/assets/i18n/en/landing.ftl
+++ b/crates/ruscker-admin/assets/i18n/en/landing.ftl
@@ -251,6 +251,9 @@ admin-images-uploaded = Image uploaded:
 admin-images-empty = No images yet. Upload the first one above.
 admin-images-delete = Delete
 admin-images-delete-confirm = Delete this image? Specs referencing the filename will fall back to the tinted cover.
+admin-images-inuse = In use
+admin-images-inuse-help = Used by a card or a landing logo
+admin-images-delete-confirm-inuse = This image is IN USE (a card or the landing). Delete anyway?
 admin-images-search = Search images…
 admin-images-no-match = No images match your search.
 

--- a/crates/ruscker-admin/assets/i18n/es/landing.ftl
+++ b/crates/ruscker-admin/assets/i18n/es/landing.ftl
@@ -251,6 +251,9 @@ admin-images-uploaded = Imagen subida:
 admin-images-empty = Aún no hay imágenes. Suba la primera arriba.
 admin-images-delete = Eliminar
 admin-images-delete-confirm = ¿Eliminar esta imagen? Las specs que referencian el archivo mostrarán el cover tintado.
+admin-images-inuse = En uso
+admin-images-inuse-help = Usada en una tarjeta o un logo de la landing
+admin-images-delete-confirm-inuse = Esta imagen está EN USO (una tarjeta o la landing). ¿Eliminar igualmente?
 admin-images-search = Buscar imágenes…
 admin-images-no-match = Ninguna imagen coincide con la búsqueda.
 

--- a/crates/ruscker-admin/assets/i18n/fr/landing.ftl
+++ b/crates/ruscker-admin/assets/i18n/fr/landing.ftl
@@ -251,6 +251,9 @@ admin-images-uploaded = Image envoyée :
 admin-images-empty = Aucune image. Envoyez la première ci-dessus.
 admin-images-delete = Supprimer
 admin-images-delete-confirm = Supprimer cette image ? Les specs qui référencent le fichier afficheront le cover teinté.
+admin-images-inuse = Utilisé
+admin-images-inuse-help = Utilisé par une carte ou un logo de la landing
+admin-images-delete-confirm-inuse = Cette image est UTILISÉE (une carte ou la landing). Supprimer quand même ?
 admin-images-search = Rechercher des images…
 admin-images-no-match = Aucune image ne correspond à la recherche.
 

--- a/crates/ruscker-admin/assets/i18n/pt/landing.ftl
+++ b/crates/ruscker-admin/assets/i18n/pt/landing.ftl
@@ -255,6 +255,9 @@ admin-images-uploaded = Imagem enviada:
 admin-images-empty = Nenhuma imagem ainda. Envie a primeira acima.
 admin-images-delete = Excluir
 admin-images-delete-confirm = Excluir essa imagem? Specs que referenciam o arquivo passarão a mostrar o cover tintado.
+admin-images-inuse = Em uso
+admin-images-inuse-help = Usada num card ou nos logos da landing
+admin-images-delete-confirm-inuse = Esta imagem está EM USO (um card ou a landing). Deletar mesmo assim?
 admin-images-search = Buscar imagens…
 admin-images-no-match = Nenhuma imagem corresponde à busca.
 

--- a/crates/ruscker-admin/assets/tailwind/input.css
+++ b/crates/ruscker-admin/assets/tailwind/input.css
@@ -985,6 +985,10 @@ textarea.spec-form-input { resize: vertical; min-height: 64px; }
   transition: border-color .12s, background .12s;
 }
 .image-upload-hint { font-size: 12px; color: var(--text-muted); }
+.image-tile-used {
+  display: inline-flex; align-items: center; gap: 4px; margin-top: 4px;
+  font-size: 10px; color: var(--color-lock, #b4690e);
+}
 .image-upload-zone.is-dragover {
   border-color: var(--color-teal-600);
   background: color-mix(in srgb, var(--color-teal-600) 8%, var(--surface-soft));

--- a/crates/ruscker-admin/src/db.rs
+++ b/crates/ruscker-admin/src/db.rs
@@ -98,6 +98,10 @@ pub async fn open(path: impl AsRef<Path>) -> Result<SqlitePool> {
     if let Err(err) = showcase::seed_if_unseeded(&cfg).await {
         tracing::warn!(error = ?err, "showcase seed skipped");
     }
+    // First-install built-in logos in the Media library (#433).
+    if let Err(err) = builtin_logos::seed_if_unseeded(&cfg).await {
+        tracing::warn!(error = ?err, "builtin logos seed skipped");
+    }
 
     Ok(pool)
 }
@@ -154,6 +158,7 @@ pub async fn open_memory() -> Result<SqlitePool> {
 }
 
 pub mod audit;
+pub mod builtin_logos;
 pub mod credentials;
 pub mod export;
 pub mod images;

--- a/crates/ruscker-admin/src/db/builtin_logos.rs
+++ b/crates/ruscker-admin/src/db/builtin_logos.rs
@@ -1,0 +1,118 @@
+//! First-install seed: copy the built-in logo SVGs into the Media library
+//! (#433) so they sit in the one image group, are pickable like uploads,
+//! and are deletable. The bundled `/assets/showcase|brand/*` routes still
+//! serve the originals for the showcase cards; these are independent DB
+//! copies served at `/assets/img/<filename>`.
+//!
+//! Idempotent: a `config_meta` marker (`builtin_logos.seeded`) records the
+//! seed so it runs once. Built-ins an operator deleted stay deleted.
+
+use anyhow::{Context, Result};
+use chrono::Utc;
+
+use crate::db::ConfigDb;
+
+const SEEDED_KEY: &str = "builtin_logos.seeded";
+
+/// Seed the built-in logos into `images` if never done on this DB. Called
+/// from [`crate::db::open`] / `open_pg` right after migrations.
+pub async fn seed_if_unseeded(db: &ConfigDb) -> Result<()> {
+    if already_seeded(db).await? {
+        return Ok(());
+    }
+    for (filename, bytes) in crate::routes::assets::BUILTIN_LOGO_ASSETS {
+        // Don't clobber an operator's upload of the same name.
+        if super::images::fetch_by_filename(db, filename)
+            .await?
+            .is_some()
+        {
+            continue;
+        }
+        let processed =
+            match crate::images::process_upload(filename, Some("image/svg+xml"), bytes.to_vec()) {
+                Ok(p) => p,
+                Err(err) => {
+                    tracing::warn!(error = ?err, filename, "skip built-in logo seed");
+                    continue;
+                }
+            };
+        super::images::insert(db, processed, None)
+            .await
+            .with_context(|| format!("seed built-in logo {filename}"))?;
+    }
+    mark_seeded(db).await?;
+    Ok(())
+}
+
+async fn already_seeded(db: &ConfigDb) -> Result<bool> {
+    let row: Option<(String,)> = match db {
+        ConfigDb::Sqlite(pool) => {
+            sqlx::query_as("SELECT value_json FROM config_meta WHERE key = ?")
+                .bind(SEEDED_KEY)
+                .fetch_optional(pool)
+                .await
+        }
+        ConfigDb::Postgres(pool) => {
+            sqlx::query_as("SELECT value_json FROM config_meta WHERE key = $1")
+                .bind(SEEDED_KEY)
+                .fetch_optional(pool)
+                .await
+        }
+    }
+    .context("check builtin_logos seed marker")?;
+    Ok(row.is_some())
+}
+
+async fn mark_seeded(db: &ConfigDb) -> Result<()> {
+    let now = Utc::now();
+    let value_json = serde_json::json!({ "seeded_at": now }).to_string();
+    match db {
+        ConfigDb::Sqlite(pool) => {
+            sqlx::query(
+                "INSERT OR REPLACE INTO config_meta (key, value_json, updated_at)
+                 VALUES (?, ?, ?)",
+            )
+            .bind(SEEDED_KEY)
+            .bind(&value_json)
+            .bind(now)
+            .execute(pool)
+            .await
+            .context("write builtin_logos seed marker (sqlite)")?;
+        }
+        ConfigDb::Postgres(pool) => {
+            sqlx::query(
+                "INSERT INTO config_meta (key, value_json, updated_at)
+                 VALUES ($1, $2, $3)
+                 ON CONFLICT (key) DO UPDATE SET value_json = $2, updated_at = $3",
+            )
+            .bind(SEEDED_KEY)
+            .bind(&value_json)
+            .bind(now)
+            .execute(pool)
+            .await
+            .context("write builtin_logos seed marker (postgres)")?;
+        }
+    }
+    Ok(())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[tokio::test]
+    async fn seeds_builtin_logos_once() {
+        let pool = crate::db::open_memory().await.unwrap();
+        let db = ConfigDb::Sqlite(pool);
+        seed_if_unseeded(&db).await.unwrap();
+        let n = super::super::images::list_all(&db).await.unwrap().len();
+        assert_eq!(
+            n,
+            crate::routes::assets::BUILTIN_LOGO_ASSETS.len(),
+            "all built-ins seeded into the library"
+        );
+        // Idempotent: a second run adds nothing.
+        seed_if_unseeded(&db).await.unwrap();
+        assert_eq!(super::super::images::list_all(&db).await.unwrap().len(), n);
+    }
+}

--- a/crates/ruscker-admin/src/routes/admin/images.rs
+++ b/crates/ruscker-admin/src/routes/admin/images.rs
@@ -63,6 +63,11 @@ struct ImagesPage<'a> {
     /// Current session role (Editor or Admin) — drives nav gating.
     role: Role,
     images: Vec<db::images::ImageMeta>,
+    /// Concatenated reference strings (every spec's logo + cover, plus the
+    /// landing header/footer logo URLs). An image is "in use" when its
+    /// `/assets/img/<filename>` appears here — drives the delete warning
+    /// (#433).
+    refs: String,
     /// Set on successful upload — drives a one-shot toast.
     flash_uploaded: Option<String>,
     flash_error: Option<String>,
@@ -111,22 +116,14 @@ impl<'a> ImagesPage<'a> {
                     "mime": img.mime_type,
                     "size": self.fmt_size(&img.size_bytes),
                     "dims": dims,
+                    // #433: referenced by a card (logo/cover) or a landing logo?
+                    "in_use": self.refs.contains(&format!("/assets/img/{}", img.filename)),
                 })
             })
             .collect();
         serde_json::to_string(&arr).unwrap_or_else(|_| "[]".into())
     }
 
-    /// Built-in framework + brand logos (read-only) for the gallery's
-    /// "built-in" section — so the gallery isn't empty on a fresh install
-    /// and mirrors what the spec-form pickers offer. Pairs of
-    /// (path, filename). Single source: [`assets::BUILTIN_LOGOS`].
-    fn builtin_logos(&self) -> Vec<(&'static str, &'static str)> {
-        crate::routes::assets::BUILTIN_LOGOS
-            .iter()
-            .map(|&p| (p, p.rsplit('/').next().unwrap_or(p)))
-            .collect()
-    }
 }
 
 async fn index(
@@ -160,6 +157,26 @@ async fn render_index(
             return (StatusCode::INTERNAL_SERVER_ERROR, "db error").into_response();
         }
     };
+    // Collect every place an image URL can be referenced, so the gallery
+    // can warn before deleting one that's in use (#433): each spec's logo +
+    // cover, and the landing header/footer logos.
+    let mut refs = String::new();
+    if let Ok(specs) = db::specs::list_all(pool).await {
+        for s in &specs {
+            for key in ["logo", "cover"] {
+                if let Some(v) = s.template_properties.0.get(key).and_then(|v| v.as_str()) {
+                    refs.push_str(v);
+                    refs.push('\n');
+                }
+            }
+        }
+    }
+    if let Ok(lc) = db::landing::fetch(pool).await {
+        for logo in &lc.logos {
+            refs.push_str(&logo.url);
+            refs.push('\n');
+        }
+    }
     let page = ImagesPage {
         locale: loc,
         theme,
@@ -169,6 +186,7 @@ async fn render_index(
         nav_section: "images",
         role,
         images,
+        refs,
         flash_uploaded,
         flash_error,
     };

--- a/crates/ruscker-admin/src/routes/admin/spec_form.rs
+++ b/crates/ruscker-admin/src/routes/admin/spec_form.rs
@@ -724,12 +724,6 @@ impl<'a> SpecFormPage<'a> {
         serde_json::to_string(&self.logo_images).unwrap_or_else(|_| "[]".into())
     }
 
-    /// Built-in framework + brand logo paths as a JSON array (Option A),
-    /// seeding the picker's "built-in logos" group so an operator can reuse
-    /// a bundled logo without typing a path. Single source: [`BUILTIN_LOGOS`].
-    fn builtin_logos_json(&self) -> String {
-        serde_json::to_string(crate::routes::assets::BUILTIN_LOGOS).unwrap_or_else(|_| "[]".into())
-    }
 
     /// Options for the kind picker: (key, label-fluent-key, tabler-icon).
     /// Order intentional — mirrors the public landing chip order.

--- a/crates/ruscker-admin/src/routes/assets.rs
+++ b/crates/ruscker-admin/src/routes/assets.rs
@@ -161,6 +161,27 @@ pub const BUILTIN_LOGOS: &[&str] = &[
     "/assets/brand/mark.svg",
 ];
 
+/// `(filename, bytes)` for the built-in logos, seeded into the Media
+/// library on first install (#433) so they live in the one image group,
+/// are pickable like uploads, and are deletable. The bundled
+/// `/assets/showcase|brand/*` routes still serve the originals for the
+/// showcase cards; these are independent DB copies under `/assets/img/`.
+pub const BUILTIN_LOGO_ASSETS: &[(&str, &[u8])] = &[
+    ("shiny.svg", SHOWCASE_SHINY),
+    ("shiny-for-python.svg", SHOWCASE_SHINY_FOR_PYTHON),
+    ("streamlit.svg", SHOWCASE_STREAMLIT),
+    ("dash.svg", SHOWCASE_DASH),
+    ("voila.svg", SHOWCASE_VOILA),
+    ("jupyter.svg", SHOWCASE_JUPYTER),
+    ("rstudio.svg", SHOWCASE_RSTUDIO),
+    ("rmarkdown.svg", SHOWCASE_RMARKDOWN),
+    ("quarto.svg", SHOWCASE_QUARTO),
+    ("fastapi.svg", SHOWCASE_FASTAPI),
+    ("plumber.svg", SHOWCASE_PLUMBER),
+    ("bokeh.svg", SHOWCASE_BOKEH),
+    ("ruscker-mark.svg", BRAND_MARK),
+];
+
 // Ruscker brand kit — see docs/BRAND.md for usage rules.
 const BRAND_MARK: &[u8] = include_bytes!("../../assets/brand/ruscker-mark.svg");
 const BRAND_MARK_FLAT: &[u8] = include_bytes!("../../assets/brand/ruscker-mark-flat.svg");

--- a/crates/ruscker-admin/templates/admin/images.html
+++ b/crates/ruscker-admin/templates/admin/images.html
@@ -91,9 +91,15 @@
                 <span><span class="opacity-60">·</span><span x-text="img.dims"></span></span>
               </template>
             </div>
+            {# In-use warning (#433): referenced by a card or a landing logo. #}
+            <template x-if="img.in_use">
+              <div class="image-tile-used" title="{{ self.t("admin-images-inuse-help") }}">
+                <i class="ti ti-alert-triangle" aria-hidden="true"></i> {{ self.t("admin-images-inuse") }}
+              </div>
+            </template>
           </div>
           <form method="post" :action="assetUrl('/admin/media/' + img.id + '/delete')"
-                onsubmit="return confirm('{{ self.t("admin-images-delete-confirm") }}');">
+                @submit="if (!confirm(img.in_use ? '{{ self.t("admin-images-delete-confirm-inuse") }}' : '{{ self.t("admin-images-delete-confirm") }}')) $event.preventDefault()">
             <button type="submit" class="image-tile-delete" title="{{ self.t("admin-images-delete") }}">
               <i class="ti ti-trash" aria-hidden="true"></i>
             </button>
@@ -141,27 +147,9 @@
   </script>
 {% endif %}
 
-{# ── Built-in logos (read-only) ───────────────────────────────
-   The framework + brand SVGs bundled in the binary. Shown so the gallery
-   isn't empty on a fresh install and mirrors what the spec-form logo/cover
-   pickers offer (#: media UX). Not deletable — they're binary assets. #}
-<div class="flex items-center gap-2 mt-8 mb-3">
-  <h2 class="text-sm font-medium">{{ self.t("admin-images-builtin") }}</h2>
-  <span class="text-xs text-[color:var(--text-faint)]">{{ self.builtin_logos().len() }}</span>
-</div>
-<section class="image-gallery">
-  {% for (path, name) in self.builtin_logos() %}
-  <div class="image-tile">
-    <a href="{{ base }}{{ path }}" target="_blank" rel="noopener" class="image-tile-frame" title="{{ path }}">
-      <img src="{{ base }}{{ path }}" alt="{{ name }}" loading="lazy" style="object-fit:contain;padding:10px">
-    </a>
-    <div class="image-tile-meta">
-      <div class="image-tile-name" title="{{ path }}">{{ name }}</div>
-      <div class="image-tile-sub"><span class="opacity-60">{{ self.t("admin-images-builtin-tag") }}</span></div>
-    </div>
-  </div>
-  {% endfor %}
-</section>
+{# Built-in logos used to render here as a separate read-only section; as
+   of #433 they're seeded into the Media library on first install, so they
+   appear in the gallery above (and are deletable) like any other image. #}
 
 {# Alpine powers BOTH the upload-zone drag-drop (the form near the top) and
    the gallery filter / "show more" below. The admin layout doesn't ship

--- a/crates/ruscker-admin/templates/admin/spec_form.html
+++ b/crates/ruscker-admin/templates/admin/spec_form.html
@@ -17,7 +17,7 @@
 
 {% block content %}
 
-<div x-data="ruscker.specForm({{ form_initial_json() }}, {{ logo_images_json() }}, {{ builtin_logos_json() }})" x-cloak>
+<div x-data="ruscker.specForm({{ form_initial_json() }}, {{ logo_images_json() }})" x-cloak>
 
   {# ── Header ───────────────────────────────────────────────── #}
   <div class="flex items-end justify-between mb-5 pb-3 border-b border-[color:var(--border)]">
@@ -831,14 +831,8 @@
             <img :src="assetUrl('/assets/img/' + name) + '?thumb'" :alt="name" loading="lazy">
           </button>
         </template>
-        <template x-for="path in pickerBuiltins()" :key="'pk-' + path">
-          <button type="button" :title="path.split('/').pop()" @click="pickImage(path)"
-                  class="image-picker-tile is-builtin" :class="pickerSelected(path) ? 'is-sel' : ''">
-            <img :src="assetUrl(path)" :alt="path" loading="lazy">
-          </button>
-        </template>
       </div>
-      <div class="image-picker-empty" x-show="!pickerUploads().length && !pickerBuiltins().length">{{ self.t("admin-images-no-match") }}</div>
+      <div class="image-picker-empty" x-show="!pickerUploads().length">{{ self.t("admin-images-no-match") }}</div>
     </div>
   </div>
 </div>
@@ -846,14 +840,12 @@
 <script src="{{ base }}/assets/js/alpine.min.js?v={{ crate::APP_VERSION }}" defer></script>
 <script>
 window.ruscker = window.ruscker || {};
-window.ruscker.specForm = (initial, logoImages, builtinLogos) => ({
+window.ruscker.specForm = (initial, logoImages) => ({
   form: initial,
   // Media-library filenames for the logo/cover pickers (#213). Inline
   // uploads unshift new names here so a fresh thumbnail appears at once.
+  // Includes the built-in logos, which are seeded into the library (#433).
   logoImages: Array.isArray(logoImages) ? logoImages : [],
-  // Built-in framework + brand logo PATHS bundled in the binary (Option A),
-  // pickable in the logo/cover pickers so a new card can reuse them.
-  builtinLogos: Array.isArray(builtinLogos) ? builtinLogos : [],
   // How many gallery tiles to render initially (#293) — keeps the DOM +
   // thumbnail requests bounded on a large media library. "Show more"
   // reveals another page.
@@ -965,10 +957,6 @@ window.ruscker.specForm = (initial, logoImages, builtinLogos) => ({
   pickerUploads() {
     const q = this.picker.q.trim().toLowerCase();
     return q ? this.logoImages.filter((n) => n.toLowerCase().includes(q)) : this.logoImages;
-  },
-  pickerBuiltins() {
-    const q = this.picker.q.trim().toLowerCase();
-    return q ? this.builtinLogos.filter((p) => p.toLowerCase().includes(q)) : this.builtinLogos;
   },
   // Inline upload to the media library, then select the result for
   // `target` ('logo' or 'cover'). Reuses the same pipeline as the


### PR DESCRIPTION
Closes #433. Built-in logos are **seeded into the Media library** on first install (idempotent), so they sit in the one gallery/picker (no separate "Built-in logos" section/group) and are **deletable** like any image. Bundled `/assets/showcase|brand/*` still serve the showcase-card originals.

**In-use warning:** the gallery flags images referenced by a card (logo/cover) or a landing logo with a badge + a stronger delete confirm — but any image is still deletable.

Seed test + full gate green (445 tests).