### PR TITLE
chore(release): bump workspace version 0.1.31 → 0.1.32

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2845,7 +2845,7 @@ dependencies = [
 
 [[package]]
 name = "ruscker-admin"
-version = "0.1.31"
+version = "0.1.32"
 dependencies = [
  "aes-gcm",
  "anyhow",
@@ -2892,7 +2892,7 @@ dependencies = [
 
 [[package]]
 name = "ruscker-cli"
-version = "0.1.31"
+version = "0.1.32"
 dependencies = [
  "anyhow",
  "clap",
@@ -2912,7 +2912,7 @@ dependencies = [
 
 [[package]]
 name = "ruscker-config"
-version = "0.1.31"
+version = "0.1.32"
 dependencies = [
  "chrono",
  "ordered-float",
@@ -2927,7 +2927,7 @@ dependencies = [
 
 [[package]]
 name = "ruscker-core"
-version = "0.1.31"
+version = "0.1.32"
 dependencies = [
  "async-trait",
  "chrono",
@@ -2940,7 +2940,7 @@ dependencies = [
 
 [[package]]
 name = "ruscker-docker"
-version = "0.1.31"
+version = "0.1.32"
 dependencies = [
  "anyhow",
  "async-stream",
@@ -2959,7 +2959,7 @@ dependencies = [
 
 [[package]]
 name = "ruscker-proxy"
-version = "0.1.31"
+version = "0.1.32"
 dependencies = [
  "anyhow",
  "axum",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -10,7 +10,7 @@ members = [
 ]
 
 [workspace.package]
-version = "0.1.31"
+version = "0.1.32"
 edition = "2021"
 rust-version = "1.85"
 license = "Apache-2.0"

--- a/book/src/news.md
+++ b/book/src/news.md
@@ -9,6 +9,38 @@ the [GitHub releases page](https://github.com/StrategicProjects/ruscker/releases
 
 ---
 
+## v0.1.32 — 2026-06-01
+
+Admin disk management, a forced first-login password change, and a more
+visible process log.
+
+**Admin**
+- New **Disk** panel (`/admin/disk`, Admin-only): list and remove
+  Ruscker-managed containers, prune every stopped one in a click
+  (label-scoped — it never touches a non-Ruscker container on the host),
+  and remove images no container or spec uses. Reclaims the space left
+  behind by scaled-down or crashed replicas and by apps you've deleted.
+- Deleting an app now **reaps its containers** instead of leaving them
+  running or stopped as orphans.
+- New accounts must **change their password on first login** — the prompt
+  can no longer be skipped, and a guard re-routes to it on every admin
+  page until the change is done. The user-admin password fields are
+  masked, with a reveal toggle.
+- The Portal logos editor uses the same **image gallery picker** as the
+  spec form — search, thumbnails, and inline upload, instead of a bare
+  path field.
+
+**Operations**
+- A one-line **startup banner** (version, bind address, base path, Docker
+  on/off, database, spec count) now appears in the admin Logs tab even at
+  the default log level — so a fresh boot is visible without `-v`. The
+  Logs tab also distinguishes "nothing logged yet" from "no log buffer".
+
+**Docs**
+- The handbook was refreshed to match the current release.
+
+---
+
 ## v0.1.18–v0.1.31 — 2026-05-31
 
 Demo images, credential unification, a redesigned media library, and portal logo support.


### PR DESCRIPTION
Cut **v0.1.32**: bumps the workspace version 0.1.31 → 0.1.32 and adds the
release notes. Includes everything merged since v0.1.31:

- **#455** force first-login password change (#454) + masked/reveal user
  password fields (#430)
- **#457** startup banner visible in the admin Logs tab + honest empty
  state (#452)
- **#458** reap an app's containers when it's deleted (#453 part A)
- **#459** admin **Disk** panel: reclaim containers + unused images,
  label-scoped prune (#453 part B)
- **#460** Portal logos use the shared image gallery picker (#451)
- **#461** docs: refresh the mdBook to v0.1.31 (#436–#450)

`Cargo.toml` + `Cargo.lock` bumped; `book/src/news.md` gains the v0.1.32
entry. `ruscker --version` → `0.1.32`; `mdbook build` clean; suite green.

After merge, pushing the `v0.1.32` tag triggers `release.yml` (multi-arch
.deb + musl tarballs + cosign-signed ghcr image + GitHub release).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
