### PR TITLE
feat(admin): landing logos use the shared image gallery picker (#451)

### DIFF
--- a/crates/ruscker-admin/src/routes/admin/landing.rs
+++ b/crates/ruscker-admin/src/routes/admin/landing.rs
@@ -55,6 +55,10 @@ struct LandingPage<'a> {
     /// Custom HTML blocks, grouped per slot. The blocks editor is
     /// folded into this page (#242) and rendered below the form.
     groups: Vec<SlotGroup>,
+    /// Media-library filenames for the logos picker (#451) — the same
+    /// shared gallery the spec form uses (includes the built-in logos
+    /// seeded into the library, #433). Empty when no DB is wired.
+    logo_images: Vec<String>,
 }
 
 impl<'a> LandingPage<'a> {
@@ -69,10 +73,11 @@ impl<'a> LandingPage<'a> {
         serde_json::to_string(&self.form).unwrap_or_else(|_| "{}".into())
     }
 
-    /// Built-in logo paths offered (via a datalist) in the logos editor —
-    /// the same bundled framework + brand SVGs the spec-form picker uses.
-    fn builtin_logos(&self) -> &'static [&'static str] {
-        crate::routes::assets::BUILTIN_LOGOS
+    /// JSON array of media-library filenames for the logos picker (#451),
+    /// passed as the 2nd argument to the Alpine `landingForm` factory —
+    /// mirrors the spec form's `logo_images_json`.
+    fn logo_images_json(&self) -> String {
+        serde_json::to_string(&self.logo_images).unwrap_or_else(|_| "[]".into())
     }
 }
 
@@ -260,6 +265,16 @@ async fn render(
             return (StatusCode::INTERNAL_SERVER_ERROR, "db error").into_response();
         }
     };
+    // Media-library filenames for the shared logos picker (#451).
+    // Non-fatal: a listing failure just leaves the gallery empty, the
+    // manual URL field still works.
+    let logo_images = match db::images::list_all(database).await {
+        Ok(imgs) => imgs.into_iter().map(|i| i.filename).collect(),
+        Err(err) => {
+            tracing::warn!(error = ?err, "landing: list images for logo picker failed");
+            Vec::new()
+        }
+    };
     let page = LandingPage {
         locale: loc,
         theme,
@@ -273,6 +288,7 @@ async fn render(
         flash_error,
         portal_title: state.config.proxy.title.trim().to_string(),
         groups,
+        logo_images,
     };
     super::render(&page)
 }

