### PR TITLE
docs(book): refresh the mdBook to v0.1.31 (#436–#450)

### DIFF
--- a/book/src/admin.md
+++ b/book/src/admin.md
@@ -30,6 +30,8 @@ Each person gets their own account (username + password). Admins manage
 accounts under **Users** (`/admin/users`): create one, assign a role,
 reset a password, or remove it. A new user gets an initial password you
 choose and is asked — once, on first login — whether to change it.
+**Password fields are masked** (type `password`) throughout the panel, so a
+shoulder-surfer can't read a password as you type it.
 
 | Role | Can do |
 |---|---|
@@ -76,10 +78,27 @@ default, so the section stays out of the way until you need it.
 Upload images (PNG/JPEG → WebP), served at `/assets/img/<file>`. These
 are the card logos and covers.
 
+The gallery is a single unified library — **built-in logos** (brand marks
+shipped with Ruscker) are seeded here automatically alongside your uploads.
+Every image can be **deleted** from the gallery; if it is referenced by any
+spec logo/cover or landing logo, the entry shows an **"in use" badge** so
+you know before deleting.
+
+When editing a spec you can open a **modal picker** (search, browse, drag
+and drop, or upload inline without leaving the form) to select a logo or
+cover. A "Choose image" button auto-uploads on file select for a one-click
+flow.
+
 ### Credentials
 A named, AES-256-GCM-encrypted store for registry credentials (needs
 `RUSCKER_MASTER_KEY`). Passwords never appear in the YAML or in the
-panel after saving.
+panel after saving. Each entry accepts either a literal password
+(encrypted at rest) or a **pure `${VAR}` env-ref** — stored verbatim and
+resolved to the real value only at container pull time.
+
+In the spec form the Registry section is a **credential picker**: type or
+select the name of a stored credential and Ruscker resolves it at spawn.
+There is no need to inline registry passwords in a spec.
 
 ### Landing editor
 Customise the public landing without a custom template:
@@ -91,6 +110,12 @@ Customise the public landing without a custom template:
 - **Analytics** — paste a provider snippet (Plausible, Matomo, GA…)
   and list its origins; Ruscker widens **only the landing's** CSP so
   the script can load.
+- **Logos** — add logos to the landing **header** or **footer** slot.
+  Each logo has its own **alignment** (left / center / right), an optional
+  **click-through link**, and a **height** in pixels. Multiple logos
+  sharing a slot and alignment render side by side. Images come from the
+  Media library — pick one with the same modal picker used in the spec
+  form.
 
 ### Blocks
 Custom HTML blocks rendered in the landing `top` (after the header) and

--- a/book/src/alternatives.md
+++ b/book/src/alternatives.md
@@ -45,8 +45,60 @@ YAML and restart". See [Migrating from ShinyProxy](./migrating.md).
 
 **What ShinyProxy still does that Ruscker doesn't (yet):** a mature
 Kubernetes operator and pluggable enterprise auth (OIDC/SAML/LDAP for
-*app access*). Ruscker's multi-host is Docker-over-ssh/tcp today, and
-its auth gates the *admin panel* (per-app ACLs are [Phase 8](./roadmap.md)).
+*app access*). Ruscker's multi-host is Docker-over-ssh/tcp today. Per-app
+visibility and access control (`access-groups` / `access-users`,
+ShinyProxy-compatible) are already supported; OIDC/SAML/LDAP gating at
+the proxy level is not (apps can handle their own auth internally).
+
+### Strip model vs. `SHINYPROXY_PUBLIC_PATH`
+
+One migration detail worth knowing: ShinyProxy uses a **no-strip** model —
+it passes the full public path to the container as the
+`SHINYPROXY_PUBLIC_PATH` environment variable, and well-behaved
+ShinyProxy demo images read that variable to self-prefix all their URLs.
+Ruscker uses a **strip** model — the proxy strips `/app/{id}` from the
+request path before forwarding, so the container always receives a
+root-relative path (e.g. `/lab/...` instead of `/app/jupyter/lab/...`).
+The container does **not** need to know its mount path; the proxy injects
+a `<base href>`, rewrites static URLs in HTML responses, and patches
+runtime fetches via a small JS shim.
+
+This means **do not set `SHINYPROXY_PUBLIC_PATH` in `container-env`** for
+Ruscker — the container would misconfigure itself and 404 on every request.
+Most apps need no mount-path configuration at all; just serve them at the
+root. Jupyter, for example, runs at `--ServerApp.base_url=/`:
+
+```yaml
+- id: jupyter
+  container-image: quay.io/jupyter/minimal-notebook:latest
+  container-port: 8888
+  container-cmd:
+    - start-notebook.py
+    - --IdentityProvider.token=
+    - --ServerApp.allow_origin=*
+    - --ServerApp.base_url=/
+```
+
+For the rare app that genuinely needs to know its external mount path — to
+build absolute URLs the proxy can't rewrite — Ruscker exposes an explicit
+opt-in token `#{publicPath}`, substituted at spawn with the spec's actual
+mount path (including any `--base-path` prefix), for use in `container-cmd`
+or `container-env`. Do **not** use it for Jupyter: under the strip model a
+non-root `base_url` makes it 404 every path (see
+[Troubleshooting](./troubleshooting.md)). Apps like Shiny, Streamlit, Dash
+and Voilà never need it.
+
+### Secrets via env-var interpolation
+
+Both Ruscker and ShinyProxy support `${VAR}` references in the YAML. The
+difference is where resolution happens. In Ruscker, `${VAR}` references
+in `container-env` values are resolved **at spawn**, not at parse: the
+literal `${DB_PASSWORD}` is stored in the config and the database; only
+when a container is actually started does Ruscker look up the environment
+variable and inject the real value. This means **secrets never land in
+the database** — the DB only ever sees the placeholder. Set secrets in
+the process environment (or in `/etc/ruscker/ruscker.env` for the systemd
+service) and reference them by name in the YAML.
 
 ## Shiny Server (open source / "Free")
 
@@ -100,10 +152,11 @@ scaling and reaping for free. See [What Ruscker can serve](./use-cases.md).
   scheduled reports, content versioning) — that's Posit Connect.
 - You're **all-in on Kubernetes** and want a CRD-native operator today —
   ShinyProxy's operator or a k8s-native platform is a better match
-  (Ruscker schedules onto Docker hosts, not k8s, as of Phase 6).
-- You need **enterprise SSO gating app access per user** right now —
-  that's [Phase 8](./roadmap.md); today Ruscker's auth covers the admin
-  panel (Viewer / Editor / Admin).
+  (Ruscker schedules onto Docker hosts, not k8s).
+- You need **enterprise SSO gating app access per user** (OIDC/SAML/LDAP
+  at the proxy level) — Ruscker's auth covers admin roles (Viewer /
+  Editor / Admin) and per-app visibility (`access-groups` / `access-users`),
+  but proxy-level SSO is not yet supported.
 
 If none of those apply and you want ShinyProxy's model without the JVM,
 start with the [Quickstart](./quickstart.md).

--- a/book/src/configuration.md
+++ b/book/src/configuration.md
@@ -14,7 +14,7 @@ A few cross-cutting concerns have dedicated chapters and field sets:
 
 - **Subpath mounting** (`server.context-path` / `--base-path`) — when
   you can't dedicate a subdomain and need the portal under
