### PR TITLE
feat(cli,admin): startup banner visible in the Logs tab + honest empty state (#452)

### DIFF
--- a/crates/ruscker-admin/assets/i18n/en/landing.ftl
+++ b/crates/ruscker-admin/assets/i18n/en/landing.ftl
@@ -475,6 +475,7 @@ admin-nav-logs = Logs
 admin-proclog-title = Logs
 admin-proclog-subtitle = Recent Ruscker process log (live).
 admin-proclog-unavailable = Log buffer not wired (the server started without the logging layer).
+admin-proclog-empty = No logs captured yet at this level. New events show up here as they happen; run the server with -v to include info-level logs.
 
 # ── spec-form advanced params (#211/#212) ──────────────────────────
 spec-form-runtime-section = Runtime

--- a/crates/ruscker-admin/assets/i18n/es/landing.ftl
+++ b/crates/ruscker-admin/assets/i18n/es/landing.ftl
@@ -475,6 +475,7 @@ admin-nav-logs = Registros
 admin-proclog-title = Registros
 admin-proclog-subtitle = Registro reciente del proceso Ruscker (en vivo).
 admin-proclog-unavailable = Búfer de registro no disponible (el servidor inició sin la capa de logging).
+admin-proclog-empty = Aún no se ha capturado ningún registro en este nivel. Los nuevos eventos aparecen aquí a medida que ocurren; ejecuta el servidor con -v para incluir registros de nivel info.
 
 # ── spec-form advanced params (#211/#212) ──────────────────────────
 spec-form-runtime-section = Runtime

--- a/crates/ruscker-admin/assets/i18n/fr/landing.ftl
+++ b/crates/ruscker-admin/assets/i18n/fr/landing.ftl
@@ -475,6 +475,7 @@ admin-nav-logs = Journaux
 admin-proclog-title = Journaux
 admin-proclog-subtitle = Journal récent du processus Ruscker (en direct).
 admin-proclog-unavailable = Tampon de journal indisponible (le serveur a démarré sans la couche de journalisation).
+admin-proclog-empty = Aucun journal capturé pour l'instant à ce niveau. Les nouveaux événements apparaissent ici au fur et à mesure ; lancez le serveur avec -v pour inclure les journaux de niveau info.
 
 # ── spec-form advanced params (#211/#212) ──────────────────────────
 spec-form-runtime-section = Runtime

--- a/crates/ruscker-admin/assets/i18n/pt/landing.ftl
+++ b/crates/ruscker-admin/assets/i18n/pt/landing.ftl
@@ -479,6 +479,7 @@ admin-nav-logs = Logs
 admin-proclog-title = Logs
 admin-proclog-subtitle = Log recente do processo Ruscker (ao vivo).
 admin-proclog-unavailable = Buffer de log não disponível (o servidor iniciou sem a camada de logging).
+admin-proclog-empty = Nenhum log capturado ainda neste nível. Novos eventos aparecem aqui conforme acontecem; rode o servidor com -v para incluir logs de nível info.
 
 # ── spec-form advanced params (#211/#212) ──────────────────────────
 spec-form-runtime-section = Runtime

--- a/crates/ruscker-admin/src/lib.rs
+++ b/crates/ruscker-admin/src/lib.rs
@@ -49,6 +49,16 @@ use sqlx::SqlitePool;
 /// templates so it never drifts from a hardcoded string.
 pub const APP_VERSION: &str = env!("CARGO_PKG_VERSION");
 
+/// Tracing target for the one-shot startup banner (#452). The CLI's
+/// default `EnvFilter` raises *just this target* to `info` so the boot
+/// summary always lands in the admin "Logs" tab — even at the default
+/// `warn` verbosity, where every other `ruscker*` info log is hidden.
+/// `EnvFilter` prefix-matches and prefers the longest match, so
+/// `ruscker=warn,ruscker_startup=info` shows the banner without
+/// un-muting the rest of the app. Keep this in sync with the directive
+/// in `ruscker-cli`'s `init_tracing`.
+pub const STARTUP_LOG_TARGET: &str = "ruscker_startup";
+
 /// Shared state injected into every request.
 #[derive(Clone)]
 pub struct AppState {
@@ -368,7 +378,11 @@ impl AdminServer {
                     let n = existing.len();
                     self.state.replicas.write().await.reset(existing);
                     if n > 0 {
-                        info!(replicas = n, "reconciled existing replicas from backend");
+                        info!(
+                            target: STARTUP_LOG_TARGET,
+                            replicas = n,
+                            "reconciled existing replicas from backend"
+                        );
                     }
                 }
                 Err(err) => {
@@ -414,13 +428,42 @@ impl AdminServer {
                 // a busy host can poll Docker stats less often (#288).
                 std::time::Duration::from_secs(self.state.config.proxy.effective_metrics_interval_secs()),
             );
+            info!(
+                target: STARTUP_LOG_TARGET,
+                "background workers started (scaler, session sweeper, metrics)"
+            );
         }
 
         let app = router_with_images(self.state.clone(), self.images_dir.as_deref());
         let listener = TcpListener::bind(self.addr)
             .await
             .with_context(|| format!("bind {}", self.addr))?;
-        info!(addr = %self.addr, images_dir = ?self.images_dir, "ruscker-admin listening");
+        // One-shot startup banner (#452): the single line operators can
+        // count on seeing in the admin "Logs" tab right after boot,
+        // confirming the build, where it bound, and which subsystems are
+        // wired. Emitted on `STARTUP_LOG_TARGET` so the default filter
+        // surfaces it even at `warn`.
+        let db_kind = match self.state.db.as_ref() {
+            None => "none",
+            Some(db::ConfigDb::Sqlite(_)) => "sqlite",
+            Some(db::ConfigDb::Postgres(_)) => "postgres",
+        };
+        let base = if self.state.base_path.is_empty() {
+            "/"
+        } else {
+            &self.state.base_path
+        };
+        info!(
+            target: STARTUP_LOG_TARGET,
+            version = APP_VERSION,
+            addr = %self.addr,
+            base_path = base,
+            docker = self.state.backend.is_some(),
+            db = db_kind,
+            specs = self.state.config.proxy.specs.len(),
+            images_dir = ?self.images_dir,
+            "ruscker started — listening"
+        );
         // `into_make_service_with_connect_info` exposes the TCP peer
         // address to handlers via `ConnectInfo<SocketAddr>` — the
         // proxy uses it as the per-client key for API rate limiting

--- a/crates/ruscker-admin/templates/admin/process_logs.html
+++ b/crates/ruscker-admin/templates/admin/process_logs.html
@@ -42,6 +42,12 @@
 {% if !available %}
   <p class="text-sm text-[color:var(--text-faint)] py-8 text-center">{{ self.t("admin-proclog-unavailable") }}</p>
 {% else %}
+  {# Buffer is wired but empty — say so explicitly so an operator can
+     tell "nothing logged yet" from a broken tab (#452). New lines still
+     stream into the <pre> below as they happen. #}
+  {% if lines.is_empty() %}
+  <p class="text-sm text-[color:var(--text-faint)] py-6 text-center">{{ self.t("admin-proclog-empty") }}</p>
+  {% endif %}
   <pre id="proclog" class="proclog-pre">{% for line in lines %}{{ line }}
 {% endfor %}</pre>
 

--- a/crates/ruscker-admin/tests/user_accounts.rs
+++ b/crates/ruscker-admin/tests/user_accounts.rs
@@ -255,6 +255,43 @@ async fn setup_page_chrome_cluster_is_outside_the_setup_form() {
     );
 }
 
+/// #452: with a log buffer wired but still empty, the Logs tab shows an
+/// explicit "nothing captured yet" message — distinct from the "buffer
+/// not wired" message — so an operator can tell an idle log from a broken
+/// tab. Renders in the default locale (pt).
+#[tokio::test]
+async fn logs_tab_distinguishes_empty_buffer_from_unwired() {
+    let (mut state, _pool) = state_with_db().await;
+    // Wired but empty.
+    state.log_buffer = Some(ruscker_admin::logbuf::LogBuffer::new(16));
+    let sid = state.admin_sessions.create(Role::Admin, None).await;
+    let cookie = format!("{COOKIE_NAME}={sid}");
+    let app = router(state);
+    let resp = app
+        .oneshot(
+            Request::builder()
+                .uri("/admin/logs")
+                .header("cookie", cookie)
+                .body(Body::empty())
+                .unwrap(),
+        )
+        .await
+        .unwrap();
+    assert_eq!(resp.status(), StatusCode::OK);
+    let bytes = axum::body::to_bytes(resp.into_body(), 1 << 20)
+        .await
+        .unwrap();
+    let body = std::str::from_utf8(&bytes).unwrap();
+    assert!(
+        body.contains("Nenhum log capturado"),
+        "empty-buffer hint missing"
+    );
+    assert!(
+        !body.contains("Buffer de log não disponível"),
+        "should not show the unwired-buffer message when a buffer exists"
+    );
+}
+
 #[tokio::test]
 async fn last_admin_cannot_be_deleted() {
     let (state, pool) = state_with_db().await;

--- a/crates/ruscker-cli/src/main.rs
+++ b/crates/ruscker-cli/src/main.rs
@@ -557,8 +557,16 @@ fn init_tracing(verbosity: u8, format: LogFormat) -> ruscker_admin::logbuf::LogB
         _ => "trace",
     };
     // `RUST_LOG` always wins when set (operators expect it); the
-    // verbosity flag only sets the default filter.
-    let env = std::env::var("RUST_LOG").unwrap_or_else(|_| format!("ruscker={level}"));
+    // verbosity flag only sets the default filter. The startup banner
+    // (#452) rides a dedicated target raised to `info` so it shows even
+    // at the default `warn` — `EnvFilter` prefers the longest target
+    // prefix, so this un-mutes only the banner, not the whole app.
+    let env = std::env::var("RUST_LOG").unwrap_or_else(|_| {
+        format!(
+            "ruscker={level},{}=info",
+            ruscker_admin::STARTUP_LOG_TARGET
+        )
+    });
     let filter = tracing_subscriber::EnvFilter::new(env);
 
     let buffer = ruscker_admin::logbuf::LogBuffer::new(2000);


### PR DESCRIPTION
Closes #452.

A aba **Logs** mostrava nada logo após o boot, deixando o operador sem saber se
era problema do Ruscker ou da aba. **Causa-raiz:** todos os `info!` de startup
(inclusive o "listening") ficam abaixo do filtro default `warn`, então o ring
buffer que alimenta a aba ficava vazio sem `-v`.

## Mudanças
- **Target dedicado `STARTUP_LOG_TARGET`** (`ruscker_startup`): o `EnvFilter`
  default do CLI sobe **só esse target** para `info`
  (`ruscker=warn,ruscker_startup=info`), então o resumo de boot aparece no nível
  padrão sem desmutar o resto (o EnvFilter prefere o prefixo de target mais
  longo). `RUST_LOG` continua mandando quando setado.
- **Banner de startup** nesse target no ponto de "listening": versão, bind,
  base-path, docker on/off, tipo de db, nº de specs, images-dir. Reconcile +
  "background workers started" também migram pro target (visíveis no default).
- **Estado-vazio honesto na aba Logs:** quando o buffer existe mas está vazio,
  mostra "nenhum log capturado ainda neste nível" — distinto da mensagem "buffer
  não disponível". Nova chave `admin-proclog-empty` (4 locales).

## Validação
- Teste de integração novo: a dica de buffer-vazio renderiza (e a de
  buffer-indisponível não).
- **Smoke real:** subindo sem `-v`, o banner aparece em `/admin/logs`
  (`INFO ruscker started — listening version=0.1.31 addr=… base_path=/box
  docker=false db=sqlite specs=8`), inclusive sob `--base-path`.
- `i18n-check` ✓, `clippy --all-targets -D warnings` ✓, suíte default ✓.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
