### PR TITLE
feat(admin): force first-login password change + reveal toggle (#430, #454)

### DIFF
--- a/crates/ruscker-admin/assets/i18n/en/landing.ftl
+++ b/crates/ruscker-admin/assets/i18n/en/landing.ftl
@@ -89,7 +89,7 @@ admin-setup-submit = Create admin
 # — Password change / first login
 admin-pw-title = Change password
 admin-pw-help = Set a new password for your account.
-admin-pw-first-prompt = You're using a password set by an administrator. Would you like to change it now?
+admin-pw-first-prompt = You're using a password set by an administrator. Set a new password to continue.
 admin-pw-current-label = Current password
 admin-pw-new-label = New password
 admin-pw-confirm-label = Confirm password
@@ -97,7 +97,7 @@ admin-pw-error-current = Current password is incorrect.
 admin-pw-error-mismatch = Passwords don't match.
 admin-pw-error-short = Password must be at least 8 characters.
 admin-pw-submit = Save password
-admin-pw-keep = Keep current password
+admin-pw-reveal = Show/hide password
 # — User management (admin)
 admin-nav-users = Users
 admin-users-title = Users
@@ -105,7 +105,7 @@ admin-users-subtitle = Create and manage who can sign in, and at which level.
 admin-users-new = New user
 admin-users-create = Create
 admin-users-initial-password = Initial password
-admin-users-initial-password-hint = The user is asked whether to change it on first login.
+admin-users-initial-password-hint = The user must change it on first login.
 admin-users-role = Role
 admin-users-col-user = User
 admin-users-col-role = Role

--- a/crates/ruscker-admin/assets/i18n/es/landing.ftl
+++ b/crates/ruscker-admin/assets/i18n/es/landing.ftl
@@ -89,7 +89,7 @@ admin-setup-submit = Crear administrador
 # — Cambio de contraseña / primer acceso
 admin-pw-title = Cambiar contraseña
 admin-pw-help = Define una nueva contraseña para tu cuenta.
-admin-pw-first-prompt = Estás usando una contraseña asignada por un administrador. ¿Quieres cambiarla ahora?
+admin-pw-first-prompt = Estás usando una contraseña asignada por un administrador. Define una nueva contraseña para continuar.
 admin-pw-current-label = Contraseña actual
 admin-pw-new-label = Nueva contraseña
 admin-pw-confirm-label = Confirmar contraseña
@@ -97,7 +97,7 @@ admin-pw-error-current = La contraseña actual es incorrecta.
 admin-pw-error-mismatch = Las contraseñas no coinciden.
 admin-pw-error-short = La contraseña debe tener al menos 8 caracteres.
 admin-pw-submit = Guardar contraseña
-admin-pw-keep = Mantener la contraseña actual
+admin-pw-reveal = Mostrar/ocultar contraseña
 # — Gestión de usuarios (admin)
 admin-nav-users = Usuarios
 admin-users-title = Usuarios
@@ -105,7 +105,7 @@ admin-users-subtitle = Crea y gestiona quién accede al panel y con qué nivel.
 admin-users-new = Nuevo usuario
 admin-users-create = Crear
 admin-users-initial-password = Contraseña inicial
-admin-users-initial-password-hint = Se le preguntará si desea cambiarla en el primer acceso.
+admin-users-initial-password-hint = El usuario deberá cambiarla en el primer acceso.
 admin-users-role = Nivel
 admin-users-col-user = Usuario
 admin-users-col-role = Nivel

--- a/crates/ruscker-admin/assets/i18n/fr/landing.ftl
+++ b/crates/ruscker-admin/assets/i18n/fr/landing.ftl
@@ -89,7 +89,7 @@ admin-setup-submit = Créer l'administrateur
 # — Changement de mot de passe / première connexion
 admin-pw-title = Changer le mot de passe
 admin-pw-help = Définissez un nouveau mot de passe pour votre compte.
-admin-pw-first-prompt = Vous utilisez un mot de passe défini par un administrateur. Voulez-vous le changer maintenant ?
+admin-pw-first-prompt = Vous utilisez un mot de passe défini par un administrateur. Définissez un nouveau mot de passe pour continuer.
 admin-pw-current-label = Mot de passe actuel
 admin-pw-new-label = Nouveau mot de passe
 admin-pw-confirm-label = Confirmer le mot de passe
@@ -97,7 +97,7 @@ admin-pw-error-current = Le mot de passe actuel est incorrect.
 admin-pw-error-mismatch = Les mots de passe ne correspondent pas.
 admin-pw-error-short = Le mot de passe doit comporter au moins 8 caractères.
 admin-pw-submit = Enregistrer le mot de passe
-admin-pw-keep = Conserver le mot de passe actuel
+admin-pw-reveal = Afficher/masquer le mot de passe
 # — Gestion des utilisateurs (admin)
 admin-nav-users = Utilisateurs
 admin-users-title = Utilisateurs
@@ -105,7 +105,7 @@ admin-users-subtitle = Créez et gérez qui peut se connecter, et à quel niveau
 admin-users-new = Nouvel utilisateur
 admin-users-create = Créer
 admin-users-initial-password = Mot de passe initial
-admin-users-initial-password-hint = Il lui sera demandé s'il veut le changer à la première connexion.
+admin-users-initial-password-hint = L'utilisateur devra le changer à la première connexion.
 admin-users-role = Niveau
 admin-users-col-user = Utilisateur
 admin-users-col-role = Niveau

--- a/crates/ruscker-admin/assets/i18n/pt/landing.ftl
+++ b/crates/ruscker-admin/assets/i18n/pt/landing.ftl
@@ -93,7 +93,7 @@ admin-setup-submit = Criar administrador
 # — Troca de senha / primeiro acesso
 admin-pw-title = Alterar senha
 admin-pw-help = Defina uma nova senha para a sua conta.
-admin-pw-first-prompt = Você está usando uma senha definida pelo administrador. Deseja trocá-la agora?
+admin-pw-first-prompt = Você está usando uma senha definida pelo administrador. Defina uma nova senha para continuar.
 admin-pw-current-label = Senha atual
 admin-pw-new-label = Nova senha
 admin-pw-confirm-label = Confirme a senha
@@ -101,7 +101,7 @@ admin-pw-error-current = Senha atual incorreta.
 admin-pw-error-mismatch = As senhas não coincidem.
 admin-pw-error-short = A senha deve ter ao menos 8 caracteres.
 admin-pw-submit = Salvar senha
-admin-pw-keep = Manter a senha atual
+admin-pw-reveal = Mostrar/ocultar senha
 # — Gestão de usuários (admin)
 admin-nav-users = Usuários
 admin-users-title = Usuários
@@ -109,7 +109,7 @@ admin-users-subtitle = Crie e gerencie quem acessa o painel e com qual nível.
 admin-users-new = Novo usuário
 admin-users-create = Criar
 admin-users-initial-password = Senha inicial
-admin-users-initial-password-hint = O usuário será consultado se quer trocá-la no primeiro acesso.
+admin-users-initial-password-hint = O usuário será obrigado a trocá-la no primeiro acesso.
 admin-users-role = Nível
 admin-users-col-user = Usuário
 admin-users-col-role = Nível

--- a/crates/ruscker-admin/src/lib.rs
+++ b/crates/ruscker-admin/src/lib.rs
@@ -548,7 +548,15 @@ pub fn router_with_images(state: AppState, _images_dir: Option<&Path>) -> Router
             move |req: axum::extract::Request, next: axum::middleware::Next| {
                 csrf_guard(req, next, trust)
             }
-        }));
+        }))
+        // Force a first-login password change (#454): a logged-in account
+        // still carrying `must_change_password` is pinned to the password
+        // page on every other `/admin/*` route. Layered on the chrome so a
+        // redirect's `Location` rides the base-path rewriter below.
+        .layer(axum::middleware::from_fn_with_state(
+            state.clone(),
+            must_change_password_guard,
+        ));
 
     // Base-path mounting (#173): when served under a subpath, rewrite the
     // chrome's root-absolute URLs / redirects to carry the prefix. Only