--- a/crates/ruscker-admin/templates/admin/_layout.html
+++ b/crates/ruscker-admin/templates/admin/_layout.html
@@ -156,6 +156,83 @@ window.ruscker.gradientDefault = () => ({
 window.ruscker.bgMode = (value) =>
   (typeof value === 'string' && /^(linear|radial)-gradient\(/.test(value.trim()))
     ? 'gradient' : 'solid';
+
+// Shared image-picker mixin (#451) — the gallery modal reused by the
+// spec form's logo/cover and the landing logos editor. Spread it into an
+// Alpine x-data factory: `...window.ruscker.imagePicker(filenames)`. It
+// owns the modal state, search, inline upload and selection; the caller
+// decides what a pick does by passing a callback to `openImagePicker`.
+// `filenames` is the media-library list (includes the seeded built-in
+// logos, #433). Pair it with the `image-picker-*` modal markup.
+window.ruscker.imagePicker = (filenames) => ({
+  logoImages: Array.isArray(filenames) ? filenames : [],
+  picker: { open: false, q: '' },
+  imgUploading: false,
+  imgError: '',
+  // Set by openImagePicker: where a pick goes, and the current value (to
+  // highlight its tile). Underscored so they don't collide with caller
+  // state when spread.
+  _pickCb: null,
+  _pickSel: '',
+  // Prefix the base path on a root-absolute asset URL (#270) — these
+  // <img :src> values are set by Alpine at runtime, after the base-path
+  // HTML rewriter has run, so a bare `/assets/img/x` would 404 under
+  // `--base-path`. A full URL is returned untouched.
+  assetUrl(p) {
+    return p && p.charAt(0) === '/' ? (window.RUSCKER_BASE || '') + p : (p || '');
+  },
+  // Library filenames filtered by the search box.
+  pickerUploads() {
+    const q = this.picker.q.trim().toLowerCase();
+    return q ? this.logoImages.filter((n) => n.toLowerCase().includes(q)) : this.logoImages;
+  },
+  // Open the gallery. `onPick(value)` receives the chosen asset path;
+  // `selected` is the current value, highlighted in the grid.
+  openImagePicker(onPick, selected) {
+    this._pickCb = onPick;
+    this._pickSel = selected || '';
+    this.picker.q = '';
+    this.imgError = '';
+    this.picker.open = true;
+  },
+  pickImage(value) {
+    if (this._pickCb) this._pickCb(value);
+    this.picker.open = false;
+  },
+  pickerSelected(value) {
+    return this._pickSel === value;
+  },
+  // Inline upload to the media library, then auto-select the result for
+  // the active target. Same endpoint + flow as the media page; no
+  // navigation. Honors RUSCKER_BASE for subpath mounts.
+  async uploadImage(event) {
+    const input = event.target;
+    const file =
+      (event.dataTransfer && event.dataTransfer.files && event.dataTransfer.files[0]) ||
+      (input && input.files && input.files[0]);
+    if (!file) return;
+    this.imgError = '';
+    this.imgUploading = true;
+    try {
+      const fd = new FormData();
+      fd.append('file', file);
+      const base = (window.RUSCKER_BASE || '');
+      const resp = await fetch(base + '/admin/media/upload-inline', { method: 'POST', body: fd });
+      const data = await resp.json().catch(() => ({}));
+      if (!resp.ok || !data.filename) {
+        this.imgError = data.error || ('upload failed (' + resp.status + ')');
+        return;
+      }
+      if (this.logoImages.indexOf(data.filename) === -1) this.logoImages.unshift(data.filename);
+      this.pickImage(data.url || ('/assets/img/' + data.filename));
+    } catch (e) {
+      this.imgError = String(e);
+    } finally {
+      this.imgUploading = false;
+      if (input && 'value' in input) input.value = '';
+    }
+  },
+});
 </script>
 
 <main class="flex-1 px-6 py-6 max-w-7xl mx-auto w-full">

--- a/crates/ruscker-admin/templates/admin/landing.html
+++ b/crates/ruscker-admin/templates/admin/landing.html
@@ -4,7 +4,7 @@
 
 {% block content %}
 
-<div x-data="ruscker.landingForm({{ form_initial_json() }})" x-cloak>
+<div x-data="ruscker.landingForm({{ form_initial_json() }}, {{ logo_images_json() }})" x-cloak>
 
   {# ── Header ───────────────────────────────────────────────── #}
   <div class="flex items-end justify-between mb-5 pb-3 border-b border-[color:var(--border)]">
@@ -232,14 +232,19 @@
         <div class="spec-form-help" style="margin-bottom:8px">{{ self.t("admin-landing-logos-help") }}</div>
         {# Submitted as one hidden JSON field; the rows below edit the array. #}
         <input type="hidden" name="logos_json" :value="JSON.stringify(logos)">
-        <datalist id="builtin-logo-list">
-          {% for path in self.builtin_logos() %}<option value="{{ path }}"></option>{% endfor %}
-        </datalist>
         <template x-for="(logo, i) in logos" :key="i">
           <div class="landing-logo-row">
-            <img :src="logo.url" alt="" class="landing-logo-thumb" x-show="logo.url">
-            <input type="text" x-model="logo.url" list="builtin-logo-list"
-                   placeholder="/assets/img/logo.png" class="spec-form-input spec-form-input--mono" style="flex:2;min-width:12rem">
+            <img :src="assetUrl(logo.url)" alt="" class="landing-logo-thumb" x-show="logo.url">
+            {# Shared gallery picker (#451): writes only this row's `url`,
+               leaving slot/align/link/height intact. The field stays
+               editable for an external/manual URL. #}
+            <button type="button" class="admin-login-btn" style="padding:6px 10px;font-size:12px;white-space:nowrap"
+                    @click="openImagePicker((v) => { logo.url = v }, logo.url)">
+              <i class="ti ti-photo" aria-hidden="true"></i>
+              {{ self.t("spec-form-choose-image") }}
+            </button>
+            <input type="text" x-model="logo.url"
+                   placeholder="/assets/img/logo.png" class="spec-form-input spec-form-input--mono" style="flex:2;min-width:10rem">
             <select x-model="logo.slot" class="theme-select">
               <option value="header">{{ self.t("admin-landing-logo-header") }}</option>
               <option value="footer">{{ self.t("admin-landing-logo-footer") }}</option>
@@ -298,6 +303,40 @@
     </aside>
 
   </div>
+
+  {# ── Image picker modal (shared mixin, #451) ───────────────────
+     Opened by a logo row's "Choose image" button via openImagePicker.
+     Same markup + `image-picker-*` styles as the spec form; the mixin
+     in _layout.html supplies the state/behaviour. #}
+  <div x-show="picker.open" x-cloak class="image-picker-overlay"
+       @keydown.escape.window="picker.open = false" @click.self="picker.open = false">
+    <div class="image-picker-modal">
+      <div class="image-picker-head">
+        <strong>{{ self.t("spec-form-choose-image") }}</strong>
+        <button type="button" class="admin-nav-link" @click="picker.open = false"><i class="ti ti-x" aria-hidden="true"></i></button>
+      </div>
+      <div class="image-picker-tools">
+        <input type="search" x-model="picker.q" placeholder="{{ self.t("admin-images-search") }}"
+               class="spec-form-input text-sm" style="max-width:16rem">
+        <label class="admin-login-btn" style="cursor:pointer;padding:6px 12px;font-size:12px"
+               :class="imgUploading ? 'opacity-50 pointer-events-none' : ''">
+          <i class="ti" :class="imgUploading ? 'ti-loader-2 animate-spin' : 'ti-upload'" aria-hidden="true"></i>
+          {{ self.t("admin-images-choose") }}
+          <input type="file" accept="image/*" class="hidden" @change="uploadImage($event)">
+        </label>
+      </div>
+      <div class="spec-form-help" style="color:var(--color-lock)" x-show="imgError" x-text="imgError" x-cloak></div>
+      <div class="image-picker-grid">
+        <template x-for="name in pickerUploads()" :key="'pk-' + name">
+          <button type="button" :title="name" @click="pickImage('/assets/img/' + name)"
+                  class="image-picker-tile" :class="pickerSelected('/assets/img/' + name) ? 'is-sel' : ''">
+            <img :src="assetUrl('/assets/img/' + name) + '?thumb'" :alt="name" loading="lazy">
+          </button>
+        </template>
+      </div>
+      <div class="image-picker-empty" x-show="!pickerUploads().length">{{ self.t("admin-images-no-match") }}</div>
+    </div>
+  </div>
 </div>
 
 {# Custom HTML blocks editor, folded in from the old standalone tab (#242). #}
@@ -309,7 +348,11 @@
 // defined in admin/_layout.html so they're shared with the
 // spec-form cover editor.
 window.ruscker = window.ruscker || {};
-window.ruscker.landingForm = (initial) => ({
+window.ruscker.landingForm = (initial, logoImages) => ({
+  // Shared image-picker mixin (#451): the logos gallery modal, search,
+  // inline upload and selection. The per-row "Choose image" button calls
+  // `openImagePicker` with a callback that writes that row's `url`.
+  ...window.ruscker.imagePicker(logoImages),
   form: initial,
   // Header/footer logos — edited as an array here, submitted as the
   // hidden `logos_json` field (bound via JSON.stringify). Seeded by

--- a/crates/ruscker-admin/tests/admin_landing_picker.rs
+++ b/crates/ruscker-admin/tests/admin_landing_picker.rs
@@ -1,0 +1,92 @@
+//! #451: the admin landing editor's logos field uses the shared image
+//! gallery picker (the same one the spec form uses), seeded with the
+//! media library filenames — including the built-in logos seeded into
+//! the library (#433). This renders `/admin/landing` as an admin and
+//! asserts the picker is wired and carries data.
+
+use axum::body::Body;
+use axum::http::{Request, StatusCode};
+use ruscker_admin::auth::{AdminAuth, Role, COOKIE_NAME};
+use ruscker_admin::{router, AppState};
+use ruscker_config::Config;
+use std::sync::Arc;
+use tower::ServiceExt;
+
+const YAML: &str = "proxy:\n  title: Test\n  specs: []\n";
+
+async fn state_with_db() -> AppState {
+    std::env::set_var("DOCKER_REGISTRY_PASSWORD", "test");
+    let path = std::env::temp_dir().join(format!("ruscker-landing-{}.db", uuid::Uuid::new_v4()));
+    // `open` runs migrations + seeds the built-in logos into the images
+    // table (#433), so the logo picker has a non-empty gallery.
+    let pool = ruscker_admin::db::open(&path).await.expect("open db");
+    let config = Config::from_yaml(YAML).expect("parse config");
+    let locales = ruscker_admin::i18n::Locales::load().expect("load locales");
+    AppState {
+        config: Arc::new(config),
+        base_path: Arc::from(""),
+        locales: Arc::new(locales),
+        admin_auth: AdminAuth::with_token("break-glass-tok"),
+        admin_sessions: Arc::new(ruscker_admin::auth::InMemoryAdminSessionStore::default()),
+        log_buffer: None,
+        login_limiter: Arc::new(ruscker_admin::auth::LoginRateLimiter::default_policy()),
+        api_limiter: Arc::new(ruscker_admin::ratelimit::ApiRateLimiter::new()),
+        db: Some(ruscker_admin::db::ConfigDb::Sqlite(pool)),
+        images_dir: None,
+        master_key: Default::default(),
+        backend: None,
+        replicas: Arc::new(tokio::sync::RwLock::new(Default::default())),
+        cookie_key: ruscker_proxy::sticky::CookieKey::random(),
+        spawn_locks: Arc::new(dashmap::DashMap::new()),
+        sessions: Arc::new(ruscker_admin::sessions::InMemorySessionStore::new()),
+        logout_index: Arc::new(dashmap::DashMap::new()),
+        leader: Arc::new(ruscker_admin::leader::AlwaysLeader),
+        metrics: ruscker_admin::metrics_cache::MetricsCache::new(),
+        draining: Arc::new(std::sync::atomic::AtomicBool::new(false)),
+    }
+}
+
+#[tokio::test]
+async fn landing_logos_use_the_shared_gallery_picker() {
+    let state = state_with_db().await;
+    let sid = state.admin_sessions.create(Role::Admin, None).await;
+    let cookie = format!("{COOKIE_NAME}={sid}");
+    let app = router(state);
+    let resp = app
+        .oneshot(
+            Request::builder()
+                .uri("/admin/landing")
+                .header("cookie", cookie)
+                .body(Body::empty())
+                .unwrap(),
+        )
+        .await
+        .unwrap();
+    assert_eq!(resp.status(), StatusCode::OK);
+    let bytes = axum::body::to_bytes(resp.into_body(), 1 << 20)
+        .await
+        .unwrap();
+    let body = std::str::from_utf8(&bytes).unwrap();
+
+    // The shared modal + per-row "Choose image" wiring is present.
+    assert!(
+        body.contains("image-picker-overlay"),
+        "shared picker modal missing"
+    );
+    assert!(
+        body.contains("openImagePicker"),
+        "per-row picker trigger missing"
+    );
+    // The Alpine factory gets a 2nd argument (the media-library list),
+    // and the built-in logos seeded into the library show up there — so
+    // the gallery is actually populated.
+    assert!(
+        body.contains("ruscker-mark.svg"),
+        "seeded built-in logos missing from the picker gallery"
+    );
+    // The old free-text-only datalist is gone.
+    assert!(
+        !body.contains("builtin-logo-list"),
+        "the datalist should be replaced by the gallery picker"
+    );
+}


### PR DESCRIPTION
Closes #451.

A aba **Portal** usava um campo de texto + datalist de built-ins para os logos,
enquanto o spec form já tinha o picker de galeria completo (busca, thumbnails,
upload inline). Esta PR traz os logos do Portal para o mesmo picker.

## Mudanças
- **Mixin compartilhado** `ruscker.imagePicker(filenames)` (Alpine) em
  `_layout.html`, ao lado dos helpers de gradiente já compartilhados. Ele cuida
  do estado do modal, busca, upload inline (`/admin/media/upload-inline`) e
  seleção; o caller passa um callback em `openImagePicker(onPick, selected)`
  decidindo o que a escolha faz — então o mesmo modal serve um campo único
  (spec form) ou **uma linha de uma lista** (landing).
- `landingForm` faz spread do mixin; cada linha de logo ganha um botão
  **"Choose image"** que escreve **só o `url` daquela linha** (slot/align/link/
  height intactos). O campo de URL continua editável (URL externa/manual).
  Removi a datalist de built-ins (redundante — os built-in logos estão semeados
  na biblioteca de mídia, #433, então aparecem na galeria).
- `landing.rs`: `LandingPage` ganha `logo_images` + `logo_images_json()`,
  populado de `db::images::list_all` (não-fatal em erro), passado como 2º arg do
  Alpine — espelha o spec form.

O picker próprio do **spec form fica intacto** (zero risco de regressão); pode
migrar para o mixin depois.

## Validação
- **Teste de integração** novo: renderiza `/admin/landing` como admin e afirma
  que o modal + gatilho por linha estão montados, os built-in logos semeados
  populam a galeria, e a datalist antiga sumiu.
- **Render-smoke ao vivo:** o HTML servido traz o 2º arg do Alpine com os 13
  filenames da biblioteca; o spec form continua renderizando o picker próprio.
- `clippy -D warnings`, paridade i18n, suíte default — verdes.

**Nota:** o comportamento de clique do Alpine (abre modal → escolher escreve
`logo.url`) não foi testado em browser (sem Playwright no ambiente); o markup +
mixin espelham exatamente o picker do spec form, já comprovado.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
