### PR TITLE
feat(admin): dashboard metric-card order + session tooltips (#469)

### DIFF
--- a/crates/ruscker-admin/assets/i18n/en/landing.ftl
+++ b/crates/ruscker-admin/assets/i18n/en/landing.ftl
@@ -602,3 +602,5 @@ admin-disk-prune-images = Remove unused
 admin-disk-prune-images-confirm = Remove all unused images?
 admin-disk-flash-images-pruned = Unused images removed.
 admin-disk-cleaning = Cleaning…
+admin-dashboard-metric-sessions-help = Sessions the replicas report currently serving.
+admin-dashboard-metric-tracker-help = Sticky sessions the proxy is tracking in the heartbeat.

--- a/crates/ruscker-admin/assets/i18n/es/landing.ftl
+++ b/crates/ruscker-admin/assets/i18n/es/landing.ftl
@@ -602,3 +602,5 @@ admin-disk-prune-images = Eliminar sin usar
 admin-disk-prune-images-confirm = ¿Eliminar todas las imágenes sin usar?
 admin-disk-flash-images-pruned = Imágenes sin usar eliminadas.
 admin-disk-cleaning = Limpiando…
+admin-dashboard-metric-sessions-help = Sesiones que las réplicas reportan atendiendo ahora.
+admin-dashboard-metric-tracker-help = Sesiones fijas (sticky) que el proxy rastrea en el heartbeat.

--- a/crates/ruscker-admin/assets/i18n/fr/landing.ftl
+++ b/crates/ruscker-admin/assets/i18n/fr/landing.ftl
@@ -602,3 +602,5 @@ admin-disk-prune-images = Supprimer les inutilisées
 admin-disk-prune-images-confirm = Supprimer toutes les images inutilisées ?
 admin-disk-flash-images-pruned = Images inutilisées supprimées.
 admin-disk-cleaning = Nettoyage…
+admin-dashboard-metric-sessions-help = Sessions que les réplicas déclarent servir actuellement.
+admin-dashboard-metric-tracker-help = Sessions persistantes (sticky) suivies par le proxy dans le heartbeat.

--- a/crates/ruscker-admin/assets/i18n/pt/landing.ftl
+++ b/crates/ruscker-admin/assets/i18n/pt/landing.ftl
@@ -606,3 +606,5 @@ admin-disk-prune-images = Remover não usadas
 admin-disk-prune-images-confirm = Remover todas as imagens não usadas?
 admin-disk-flash-images-pruned = Imagens não usadas removidas.
 admin-disk-cleaning = Limpando…
+admin-dashboard-metric-sessions-help = Sessões que as réplicas reportam atendendo agora.
+admin-dashboard-metric-tracker-help = Sessões fixas (sticky) rastreadas pelo proxy no heartbeat.

--- a/crates/ruscker-admin/templates/admin/dashboard.html
+++ b/crates/ruscker-admin/templates/admin/dashboard.html
@@ -122,19 +122,22 @@
 {% endif %}
 
 <div class="dash-metric-grid" id="dash-metrics">
+  {# Capacity → load → resources. The two session metrics sit side by
+     side so they can be compared (#469); tooltips spell out the
+     difference (replica-reported vs. proxy-tracked sticky sessions). #}
   <div class="dash-metric">
     <div class="dash-metric-label"><i class="ti ti-box"></i>{{ self.t("admin-dashboard-metric-containers") }}</div>
     <div class="dash-metric-value" data-metric="containers">{{ total_containers }}</div>
   </div>
   <div class="dash-metric">
-    <div class="dash-metric-label"><i class="ti ti-users"></i>{{ self.t("admin-dashboard-metric-sessions") }}</div>
-    <div class="dash-metric-value" data-metric="sessions">{{ total_sessions }}</div>
-  </div>
-  <div class="dash-metric">
     <div class="dash-metric-label"><i class="ti ti-apps"></i>{{ self.t("admin-dashboard-metric-specs") }}</div>
     <div class="dash-metric-value" data-metric="specs">{{ spec_count }}</div>
   </div>
-  <div class="dash-metric">
+  <div class="dash-metric" title="{{ self.t("admin-dashboard-metric-sessions-help") }}">
+    <div class="dash-metric-label"><i class="ti ti-users"></i>{{ self.t("admin-dashboard-metric-sessions") }}</div>
+    <div class="dash-metric-value" data-metric="sessions">{{ total_sessions }}</div>
+  </div>
+  <div class="dash-metric" title="{{ self.t("admin-dashboard-metric-tracker-help") }}">
     <div class="dash-metric-label"><i class="ti ti-activity"></i>{{ self.t("admin-dashboard-metric-tracker") }}</div>
     <div class="dash-metric-value" data-metric="tracker">{{ tracker_sessions }}</div>
   </div>


### PR DESCRIPTION
Closes #469.

Os dois cards de sessão — **Sessões ativas** (soma de `sessions_active` das réplicas) e **Sessões rastreadas** (`SessionTracker::len()`) — estavam separados pelo card "Apps com réplica", então não dava pra comparar e a diferença não era explicada.

- Reordena os cards num fluxo capacidade → carga → recursos: **Containers · Apps com réplica · Sessões ativas · Sessões rastreadas · Memória**. Os dois cards de sessão agora ficam lado a lado.
- Tooltip em cada card de sessão explicando o que conta (reportado pelas réplicas vs. sticky rastreado pelo proxy). 2 chaves i18n × 4 locales.

Só template/i18n: o **patcher SSE mira por `data-metric`** (não por posição), então as atualizações ao vivo não são afetadas — confirmado por render-smoke (ordem = containers·specs·sessions·tracker·memory, tooltips presentes). clippy `-D warnings` + i18n parity verdes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)