### PR TITLE
fix(admin): disk panel UX — button style, column spacing, prune feedback

### DIFF
--- a/crates/ruscker-admin/assets/i18n/en/landing.ftl
+++ b/crates/ruscker-admin/assets/i18n/en/landing.ftl
@@ -601,3 +601,4 @@ admin-disk-flash-error = The operation failed. Check the logs.
 admin-disk-prune-images = Remove unused
 admin-disk-prune-images-confirm = Remove all unused images?
 admin-disk-flash-images-pruned = Unused images removed.
+admin-disk-cleaning = Cleaning…

--- a/crates/ruscker-admin/assets/i18n/es/landing.ftl
+++ b/crates/ruscker-admin/assets/i18n/es/landing.ftl
@@ -601,3 +601,4 @@ admin-disk-flash-error = La operación falló. Revisa los registros.
 admin-disk-prune-images = Eliminar sin usar
 admin-disk-prune-images-confirm = ¿Eliminar todas las imágenes sin usar?
 admin-disk-flash-images-pruned = Imágenes sin usar eliminadas.
+admin-disk-cleaning = Limpiando…

--- a/crates/ruscker-admin/assets/i18n/fr/landing.ftl
+++ b/crates/ruscker-admin/assets/i18n/fr/landing.ftl
@@ -601,3 +601,4 @@ admin-disk-flash-error = L'opération a échoué. Consultez les journaux.
 admin-disk-prune-images = Supprimer les inutilisées
 admin-disk-prune-images-confirm = Supprimer toutes les images inutilisées ?
 admin-disk-flash-images-pruned = Images inutilisées supprimées.
+admin-disk-cleaning = Nettoyage…

--- a/crates/ruscker-admin/assets/i18n/pt/landing.ftl
+++ b/crates/ruscker-admin/assets/i18n/pt/landing.ftl
@@ -605,3 +605,4 @@ admin-disk-flash-error = A operação falhou. Veja os logs.
 admin-disk-prune-images = Remover não usadas
 admin-disk-prune-images-confirm = Remover todas as imagens não usadas?
 admin-disk-flash-images-pruned = Imagens não usadas removidas.
+admin-disk-cleaning = Limpando…

--- a/crates/ruscker-admin/assets/tailwind/input.css
+++ b/crates/ruscker-admin/assets/tailwind/input.css
@@ -689,6 +689,12 @@ body {
   padding: 11px 12px;
   margin-top: 4px;
 }