-  `example.org/box/`. See [Mounting under a base path][base-path] in
+  `example.org/apps/`. See [Mounting under a base path][base-path] in
   the deploy guide and [`server.context-path`](#servercontext-path--subpath-mounting)
   in the schema below.
 - **Per-user access** (`access-groups` / `access-users`) — restrict
@@ -24,15 +24,22 @@ A few cross-cutting concerns have dedicated chapters and field sets:
   in the schema. Group membership is set per user in the admin users
   page.
 - **Active-active HA** — when running more than one Ruscker instance
-  behind a load balancer, the **sign-in session** must be
-  pinned to one upstream until the shared session store ships. See
-  [Sticky upstream for the sign-in session][ha-sticky] in the deploy
-  guide.
-- **Branding, SEO, analytics, custom HTML** — see
-  [`proxy.landing-customization`](#proxylanding-customization) below.
+  behind a load balancer, point them at a shared Postgres for the
+  **sign-in session** so any node can serve any authenticated request;
+  if you can't, pin the session-bearing paths to one upstream. See
+  [Shared admin sessions][ha-sticky] in the deploy guide.
+- **Branding, logos, SEO, analytics, custom HTML** — header/footer
+  logos, colors, SEO/social meta, analytics snippets, and custom HTML
+  blocks. See [`proxy.landing-customization`](#proxylanding-customization)
+  below.
+- **Named registry credentials** (`docker-registry-credential`) — store
+  registry passwords encrypted in the admin panel and reference them by
+  name instead of writing credentials inline. See
+  [Registry credentials](#containerized-specs-shiny-streamlit-dash-voilà-api)
+  in the schema below.
 
 [base-path]: ./deploying.md#4b-mounting-under-a-base-path-subpath
-[ha-sticky]: ./deploying.md#sticky-upstream-for-the-sign-in-session-admin-app-api
+[ha-sticky]: ./deploying.md#shared-admin-sessions-eliminate-the-sticky-upstream-caveat
 
 ## Per-user access
 

--- a/book/src/deploying.md
+++ b/book/src/deploying.md
@@ -115,7 +115,7 @@ Terminate TLS at your edge / load balancer and forward to nginx with
 ```nginx
 server {
     listen 80;
-    server_name portal.example.gov;
+    server_name portal.example.com;
 
     # Media-library / card-image uploads. nginx defaults to 1 MB, which
     # silently 413s any larger image before it reaches Ruscker (the admin
@@ -140,12 +140,19 @@ Set `server.useForwardHeaders: true` in the YAML so Ruscker trusts
 `X-Forwarded-*` (needed for `Secure` cookies and per-client API rate
 limiting).
 
-> The live dashboard streams over Server-Sent Events
-> (`/admin/dashboard/events`). If its updates lag, nginx is buffering
-> the stream — disable it for that path:
+> Two Ruscker endpoints stream over **Server-Sent Events** (SSE):
+> the live dashboard (`/admin/dashboard/events`) and the Ruscker log
+> tail (`/admin/logs/stream`). nginx's default response buffering
+> delays or blocks these streams — disable it for both paths:
 >
 > ```nginx
 > location = /admin/dashboard/events {
+>     proxy_pass http://127.0.0.1:8090;
+>     proxy_buffering off;
+>     proxy_read_timeout 1h;
+>     # + the same proxy_set_header lines as above
+> }
+> location = /admin/logs/stream {
 >     proxy_pass http://127.0.0.1:8090;
 >     proxy_buffering off;
 >     proxy_read_timeout 1h;
@@ -173,29 +180,29 @@ reload.
 ## 4b. Mounting under a base path (subpath)
 
 When you can't create a subdomain (no DNS governance), serve the whole
-portal under a subpath like `example.org/box/`. Start Ruscker with
-`--base-path /box` (or `server.context-path: /box` in the config —
+portal under a subpath like `example.org/apps/`. Start Ruscker with
+`--base-path /apps` (or `server.context-path: /apps` in the config —
 ShinyProxy's `server.servlet.context-path` is also accepted), and point
 nginx at it **preserving the prefix** (no trailing path on `proxy_pass`,
-so the `/box` stays in the forwarded URL):
+so the `/apps` stays in the forwarded URL):
 
 ```nginx
-# Forward both the bare /box and everything under /box/ — without an
+# Forward both the bare /apps and everything under /apps/ — without an
 # nginx-side redirect (Ruscker does its own canonicalization below).
-location = /box  { proxy_pass http://127.0.0.1:8080; /* + proxy_set_header from §3 */ }
-location /box/   { proxy_pass http://127.0.0.1:8080; /* + proxy_set_header from §3 */ }
+location = /apps  { proxy_pass http://127.0.0.1:8080; /* + proxy_set_header from §3 */ }
+location /apps/   { proxy_pass http://127.0.0.1:8080; /* + proxy_set_header from §3 */ }
 ```
 
-Ruscker then nests every route under `/box` (`/box`, `/box/admin/…`,
-`/box/app/{spec}/…`), rewrites the URLs/redirects it emits to carry the
+Ruscker then nests every route under `/apps` (`/apps`, `/apps/admin/…`,
+`/apps/app/{spec}/…`), rewrites the URLs/redirects it emits to carry the
 prefix, and injects a small runtime shim so JS-built requests (the live
-dashboard's SSE, `fetch`, etc.) resolve under `/box` too. `/healthz` and
+dashboard's SSE, `fetch`, etc.) resolve under `/apps` too. `/healthz` and
 `/readyz` stay at the **root** for load-balancer probes — don't put them
-behind the `/box` locations. `--base-path` is empty by default, so
+behind the `/apps` locations. `--base-path` is empty by default, so
 root-mounted deploys are unaffected.
 
-> The canonical landing URL is `/box` (no trailing slash); a request to
-> `/box/` 308-redirects to it. Keeping nginx as a plain `proxy_pass`
+> The canonical landing URL is `/apps` (no trailing slash); a request to
+> `/apps/` 308-redirects to it. Keeping nginx as a plain `proxy_pass`
 > (never redirecting) means that single hop can't loop.
 
 ## 5. Health checks

--- a/book/src/faq.md
+++ b/book/src/faq.md
@@ -60,7 +60,10 @@ By default in a local **SQLite** database (`--db`), with YAML as the
 import/export format. For multi-instance HA the same admin catalog and the
 session store live in shared **Postgres** (`--config-db-url` /
 `--session-store-url`). Secrets never go in YAML — use `${ENV_VAR}`
-interpolation; the credentials store is AES-encrypted at rest.
+interpolation. The named credentials store is AES-encrypted at rest; it
+also accepts a pure `${VAR}` env-ref as the password (stored verbatim,
+resolved at pull time, so the decryption key is never needed for env-based
+credentials).
 
 ### Can I run more than one instance for high availability?
 
@@ -73,14 +76,16 @@ One operational caveat: until a shared admin-session store ships, pin
 the **sign-in session** paths to a single upstream — see
 [Sticky upstream for the sign-in session][ha-sticky].
 
-[ha-sticky]: ./deploying.md#sticky-upstream-for-the-sign-in-session-admin-app-api
+[ha-sticky]: ./deploying.md#fallback-sticky-upstream
 
 ### Is it production-ready?
 
-Ruscker runs in production. Releases are multi-arch
-and cosign-signed; see the [release notes](./news.md) for the current
-version and what changed in each. The [Roadmap](./roadmap.md) tracks what's shipped
-(Phases 0–7) and what's planned (Phase 8: external auth).
+Yes. The current release is **v0.1.31** — Phases 0–7 are complete and
+the proxy is production-ready and horizontally scalable.
+Releases are multi-arch and cosign-signed; see the
+[release notes](./news.md) and the [Roadmap](./roadmap.md).
+Phase 8 (external auth: OIDC / SAML / LDAP) is the main remaining
+optional work.
 
 ### What platforms does it run on?
 

--- a/book/src/installation.md
+++ b/book/src/installation.md
@@ -5,10 +5,15 @@ Ruscker is a single binary. Pick the packaging that fits your host.
 ## Debian / Ubuntu (`.deb`)
 
 The most ShinyProxy-like install: a systemd service on your Docker
-host.
+host. Packages for **amd64** and **arm64** are attached to every
+[GitHub release](https://github.com/StrategicProjects/ruscker/releases).
 
 ```sh
-sudo apt install ./ruscker_<version>_amd64.deb
+# amd64
+sudo apt install ./ruscker_<version>-1_amd64.deb
+
+# arm64
+sudo apt install ./ruscker_<version>-1_arm64.deb
 ```
 
 This:
@@ -31,6 +36,22 @@ Edit `/etc/ruscker/application.yml`, put secrets in
 `/etc/ruscker/ruscker.env`, then `sudo systemctl restart ruscker`. See
 [Deploying in production](./deploying.md) to enable the `--docker`
 backend and put it behind nginx.
+
+## Static musl tarball
+
+For hosts without a package manager, or for quick installs without a
+systemd unit, download the static musl binary directly. Tarballs for
+**amd64** and **arm64** are on the
+[releases page](https://github.com/StrategicProjects/ruscker/releases).
+
+```sh
+tar -xzf ruscker-<version>-linux-amd64.tar.gz
+sudo install -m 755 ruscker-<version>-linux-amd64/ruscker /usr/local/bin/ruscker
+ruscker --version
+```
+
+The binary has no shared-library dependencies and runs on any
+glibc-free or glibc Linux system.
 
 ## Docker
 
@@ -79,10 +100,10 @@ cosign verify ghcr.io/strategicprojects/ruscker:<version> \
   --certificate-identity-regexp '^https://github.com/StrategicProjects/ruscker/' \
   --certificate-oidc-issuer https://token.actions.githubusercontent.com
 
-# A downloaded asset
-cosign verify-blob ruscker-linux-amd64.tar.gz \
-  --signature ruscker-linux-amd64.tar.gz.sig \
-  --certificate ruscker-linux-amd64.tar.gz.pem \
+# A downloaded asset (tarball or .deb)
+cosign verify-blob ruscker-<version>-linux-amd64.tar.gz \
+  --signature ruscker-<version>-linux-amd64.tar.gz.sig \
+  --certificate ruscker-<version>-linux-amd64.tar.gz.pem \
   --certificate-identity-regexp '^https://github.com/StrategicProjects/ruscker/' \
   --certificate-oidc-issuer https://token.actions.githubusercontent.com
 ```
@@ -94,6 +115,7 @@ The exact commands are also printed in each release's notes.
 ```text
 ruscker serve --config <path> [--bind 0.0.0.0:8080] [--docker]
               [--db <file>] [--images-dir <dir>] [--log-format json]
+              [--base-path <prefix>]
 ```
 
 | Flag | What it does |
@@ -104,6 +126,7 @@ ruscker serve --config <path> [--bind 0.0.0.0:8080] [--docker]
 | `--db` | SQLite file backing the admin panel. Without it, `/admin/*` is read-only-ish and the editor returns 503. |
 | `--images-dir` | Directory served at `/assets/img/`. Auto-discovered from the config / ShinyProxy `template-path` when omitted. |
 | `--log-format` | `text` (default) or `json`. |
+| `--base-path` | Mount the whole portal under a URL prefix (e.g. `--base-path /apps`). Overrides `server.context-path` in the YAML. Health probes (`/healthz`, `/readyz`) stay at the root. |
 
 Secrets come from the environment: `RUSCKER_ADMIN_TOKEN`,
 `RUSCKER_MASTER_KEY`, `RUSCKER_COOKIE_KEY`,

--- a/book/src/introduction.md
+++ b/book/src/introduction.md
@@ -5,13 +5,16 @@
 
 # Ruscker
 
-**Ruscker** is a lightweight Rust alternative to **ShinyProxy** and
-**Shiny Server Free**. It hosts and load-balances containerized
-interactive web apps — R/Shiny, Streamlit, Dash, Voilà — and stateless
-HTTP APIs (Plumber2, FastAPI) behind a single proxy, with a custom
-landing page and a real admin panel.
+**Ruscker** is a **portal and orchestrator** for containerized web
+workloads behind one proxy. It handles two shapes:
 
-It ships as a **single static binary, no JVM** — so the idle footprint
+- **Container-per-session** interactive apps — R/Shiny, Streamlit,
+  Dash, Voilà, Jupyter, RStudio.
+- **Container-per-API** stateless HTTP services — Plumber2, FastAPI.
+
+It keeps a ShinyProxy-compatible YAML schema for low-friction migration,
+ships as a **single static binary, no JVM**, and adds a real admin
+panel, a live monitoring dashboard, and load balancing. Idle footprint
 is megabytes, not hundreds of megabytes, and startup is instant.
 
 ## How it works
@@ -37,12 +40,11 @@ proper admin panel, a monitoring dashboard, and load balancing.
 
 ## In production
 
-Ruscker is on **v0.1.3** and runs in production today. Where the
+Ruscker is on **v0.1.31** and runs in production today. Where the
 JVM-based stack it replaced idled at hundreds of megabytes, Ruscker
 idles in the low tens:
 
-> **~540 MB → ~16 MB idle** — roughly a 30× cut, on the same machine
-> serving the same apps.
+> **~540 MB → ~16 MB idle** — roughly a 30× cut.
 
 A real 31-spec config migrated with **no unsupported features**, and
 apps spawn on demand. Releases are multi-arch and **cosign-signed**;
@@ -51,21 +53,32 @@ the [Roadmap](./roadmap.md) tracks what's shipped and what's next.
 ## What's in the box
 
 - **Reverse proxy + load balancer** with sticky sessions, WebSocket
-  forwarding, per-spec replica pools, an auto-scaler, and absolute-URL
-  rewriting so unmodified Shiny/Streamlit apps work behind a sub-path.
+  forwarding, per-spec replica pools, an auto-scaler, and URL rewriting
+  (a generalized runtime shim patches `fetch`, `XMLHttpRequest`,
+  `WebSocket`, `script.src`, `link.href`, and more) so unmodified apps
+  work behind a sub-path.
 - **Container backend** (Docker) that spawns app containers on demand,
-  applies per-container CPU/memory limits, and reaps idle ones.
-- **Admin panel** — apps CRUD, image/media library, encrypted
-  credentials store, landing-page editor (colors, intros, SEO, social
-  meta, analytics, custom HTML blocks), audit log, **user accounts with
+  applies per-container CPU/memory limits, and reaps idle ones. Per-spec
+  `container-env` and `container-cmd` let you configure notebook servers
+  (Jupyter, RStudio) without custom images.
+- **Admin panel** — apps CRUD with a full advanced form, a unified
+  media library (built-in logos, uploads, drag-and-drop, "in use"
+  badges), an encrypted credentials store (AES literal or `${VAR}`
+  env-ref, resolved only at pull time), a landing-page editor (colors,
+  intros, SEO, social meta, analytics, custom HTML blocks, header/footer
+  logos with alignment and links), audit log, **user accounts with
   Viewer / Editor / Admin roles**, and a live monitoring dashboard
-  (CPU/memory sparklines, live-follow logs, stop/restart).
-- **Operations**: `/healthz` + `/readyz` probes, graceful shutdown,
-  structured (JSON) logging, per-API rate limiting + CORS, request
-  body-size limits, and an opt-in Prometheus `/metrics` endpoint.
-- **Distribution**: a multi-arch Docker image, a Debian package with a
-  hardened `systemd` unit, static musl tarballs, a Homebrew tap, and
-  cosign-signed artifacts.
+  (CPU/memory, live-follow logs, stop/restart).
+- **Sub-path mounting**: serve the whole portal under a prefix via
+  `server.context-path` (ShinyProxy-compatible) or `--base-path`. Health
+  probes (`/healthz`, `/readyz`) stay at the root for load balancers.
+- **Operations**: graceful shutdown, structured (JSON) logging, per-API
+  rate limiting + CORS, request body-size limits, gzip/br compression,
+  immutable-versioned static assets, and an opt-in Prometheus `/metrics`
+  endpoint.
+- **Distribution**: a cosign-signed multi-arch container image
+  (`ghcr.io/strategicprojects/ruscker`), a Debian package with a
+  hardened `systemd` unit, static musl tarballs, and a Homebrew tap.
 
 ## Where to next
 

--- a/book/src/migrating.md
+++ b/book/src/migrating.md
@@ -13,9 +13,9 @@ ruscker validate --strict-compat application.yml # migration pre-flight
 ```
 
 `--strict-compat` lists every ShinyProxy feature your config uses that
-Ruscker does **not** honour (e.g. Kubernetes backend, per-spec
-`volumes`/`environment`, non-`none` authentication) and exits non-zero
-if it finds any. A clean run means a drop-in migration.
+Ruscker does **not** honour (e.g. Kubernetes backend, `minimum-seats-available`,
+non-`none` authentication) and exits non-zero if it finds any. A clean
+run means a drop-in migration.
 
 > In production, a real 31-spec ShinyProxy 3.2.0 config reported
 > **"no unsupported features"**.
@@ -24,7 +24,68 @@ The validator also flags **plaintext credentials** in the YAML — move
 any `docker-registry-password` to `${DOCKER_REGISTRY_PASSWORD}` and set
 the variable in the environment (or `/etc/ruscker/ruscker.env`).
 
-## 2. Card logos
+## 2. Credentials and env-var interpolation
+
+Any string value in `application.yml` can reference an environment
+variable with `${VAR}` or `${VAR:-default}`:
+
+```yaml
+docker-registry-password: ${DOCKER_REGISTRY_PASSWORD}
+```
+
+The literal `${VAR}` token is what gets stored (in the config file, the
+database, and exports) — it is resolved to the real value only when a
+container is actually spawned. This means registry passwords and
+per-spec `container-env` secrets **never land in the database**.
+
+For teams managing several apps that share a registry credential,
+Ruscker also has a **named credential store** in the admin panel.
+Store the credential there once, then reference it by name in the spec:
+
+```yaml
+- id: my_app
+  container-image: registry.example.com/team/app:latest
+  docker-registry-credential: my-registry-cred   # name from the store
+```
+
+When `docker-registry-credential` is set, it takes precedence over the
+inline `docker-registry-username` / `docker-registry-password` fields.
+The credential store accepts either an encrypted password or a pure
+`${VAR}` env-ref (resolved at pull time, not stored in cleartext).
+
+> The inline fields are still valid and kept for back-compat — use
+> whichever fits your workflow.
+
+## 3. Sub-path mounting (`context-path`)
+
+If you run Ruscker on a path prefix rather than a dedicated subdomain
+(e.g. `example.org/apps/` instead of `apps.example.org`), use
+`server.context-path`:
+
+```yaml
+server:
+  context-path: /apps    # normalized: leading slash, no trailing slash
+```
+
+ShinyProxy's nested form is also accepted without changes:
+
+```yaml
+server:
+  servlet.context-path: /apps
+```
+
+Or override it at startup with the CLI flag (wins over YAML):
+
+```sh
+ruscker serve --base-path /apps --config application.yml ...
+```
+
+The portal and admin routes are all mounted under the prefix; the
+health probes (`/healthz`, `/readyz`) stay at the root so your load
+balancer does not need to know the prefix. Your reverse proxy just
+needs to forward requests under the same path through to Ruscker.
+
+## 4. Card logos
 
 ShinyProxy serves card logos from its `template-path`'s `assets/img/`
 folder. When you run `serve` without `--images-dir`, Ruscker
@@ -35,7 +96,10 @@ auto-discovers them next to the config:
 
 So a config left in place finds its logos with no extra flags.
 
-## 3. Side-by-side cutover (recommended)
+You can also upload images through the admin **Media** panel and
+reference them by filename in the spec's `logo` field.
+
+## 5. Side-by-side cutover (recommended)
 
 You don't have to flip everything at once. A safe pattern (proven in
 production) keeps ShinyProxy reachable while Ruscker takes the root:
@@ -52,14 +116,31 @@ bookmarks keep working after the cutover.
 ## What Ruscker adds
 
 Beyond parity, you also get: a real admin panel (no more hand-editing
-YAML), a monitoring dashboard, per-API rate-limiting/CORS, health
-probes, graceful shutdown, and a tiny footprint. See
+YAML), a live monitoring dashboard, per-spec `container-env` /
+`container-cmd` injection, per-API rate-limiting and CORS, per-user
+and per-group app visibility, health probes, graceful shutdown, and a
+tiny footprint — idle memory drops from ~540 MB to ~16 MB. See
 [The admin panel](./admin.md).
 
 ## Not supported (yet)
 
-Authentication schemes other than `none`, the Kubernetes backend, and
-a few per-spec fields (`volumes`, `environment`, `labels`, …) are
-parsed but ignored — `validate --strict-compat` is the source of
-truth. For apps that handle their own auth (a common case), `none` is
-correct: Ruscker just routes traffic.
+Authentication schemes other than `none` and the Kubernetes backend
+are the main gaps — `validate --strict-compat` is the authoritative
+source of truth for your specific config. For apps that handle their
+own auth (a common case), `none` is correct: Ruscker just routes
+traffic.
+
+The following ShinyProxy per-spec fields are accepted by the parser
+but currently ignored:
+
+- `minimum-seats-available` — use `min-replicas` instead
+- `labels` — custom container labels (phase 3.5)
+- `network-connections` — container network wiring (phase 3.5)
+- `kubernetes-*` — Kubernetes backend
+
+Fields that **are** now fully supported (and no longer flagged by
+`--strict-compat`): `volumes`, `container-env`, `container-cmd`,
+`port` (maps to `container-port`), and the scaling and lifecycle knobs
+`scale-up-threshold`, `scale-down-threshold`, `scale-down-grace`,
+`max-lifetime`, `container-lifetime`, `drain-timeout`,
+`stop-on-logout`, and `concurrent-requests-per-replica`.

--- a/book/src/news.md
+++ b/book/src/news.md
@@ -9,6 +9,104 @@ the [GitHub releases page](https://github.com/StrategicProjects/ruscker/releases
 
 ---
 
+## v0.1.18–v0.1.31 — 2026-05-31
+
+Demo images, credential unification, a redesigned media library, and portal logo support.
+
+**Demo app images**
+- **Dash**, **FastAPI**, and **Quarto** showcase cards now use dedicated
+  fork images on Docker Hub (`milkway/ruscker-dash-demo`,
+  `milkway/ruscker-fastapi-demo`, `milkway/ruscker-quarto-demo`).
+  Dash and FastAPI serve at the container root (no
+  `SHINYPROXY_PUBLIC_PATH` configuration needed). The Quarto demo is a
+  static nginx image (~67 MB).
+
+**Credentials store**
+- The named-credential store now accepts a **pure `${VAR}` env-ref** as
+  a password (stored verbatim, resolved only at pull time), in addition
+  to the existing AES-encrypted literal. "Pure" means a whole-token
+  `${VAR}` — a value with a literal prefix like `prefix${VAR}` is not
+  stored verbatim; it is treated as a literal and AES-encrypted (security
+  fix).
+- The spec-form Registry section is now a **credential picker**; the
+  inline domain/user/password fields are hidden back-compat fallbacks.
+
+**Media library**
+- Built-in logos are **seeded into the Media library** on first start
+  (idempotent) — one unified gallery, no separate "Built-in logos"
+  group. Each logo is **deletable** and shows an **"in use" badge**
+  (cross-references spec logo/cover and landing logos).
+- A **modal picker** in the spec form provides search, uploads, and
+  inline upload without leaving the form; drag-and-drop is supported on
+  both the modal and the media page.
+
+**Portal header/footer logos**
+- The landing editor supports logos in the **header and footer slots**,
+  each with alignment (left/center/right), an optional click-through
+  link, and a per-logo height.
+
+**Security fixes**
+- Username charset and credential-name charset are now validated,
+  making credentials safely deletable.
+- Admin password fields in the spec and user forms are now
+  **masked / write-only**.
+
+**Proxy**
+- API requests (kind `Api`) are now routed by **in-flight request
+  count** instead of seat count, and the in-flight guard spans the
+  full streaming response body.
+
+---
+
+## v0.1.4–v0.1.17 — 2026-05-29
+
+Live UX fixes, security hardening, and a performance pass.
+
+**Live UX fixes**
+- **Cold-start splash**: a loading screen appears on first navigation to
+  an app while its container is starting.
+- **RStudio Server**: the proxy injects the `X-RStudio-Root-Path` header
+  so RStudio rewrites its own internal links correctly behind the mount.
+- **`App` kind** added for notebook-style apps (Jupyter, RStudio) that
+  don't fit the Shiny or plain API model.
+- Relative font URLs fixed so icons resolve correctly when served under
+  a sub-path.
+- Alpine.js CSP flag corrected (`'unsafe-eval'`) so popovers and dynamic
+  filters work.
+- Version number shown in the admin footer.
+- The admin **Blocks editor** is folded into the Portal settings page.
+
+**Security hardening**
+- Ruscker's own session cookies are stripped before forwarding requests
+  to app containers — the admin session no longer leaks upstream.
+- CSRF guard (Fetch-Metadata / Origin check) on all chrome-mutating
+  actions.
+- `${VAR}` secrets in `container-env` and registry passwords are
+  preserved verbatim through import/export and resolved only at spawn
+  or pull time — they never appear in cleartext in the database.
+- Container log access is gated to Editor-and-above accounts.
+
+**Performance**
+- **gzip / Brotli compression** on all HTML, CSS, and JS chrome
+  responses.
+- **`?v={version}`** appended to bundled CSS/JS URLs for
+  cache-busting on upgrade.
+- **ETag** validation on `/assets/img` image responses — revalidation
+  returns a cheap 304.
+- **WebP thumbnails** in media galleries.
+- Configurable **`proxy.metrics-interval`** (seconds) for dashboard
+  stats polling; Docker stats fan-out is now bounded.
+- Dashboard snapshot is memoized per locale across SSE tabs; the SSE
+  patcher updates individual cells instead of replacing whole rows.
+
+**Admin**
+- Spec editing is now fully gated: specs that exist only in YAML (not
+  the database) are shown read-only in `/admin/specs`.
+- The media gallery at `/admin/media` is a client-side Alpine page with
+  filename search and paginated "show more" (24 per page).
+
+---
+
 ## v0.1.3 — 2026-05-29
 
 Admin & UX polish, plus proxy fixes that unlock notebook-style apps.
@@ -51,7 +149,7 @@ Admin & UX polish, plus proxy fixes that unlock notebook-style apps.
 High-availability / multi-host hardening and sub-path mounting.
 
 - **Mount under a sub-path.** `server.context-path` (ShinyProxy-
-  compatible) or the `--base-path /box` flag serves the whole portal
+  compatible) or the `--base-path /portal` flag serves the whole portal
   under a prefix, for reverse proxies that can't give Ruscker its own
   subdomain. Health probes stay at the root for load balancers.
 - **Fully-public portals** can hide the sign-in entrance with

--- a/book/src/quickstart.md
+++ b/book/src/quickstart.md
@@ -52,7 +52,15 @@ ruscker serve --config application.yml --bind 127.0.0.1:8080 \
   --docker --db ruscker.db
 ```
 
-Prefer the container image? Mount your config and the Docker socket:
+On first boot with `--db`, Ruscker seeds 13 showcase cards into the
+portal automatically — one live demo per supported framework (Shiny,
+Streamlit, Dash, Voilà, Jupyter, RStudio, …) plus external links for
+the rest. The seed is idempotent; cards you delete stay deleted on
+subsequent boots. Framework logos are also seeded into the Media
+library so they appear in the image picker alongside your own uploads.
+
+Prefer the container image? Mount your config and the Docker socket
+(the image is cosign-signed; `:latest` tracks the current release):
 
 ```sh
 docker run --rm -p 8080:8080 \
@@ -72,19 +80,27 @@ docker run --rm -p 8080:8080 \
 | <http://127.0.0.1:8080/healthz> | liveness (always `200`) |
 
 The first request to `/app/hello/` spawns a container on demand; it's
-reaped automatically once idle. Refresh the [admin dashboard](./admin.md)
-to watch the replica start, serve, and stop.
+reaped automatically once idle.
 
 ## What just happened
 
 Ruscker rendered the landing page from your config, and on the first
 request to the app it asked Docker to start `traefik/whoami`, routed you
-to it, and will reap it when idle. For a real interactive app (Shiny,
-Streamlit, Dash, Voilà) the model is the same — Ruscker adds sticky
-sessions and WebSocket forwarding automatically. See
-[What Ruscker can serve](./use-cases.md) for the framework list and
-[Configuration](./configuration.md) for every spec field (replica pools,
-CPU/memory limits, registry credentials, routing, rate limits…).
+to it, and will reap it when idle. For a real interactive app — Shiny,
+Streamlit, Dash, Voilà, Jupyter, RStudio — the model is the same:
+Ruscker adds sticky sessions and WebSocket forwarding automatically.
+For stateless APIs (Plumber2, FastAPI) it load-balances across replicas
+with no sticky overhead.
+
+If you started with `--db`, the landing page already shows the seeded
+showcase cards. Click any live-demo card to see on-demand container
+spawn in action, then watch the [admin dashboard](./admin.md) to see
+the replica start, serve, and stop.
+
+See [What Ruscker can serve](./use-cases.md) for the full framework
+list and [Configuration](./configuration.md) for every spec field
+(replica pools, CPU/memory limits, registry credentials, routing, rate
+limits…).
 
 ## Next steps
 
@@ -101,4 +117,4 @@ CPU/memory limits, registry credentials, routing, rate limits…).
 - [Troubleshooting](./troubleshooting.md) — when an app won't load.
 
 [base-path]: ./deploying.md#4b-mounting-under-a-base-path-subpath
-[ha-sticky]: ./deploying.md#sticky-upstream-for-the-sign-in-session-admin-app-api
+[ha-sticky]: ./deploying.md#shared-admin-sessions-eliminate-the-sticky-upstream-caveat

--- a/book/src/roadmap.md
+++ b/book/src/roadmap.md
@@ -1,11 +1,11 @@
 # Roadmap
 
-Ruscker is at **v0.1.3** — Phases 0 through 7 are done and the proxy is
+Ruscker is at **v0.1.31** — Phases 0 through 7 are done and the proxy is
 production-ready and horizontally scalable. Phase 8 (external auth) is
 the main optional, demand-driven work left. For what changed in each
 release, see the [release notes](./news.md).
 
-![Roadmap timeline: phases 0–7 are done — 0 to 5 shipped in v0.1.0 (scaffolding, landing page, persistence + admin CRUD, proxy + Docker backend, monitoring dashboard, production polish); phase 6 (multi-host scheduling, app visibility, sub-path mounting) across v0.1.1–v0.1.2; phase 7 (HA / multi-instance) in v0.1.1. The latest release v0.1.3 adds admin/UX + proxy polish. Phase 8 (external auth) is planned and optional.](images/roadmap.svg)
+![Roadmap timeline: phases 0–7 are done — 0 to 5 shipped in v0.1.0 (scaffolding, landing page, persistence + admin CRUD, proxy + Docker backend, monitoring dashboard, production polish); phase 6 (multi-host scheduling, app visibility, sub-path mounting) across v0.1.1–v0.1.2; phase 7 (HA / multi-instance) in v0.1.1. The latest release v0.1.31 adds demo forks, URL-rewrite modernization, unified credentials, media library, portal logos, and security + perf fixes. Phase 8 (external auth) is planned and optional.](images/roadmap.svg)
 
 ## Shipped
 
@@ -70,6 +70,51 @@ instances behind an L4 load balancer can share state and any instance
 can serve any session; one scaler leader via Postgres advisory locks,
 with failover. A runnable 2-instance compose harness lives in
 `examples/ha/`. See [Deployment shapes](./architecture.md#deployment-shapes).
+
+### Post-phase polish → **v0.1.4 – v0.1.31**
+
+Incremental improvements shipped after Phase 7.
+
+**Demo app images.** The Dash, FastAPI, and Quarto showcase cards now
+point to dedicated **`milkway/ruscker-*-demo`** images on Docker Hub.
+The Quarto demo is a static nginx image (~67 MB); Dash and FastAPI serve
+at the root without needing `SHINYPROXY_PUBLIC_PATH`. Demo forks for
+Shiny, Streamlit, and Voilà are **backlog** — those cards still point to
+upstream images.
+
+**URL-rewrite modernization.** The runtime shim that rewrites relative
+asset paths under `/app/{id}/` is now generalized to patch
+`script.src`, `link.href`, `img.src`, and `setAttribute`, which retired
+the Voilà-specific rewriter. The Jupyter-config rewriter (`rewrite_jupyter_config`)
+is kept: JupyterLab builds absolute same-origin API URLs from
+`PageConfig.baseUrl` that a root-relative shim cannot intercept. A
+full absolute-URL Path B rewrite (handling apps that hard-code
+`window.location.origin`) is **deferred** — the current shim covers all
+validated app types.
+
+**Credentials.** The named-credential store now accepts a pure
+`${VAR}` env-ref in addition to an AES-256-GCM literal, resolved only
+at container pull time. The spec form's Registry section is now a
+credential picker; inline domain/user/password fields remain as
+back-compat.
+
+**Media library.** Built-in logos are seeded into the unified media
+library (deletable, with an "in use" badge). The spec-form image picker
+supports inline upload. Gallery pages are paginated with search.
+
+**Portal logos.** The landing editor supports per-slot logos (header /
+footer) with alignment (left / center / right), an optional link, and a
+per-logo height.
+
+**Performance.** gzip/br compression on admin and landing responses;
+`?v=<version>` immutable cache headers on bundled CSS/JS; ETag on media
+assets; WebP thumbnails; bounded Docker stats fan-out with a
+configurable `metrics-interval`.
+
+**Security fixes.** API routing uses in-flight count (not seats);
+charset validation on usernames and credential names; admin password
+fields are write-only in the UI; `${VAR}` resolution returns an error
+when the variable is unset (names the missing variable).
 
 ## Planned (optional)
 

--- a/book/src/troubleshooting.md
+++ b/book/src/troubleshooting.md
@@ -34,9 +34,25 @@ reinstall**, not just editing files on the server:
 `sudo dpkg -i --force-confold ruscker_<version>_amd64.deb && sudo
 systemctl restart ruscker`.
 
-## `413 Payload Too Large` on an upload
-A `max-body-size` cap is in effect (global `proxy.max-body-size` or a
-per-spec override). Raise it for that spec or globally.
+## `413 Payload Too Large` on a Media upload
+There are two independent size limits in the upload path; the **nginx
+limit fires first** and is the more common culprit.
+
+**nginx (most common).** nginx's default `client_max_body_size` is 1 MB.
+Any upload larger than that is rejected by nginx before Ruscker even sees
+the request — the admin shows a generic "upload doesn't work" failure with
+no obvious error. Ruscker itself accepts up to 12 MB for media uploads.
+Set a higher limit in your nginx server block:
+
+```nginx
+client_max_body_size 16m;
+```
+
+See the full nginx snippet in [Deploying](./deploying.md).
+
+**Ruscker `proxy.max-body-size`.** A separate cap applies to requests
+forwarded to app containers. If a specific API spec rejects large POSTs
+with 413, raise `proxy.max-body-size` globally or as a per-spec override.
 
 ## `429 Too Many Requests` from an API
 The spec's `api.rate-limit` is throttling the caller. The `Retry-After`
@@ -83,11 +99,72 @@ buffers the response will hold the stream back. Disable buffering for
 `/admin/dashboard/events` — see the nginx note in
 [Deploying](./deploying.md).
 
+## The favicon doesn't appear in Safari (or shows a stale icon)
+Safari caches favicons aggressively and sometimes keeps serving a stale
+or broken icon long after you upgrade Ruscker. To force a refresh:
+
+1. In Safari, go to **Settings → Advanced** and enable the **Develop**
+   menu.
+2. Open **Develop → Empty Caches**, then reload the page.
+3. If that isn't enough, close all tabs pointing at the site and reopen
+   them.
+
+For iOS Safari, a full Safari data clear (**Settings → Safari → Clear
+History and Website Data**) removes the icon cache.
+
+This is a browser-side caching behaviour, not a Ruscker bug. The favicon
+markup was hardened in v0.1.18 (the `sizes="any"` attribute that confused
+Safari's icon selection was removed).
+
 ## `docker pull ghcr.io/strategicprojects/ruscker` is denied
 A freshly-published image package starts **private**. Either make the
 package public (Packages → the package → *Package settings* →
 visibility), or authenticate: `docker login ghcr.io` with a token that
 has `read:packages`.
+
+## Jupyter or Voilà loads a blank page / 404s on assets
+Ruscker uses a **strip model**: `/app/{id}` is stripped from the request
+path before forwarding, so the container always sees a root-relative path.
+The proxy injects a `<base href>`, rewrites static URLs in HTML responses,
+and patches runtime JavaScript via a shim — most apps (Shiny, Streamlit,
+Dash, Voilà) need no special configuration.
+
+**Voilà** — no special setup is required; the generalized runtime shim
+handles Voilà's RequireJS bootstrap.
+
+**JupyterLab / Jupyter Notebook** — the proxy also rewrites the
+`jupyter-config-data` JSON block (where Lab stores `baseUrl`,
+`fullStaticUrl`, and related paths) so the browser loads its chunks from
+under the mount. Because Ruscker strips the mount prefix before
+forwarding, the container should serve at **root** (`base_url=/`) and let
+the proxy do the prefixing. Configure the spec like this:
+
+```yaml
+- id: jupyter
+  container-image: quay.io/jupyter/minimal-notebook:latest
+  container-port: 8888
+  container-cmd:
+    - start-notebook.py
+    - --IdentityProvider.token=
+    - --ServerApp.allow_origin=*
+    - --ServerApp.base_url=/
+```
+
+`--IdentityProvider.token=` disables the login token so the proxy can
+forward requests without authentication, and `--ServerApp.allow_origin=*`
+lets the kernel WebSocket connect. Do **not** set
+`--ServerApp.base_url=#{publicPath}`: under Ruscker's strip model the
+container never sees the mount prefix, so a non-root `base_url` makes
+Jupyter 404 every path.
+
+**Do not set `SHINYPROXY_PUBLIC_PATH`** in `container-env` either. That
+variable is a ShinyProxy convention; Ruscker does not use it, and if a
+container reads it to self-prefix URLs it will 404 on every request.
+
+If assets still 404 after configuring the above, check
+`docker logs <ruscker-container-id>` for startup errors and verify the
+image's server is listening on the port you set in `container-port`
+(Jupyter uses 8888; the Ruscker default is 3838, the Shiny Server port).
 
 ## Inspecting what's running
 ```sh

--- a/book/src/use-cases.md
+++ b/book/src/use-cases.md
@@ -12,11 +12,53 @@ Each app becomes a card on the landing page and a route under
 spawning, sticky sessions, WebSocket upgrades, URL rewriting, load
 balancing, and reaping idle containers.
 
+## Showcase demos
+
+A fresh Ruscker install seeds 13 demo cards automatically. Three of them
+use own-fork images published on Docker Hub; the rest link to official
+docs or use well-known public images:
+
+| Card | Image | Notes |
+|---|---|---|
+| Shiny | `openanalytics/shinyproxy-demo:latest` | R Shiny demo app, port 3838 |
+| Shiny for Python | `openanalytics/shinyproxy-shiny-for-python-demo:latest` | Python, port 8080 |
+| Jupyter | `quay.io/jupyter/minimal-notebook:latest` | token-less, `base_url=/` |
+| RStudio Server | `rocker/rstudio:latest` | per-session IDE, port 8787 |
+| R Markdown | `openanalytics/shinyproxy-rmarkdown-demo:latest` | Shiny backend, port 3838 |
+| Streamlit | `openanalytics/shinyproxy-streamlit-demo:latest` | port 8501 |
+| **Dash** | **`milkway/ruscker-dash-demo:latest`** | our fork — serves at root, no env quirks; multi-arch |
+| **Quarto** | **`milkway/ruscker-quarto-demo:latest`** | our fork — pre-rendered static HTML on nginx (~67 MB vs ~430 MB) |
+| **FastAPI** | **`milkway/ruscker-fastapi-demo:latest`** | our fork — stateless API kind; multi-arch |
+| Voilà | `openanalytics/shinyproxy-voila-demo:latest` | Jupyter notebooks as apps |
+| Bokeh | *(external link)* | docs card, no container |
+| Plumber | *(external link)* | docs card, no container |
+| Ruscker | *(external link)* | docs card, no container |
+
+The three own-fork images (`milkway/ruscker-dash-demo`, `milkway/ruscker-fastapi-demo`,
+`milkway/ruscker-quarto-demo`) are the reference for "how to make a Ruscker-ready
+container": they serve at root, ship no `SHINYPROXY_PUBLIC_PATH` dependency,
+and the Dash/FastAPI forks are multi-arch (amd64 + arm64).
+
+Seeding is idempotent — it only runs once per database. If you delete a
+showcase card, it stays gone on subsequent restarts.
+
 ## Interactive, stateful apps
 
-State lives on the server and the client holds a reactive WebSocket —
-the Shiny model. These need **sticky sessions + WebSocket forwarding**,
-which Ruscker does by default.
+There are two interactive spec kinds in Ruscker:
+
+- **`shiny`** — the Shiny model: state on the server, a reactive WebSocket
+  connection per session. Sticky sessions and WebSocket forwarding are
+  on by default. Covers R Shiny and Shiny for Python.
+- **`app`** (interactive app) — same sticky-session + WebSocket behavior,
+  but for apps that aren't Shiny specifically: Streamlit, Dash, Voilà,
+  JupyterLab, RStudio Server, and similar. Use `type: app` in your spec
+  (or Ruscker infers it from well-known `type:` values like `streamlit`,
+  `dash`, `voila`).
+
+Both kinds give each session its own container slot and forward WebSocket
+upgrades transparently.
+
+Supported frameworks:
 
 - **R** — Shiny (the reference case), Quarto Live, `flexdashboard` with
   `runtime: shiny`.
@@ -53,7 +95,8 @@ benefit from per-spec replica limits.
 Each user gets an isolated container — the JupyterHub pattern, with
 Ruscker's portal and admin on top.
 
-- JupyterLab / Jupyter Notebook, RStudio Server, `code-server` (VS Code
+- JupyterLab / Jupyter Notebook (included in the showcase seed),
+  RStudio Server (included in the showcase seed), `code-server` (VS Code
   in the browser), Theia, Marimo Lab.
 
 ## BI and data exploration
@@ -102,7 +145,7 @@ Surface a DB console as just another card on the portal.
 
 ## Who it's for
 
-- **Governments, universities and research centers** publishing analytics
+- **Public sector, universities and research centers** publishing analytics
   dashboards for the public or for staff.
 - **BI and data-science teams** that want to ship R/Shiny and
   Python/Streamlit apps without standing up a Kubernetes cluster.

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -8,7 +8,7 @@ how the pieces fit together.
 
 ![How Ruscker works: browsers and API clients hit a single Ruscker binary, which serves the landing page + admin and reverse-proxies to app containers it spawns on demand via the Docker daemon.](images/architecture.svg)
 
-All of this is a single Rust process — one static binary, ~14 MB idle,
+All of this is a single Rust process — one static binary, ~16 MB idle,
 no JVM. Visitors and API clients reach it on one port; it serves the
 landing page and admin UI, reverse-proxies `/app/{spec}` and
 `/api/{spec}` to the right replica (keeping Shiny sessions sticky and
@@ -61,10 +61,88 @@ impl, not a rewrite — see [Deployment shapes](#deployment-shapes) and
 ```
 1. Client hits  https://portal/api/data-api/v1/data
 2. Spec.kind() == Api  → no sticky cookie path
-3. Router.pick() with RoundRobin → R3
-4. Forward request, stream response
-5. No state, no follow-up — done.
+3. Router.pick() balances by in-flight request count → R3
+4. Bump R3's in-flight gauge, forward request, stream response
+5. In-flight gauge drops only after the full body has streamed out
+6. No session state, no follow-up — done.
 ```
+
+An `Api` spec has no sticky sessions, so its replicas have no seat
+notion to balance on. Instead the proxy keeps a per-replica **in-flight
+request gauge** (`routes::proxy::INFLIGHT`, a process-global `DashMap`)
+and least-connections routing picks the replica with the **fewest
+in-flight requests**, not the most free seats. An RAII
+`routes::proxy::InflightGuard` bumps the gauge when the forward starts;
+crucially it is **moved into the streaming response body**, so it only
+drops once the whole (possibly long) download has been sent to the
+client — a large file transfer keeps counting against the replica for
+its full duration, and the scaler sees real concurrency rather than a
+spike that vanishes the instant headers are written.
+
+### Proxying an app under `/app/{spec}/` — the strip-and-rewrite model
+
+A containerised app expects to live at the host root: it emits
+`/lib/jquery.js`, opens `WebSocket('/websocket')`, redirects to `/lab`.
+Ruscker serves it from a sub-path (`/app/sales-dashboard/`). Two halves
+reconcile that gap.
+
+**On the way in, the proxy *strips* the mount prefix.** `forward()`
+matches `/app/{spec}/{*rest}` and forwards only the `*rest` portion to
+the container, so a request for `/app/sales-dashboard/lib/x` reaches the
+upstream as `/lib/x` — the container believes it is at the root and
+never has to know its public path. (This is the opposite of ShinyProxy's
+no-strip model; apps should be configured to serve at root, not to
+self-prefix.) The proxy also stamps `X-Forwarded-Prefix` /
+`X-Script-Name` / `X-RStudio-Root-Path` with the public mount so apps
+that *do* build their own absolute URLs (RStudio, Jupyter) emit correct
+links — see `routes::proxy::apply_smart_routing_headers`.
+
+**On the way out, the proxy *rewrites* the response so the browser sends
+follow-up requests back under the mount.** This lives in
+`routes::rewrite` (`inject_base_href`) and runs only on the
+`/app/` route family, only for HTML responses:
+
+- **`<base href="/app/{spec}/">`** is injected at the top of `<head>`,
+  so relative URLs (`foo.css`, `./img/x.png`) resolve under the mount.
+- **Root-absolute attribute URLs** (`<script src="/lib/x">`,
+  `<link href="/...">`, `<form action="/...">`, …) are prefixed with the
+  mount via a streaming `lol_html` pass over a narrow selector set. A
+  skip-list (`/admin/`, `/assets/`, `/app/`, …) avoids double-prefixing
+  Ruscker's own chrome; notably `/api/` is **not** skipped, because under
+  the mount it is the *app's* own namespace (Jupyter's REST + kernel
+  WebSocket live there).
+- **A runtime JS shim** is prepended before any page script. It
+  monkey-patches `fetch`, `XMLHttpRequest.open`, and `WebSocket` to
+  prefix absolute paths built at runtime. The shim was **generalized**
+  to also patch the resource-loading property setters
+  `HTMLScriptElement.prototype.src`,
+  `HTMLLinkElement.prototype.href`, and `HTMLImageElement.prototype.src`
+  (plus `iframe`/`audio`/`video`/`source` and `Element.setAttribute`).
+  Those are the browser's *own* fetches — never visible to the fetch/XHR
+  wrappers — so patching them covers RequireJS/webpack chunk loading and
+  runtime-set images generically.
+- **A redirect `Location` header** that points at a root-absolute path
+  (an app's `302 → /lab`) is prefixed the same way, so the redirect stays
+  inside the app instead of escaping to a Ruscker 404.
+
+The generalized shim **retired the old Voilà-specific rewrite**: Voilà's
+RequireJS bootstrap assigns its static URLs to `script.src` at runtime,
+which the patched `src` setter now prefixes without a bespoke pass.
+
+**JupyterLab is the one app that still needs a special case**
+(`rewrite::rewrite_jupyter_config`). Lab is served with `base_url=/` and
+reports `baseUrl: "/"` in its `jupyter-config-data` JSON; its bootstrap
+then builds **absolute, same-origin** API and static URLs from that
+config and injects `<script src=…>` for its lazy chunks. Because those
+URLs are absolute strings baked into a config object — not relative paths
+the browser resolves against `<base href>`, and not paths a root-relative
+shim can intercept — Ruscker rewrites the `baseUrl` and `full*Url` fields
+of that JSON to carry the mount before the HTML pass.
+
+The base-path mount (Ruscker itself served under, e.g., `/apps`) is the
+inverse rewrite and is handled separately: templates emit `{{ base }}`-
+prefixed URLs directly, so the chrome no longer needs a per-request body
+rewrite — only the redirect `Location` header (`prefix_base_path`).
 
 ## Module boundaries
 
@@ -150,7 +228,7 @@ for git versioning, but the running config lives in SQLite.
 
 ## Deployment shapes
 
-![Two deployment shapes. Single-node (today): a reverse proxy in front of one Ruscker driving the local Docker daemon and its app containers. Multi-node HA (planned, Phase 7): an L4 load balancer fans to two Ruscker instances sharing session state in Postgres, scheduling onto Docker Swarm or Kubernetes.](images/deployment.svg)
+![Two deployment shapes. Single-node (default): a reverse proxy in front of one Ruscker driving the local Docker daemon and its app containers. Multi-node HA (active-active): an L4 load balancer fans to two Ruscker instances sharing config and session state in Postgres, with one scaler leader at a time.](images/deployment.svg)
 
 ### Single-node (default)
 
@@ -158,13 +236,17 @@ A reverse proxy terminates TLS in front of a single Ruscker, which
 talks to the local Docker daemon over its socket. This is what 99% of
 installs run — simple, fast, easy to operate.
 
-### Multi-node HA (planned — Phase 7)
+### Multi-node HA (active-active, since Phase 7)
 
-Two Ruscker instances behind an L4 load balancer share session state in
-Postgres, so either can serve any session, and schedule onto a
-multi-host backend (Phase 6). Tracked on the Roadmap (Phases 6–7); the
-`ContainerBackend` / `SessionStore` traits already leave room for it
-without touching proxy code.
+Two or more Ruscker instances behind an L4 load balancer share a Postgres
+config catalog and session store, so either can serve any session.
+Exactly one instance holds the scaler leadership at a time via a Postgres
+advisory lock; standbys serve traffic and reconcile counts but skip the
+spawn/reap loop. The sticky cookie is an HMAC over a shared key, so any
+instance can validate any other's cookie. The `ContainerBackend` /
+`SessionStore` traits leave room for a multi-host or Kubernetes backend
+without touching proxy code. See the deployment guide's
+"Running active-active" section for the runnable example.
 
 ## What's not covered here
 

--- a/docs/SECURITY.md
+++ b/docs/SECURITY.md
@@ -5,10 +5,10 @@ Status: living document. Tracks the Phase 5 security audit
 **[accepted limitation]**, or **[deferred]**. File references use
 `crate/path:symbol` so they survive line-number drift.
 
-> **Scope.** This covers the MVP (v0.1.0): single-operator
-> install, Ruscker behind a TLS-terminating reverse proxy, Docker
-> on the same host. Multi-tenant / shared-team auth (OIDC, RBAC)
-> is out of scope until Phase 8.
+> **Scope.** This covers v0.1.31: single-operator install, Ruscker
+> behind a TLS-terminating reverse proxy, Docker on the same host.
+> Multi-tenant / shared-team auth (OIDC, RBAC) is out of scope until
+> Phase 8.
 
 ---
 
@@ -94,6 +94,23 @@ Status: living document. Tracks the Phase 5 security audit
   remaining admin. Audit entries record the acting username (or
   `token` for a break-glass session). Per-app ACLs and external IdPs
   (OIDC/SAML/LDAP) remain Phase 8.
+- **[implemented]** Identifier charset validation (#429 / #423) — a
+  username (`db::users::is_valid_username`) and a stored-credential name
+  (`routes::admin::credentials::is_valid_credential_name`) must be
+  non-empty and made only of identifier-ish chars (letters, digits,
+  `_ . -`, plus `@` for e-mail logins). Both land **un-encoded** in a
+  per-resource admin action URL path segment
+  (`/admin/users/{username}/...`, `/admin/credentials/{name}/delete`), so
+  a `/`, `?`, `#`, or space would make the account/credential impossible
+  to edit or delete from the UI — the validation keeps every row
+  manageable (and therefore deletable). Rejected → the form re-renders
+  with an error, no row written.
+- **[implemented]** Password fields are **write-only** in the admin
+  forms (#430) — the user form and the spec-form Registry section never
+  pre-fill or render a stored password; a blank field keeps the existing
+  value, and the input is masked so a shoulder-surfer can't read a
+  freshly-typed secret. Server-side, a blank password on edit is a no-op,
+  not a wipe.
 - **[implemented]** Bind-mount **`volumes` are Admin-only** (#302). A
   spec's `volumes` map to Docker `HostConfig.binds` — i.e. host
   filesystem / `docker.sock` access — so an Editor (who can otherwise
@@ -111,6 +128,19 @@ Status: living document. Tracks the Phase 5 security audit
   AES-256-GCM — `crypto::MasterKey::{encrypt,decrypt}`. A fresh
   random nonce per encryption, stored alongside the ciphertext;
   never reused (new nonce on every `upsert`).
+- **[implemented]** Unified credential store, two storage modes (#351) —
+  `db::credentials::upsert` accepts **either** a literal password
+  (AES-256-GCM at rest, as above) **or** a pure `${VAR}` env-ref (stored
+  **verbatim**, never encrypted, flagged by an empty nonce — a real GCM
+  nonce is 12 bytes, never empty — and resolved from the environment only
+  at pull time). The env-ref branch is gated on
+  `ruscker_config::env::is_pure_env_ref`: the value must consist
+  **entirely** of valid `${VAR}` / `${VAR:-default}` tokens (whole-token
+  only). A value with any literal text — e.g. `prefix${VAR}` or a
+  malformed `abc${def` — is **not** kept verbatim; it's treated as a
+  literal secret and AES-encrypted. This is the #422 fix: a loose
+  `contains("${")` test would have stored such a literal in cleartext at
+  rest. Either way the DB never holds resolved cleartext.
 - **[implemented]** Master key held in `Zeroizing<[u8; 32]>`
   inside an `Arc` — wiped on last drop. Cookie key likewise
   (`ruscker_proxy::sticky::CookieKey`).
@@ -125,8 +155,10 @@ Status: living document. Tracks the Phase 5 security audit
   the resolved secret never lands in the config DB or an export. The
   admin spec form treats the password as **write-only** — never
   pre-filled or rendered; a blank field keeps the stored value.
-  `docker-registry-credential` (the AES-encrypted store) is preferred
-  for new flows. **`container-env` values** get the same treatment
+  `docker-registry-credential` (the named store — AES literal **or** a
+  verbatim `${VAR}` env-ref, see above) is preferred for new flows; the
+  spec-form Registry section is now just the picker for a stored
+  credential. **`container-env` values** get the same treatment
   (#272): a `${VAR}` in a `container-env` value is preserved literal at
   parse and resolved only at spawn (`Spec::resolved_env_pairs`), so an
   app secret passed via `${VAR}` never lands in the DB either. A missing
@@ -284,7 +316,7 @@ Status: living document. Tracks the Phase 5 security audit
 Minimal Caddy:
 
 ```caddy
-portal.example.gov.br {
+portal.example.org {
     reverse_proxy 127.0.0.1:8080 {
         header_up X-Forwarded-Proto {scheme}
     }
@@ -296,7 +328,7 @@ Minimal nginx:
 ```nginx
 server {
     listen 443 ssl;
-    server_name portal.example.gov.br;
+    server_name portal.example.org;
     # ssl_certificate ... ssl_certificate_key ...;
     location / {
         proxy_pass http://127.0.0.1:8080;

--- a/docs/YAML_SCHEMA.md
+++ b/docs/YAML_SCHEMA.md
@@ -28,9 +28,9 @@ server:
   servlet:
     session:
       timeout: 3600
-  context-path: /box                  # Mount portal under a subpath (see below)
+  context-path: /apps                  # Mount portal under a subpath (see below)
   # ShinyProxy's nested form is also accepted:
-  servlet.context-path: /box
+  servlet.context-path: /apps
 ```
 
 Resolved via `Server::session_timeout_secs()` — either form works.
@@ -38,10 +38,10 @@ Resolved via `Server::session_timeout_secs()` — either form works.
 ### `server.context-path` — subpath mounting
 
 Serves the whole portal under a URL prefix when you can't dedicate a
-subdomain (e.g. `example.org/box/` instead of `box.example.org/`).
+subdomain (e.g. `example.org/apps/` instead of `box.example.org/`).
 Normalized form: leading slash, no trailing slash (`"box"`,
-`"/box/"`, and `"/box"` all become `/box`). The CLI flag
-`--base-path /box` overrides the YAML.
+`"/apps/"`, and `"/apps"` all become `/apps`). The CLI flag
+`--base-path /apps` overrides the YAML.
 
 ShinyProxy emits this as `server.servlet.context-path`; the flat
 `server.context-path` form is also accepted. Empty / absent ⇒ served
@@ -172,6 +172,18 @@ proxy:
               data-domain="example.org"></script>
     analytics-origins: "https://plausible.io"   # space-separated; widens landing CSP
 
+    # Operator CSS — injected as a <style> late in the landing <head>,
+    # so it can override the built-in styles
+    custom-css: ".rk-card { border-radius: 0; }"
+
+    # Header / footer logos (admin-managed in the live editor; see below)
+    logos:
+      - url: /assets/img/org-mark.png   # uploaded, built-in, or absolute URL
+        slot: header                    # `header` | `footer`
+        align: left                     # `left` | `center` | `right`
+        link: https://org.example       # optional click-through
+        height: 40                      # render height in px
+
     # Sign-in visibility (anonymous viewers only)
     show-admin-link: true              # default true; false hides the entrance
 
@@ -197,8 +209,20 @@ Field reference:
 | `og-image` | path / URL | none | `og:image` for social-share. |
 | `analytics-html` | string | none | **Trusted** raw HTML, injected verbatim into landing `<head>`. |
 | `analytics-origins` | string | none | Space-separated origins added to the landing CSP (`script-src`/`connect-src`/`img-src`). |
+| `custom-css` | string | none | **Trusted** raw CSS, injected as a `<style>` late in the landing `<head>` so it overrides the built-in styles. |
 | `show-admin-link` | bool | `true` | When `false`, anonymous visitors don't see the "Sign in" entrance. Logged-in users still see their panel link. |
+| `logos[]` | list | `[]` | Header/footer logos (see below). |
 | `blocks[]` | list | `[]` | Custom HTML blocks (see below). |
+
+`logos[]` subfields:
+
+| Field | Type | Default | Notes |
+|---|---|---|---|
+| `url` | string | required | Image URL — `/assets/img/...` (uploaded), a built-in (`/assets/showcase/...`, `/assets/brand/...`), or an absolute URL. |
+| `slot` | enum | required | `header` or `footer` — where the logo renders. |
+| `align` | enum | required | `left`, `center`, or `right` within the slot. Logos sharing a slot+alignment render side by side. |
+| `link` | URL | none | Optional click-through — when set, the logo becomes an `<a>`. |
+| `height` | px | default | Per-logo render height in pixels; falls back to a built-in default when unset. |
 
 `blocks[]` subfields:
 
@@ -210,17 +234,19 @@ Field reference:
 | `csp-origins` | string | `""` | Space-separated origins this block's content needs, folded into the landing CSP. |
 | `enabled` | bool | `true` | Toggle without deleting. |
 
-> **Trust model:** `analytics-html` and `blocks[].html` are rendered
-> unescaped. Only set them from a trusted source. Anything the
-> snippet loads from outside Ruscker's origin must also be listed in
+> **Trust model:** `analytics-html`, `custom-css`, and `blocks[].html`
+> are rendered unescaped. Only set them from a trusted source. Anything
+> the snippet loads from outside Ruscker's origin must also be listed in
 > the matching `*-origins` field, otherwise the landing's CSP blocks
 > it.
 
-Blocks are **admin-managed in the live landing editor** and stored in
-their own DB table; the `blocks[]` slot in this YAML schema exists so
-a future `ruscker export` round-trip can serialize them, but at the
-moment the import/export path does **not** populate it — operators
-edit blocks from the admin UI. SEO, analytics, and `show-admin-link`
+`custom-css`, `logos[]`, and `blocks[]` are **admin-managed in the live
+landing editor** (the logos picker and blocks editor live on the Portal
+page). Blocks are stored in their own DB table; the `blocks[]` slot in
+this YAML schema exists so a future `ruscker export` round-trip can
+serialize them, but at the moment the import/export path does **not**
+populate it — operators edit blocks from the admin UI. `logos[]` does
+round-trip through import/export. SEO, analytics, and `show-admin-link`
 are deploy-level policy and live only in this block.
 
 ## Specs
@@ -262,6 +288,9 @@ A spec describes one app, API, or external link. Every spec has an
   docker-registry-username: acme
   docker-registry-password: ${DOCKER_REGISTRY_PASSWORD}   # use env vars!
   docker-registry-domain: docker.io
+  docker-registry-credential: dockerhub-acme   # OR reference a stored
+                                      #   credential by name (Ruscker
+                                      #   extension; see below)
   volumes:                            # bind mounts (ShinyProxy-compatible)
     - /srv/myapp/data:/data           #   persistent data
     - /srv/myapp/www:/www:ro          #   static assets, read-only
@@ -303,6 +332,25 @@ always sees everything; an anonymous visitor sees only open apps. Group
 membership is set per user in the admin panel. Enforcement is real (not
 just hiding the card). See the [Roadmap](ROADMAP.md) Phase 8.
 
+#### Registry credentials — inline vs. named (`docker-registry-credential`)
+
+A spec can authenticate to a private registry two ways:
+
+1. **Inline** `docker-registry-username` / `docker-registry-password` /
+   `docker-registry-domain` — ShinyProxy-compatible. Always use
+   `${ENV_VAR}` for the password (never a literal in YAML).
+2. **Named** `docker-registry-credential: <name>` — a **Ruscker
+   extension** that references an entry in the admin's encrypted
+   credential store (managed under **Credentials** in the admin panel).
+   The username, password, and registry are resolved from the store at
+   **pull time** (decrypted with `RUSCKER_MASTER_KEY`), so no secret —
+   not even a `${VAR}` reference — needs to live in the spec at all.
+
+When `docker-registry-credential` is set, it **takes precedence** over
+the inline `docker-registry-*` fields for that spec. Leave it unset to
+use the inline fields. The spec form's **Registry** section is a picker
+over stored credential names.
+
 ### Smart routing — sub-path context for the upstream
 
 Ruscker mounts each app under a sub-path (`/app/{id}`, `/api/{id}`) but
@@ -342,6 +390,33 @@ mechanisms bridge that gap:
    `inject-base-href` only affects `/app/{id}` responses; `/api/{id}`
    responses are never rewritten. Editable in the admin **Advanced**
    form under **Routing**.
+
+3. **The `#{publicPath}` token (opt-in).** For an app that needs its
+   *own* base-url told to it as a config value — Jupyter's
+   `--ServerApp.base_url`, for instance — drop the literal token
+   `#{publicPath}` into any `container-cmd` argument or `container-env`
+   value. At spawn it's substituted with the spec's public mount path
+   **with a trailing slash** (e.g. `/app/{id}/`, or `/apps/app/{id}/`
+   under a base path; `/api/{id}/` for APIs). This is Ruscker's analog
+   of ShinyProxy's `SHINYPROXY_PUBLIC_PATH`, but it is **never injected
+   automatically** — Ruscker strips the mount prefix before forwarding,
+   so most apps should serve at root and rely on the rewriting above.
+   Reach for the token only when an app genuinely needs the public path
+   in its own configuration:
+
+   ```yaml
+   - id: jupyter
+     container-image: org/jupyter:tag
+     type: app
+     container-cmd:
+       - jupyter
+       - lab
+       - --ServerApp.base_url=#{publicPath}
+   ```
+
+   Note `#{publicPath}` is resolved at **spawn**, distinct from the
+   parse-time `${VAR}` env interpolation, which never sees this runtime
+   value.
 
 ### External link specs (no container)
 


### PR DESCRIPTION
Refresh do mdBook (livro público) de **v0.1.3 → v0.1.31**, cobrindo as 15
páginas das issues #436–#450.

Closes #436, closes #437, closes #438, closes #439, closes #440, closes #441,
closes #442, closes #443, closes #444, closes #445, closes #446, closes #447,
closes #448, closes #449, closes #450.

## Como foi feito
Passe multi-agente: um **editor** + um **verificador** por página (32 agentes),
depois um **review de consistência** entre páginas. Cada afirmação foi checada
contra o código; o conjunto inteiro foi re-verificado à mão.

## Destaques
- **news**: entradas agrupadas v0.1.4–v0.1.17 e v0.1.18–v0.1.31.
- **introduction/use-cases/alternatives**: posicionamento atual; demos como
  forks próprios (`milkway/ruscker-*-demo`); modelo strip vs no-strip do
  ShinyProxy; token `#{publicPath}` — e por que o Jupyter usa `base_url=/`
  (não o token) sob o strip.
- **quickstart/installation**: fluxo `serve --docker`, showcase + logos
  built-in semeados na Media; `.deb` multi-arch + musl + imagem ghcr cosign.
- **migrating/configuration (+YAML_SCHEMA)**: credenciais via `${VAR}`,
  base-path/`server.context-path`, `docker-registry-credential` nomeada, logos
  header/footer do Portal, `custom-css`.
- **admin**: Media (Choose image, modal, built-in logos deletáveis + badge
  "em uso"), seletor único de credencial, logos do Portal, senhas mascaradas.
- **deploying/troubleshooting**: `client_max_body_size` p/ uploads, forwarded
  headers, SSE buffering, base-path; fixes de upload, favicon Safari, Jupyter/Voilà.
- **architecture (ARCHITECTURE.md, incluído)**: modelo strip-and-rewrite +
  shim genérico (`script.src`/`img.src`; `rewrite_voila` aposentado,
  `rewrite_jupyter_config` mantido); in-flight metering da API.
- **security (SECURITY.md, incluído)**: escopo → v0.1.31; store unificado de
  credenciais (AES ou `${VAR}` env-ref puro, #422); CSRF; validação de charset
  de username/credencial; senhas mascaradas.
- **roadmap/faq**: status atual.

## Higiene de doc pública
- **Zero** referências a governo/cliente (a única menção de footprint é o
  genérico **540 MB → ~16 MB idle**). Exemplos de subpath normalizados para
  `/apps`. Correções de leaks pelo verify: "Governments"→"Public sector",
  `portal.example.gov.br`→`.org`, `/box`→`/apps`.
- Corrigida uma **contradição real**: alternatives.md recomendava
  `--ServerApp.base_url=#{publicPath}` pro Jupyter, que **404a** sob o strip —
  alinhado ao showcase/troubleshooting (`base_url=/`).
- `mdbook build` limpo.

Nota: `architecture.md`/`security.md`/`configuration.md` do book são wrappers
`{{#include ../../docs/*.md}}`, então as edições caem em `docs/ARCHITECTURE.md`,
`docs/SECURITY.md`, `docs/YAML_SCHEMA.md` — que renderizam no livro.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
