### PR TITLE
feat(admin): group the Portal editor's visual sections (#471)

### DIFF
--- a/crates/ruscker-admin/templates/admin/landing.html
+++ b/crates/ruscker-admin/templates/admin/landing.html
@@ -138,6 +138,48 @@
         </div>
       </div>
 
+      {# ── Header / footer logos (visual identity, grouped with Colors #471) #}
+      <div class="spec-form-section-title">{{ self.t("admin-landing-logos") }}</div>
+      <div class="spec-form-field">
+        <div class="spec-form-help" style="margin-bottom:8px">{{ self.t("admin-landing-logos-help") }}</div>
+        {# Submitted as one hidden JSON field; the rows below edit the array. #}
+        <input type="hidden" name="logos_json" :value="JSON.stringify(logos)">
+        <template x-for="(logo, i) in logos" :key="i">
+          <div class="landing-logo-row">
+            <img :src="assetUrl(logo.url)" alt="" class="landing-logo-thumb" x-show="logo.url">
+            {# Shared gallery picker (#451): writes only this row's `url`,
+               leaving slot/align/link/height intact. The field stays
+               editable for an external/manual URL. #}
+            <button type="button" class="admin-login-btn" style="padding:6px 10px;font-size:12px;white-space:nowrap"
+                    @click="openImagePicker((v) => { logo.url = v }, logo.url)">
+              <i class="ti ti-photo" aria-hidden="true"></i>
+              {{ self.t("spec-form-choose-image") }}
+            </button>
+            <input type="text" x-model="logo.url"
+                   placeholder="/assets/img/logo.png" class="spec-form-input spec-form-input--mono" style="flex:2;min-width:10rem">
+            <select x-model="logo.slot" class="theme-select">
+              <option value="header">{{ self.t("admin-landing-logo-header") }}</option>
+              <option value="footer">{{ self.t("admin-landing-logo-footer") }}</option>
+            </select>
+            <select x-model="logo.align" class="theme-select">
+              <option value="left">{{ self.t("admin-landing-logo-left") }}</option>
+              <option value="center">{{ self.t("admin-landing-logo-center") }}</option>
+              <option value="right">{{ self.t("admin-landing-logo-right") }}</option>
+            </select>
+            <input type="url" x-model="logo.link" placeholder="https://…"
+                   class="spec-form-input" style="flex:1;min-width:8rem" title="{{ self.t("admin-landing-logo-link") }}">
+            <input type="number" x-model.number="logo.height" min="8" max="240" placeholder="32"
+                   class="spec-form-input" style="width:4.5rem" title="{{ self.t("admin-landing-logo-height") }}">
+            <button type="button" class="admin-nav-link" @click="logos.splice(i, 1)"
+                    title="{{ self.t("admin-landing-clear") }}"><i class="ti ti-trash" aria-hidden="true"></i></button>
+          </div>
+        </template>
+        <button type="button" class="admin-nav-link mt-2"
+                @click="logos.push({ url: '', slot: 'header', align: 'left', link: null, height: 32 })">
+          <i class="ti ti-plus" aria-hidden="true"></i> {{ self.t("admin-landing-logo-add") }}
+        </button>
+      </div>
+
       <div class="spec-form-section-title">{{ self.t("admin-landing-intro") }}</div>
 
       <div class="spec-form-field">
@@ -224,48 +266,6 @@
                   placeholder=".rcard { border-radius: 6px } &#10;:root { --color-link: #1d9e75 }"
                   class="spec-form-input spec-form-input--mono">{{ form.custom_css }}</textarea>
         <div class="spec-form-help">{{ self.t("admin-landing-custom-css-help") }}</div>
-      </div>
-
-      {# ── Header / footer logos ─────────────────────────────── #}
-      <div class="spec-form-section-title">{{ self.t("admin-landing-logos") }}</div>
-      <div class="spec-form-field">
-        <div class="spec-form-help" style="margin-bottom:8px">{{ self.t("admin-landing-logos-help") }}</div>
-        {# Submitted as one hidden JSON field; the rows below edit the array. #}
-        <input type="hidden" name="logos_json" :value="JSON.stringify(logos)">
-        <template x-for="(logo, i) in logos" :key="i">
-          <div class="landing-logo-row">
-            <img :src="assetUrl(logo.url)" alt="" class="landing-logo-thumb" x-show="logo.url">
-            {# Shared gallery picker (#451): writes only this row's `url`,
-               leaving slot/align/link/height intact. The field stays
-               editable for an external/manual URL. #}
-            <button type="button" class="admin-login-btn" style="padding:6px 10px;font-size:12px;white-space:nowrap"
-                    @click="openImagePicker((v) => { logo.url = v }, logo.url)">
-              <i class="ti ti-photo" aria-hidden="true"></i>
-              {{ self.t("spec-form-choose-image") }}
-            </button>
-            <input type="text" x-model="logo.url"
-                   placeholder="/assets/img/logo.png" class="spec-form-input spec-form-input--mono" style="flex:2;min-width:10rem">
-            <select x-model="logo.slot" class="theme-select">
-              <option value="header">{{ self.t("admin-landing-logo-header") }}</option>
-              <option value="footer">{{ self.t("admin-landing-logo-footer") }}</option>
-            </select>
-            <select x-model="logo.align" class="theme-select">
-              <option value="left">{{ self.t("admin-landing-logo-left") }}</option>
-              <option value="center">{{ self.t("admin-landing-logo-center") }}</option>
-              <option value="right">{{ self.t("admin-landing-logo-right") }}</option>
-            </select>
-            <input type="url" x-model="logo.link" placeholder="https://…"
-                   class="spec-form-input" style="flex:1;min-width:8rem" title="{{ self.t("admin-landing-logo-link") }}">
-            <input type="number" x-model.number="logo.height" min="8" max="240" placeholder="32"
-                   class="spec-form-input" style="width:4.5rem" title="{{ self.t("admin-landing-logo-height") }}">
-            <button type="button" class="admin-nav-link" @click="logos.splice(i, 1)"
-                    title="{{ self.t("admin-landing-clear") }}"><i class="ti ti-trash" aria-hidden="true"></i></button>
-          </div>
-        </template>
-        <button type="button" class="admin-nav-link mt-2"
-                @click="logos.push({ url: '', slot: 'header', align: 'left', link: null, height: 32 })">
-          <i class="ti ti-plus" aria-hidden="true"></i> {{ self.t("admin-landing-logo-add") }}
-        </button>
       </div>
 
     </form>


### PR DESCRIPTION
Closes #471.

As seções do editor de Portal estavam: Cores · Intro · Intro-idioma · SEO · Analytics · Custom CSS · **Logos** — então as seções **visuais/branding** ficavam espalhadas (Cores no topo, **Logos jogado no fim**), com conteúdo/meta no meio, e o Custom CSS (avançado) antes dos Logos.

Reordena para um fluxo natural **identidade → conteúdo → meta → avançado**: **Cores · Logos · Intro · Intro-idioma · SEO · Analytics · Custom CSS**. Sobe a seção Logos pra junto de Cores; o Custom CSS cai pro fim (override de power-user).

Move de bloco só no template — o picker de logos (modal #460) + o binding `logos_json` ficam intactos. Render-smoke confirmou a ordem (Cores, Logos, Intro, Intro-idioma, SEO, Analytics, CSS, Prévia); o template compila (Askama).

🤖 Generated with [Claude Code](https://claude.com/claude-code)