### PR TITLE
fix(admin): showcase demos use min-replicas 0 (no pre-spawn on fresh install) (#478)

### DIFF
--- a/crates/ruscker-admin/src/db/showcase.rs
+++ b/crates/ruscker-admin/src/db/showcase.rs
@@ -168,6 +168,11 @@ fn card(
         if let Some(p) = platform {
             spec_json.insert("platform".into(), json!(p));
         }
+        // Demos spawn on demand, not at boot (#478): the default
+        // `min-replicas` is 1 for interactive apps, which would pre-spawn
+        // every showcase container on a fresh install (heavy + pointless
+        // until someone opens a card). 0 ⇒ cold-start on first click.
+        spec_json.insert("min-replicas".into(), json!(0));
     } else {
         // External link card — explicit kind so Spec::kind() doesn't
         // need to infer.


### PR DESCRIPTION
## Resumo

Cards de showcase containerizados herdam o default de `min-replicas` = 1 dos
apps interativos. Numa instalação nova com `--db` + Docker conectado, isso
**pré-spawna todos os containers de demo no boot** — pesado e inútil até alguém
abrir um card.

Fixa os specs de container do showcase em `min-replicas: 0` → cold-start no
primeiro clique. Cards de link externo não são afetados (não têm container).

## Smoke real

Validado localmente: com auto-docker ligado e o catálogo showcase, `docker ps`
mostra **0 containers** no boot (antes subia ~10); o card faz cold-start ao
abrir.

🤖 Generated with [Claude Code](https://claude.com/claude-code)