### PR TITLE
chore(release): bump workspace version 0.1.32 → 0.1.33

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2845,7 +2845,7 @@ dependencies = [
 
 [[package]]
 name = "ruscker-admin"
-version = "0.1.32"
+version = "0.1.33"
 dependencies = [
  "aes-gcm",
  "anyhow",
@@ -2892,7 +2892,7 @@ dependencies = [
 
 [[package]]
 name = "ruscker-cli"
-version = "0.1.32"
+version = "0.1.33"
 dependencies = [
  "anyhow",
  "clap",
@@ -2912,7 +2912,7 @@ dependencies = [
 
 [[package]]
 name = "ruscker-config"
-version = "0.1.32"
+version = "0.1.33"
 dependencies = [
  "chrono",
  "ordered-float",
@@ -2927,7 +2927,7 @@ dependencies = [
 
 [[package]]
 name = "ruscker-core"
-version = "0.1.32"
+version = "0.1.33"
 dependencies = [
  "async-trait",
  "chrono",
@@ -2940,7 +2940,7 @@ dependencies = [
 
 [[package]]
 name = "ruscker-docker"
-version = "0.1.32"
+version = "0.1.33"
 dependencies = [
  "anyhow",
  "async-stream",
@@ -2959,7 +2959,7 @@ dependencies = [
 
 [[package]]
 name = "ruscker-proxy"
-version = "0.1.32"
+version = "0.1.33"
 dependencies = [
  "anyhow",
  "axum",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -10,7 +10,7 @@ members = [
 ]
 
 [workspace.package]
-version = "0.1.32"
+version = "0.1.33"
 edition = "2021"
 rust-version = "1.85"
 license = "Apache-2.0"

--- a/book/src/faq.md
+++ b/book/src/faq.md
@@ -80,7 +80,7 @@ the **sign-in session** paths to a single upstream — see
 
 ### Is it production-ready?
 
-Yes. The current release is **v0.1.31** — Phases 0–7 are complete and
+Yes. The current release is **v0.1.33** — Phases 0–7 are complete and
 the proxy is production-ready and horizontally scalable.
 Releases are multi-arch and cosign-signed; see the
 [release notes](./news.md) and the [Roadmap](./roadmap.md).

--- a/book/src/introduction.md
+++ b/book/src/introduction.md
@@ -40,7 +40,7 @@ proper admin panel, a monitoring dashboard, and load balancing.
 
 ## In production
 
-Ruscker is on **v0.1.31** and runs in production today. Where the
+Ruscker is on **v0.1.33** and runs in production today. Where the
 JVM-based stack it replaced idled at hundreds of megabytes, Ruscker
 idles in the low tens:
 

--- a/book/src/news.md
+++ b/book/src/news.md
@@ -9,6 +9,23 @@ the [GitHub releases page](https://github.com/StrategicProjects/ruscker/releases
 
 ---
 
+## v0.1.33 — 2026-06-01
+
+A bulk image cleanup on the disk panel, plus a documentation fix.
+
+**Admin**
+- The **Disk** panel gains a **"Remove unused" images** button: reclaim
+  every image no container uses and no spec references, in one click.
+  It complements the existing one-click "remove stopped containers" —
+  and, like everything on the panel, it only touches that exact unused
+  subset (never a host-wide `docker image prune`, never `--force`).
+
+**Docs**
+- The documented idle footprint is now ~14 MB (the measured value),
+  down from the rounded ~16 MB.
+
+---
+
 ## v0.1.32 — 2026-06-01
 
 Admin disk management, a forced first-login password change, and a more

--- a/book/src/roadmap.md
+++ b/book/src/roadmap.md
@@ -1,6 +1,6 @@
 # Roadmap
 
-Ruscker is at **v0.1.31** — Phases 0 through 7 are done and the proxy is
+Ruscker is at **v0.1.33** — Phases 0 through 7 are done and the proxy is
 production-ready and horizontally scalable. Phase 8 (external auth) is
 the main optional, demand-driven work left. For what changed in each
 release, see the [release notes](./news.md).
@@ -71,7 +71,7 @@ can serve any session; one scaler leader via Postgres advisory locks,
 with failover. A runnable 2-instance compose harness lives in
 `examples/ha/`. See [Deployment shapes](./architecture.md#deployment-shapes).
 
-### Post-phase polish → **v0.1.4 – v0.1.31**
+### Post-phase polish → **v0.1.4 – v0.1.33**
 
 Incremental improvements shipped after Phase 7.
 
@@ -115,6 +115,16 @@ configurable `metrics-interval`.
 charset validation on usernames and credential names; admin password
 fields are write-only in the UI; `${VAR}` resolution returns an error
 when the variable is unset (names the missing variable).
+
+**Disk management & admin polish (v0.1.32–v0.1.33).** A new **Disk**
+panel reclaims space: remove containers, prune every stopped one
+(label-scoped, never touching a non-Ruscker container), and remove
+unused images — individually or all at once. Deleting an app now reaps
+its containers instead of leaving orphans. New accounts must change
+their password on first login. A one-line startup banner (version,
+bind, base path, Docker, database, spec count) shows in the admin Logs
+tab at the default log level. The Portal logos editor reuses the spec
+form's image gallery picker.
 
 ## Planned (optional)
 

--- a/docs/SECURITY.md
+++ b/docs/SECURITY.md
@@ -5,7 +5,7 @@ Status: living document. Tracks the Phase 5 security audit
 **[accepted limitation]**, or **[deferred]**. File references use
 `crate/path:symbol` so they survive line-number drift.
 
-> **Scope.** This covers v0.1.31: single-operator install, Ruscker
+> **Scope.** This covers v0.1.33: single-operator install, Ruscker
 > behind a TLS-terminating reverse proxy, Docker on the same host.
 > Multi-tenant / shared-team auth (OIDC, RBAC) is out of scope until
 > Phase 8.


### PR DESCRIPTION
Cut **v0.1.33**. Contents since v0.1.32:
- **#464** bulk *"remove all unused images"* on the disk panel (#463)
- **#465** docs: idle footprint corrected to ~14 MB

Docs updated for the release: `news.md` v0.1.33 entry; "current release" refs (introduction/faq/roadmap/SECURITY scope) → v0.1.33; roadmap polish section notes the v0.1.32–v0.1.33 disk management. `mdbook build` clean.

After merge, the `v0.1.33` tag triggers `release.yml`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)