### PR TITLE
docs: update the documented idle footprint to ~14 MB

### DIFF
--- a/book/src/alternatives.md
+++ b/book/src/alternatives.md
@@ -16,7 +16,7 @@ ShinyProxy's `application.yml`.
 | | **Ruscker** | **ShinyProxy** | **Shiny Server** (open source) | **Posit Connect** | **JupyterHub** |
 |---|---|---|---|---|---|
 | Runtime | Rust — single static binary | JVM (Java / Spring) | C++ / Node | proprietary | Python |
-| Idle footprint | **~16 MB** | ~300–540 MB | moderate | heavy | moderate–heavy |
+| Idle footprint | **~14 MB** | ~300–540 MB | moderate | heavy | moderate–heavy |
 | Per-session isolation | ✅ container/session | ✅ container/session | ❌ shared R processes | ✅ | ✅ per-user |
 | Frameworks | Shiny, Streamlit, Dash, Voilà, Plumber, FastAPI — any HTTP/WS container | any container | **R/Shiny only** | R, Python, Quarto, APIs | Jupyter/Python (+ images) |
 | Admin UI | ✅ live dashboard + full CRUD | minimal | edit config + restart | ✅ rich | partial |

--- a/book/src/faq.md
+++ b/book/src/faq.md
@@ -11,7 +11,7 @@ to silently ignore them). See [Migrating from ShinyProxy](./migrating.md).
 
 No. Ruscker is a single static binary written in Rust. There's no JVM, no
 Java toolchain, and no application server to manage — the idle footprint
-is **~16 MB** instead of the hundreds of MB a JVM-based proxy idles at.
+is **~14 MB** instead of the hundreds of MB a JVM-based proxy idles at.
 
 ### Which app frameworks can it host?
 

--- a/book/src/introduction.md
+++ b/book/src/introduction.md
@@ -44,7 +44,7 @@ Ruscker is on **v0.1.31** and runs in production today. Where the
 JVM-based stack it replaced idled at hundreds of megabytes, Ruscker
 idles in the low tens:
 
-> **~540 MB → ~16 MB idle** — roughly a 30× cut.
+> **~540 MB → ~14 MB idle** — roughly a 38× cut.
 
 A real 31-spec config migrated with **no unsupported features**, and
 apps spawn on demand. Releases are multi-arch and **cosign-signed**;

--- a/book/src/migrating.md
+++ b/book/src/migrating.md
@@ -119,7 +119,7 @@ Beyond parity, you also get: a real admin panel (no more hand-editing
 YAML), a live monitoring dashboard, per-spec `container-env` /
 `container-cmd` injection, per-API rate-limiting and CORS, per-user
 and per-group app visibility, health probes, graceful shutdown, and a
-tiny footprint — idle memory drops from ~540 MB to ~16 MB. See
+tiny footprint — idle memory drops from ~540 MB to ~14 MB. See
 [The admin panel](./admin.md).
 
 ## Not supported (yet)

--- a/book/src/roadmap.md
+++ b/book/src/roadmap.md
@@ -53,7 +53,7 @@ installer, a **Homebrew tap**, and **cosign-signed** release artifacts.
 
 > **Production milestone.** Ruscker replaced a JVM-based stack on the
 > same machine serving the same apps, cutting idle memory from
-> **~540 MB to ~16 MB** (~30×). A real 31-spec config migrated with no
+> **~540 MB to ~14 MB** (~38×). A real 31-spec config migrated with no
 > unsupported features.
 
 ### Phase 6 — Multi-host scheduling → **v0.1.1 / v0.1.2**

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -8,7 +8,7 @@ how the pieces fit together.
 
 ![How Ruscker works: browsers and API clients hit a single Ruscker binary, which serves the landing page + admin and reverse-proxies to app containers it spawns on demand via the Docker daemon.](images/architecture.svg)
 
-All of this is a single Rust process — one static binary, ~16 MB idle,
+All of this is a single Rust process — one static binary, ~14 MB idle,
 no JVM. Visitors and API clients reach it on one port; it serves the
 landing page and admin UI, reverse-proxies `/app/{spec}` and
 `/api/{spec}` to the right replica (keeping Shiny sessions sticky and


### PR DESCRIPTION
Mede o footprint idle real do v0.1.32 (~14 MB, igual ao milestone de prod — as features novas são código de request-path, não estado idle) e alinha a doc, que arredondava p/ ~16 MB. O multiplicador vs JVM 540 MB vira ~38×. Atualizado em introduction/alternatives/faq/migrating/roadmap + ARCHITECTURE.md (incluído no book). O `client_max_body_size 16m` do nginx é outra coisa e ficou intacto. `mdbook build` limpo.

🤖 Generated with [Claude Code](https://claude.com/claude-code)