### PR TITLE
feat(admin): bulk "remove all unused images" on the disk panel (#463)

### DIFF
--- a/crates/ruscker-admin/assets/i18n/en/landing.ftl
+++ b/crates/ruscker-admin/assets/i18n/en/landing.ftl
@@ -598,3 +598,6 @@ admin-disk-flash-removed = Removed.
 admin-disk-flash-pruned = Stopped containers removed.
 admin-disk-flash-nothing = Nothing to remove.
 admin-disk-flash-error = The operation failed. Check the logs.
+admin-disk-prune-images = Remove unused
+admin-disk-prune-images-confirm = Remove all unused images?
+admin-disk-flash-images-pruned = Unused images removed.

--- a/crates/ruscker-admin/assets/i18n/es/landing.ftl
+++ b/crates/ruscker-admin/assets/i18n/es/landing.ftl
@@ -598,3 +598,6 @@ admin-disk-flash-removed = Eliminado.
 admin-disk-flash-pruned = Contenedores detenidos eliminados.
 admin-disk-flash-nothing = Nada que eliminar.
 admin-disk-flash-error = La operación falló. Revisa los registros.
+admin-disk-prune-images = Eliminar sin usar
+admin-disk-prune-images-confirm = ¿Eliminar todas las imágenes sin usar?
+admin-disk-flash-images-pruned = Imágenes sin usar eliminadas.

--- a/crates/ruscker-admin/assets/i18n/fr/landing.ftl
+++ b/crates/ruscker-admin/assets/i18n/fr/landing.ftl
@@ -598,3 +598,6 @@ admin-disk-flash-removed = Supprimé.
 admin-disk-flash-pruned = Conteneurs arrêtés supprimés.
 admin-disk-flash-nothing = Rien à supprimer.
 admin-disk-flash-error = L'opération a échoué. Consultez les journaux.
+admin-disk-prune-images = Supprimer les inutilisées
+admin-disk-prune-images-confirm = Supprimer toutes les images inutilisées ?
+admin-disk-flash-images-pruned = Images inutilisées supprimées.

--- a/crates/ruscker-admin/assets/i18n/pt/landing.ftl
+++ b/crates/ruscker-admin/assets/i18n/pt/landing.ftl
@@ -602,3 +602,6 @@ admin-disk-flash-removed = Removido.
 admin-disk-flash-pruned = Containers parados removidos.
 admin-disk-flash-nothing = Nada a remover.
 admin-disk-flash-error = A operação falhou. Veja os logs.
+admin-disk-prune-images = Remover não usadas
+admin-disk-prune-images-confirm = Remover todas as imagens não usadas?
+admin-disk-flash-images-pruned = Imagens não usadas removidas.

--- a/crates/ruscker-admin/src/routes/admin/disk.rs
+++ b/crates/ruscker-admin/src/routes/admin/disk.rs
@@ -29,6 +29,7 @@ pub fn routes() -> Router<AppState> {
         .route("/admin/disk/containers/remove", post(remove_container))
         .route("/admin/disk/containers/prune", post(prune_stopped))
         .route("/admin/disk/images/remove", post(remove_image))
+        .route("/admin/disk/images/prune", post(prune_images))
 }
 
 /// One image row, enriched with whether it's safe to remove.
@@ -69,6 +70,8 @@ struct DiskPage<'a> {
     images: Vec<ImageRow>,
     /// How many of `containers` are stopped (drives the prune button).
     stopped_count: usize,
+    /// How many images are unused (drives the "remove all unused" button).
+    unused_images_count: usize,
     /// Sum of image sizes (may over-count shared layers — labelled as
     /// such in the UI).
     images_total_bytes: i64,
@@ -119,6 +122,7 @@ async fn index(
     let (flash, flash_error) = match q.flash.as_deref() {
         Some("removed") => (Some("admin-disk-flash-removed"), false),
         Some("pruned") => (Some("admin-disk-flash-pruned"), false),
+        Some("images-pruned") => (Some("admin-disk-flash-images-pruned"), false),
         Some("nothing") => (Some("admin-disk-flash-nothing"), false),
         Some("error") => (Some("admin-disk-flash-error"), true),
         _ => (None, false),
@@ -138,6 +142,7 @@ async fn index(
             containers: Vec::new(),
             images: Vec::new(),
             stopped_count: 0,
+            unused_images_count: 0,
             images_total_bytes: 0,
             flash,
             flash_error,
@@ -149,15 +154,12 @@ async fn index(
 
     // Which image refs does the live catalog reference? Used to flag an
     // image as "in use by a spec" so the panel won't offer to remove it.
-    let catalog = crate::catalog::effective_specs(state.db.as_ref(), &state.config).await;
-    let spec_images: HashSet<String> = catalog
-        .iter()
-        .filter_map(|s| s.container_image.clone())
-        .collect();
+    let spec_images = spec_image_refs(&state).await;
 
     let stopped_count = containers.iter().filter(|c| !c.running).count();
     let images_total_bytes = images.iter().map(|i| i.size_bytes).sum();
-    let images = images.into_iter().map(|i| image_row(i, &spec_images)).collect();
+    let images: Vec<ImageRow> = images.into_iter().map(|i| image_row(i, &spec_images)).collect();
+    let unused_images_count = images.iter().filter(|r| !r.in_use()).count();
 
     super::render(&DiskPage {
         locale: loc,
@@ -171,10 +173,29 @@ async fn index(
         containers,
         images,
         stopped_count,
+        unused_images_count,
         images_total_bytes,
         flash,
         flash_error,
     })
+}
+
+/// The set of image refs the live (DB-first) catalog references — an
+/// image carrying one of these tags is "in use by a spec" and is never
+/// offered for removal.
+async fn spec_image_refs(state: &AppState) -> HashSet<String> {
+    crate::catalog::effective_specs(state.db.as_ref(), &state.config)
+        .await
+        .iter()
+        .filter_map(|s| s.container_image.clone())
+        .collect()
+}
+
+/// An image is safe to reclaim when no container uses it (`containers`
+/// is 0 or unknown-as-non-positive) **and** no current spec references
+/// it by tag. Same rule the per-row remove button uses.
+fn image_unused(i: &ImageInfo, spec_images: &HashSet<String>) -> bool {
+    i.containers <= 0 && !i.tags.iter().any(|t| spec_images.contains(t))
 }
 
 /// Build a display row, resolving the primary tag and the in-use flags.
@@ -258,8 +279,83 @@ async fn remove_image(
     }
 }
 
+/// Remove every **unused** image in one click (#463) — `containers == 0`
+/// and not referenced by any current spec. Never `--force`s, and never
+/// runs a host-wide `docker image prune`: it only removes the exact
+/// subset the panel flags as unused, so a non-Ruscker image the host
+/// happens to have stays put.
+async fn prune_images(_: RequireAdmin, State(state): State<AppState>) -> Response {
+    let Some(backend) = state.backend.as_ref() else {
+        return redirect("error");
+    };
+    let images = match backend.list_images().await {
+        Ok(v) => v,
+        Err(e) => {
+            tracing::warn!(error = %e, "disk: list images for prune failed");
+            return redirect("error");
+        }
+    };
+    let spec_images = spec_image_refs(&state).await;
+    let unused: Vec<String> = images
+        .into_iter()
+        .filter(|i| image_unused(i, &spec_images))
+        .map(|i| i.id)
+        .collect();
+    if unused.is_empty() {
+        return redirect("nothing");
+    }
+    let mut removed = 0;
+    for id in &unused {
+        match backend.remove_image(id).await {
+            Ok(()) => removed += 1,
+            // Best-effort: an image that turned in-use between listing and
+            // removal (or a multi-tag image) just stays — logged, not fatal.
+            Err(e) => tracing::warn!(error = %e, id = %id, "disk: prune image failed"),
+        }
+    }
+    if removed > 0 {
+        redirect("images-pruned")
+    } else {
+        redirect("error")
+    }
+}
+
 /// Post/redirect/get back to the panel with a one-word flash code. The
 /// base-path response rewriter re-prefixes the `Location` header.
 fn redirect(flash: &str) -> Response {
     Redirect::to(&format!("/admin/disk?flash={flash}")).into_response()
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn img(tags: &[&str], containers: i64) -> ImageInfo {
+        ImageInfo {
+            id: "sha256:abc".into(),
+            tags: tags.iter().map(|s| s.to_string()).collect(),
+            size_bytes: 1,
+            containers,
+        }
+    }
+
+    /// #463: bulk prune must reclaim only images no container uses and no
+    /// spec references — never an image still in use.
+    #[test]
+    fn image_unused_only_when_no_container_and_no_spec() {
+        let catalog: HashSet<String> = ["nginx:alpine".to_string()].into_iter().collect();
+
+        // Referenced by a spec → in use, never pruned.
+        assert!(!image_unused(&img(&["nginx:alpine"], 0), &catalog));
+        // A container uses it → in use.
+        assert!(!image_unused(&img(&["other:1"], 3), &catalog));
+        // No container, not in the catalog → reclaimable.
+        assert!(image_unused(&img(&["leftover:1"], 0), &catalog));
+        // Dangling (untagged), no container → reclaimable.
+        assert!(image_unused(&img(&[], 0), &catalog));
+        // Daemon couldn't count containers (-1, non-positive) and it's not
+        // in the catalog → treated as reclaimable; remove_image runs
+        // without --force, so the daemon still refuses a truly in-use one.
+        assert!(image_unused(&img(&["x:1"], -1), &catalog));
+    }
 }

--- a/crates/ruscker-admin/templates/admin/disk.html
+++ b/crates/ruscker-admin/templates/admin/disk.html
@@ -83,9 +83,20 @@
   {# ── Images ─────────────────────────────────────────────────── #}
   <div class="flex items-end justify-between mb-2 mt-6">
     <h2 class="text-sm font-medium">{{ self.t("admin-disk-images-heading") }}</h2>
-    <span class="text-xs text-[color:var(--text-muted)]">
-      {{ self.t("admin-disk-images-total") }}: {{ self.human(images_total_bytes) }}
-    </span>
+    <div class="flex items-center gap-3">
+      {% if unused_images_count > 0 %}
+      <form method="post" action="{{ base }}/admin/disk/images/prune"
+            onsubmit="return confirm('{{ self.t("admin-disk-prune-images-confirm") }}')">
+        <button type="submit" class="dash-action dash-action--danger" style="width:auto;padding:6px 12px">
+          <i class="ti ti-trash" aria-hidden="true"></i>
+          {{ self.t("admin-disk-prune-images") }} ({{ unused_images_count }})
+        </button>
+      </form>
+      {% endif %}
+      <span class="text-xs text-[color:var(--text-muted)]">
+        {{ self.t("admin-disk-images-total") }}: {{ self.human(images_total_bytes) }}
+      </span>
+    </div>
   </div>
   <p class="text-xs text-[color:var(--text-faint)] mb-2">{{ self.t("admin-disk-images-note") }}</p>
 


### PR DESCRIPTION
Closes #463. Follow-up ao painel de disco (#453).

O painel já removia **todos os containers parados** num clique ("Remover
parados (N)" → `prune_stopped`, escopado ao label) — isso cobre "apagar todos
os containers não usados". Esta PR adiciona o equivalente para **imagens**.

## Mudanças
- Nova rota `POST /admin/disk/images/prune` remove de uma vez **todas as imagens
  não usadas**: `containers == 0` **e** não referenciada por nenhum spec do
  catálogo (mesma regra do botão por-linha, fatorada em `image_unused` +
  `spec_image_refs`). Remove **só esse subconjunto** — nunca um `docker image
  prune` global do host, e **sem `--force`** (o daemon recusa imagem realmente
  em uso, como rede de segurança).
- Botão **"Remover não usadas (N)"** ao lado do total de imagens, só aparece
  quando há ≥1 não usada; `confirm()` + flash de resultado.
- `DiskPage.unused_images_count`; flash `images-pruned`; 3 chaves i18n × 4 locales.

## Validação
- **Teste unitário** do predicado `image_unused` (em uso por container OU spec →
  mantida; senão → recuperável; inclui o caso `containers == -1` desconhecido).
- **Render-smoke**: o botão + contagem renderizam e postam pra rota de prune.
- **Não rodei o bulk prune ao vivo** no host de dev de propósito — imagens não
  têm label `ruscker.*`, então deletaria também imagens não-relacionadas sem
  container (27 nesta máquina). O `remove_image` em si já é coberto pelo teste
  docker-it do #459.
- `clippy -D warnings`, paridade i18n, suíte default — verdes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