@@ -626,6 +634,67 @@ pub fn router_with_images(state: AppState, _images_dir: Option<&Path>) -> Router
         .merge(routes::health::routes())
         .layer(CookieManagerLayer::new())
         .with_state(state)
+}
+
+/// Force a first-login password change (#454).
+///
+/// A user account created in the admin gets `must_change_password = true`
+/// (see `db::users::create`). Login already redirects such a user to the
+/// self-service password page, but nothing stopped them from navigating
+/// straight to `/admin/dashboard` and keeping the admin-assigned initial
+/// password. This guard closes that gap: on any `/admin/*` route other
+/// than the password page / login / logout / first-admin setup, a session
+/// whose account still needs a change is bounced back to
+/// `/admin/account/password`.
+///
+/// Break-glass token sessions (no `actor`) and anonymous requests pass
+/// through untouched — they have no account to rotate, and the routes'
+/// own guards handle authentication. The cost is one indexed user lookup
+/// per gated admin request; the admin panel is low-traffic and the proxy
+/// hot path (`/app`, `/api`) never reaches this layer.
+async fn must_change_password_guard(
+    axum::extract::State(state): axum::extract::State<AppState>,
+    req: axum::extract::Request,
+    next: axum::middleware::Next,
+) -> axum::response::Response {
+    use axum::response::IntoResponse;
+    let path = req.uri().path();
+    let gated = path.starts_with("/admin/")
+        && !path.starts_with("/admin/account")
+        && !path.starts_with("/admin/login")
+        && !path.starts_with("/admin/logout")
+        && !path.starts_with("/admin/setup");
+    if gated {
+        if let Some(pool) = state.db.as_ref() {
+            // Cookies are populated by the outer CookieManagerLayer, so the
+            // extension is always present here; read the opaque session id
+            // straight from it to avoid re-running the full extractor.
+            let session_id = req
+                .extensions()
+                .get::<tower_cookies::Cookies>()
+                .and_then(|c| c.get(auth::COOKIE_NAME).map(|c| c.value().to_string()));
+            if let Some(id) = session_id {
+                if let Some(actor) = state
+                    .admin_sessions
+                    .validate(&id)
+                    .await
+                    .and_then(|info| info.actor)
+                {
+                    let must = db::users::fetch(pool, &actor)
+                        .await
+                        .ok()
+                        .flatten()
+                        .map(|u| u.must_change_password)
+                        .unwrap_or(false);
+                    if must {
+                        return axum::response::Redirect::to("/admin/account/password")
+                            .into_response();
+                    }
+                }
+            }
+        }
+    }
+    next.run(req).await
 }
 
 /// Baseline security response headers for Ruscker's own pages.