+/* Destructive labelled button — same shape as the primary button so it
+   reads as part of the app, but red to signal it removes things (the
+   disk panel's "remove stopped / remove unused" bulk actions). */
+.admin-login-btn--danger { background: var(--color-lock); }
+.admin-login-btn--danger:hover { background: #dc2626; }
+.admin-login-btn:disabled { opacity: 0.6; cursor: default; }
 .admin-login-error {
   display: flex; align-items: center; gap: 8px;
   background: rgba(239, 68, 68, 0.08);

--- a/crates/ruscker-admin/templates/admin/disk.html
+++ b/crates/ruscker-admin/templates/admin/disk.html
@@ -3,6 +3,14 @@
 {% block title %}{{ self.t("admin-disk-title") }} · Ruscker{% endblock %}
 
 {% block content %}
+<style>
+  /* Even column spacing for the disk tables (#disk-ux) — the right-aligned
+     Size column was butting up against Usage. First/last cells stay flush
+     with the section edges. */
+  .disk-table th, .disk-table td { padding: 7px 14px; vertical-align: middle; }
+  .disk-table th:first-child, .disk-table td:first-child { padding-left: 0; }
+  .disk-table th:last-child, .disk-table td:last-child { padding-right: 0; }
+</style>
 <div class="flex items-end justify-between mb-3">
   <div>
     <h1 class="text-xl font-medium tracking-tight">{{ self.t("admin-disk-title") }}</h1>
@@ -29,9 +37,11 @@
   <div class="flex items-end justify-between mb-2 mt-4">
     <h2 class="text-sm font-medium">{{ self.t("admin-disk-containers-heading") }}</h2>
     {% if stopped_count > 0 %}
-    <form method="post" action="{{ base }}/admin/disk/containers/prune"
+    <form method="post" action="{{ base }}/admin/disk/containers/prune" class="disk-prune-form"
           onsubmit="return confirm('{{ self.t("admin-disk-prune-confirm") }}')">
-      <button type="submit" class="dash-action dash-action--danger" style="width:auto;padding:6px 12px">
+      <button type="submit" class="admin-login-btn admin-login-btn--danger"
+              style="padding:7px 12px;font-size:12px"
+              data-busy="{{ self.t("admin-disk-cleaning") }}">
         <i class="ti ti-trash" aria-hidden="true"></i>
         {{ self.t("admin-disk-prune") }} ({{ stopped_count }})
       </button>
@@ -42,7 +52,7 @@
   {% if containers.is_empty() %}
   <p class="text-sm text-[color:var(--text-faint)] py-4">{{ self.t("admin-disk-no-containers") }}</p>
   {% else %}
-  <table class="w-full text-sm" style="border-collapse:collapse">
+  <table class="w-full text-sm disk-table" style="border-collapse:collapse">
     <thead>
       <tr class="text-left text-[color:var(--text-muted)]" style="border-bottom:0.5px solid var(--border)">
         <th class="py-2">{{ self.t("admin-disk-col-container") }}</th>
@@ -85,9 +95,11 @@
     <h2 class="text-sm font-medium">{{ self.t("admin-disk-images-heading") }}</h2>
     <div class="flex items-center gap-3">
       {% if unused_images_count > 0 %}
-      <form method="post" action="{{ base }}/admin/disk/images/prune"
+      <form method="post" action="{{ base }}/admin/disk/images/prune" class="disk-prune-form"
             onsubmit="return confirm('{{ self.t("admin-disk-prune-images-confirm") }}')">
-        <button type="submit" class="dash-action dash-action--danger" style="width:auto;padding:6px 12px">
+        <button type="submit" class="admin-login-btn admin-login-btn--danger"
+                style="padding:7px 12px;font-size:12px"
+                data-busy="{{ self.t("admin-disk-cleaning") }}">
           <i class="ti ti-trash" aria-hidden="true"></i>
           {{ self.t("admin-disk-prune-images") }} ({{ unused_images_count }})
         </button>
@@ -103,7 +115,7 @@
   {% if images.is_empty() %}
   <p class="text-sm text-[color:var(--text-faint)] py-4">{{ self.t("admin-disk-no-images") }}</p>
   {% else %}
-  <table class="w-full text-sm" style="border-collapse:collapse">
+  <table class="w-full text-sm disk-table" style="border-collapse:collapse">
     <thead>
       <tr class="text-left text-[color:var(--text-muted)]" style="border-bottom:0.5px solid var(--border)">
         <th class="py-2">{{ self.t("admin-disk-col-image") }}</th>
@@ -150,4 +162,20 @@
   {% endif %}
 
 {% endif %}
+
+<script>
+  // Show a "cleaning…" state on the bulk prune buttons while the POST
+  // runs (it can take a few seconds for many containers/images). The
+  // inline confirm() runs first; we only kick in if it wasn't cancelled.
+  document.addEventListener('submit', function (e) {
+    var form = e.target;
+    if (!form.classList || !form.classList.contains('disk-prune-form')) return;
+    if (e.defaultPrevented) return; // confirm() was cancelled
+    var btn = form.querySelector('button[type="submit"]');
+    if (!btn) return;
+    var busy = btn.getAttribute('data-busy') || 'Cleaning…';
+    btn.disabled = true;
+    btn.innerHTML = '<i class="ti ti-loader-2 animate-spin" aria-hidden="true"></i> ' + busy;
+  });
+</script>
 {% endblock %}


### PR DESCRIPTION
Polish do painel de disco (#453/#463), tudo template/CSS/i18n:

- **Estilo dos botões bulk** — "remover parados / remover não usadas" usavam `dash-action` (estilo de botão-ícone pequeno), destoando do app. Agora usam o botão padrão (`admin-login-btn`) com um novo modifier vermelho `--danger` — consistente com o resto, ainda claramente destrutivo.
- **Espaçamento de colunas** — na tabela de imagens a coluna Tamanho (à direita) colava em Uso (células sem padding horizontal). Uma regra `.disk-table` dá espaçamento uniforme, com primeira/última colunas rentes às bordas.
- **Feedback de "limpando…"** — os botões bulk mostram estado ocupado (spinner + desabilitado) no submit, dando feedback enquanto o POST roda. Listener vanilla delegado; ignora quando o confirm() foi cancelado.

**Volumes:** não adicionei botão — o Ruscker monta diretórios do host (bind-mounts), não volumes Docker gerenciados; não há nada "do Ruscker" pra prune, e um botão significaria `docker volume prune` global (quebra a segurança label-scoped). **Containers** já tinham a ação (o botão "remover parados", agora restilizado).

Render-smoke confirmou o markup + o CSS `--danger` servido. clippy/i18n/suíte verdes. (Visual/animação não testados em browser — sem Playwright; markup espelha padrões já comprovados.)

🤖 Generated with [Claude Code](https://claude.com/claude-code)