### PR TITLE
fix(admin): live title/subtitle preview + optional subtitle (#468)

### DIFF
--- a/crates/ruscker-admin/assets/i18n/en/landing.ftl
+++ b/crates/ruscker-admin/assets/i18n/en/landing.ftl
@@ -608,4 +608,4 @@ admin-landing-header = Header
 admin-landing-portal-title = Portal title
 admin-landing-portal-title-help = Shown at the top of the landing. Blank uses the config title (proxy.title).
 admin-landing-portal-subtitle = Subtitle
-admin-landing-portal-subtitle-help = The line under the title. Blank uses the default subtitle.
+admin-landing-portal-subtitle-help = The line under the title. Leave blank to hide it.

--- a/crates/ruscker-admin/assets/i18n/es/landing.ftl
+++ b/crates/ruscker-admin/assets/i18n/es/landing.ftl
@@ -608,4 +608,4 @@ admin-landing-header = Encabezado
 admin-landing-portal-title = Título del portal
 admin-landing-portal-title-help = Aparece arriba en la landing. En blanco usa el título del config (proxy.title).
 admin-landing-portal-subtitle = Subtítulo
-admin-landing-portal-subtitle-help = La línea bajo el título. En blanco usa el subtítulo por defecto.
+admin-landing-portal-subtitle-help = La línea bajo el título. Déjalo en blanco para ocultarlo.

--- a/crates/ruscker-admin/assets/i18n/fr/landing.ftl
+++ b/crates/ruscker-admin/assets/i18n/fr/landing.ftl
@@ -608,4 +608,4 @@ admin-landing-header = En-tête
 admin-landing-portal-title = Titre du portail
 admin-landing-portal-title-help = Affiché en haut de la landing. Vide : utilise le titre de la config (proxy.title).
 admin-landing-portal-subtitle = Sous-titre
-admin-landing-portal-subtitle-help = La ligne sous le titre. Vide : utilise le sous-titre par défaut.
+admin-landing-portal-subtitle-help = La ligne sous le titre. Laissez vide pour le masquer.

--- a/crates/ruscker-admin/assets/i18n/pt/landing.ftl
+++ b/crates/ruscker-admin/assets/i18n/pt/landing.ftl
@@ -612,4 +612,4 @@ admin-landing-header = Cabeçalho
 admin-landing-portal-title = Título do portal
 admin-landing-portal-title-help = Aparece no topo da landing. Em branco, usa o título do config (proxy.title).
 admin-landing-portal-subtitle = Subtítulo
-admin-landing-portal-subtitle-help = A linha abaixo do título. Em branco, usa o subtítulo padrão.
+admin-landing-portal-subtitle-help = A linha abaixo do título. Em branco, o subtítulo fica oculto.

--- a/crates/ruscker-admin/src/routes/landing.rs
+++ b/crates/ruscker-admin/src/routes/landing.rs
@@ -270,8 +270,10 @@ async fn index(
             cfg_title.to_string()
         }
     });
-    let header_subtitle =
-        not_blank(&lc.subtitle).unwrap_or_else(|| state.locales.t(loc, "landing-subtitle", None));
+    // The subtitle is optional (#468): a blank override hides it entirely
+    // (the template skips the `<p>` when empty). The localized default is
+    // only a placeholder hint in the editor, not a forced fallback.
+    let header_subtitle = not_blank(&lc.subtitle).unwrap_or_default();
 
     let page = LandingPage {
         locale: loc,

--- a/crates/ruscker-admin/templates/admin/landing.html
+++ b/crates/ruscker-admin/templates/admin/landing.html
@@ -295,8 +295,14 @@
              :style="(form.header_bg ? `background:${form.header_bg};` : '') + (form.header_fg ? `color:${form.header_fg};` : '')">
           <div class="landing-preview-header-inner">
             <div>
-              <div class="landing-preview-title">{{ portal_title }}</div>
-              <div class="landing-preview-sub">{{ self.t("landing-subtitle") }}</div>
+              {# Live preview (#468): title binds to the form, falling back
+                 to the config title; subtitle is optional (hidden when blank). #}
+              <div class="landing-preview-title">
+                <span x-show="(form.title || '').trim()" x-text="form.title"></span>
+                <span x-show="!(form.title || '').trim()">{{ portal_title }}</span>
+              </div>
+              <div class="landing-preview-sub" x-show="(form.subtitle || '').trim()"
+                   x-text="form.subtitle" x-cloak></div>
             </div>
             <div class="landing-preview-count">N</div>
           </div>


### PR DESCRIPTION
Dois fixes do teste local do header editável (#468):

- **Preview ao vivo:** o preview do editor mostrava o título do config (estático) e o subtítulo i18n — não atualizava ao digitar. Agora liga em `form.title`/`form.subtitle` (`x-text`), com o título do config como fallback quando o campo está vazio.
- **Subtítulo opcional:** em branco agora **oculta** o subtítulo (o `<p>` público é pulado) em vez de cair no default localizado. O default fica só como placeholder/dica no editor; help atualizado nos 4 locales.

clippy `-D warnings`, i18n paridade, suíte verde; smoke ao vivo confirma o header sem subtítulo quando não setado.

🤖 Generated with [Claude Code](https://claude.com/claude-code)