### PR TITLE
feat(cli): auto-connect Docker by default; add --no-docker (#477)

### DIFF
--- a/book/src/quickstart.md
+++ b/book/src/quickstart.md
@@ -39,12 +39,14 @@ ruscker validate application.yml
 ## 3. Run it
 
 ```sh
-ruscker serve --config application.yml --bind 127.0.0.1:8080 --docker
+ruscker serve --config application.yml --bind 127.0.0.1:8080
 ```
 
-`--docker` enables the backend that spawns app containers; without it the
-landing page and admin still work but `/app/*` returns 503. To unlock the
-admin panel, also pass an admin token and a DB:
+Ruscker **auto-connects to Docker** when the daemon socket is reachable, so
+app containers spawn out of the box. Pass `--no-docker` to run landing-only
+(then `/app/*` returns 503); pass `--docker` to make a failed connect a fatal
+error instead of falling back to landing-only (useful for a remote daemon). To
+unlock the admin panel, also pass an admin token and a DB:
 
 ```sh
 RUSCKER_ADMIN_TOKEN=$(openssl rand -hex 32) \

--- a/crates/ruscker-cli/src/main.rs
+++ b/crates/ruscker-cli/src/main.rs
@@ -161,11 +161,18 @@ enum Command {
         #[arg(long, env = "RUSCKER_MASTER_KEY")]
         master_key: Option<String>,
 
-        /// Enable the local Docker backend. Required for the
-        /// proxy routes (`/app/*`, `/api/*`) to actually spawn
-        /// containers. Without it those routes return 503.
+        /// Force the Docker backend on. By default Ruscker auto-connects
+        /// when the daemon socket is reachable; `--docker` makes a failed
+        /// connect a fatal boot error instead of a landing-only fallback
+        /// (useful for a remote/explicit Docker host).
         #[arg(long)]
         docker: bool,
+
+        /// Run landing-only: never connect to Docker even if the socket
+        /// is reachable. The proxy routes (`/app/*`, `/api/*`) return 503.
+        /// Opts out of the default auto-connect.
+        #[arg(long, conflicts_with = "docker")]
+        no_docker: bool,
 
         /// Postgres DSN for the shared HA session store
         /// (`postgres://user:pass@host/db`). When set, several Ruscker
@@ -221,6 +228,7 @@ fn main() -> Result<()> {
             admin_token,
             master_key,
             docker,
+            no_docker,
             session_store_url,
             admin_session_store_url,
             base_path,
@@ -233,6 +241,7 @@ fn main() -> Result<()> {
             admin_token,
             master_key,
             docker,
+            no_docker,
             session_store_url,
             admin_session_store_url,
             base_path_override: base_path,
@@ -402,6 +411,7 @@ struct ServeArgs {
     admin_token: Option<String>,
     master_key: Option<String>,
     docker: bool,
+    no_docker: bool,
     session_store_url: Option<String>,
     admin_session_store_url: Option<String>,
     base_path_override: Option<String>,
@@ -418,6 +428,7 @@ fn cmd_serve(args: ServeArgs) -> Result<()> {
         admin_token,
         master_key,
         docker,
+        no_docker,
         session_store_url,
         admin_session_store_url,
         base_path_override,
@@ -475,32 +486,50 @@ fn cmd_serve(args: ServeArgs) -> Result<()> {
         if let Some(k) = master_key {
             server = server.with_master_key(k).context("invalid --master-key")?;
         }
-        if docker {
-            let backend: std::sync::Arc<dyn ruscker_core::ContainerBackend> = if hosts.is_empty() {
-                std::sync::Arc::new(
-                    ruscker_docker::LocalDockerBackend::local()
-                        .context("connect to Docker daemon")?,
-                )
-            } else {
-                tracing::info!(count = hosts.len(), "multi-host backend");
-                std::sync::Arc::new(
-                    ruscker_docker::MultiHostDockerBackend::connect(&hosts)
-                        .context("connect to Docker hosts")?,
-                )
-            };
-            server = server.with_backend(backend);
-        } else if is_local_docker_reachable() {
-            // #184: the operator started without `--docker` on a host
-            // where the daemon socket is reachable. Spawning containers
-            // is the whole point of the proxy, so nudge them once at
-            // startup — this is a hint, not a hard requirement (the
-            // landing + admin still work in proxy-less mode).
-            tracing::warn!(
-                "Docker socket is reachable at /var/run/docker.sock but --docker is OFF — \
-                 app containers will not spawn. If you installed from the Ruscker .deb \
-                 package run `sudo ruscker-enable-docker`; otherwise add --docker to the \
-                 command line."
-            );
+        // Docker backend (#477): the default is **auto** — connect when
+        // the daemon is reachable, so a fresh install just works. `--docker`
+        // forces it on (a failed connect is then a fatal boot error, e.g.
+        // for a remote host); `--no-docker` forces landing-only.
+        if no_docker {
+            // Explicit landing-only — nothing to wire, no nudge.
+        } else if !hosts.is_empty() {
+            // Multi-host is itself an explicit opt-in (the operator listed
+            // hosts); `connect` validates them and fails only on zero.
+            tracing::info!(count = hosts.len(), "multi-host backend");
+            let backend = ruscker_docker::MultiHostDockerBackend::connect(&hosts)
+                .context("connect to Docker hosts")?;
+            server = server.with_backend(std::sync::Arc::new(backend));
+        } else if docker || is_local_docker_reachable() {
+            // `docker` ⇒ forced on; otherwise auto (the socket file exists).
+            match ruscker_docker::LocalDockerBackend::local() {
+                Ok(b) => {
+                    let backend: std::sync::Arc<dyn ruscker_core::ContainerBackend> =
+                        std::sync::Arc::new(b);
+                    // The socket file can be present while the service user
+                    // lacks access (not in the `docker` group) — that only
+                    // surfaces on a real API call, so probe before committing.
+                    match backend.list().await {
+                        Ok(_) => server = server.with_backend(backend),
+                        Err(e) if docker => {
+                            return Err(anyhow::anyhow!("{e}"))
+                                .context("--docker is set but the Docker daemon is unreachable");
+                        }
+                        Err(e) => tracing::warn!(
+                            error = %e,
+                            "Docker socket is present but the daemon is unreachable (the \
+                             service user may not be in the `docker` group) — running \
+                             landing-only; app containers won't spawn. Run \
+                             `sudo ruscker-enable-docker` or add the user to the `docker` \
+                             group; pass --no-docker to silence this."
+                        ),
+                    }
+                }
+                Err(e) if docker => return Err(e).context("connect to Docker daemon"),
+                Err(e) => tracing::warn!(
+                    error = ?e,
+                    "could not initialise the Docker client — running landing-only"
+                ),
+            }
         }
         // Config database: Postgres (shared HA catalog) takes precedence
         // over the SQLite path when both are given.


### PR DESCRIPTION
Closes #477.

Um `ruscker serve` fresh agora usa Docker **por padrão**, em vez de mostrar "Docker backend is not connected" até o operador lembrar do `--docker`.

## Comportamento
| Invocação | Resultado |
|---|---|
| `serve` (sem flag) | **auto**: conecta se o socket é acessível e o **probe** (`backend.list()`) passa; se o socket existe mas a conexão falha (ex.: fora do grupo `docker`), cai pra **landing-only com WARN** — sem derrubar o boot |
| `serve --docker` | força ligado: connect falho vira **erro fatal** de boot (daemon remoto/explícito) |
| `serve --no-docker` | força landing-only mesmo com socket acessível (`conflicts_with --docker`) |

O WARN antigo ("socket reachable but --docker is OFF") sai — o default agora simplesmente conecta.

## Validação (host com Docker)
- auto → `docker=true`; `--no-docker` → `docker=false` (sem nudge); `--docker --no-docker` → erro de conflito do clap.
- clippy `-D warnings` + testes do cli verdes; mdbook builda; quickstart atualizado.

## Follow-up (não nesta PR)
Sweep maior de docs/packaging (deploying/installation/admin/troubleshooting + comentário do `ruscker.service` + `ruscker-enable-docker` que pode dropar `--docker` e só adicionar o grupo) pra casar com o novo default.

🤖 Generated with [Claude Code](https://claude.com/claude-code)