--- a/crates/ruscker-admin/src/routes/admin.rs
+++ b/crates/ruscker-admin/src/routes/admin.rs
@@ -543,9 +543,6 @@ pub struct PasswordForm {
     pub current: String,
     pub new_password: String,
     pub confirm: String,
-    /// Present (any value) when the user clicked "keep current" on the
-    /// first-login prompt.
-    pub skip: Option<String>,
 }
 
 async fn password_submit(
@@ -566,12 +563,9 @@ async fn password_submit(
             .into_response();
     };
 
-    // First-login "keep current password" — just clear the prompt.
-    if form.skip.is_some() {
-        let _ = db::users::clear_must_change(pool, &actor).await;
-        return Redirect::to("/admin/dashboard").into_response();
-    }
-
+    // First login is mandatory (#454): there is no "keep current"
+    // escape — the only way past the prompt is a real password change
+    // below, which clears `must_change_password` via `set_password`.
     let first = db::users::fetch(pool, &actor)
         .await
         .ok()

--- a/crates/ruscker-admin/templates/admin/account_password.html
+++ b/crates/ruscker-admin/templates/admin/account_password.html
@@ -40,13 +40,9 @@
         <i class="ti ti-key" aria-hidden="true"></i>
         {{ self.t("admin-pw-submit") }}
       </button>
-      {% if first %}
-        {# First-login prompt: let the user keep the assigned password. #}
-        <button type="submit" name="skip" value="1"
-                class="text-sm text-[color:var(--text-muted)] underline">
-          {{ self.t("admin-pw-keep") }}
-        </button>
-      {% endif %}
+      {# First login is mandatory (#454): no "keep current" escape — the
+         admin-assigned initial password must be rotated to proceed. The
+         middleware guard re-routes here until it is. #}
     </div>
   </form>
 </div>

--- a/crates/ruscker-admin/templates/admin/users.html
+++ b/crates/ruscker-admin/templates/admin/users.html
@@ -35,7 +35,19 @@
     </label>
     <label class="admin-login-field" style="margin:0">
       <span class="admin-login-label">{{ self.t("admin-users-initial-password") }}</span>
-      <input type="password" name="password" required autocomplete="new-password" placeholder="••••••••">
+      {# type=password is the secure default; the reveal toggle (#430) flips
+         it to text via a framework-free delegated listener at the foot of
+         the page — no Alpine dependency, so it works even if Alpine is
+         absent (cf. the #433 images-gallery regression). #}
+      <span style="position:relative;display:block">
+        <input type="password" name="password" required autocomplete="new-password"
+               placeholder="••••••••" style="padding-right:2.2rem">
+        <button type="button" tabindex="-1" class="pw-reveal"
+                title="{{ self.t("admin-pw-reveal") }}"
+                style="position:absolute;right:8px;top:50%;transform:translateY(-50%);background:none;border:0;cursor:pointer;color:var(--text-muted);line-height:0;padding:0">
+          <i class="ti ti-eye" aria-hidden="true"></i>
+        </button>
+      </span>
     </label>
     <label class="admin-login-field" style="margin:0">
       <span class="admin-login-label">{{ self.t("admin-users-role") }}</span>
@@ -98,8 +110,15 @@
           {# Reset password — reveals a tiny inline form. #}
           <form method="post" action="{{ base }}/admin/users/{{ u.username }}/password"
                 style="display:inline-flex;gap:4px;align-items:center" autocomplete="off">
-            <input type="password" name="password" placeholder="{{ self.t("admin-users-new-password") }}"
-                   style="width:120px" autocomplete="new-password">
+            <span style="position:relative;display:inline-block">
+              <input type="password" name="password" placeholder="{{ self.t("admin-users-new-password") }}"
+                     style="width:140px;padding-right:1.8rem" autocomplete="new-password">
+              <button type="button" tabindex="-1" class="pw-reveal"
+                      title="{{ self.t("admin-pw-reveal") }}"
+                      style="position:absolute;right:6px;top:50%;transform:translateY(-50%);background:none;border:0;cursor:pointer;color:var(--text-muted);line-height:0;padding:0">
+                <i class="ti ti-eye" aria-hidden="true"></i>
+              </button>
+            </span>
             <button type="submit" class="dash-action" title="{{ self.t("admin-users-reset-password") }}"><i class="ti ti-key"></i></button>
           </form>
           <form method="post" action="{{ base }}/admin/users/{{ u.username }}/delete" style="display:inline"
@@ -111,4 +130,21 @@
     {% endfor %}
   </tbody>
 </table>
+
+<script>
+  // Reveal/hide toggle for the admin user password inputs (#430). One
+  // delegated listener, no framework: clicking a `.pw-reveal` button
+  // flips the adjacent input's type and swaps the eye icon. Kept inline
+  // (the admin CSP already allows inline chrome scripts).
+  document.addEventListener('click', function (e) {
+    var btn = e.target.closest && e.target.closest('.pw-reveal');
+    if (!btn) return;
+    var input = btn.parentNode.querySelector('input');
+    if (!input) return;
+    var reveal = input.type === 'password';
+    input.type = reveal ? 'text' : 'password';
+    var icon = btn.querySelector('i');
+    if (icon) icon.className = 'ti ' + (reveal ? 'ti-eye-off' : 'ti-eye');
+  });
+</script>
 {% endblock %}

--- a/crates/ruscker-admin/tests/user_accounts.rs
+++ b/crates/ruscker-admin/tests/user_accounts.rs
@@ -255,6 +255,119 @@ async fn setup_page_chrome_cluster_is_outside_the_setup_form() {
     );
 }
 
+async fn get(state: AppState, uri: &str, cookie: Option<&str>) -> (StatusCode, String) {
+    let app = router(state);
+    let mut b = Request::builder().method("GET").uri(uri);
+    if let Some(c) = cookie {
+        b = b.header("cookie", c);
+    }
+    let resp = app.oneshot(b.body(Body::empty()).unwrap()).await.unwrap();
+    let status = resp.status();
+    let loc = resp
+        .headers()
+        .get("location")
+        .and_then(|v| v.to_str().ok())
+        .unwrap_or("")
+        .to_string();
+    (status, loc)
+}
+
+/// #454: a logged-in account that still carries `must_change_password`
+/// is bounced off every other admin route back to the password page —
+/// so the post-login prompt can't be skipped by navigating away.
+#[tokio::test]
+async fn must_change_user_is_pinned_to_password_page() {
+    let (state, pool) = state_with_db().await;
+    ruscker_admin::db::users::create(
+        &ruscker_admin::db::ConfigDb::Sqlite(pool.clone()),
+        "bob",
+        "bobpass12",
+        Role::Viewer,
+        true,
+        &[],
+        None,
+    )
+    .await
+    .unwrap();
+    let sid = state
+        .admin_sessions
+        .create(Role::Viewer, Some("bob".into()))
+        .await;
+    let cookie = format!("{COOKIE_NAME}={sid}");
+
+    // Any other admin route redirects to the change-password page.
+    let (status, loc) = get(state.clone(), "/admin/dashboard", Some(&cookie)).await;
+    assert_eq!(status, StatusCode::SEE_OTHER);
+    assert_eq!(loc, "/admin/account/password");
+
+    // …but the password page itself stays reachable (no redirect loop).
+    let (pw_status, _) = get(state, "/admin/account/password", Some(&cookie)).await;
+    assert_eq!(pw_status, StatusCode::OK);
+}
+
+/// #454: completing the change clears the flag, and the guard then lets
+/// the user through. There is no "keep current" escape hatch any more —
+/// a real password change is the only way past.
+#[tokio::test]
+async fn changing_password_lifts_the_guard() {
+    let (state, pool) = state_with_db().await;
+    ruscker_admin::db::users::create(
+        &ruscker_admin::db::ConfigDb::Sqlite(pool.clone()),
+        "bob",
+        "bobpass12",
+        Role::Viewer,
+        true,
+        &[],
+        None,
+    )
+    .await
+    .unwrap();
+    let sid = state
+        .admin_sessions
+        .create(Role::Viewer, Some("bob".into()))
+        .await;
+    let cookie = format!("{COOKIE_NAME}={sid}");
+
+    let (status, loc) = post(
+        state.clone(),
+        "/admin/account/password",
+        "current=bobpass12&new_password=bobpass-new9&confirm=bobpass-new9",
+        Some(&cookie),
+    )
+    .await;
+    assert_eq!(status, StatusCode::SEE_OTHER);
+    assert_eq!(loc, "/admin/dashboard");
+
+    // The guard no longer fires — the dashboard renders.
+    let (dash_status, _) = get(state, "/admin/dashboard", Some(&cookie)).await;
+    assert_eq!(dash_status, StatusCode::OK);
+}
+
+/// A normal account (no pending change) reaches the panel untouched —
+/// the guard must not redirect everyone.
+#[tokio::test]
+async fn settled_user_reaches_the_dashboard() {
+    let (state, pool) = state_with_db().await;
+    ruscker_admin::db::users::create(
+        &ruscker_admin::db::ConfigDb::Sqlite(pool.clone()),
+        "alice",
+        "alicepass1",
+        Role::Editor,
+        false,
+        &[],
+        None,
+    )
+    .await
+    .unwrap();
+    let sid = state
+        .admin_sessions
+        .create(Role::Editor, Some("alice".into()))
+        .await;
+    let cookie = format!("{COOKIE_NAME}={sid}");
+    let (status, _) = get(state, "/admin/dashboard", Some(&cookie)).await;
+    assert_eq!(status, StatusCode::OK);
+}
+
 #[tokio::test]
 async fn last_admin_cannot_be_deleted() {
     let (state, pool) = state_with_db().await;


### PR DESCRIPTION
Closes #430, closes #454.

Two related admin password-UX changes, validated with a real end-to-end smoke.

## #454 — força a troca de senha no primeiro acesso
Hoje contas novas já nascem com `must_change_password = true` e o login
redireciona para `/admin/account/password`, mas o prompt era **pulável**
("manter senha atual") e dava para burlar navegando direto para outra URL
admin. Agora:
- removido o botão "manter senha atual" + o branch `skip` do `password_submit`
  — trocar de fato é a única forma de prosseguir;
- novo middleware `must_change_password_guard` no chrome **prende** qualquer
  conta logada que ainda precise trocar à página de senha em toda rota
  `/admin/*` (exceto `account`/`login`/`logout`/`setup`). Sessões token e
  anônimas passam. Custo: 1 lookup indexado por request de admin; o hot path
  `/app`/`/api` não passa por essa layer.
- Cópia reescrita para "obrigatório" nos 4 locales; `admin-pw-keep` aposentada.

## #430 — mascarar + revelar os campos de senha de usuários
Os inputs já eram `type="password"` (mascarados em `6ad38e4`); este PR adiciona
o **toggle de revelar/ocultar** (olho) sugerido na issue, nos campos de criar e
resetar senha. Listener delegado **sem framework** (sem dependência de Alpine —
evita a regressão da galeria #433). Nova chave `admin-pw-reveal`.

## Testes
- 3 testes de integração novos em `user_accounts.rs`: o guard prende, a troca
  libera, e um usuário "settled" passa direto.
- **Smoke real** (curl, binário rodando): setup → criar usuário → login força
  troca → guard bloqueia dashboard → troca → dashboard 200.
- `i18n-check` ✓, `clippy --all-targets -D warnings` ✓, suíte default ✓.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
