### PR TITLE
feat(admin): modernize the Portal editor — section cards, logo cards, margin + theme swatches (#482)

### DIFF
--- a/crates/ruscker-admin/assets/i18n/en/landing.ftl
+++ b/crates/ruscker-admin/assets/i18n/en/landing.ftl
@@ -563,6 +563,7 @@ admin-landing-logo-center = Center
 admin-landing-logo-right = Right
 admin-landing-logo-link = Link (optional)
 admin-landing-logo-height = Height (px)
+admin-landing-logo-margin = Margin (px)
 admin-landing-logo-add = Add logo
 
 # — Disk management (admin) #453

--- a/crates/ruscker-admin/assets/i18n/en/landing.ftl
+++ b/crates/ruscker-admin/assets/i18n/en/landing.ftl
@@ -564,6 +564,9 @@ admin-landing-logo-right = Right
 admin-landing-logo-link = Link (optional)
 admin-landing-logo-height = Height (px)
 admin-landing-logo-margin = Margin (px)
+admin-landing-logo-image = Image
+admin-landing-logo-slot-label = Position
+admin-landing-logo-align-label = Alignment
 admin-landing-logo-add = Add logo
 
 # — Disk management (admin) #453

--- a/crates/ruscker-admin/assets/i18n/en/landing.ftl
+++ b/crates/ruscker-admin/assets/i18n/en/landing.ftl
@@ -552,6 +552,14 @@ admin-proclog-download = Download full log
 landing-empty = Nothing here yet.
 
 admin-landing-style = Style (CSS)
+admin-landing-card-appearance = Appearance
+admin-landing-card-content = Content
+admin-landing-card-meta = SEO & analytics
+admin-landing-card-header-desc = Title and subtitle shown at the top of the portal.
+admin-landing-card-appearance-desc = Header colours and each theme's palette (light/dark).
+admin-landing-card-content-desc = The portal's intro text, general and per language.
+admin-landing-card-meta-desc = Search/share metadata and the analytics snippet.
+admin-landing-card-style-desc = Custom CSS, injected last (escape hatch).
 admin-landing-custom-css = Custom CSS
 admin-landing-custom-css-help = CSS injected at the end of the landing <head> — overrides the built-in styles. Target stable classes/variables (.rcard, .tint-*, --color-link, header vars). Admin-trusted; take care not to break the layout.
 admin-landing-logos = Header / footer logos

--- a/crates/ruscker-admin/assets/i18n/es/landing.ftl
+++ b/crates/ruscker-admin/assets/i18n/es/landing.ftl
@@ -564,6 +564,9 @@ admin-landing-logo-right = Derecha
 admin-landing-logo-link = Enlace (opcional)
 admin-landing-logo-height = Altura (px)
 admin-landing-logo-margin = Margen (px)
+admin-landing-logo-image = Imagen
+admin-landing-logo-slot-label = Posición
+admin-landing-logo-align-label = Alineación
 admin-landing-logo-add = Añadir logo
 
 # — Gestión de disco (admin) #453

--- a/crates/ruscker-admin/assets/i18n/es/landing.ftl
+++ b/crates/ruscker-admin/assets/i18n/es/landing.ftl
@@ -552,6 +552,14 @@ admin-proclog-download = Descargar log completo
 landing-empty = Nada por aquí.
 
 admin-landing-style = Estilo (CSS)
+admin-landing-card-appearance = Apariencia
+admin-landing-card-content = Contenido
+admin-landing-card-meta = SEO y analítica
+admin-landing-card-header-desc = Título y subtítulo mostrados en la parte superior del portal.
+admin-landing-card-appearance-desc = Colores del encabezado y la paleta de cada tema (claro/oscuro).
+admin-landing-card-content-desc = El texto introductorio del portal, general y por idioma.
+admin-landing-card-meta-desc = Metadatos de búsqueda/compartir y el fragmento de analítica.
+admin-landing-card-style-desc = CSS personalizado, inyectado al final (escape hatch).
 admin-landing-custom-css = CSS personalizado
 admin-landing-custom-css-help = CSS inyectado al final del <head> de la landing — sobrescribe los estilos por defecto. Apunta a clases/variables estables (.rcard, .tint-*, --color-link, variables del header). De confianza (admin); cuidado con romper el diseño.
 admin-landing-logos = Logos de cabecera/pie

--- a/crates/ruscker-admin/assets/i18n/es/landing.ftl
+++ b/crates/ruscker-admin/assets/i18n/es/landing.ftl
@@ -563,6 +563,7 @@ admin-landing-logo-center = Centro
 admin-landing-logo-right = Derecha
 admin-landing-logo-link = Enlace (opcional)
 admin-landing-logo-height = Altura (px)
+admin-landing-logo-margin = Margen (px)
 admin-landing-logo-add = Añadir logo
 
 # — Gestión de disco (admin) #453

--- a/crates/ruscker-admin/assets/i18n/fr/landing.ftl
+++ b/crates/ruscker-admin/assets/i18n/fr/landing.ftl
@@ -552,6 +552,14 @@ admin-proclog-download = Télécharger le journal complet
 landing-empty = Rien ici pour l'instant.
 
 admin-landing-style = Style (CSS)
+admin-landing-card-appearance = Apparence
+admin-landing-card-content = Contenu
+admin-landing-card-meta = SEO et analytics
+admin-landing-card-header-desc = Titre et sous-titre affichés en haut du portail.
+admin-landing-card-appearance-desc = Couleurs de l'en-tête et la palette de chaque thème (clair/sombre).
+admin-landing-card-content-desc = Le texte d'introduction du portail, général et par langue.
+admin-landing-card-meta-desc = Métadonnées de recherche/partage et le snippet d'analytics.
+admin-landing-card-style-desc = CSS personnalisé, injecté en dernier (échappatoire).
 admin-landing-custom-css = CSS personnalisé
 admin-landing-custom-css-help = CSS injecté à la fin du <head> de la landing — remplace les styles intégrés. Ciblez des classes/variables stables (.rcard, .tint-*, --color-link, variables d'en-tête). De confiance (admin) ; attention à ne pas casser la mise en page.
 admin-landing-logos = Logos en-tête/pied

--- a/crates/ruscker-admin/assets/i18n/fr/landing.ftl
+++ b/crates/ruscker-admin/assets/i18n/fr/landing.ftl
@@ -564,6 +564,9 @@ admin-landing-logo-right = Droite
 admin-landing-logo-link = Lien (optionnel)
 admin-landing-logo-height = Hauteur (px)
 admin-landing-logo-margin = Marge (px)
+admin-landing-logo-image = Image
+admin-landing-logo-slot-label = Position
+admin-landing-logo-align-label = Alignement
 admin-landing-logo-add = Ajouter un logo
 
 # — Gestion du disque (admin) #453

--- a/crates/ruscker-admin/assets/i18n/fr/landing.ftl
+++ b/crates/ruscker-admin/assets/i18n/fr/landing.ftl
@@ -563,6 +563,7 @@ admin-landing-logo-center = Centre
 admin-landing-logo-right = Droite
 admin-landing-logo-link = Lien (optionnel)
 admin-landing-logo-height = Hauteur (px)
+admin-landing-logo-margin = Marge (px)
 admin-landing-logo-add = Ajouter un logo
 
 # — Gestion du disque (admin) #453

--- a/crates/ruscker-admin/assets/i18n/pt/landing.ftl
+++ b/crates/ruscker-admin/assets/i18n/pt/landing.ftl
@@ -567,6 +567,7 @@ admin-landing-logo-center = Centro
 admin-landing-logo-right = Direita
 admin-landing-logo-link = Link (opcional)
 admin-landing-logo-height = Altura (px)
+admin-landing-logo-margin = Margem (px)
 admin-landing-logo-add = Adicionar logo
 
 # — Gestão de disco (admin) #453

--- a/crates/ruscker-admin/assets/i18n/pt/landing.ftl
+++ b/crates/ruscker-admin/assets/i18n/pt/landing.ftl
@@ -556,6 +556,14 @@ admin-proclog-download = Baixar log completo
 landing-empty = Nada por aqui.
 
 admin-landing-style = Estilo (CSS)
+admin-landing-card-appearance = Aparência
+admin-landing-card-content = Conteúdo
+admin-landing-card-meta = SEO e Analytics
+admin-landing-card-header-desc = Título e subtítulo exibidos no topo do portal.
+admin-landing-card-appearance-desc = Cores do cabeçalho e a paleta de cada tema (claro/escuro).
+admin-landing-card-content-desc = O texto introdutório do portal, geral e por idioma.
+admin-landing-card-meta-desc = Metadados de busca/compartilhamento e o snippet de analytics.
+admin-landing-card-style-desc = CSS customizado, injetado por último (escape hatch).
 admin-landing-custom-css = CSS personalizado
 admin-landing-custom-css-help = CSS injetado no fim do <head> da landing — sobrescreve o estilo padrão. Mire classes/variáveis estáveis (.rcard, .tint-*, --color-link, vars do header). Admin-confiável; cuidado para não quebrar o layout.
 admin-landing-logos = Logos do cabeçalho/rodapé

--- a/crates/ruscker-admin/assets/i18n/pt/landing.ftl
+++ b/crates/ruscker-admin/assets/i18n/pt/landing.ftl
@@ -568,6 +568,9 @@ admin-landing-logo-right = Direita
 admin-landing-logo-link = Link (opcional)
 admin-landing-logo-height = Altura (px)
 admin-landing-logo-margin = Margem (px)
+admin-landing-logo-image = Imagem
+admin-landing-logo-slot-label = Posição
+admin-landing-logo-align-label = Alinhamento
 admin-landing-logo-add = Adicionar logo
 
 # — Gestão de disco (admin) #453

--- a/crates/ruscker-admin/assets/tailwind/input.css
+++ b/crates/ruscker-admin/assets/tailwind/input.css
@@ -1067,6 +1067,53 @@ textarea.spec-form-input { resize: vertical; min-height: 64px; }
   padding: 3px; background: var(--surface-soft);
 }
 
+/* Logo editor cards (#482 UX): one labelled card per logo, replacing the
+   flat unlabelled control row. */
+.landing-logo-card {
+  border: 0.5px solid var(--border, rgba(120,120,120,0.25));
+  border-radius: 10px;
+  background: var(--surface);
+  padding: 12px 14px;
+  margin-bottom: 10px;
+}
+.landing-logo-card__head { display: flex; align-items: flex-start; gap: 10px; }
+.landing-logo-card__head .landing-logo-thumb { width: 44px; height: 44px; flex: none; }
+.landing-logo-thumb--empty {
+  display: inline-flex; align-items: center; justify-content: center;
+  color: var(--text-muted); font-size: 18px;
+}
+.landing-logo-image-row { display: flex; gap: 8px; align-items: center; }
+.landing-logo-pick { padding: 7px 11px; font-size: 12px; white-space: nowrap; flex: none; }
+.landing-logo-card__remove { flex: none; margin-top: 22px; }
+.landing-logo-card__grid {
+  display: grid;
+  grid-template-columns: repeat(auto-fit, minmax(132px, 1fr));
+  gap: 12px;
+  margin-top: 14px;
+}
+.landing-logo-field { display: flex; flex-direction: column; gap: 5px; min-width: 0; }
+.landing-logo-field > label {
+  font-size: 11px; font-weight: 600; color: var(--text-muted);
+  text-transform: uppercase; letter-spacing: 0.04em;
+}
+
+/* Segmented pill control — slot / alignment pickers. */
+.seg-control {
+  display: inline-flex; width: fit-content; max-width: 100%;
+  border: 0.5px solid var(--border, rgba(120,120,120,0.25));
+  border-radius: 8px; overflow: hidden;
+}
+.seg-control button {
+  display: inline-flex; align-items: center; justify-content: center; gap: 5px;
+  padding: 7px 12px; background: var(--surface); border: 0; cursor: pointer;
+  color: var(--text-muted); font-family: inherit; font-size: 13px; line-height: 1.2;
+  transition: background 0.12s, color 0.12s;
+}
+.seg-control button:hover { background: var(--surface-soft); color: var(--text); }
+.seg-control button + button { border-left: 0.5px solid var(--border, rgba(120,120,120,0.25)); }
+.seg-control button.is-active { background: var(--color-teal-600); color: #fff; }
+.seg-control .ti { font-size: 16px; }
+
 /* Public landing header/footer logo bars (admin-managed) */
 .landing-logo-bar {
   display: grid; grid-template-columns: 1fr auto 1fr; align-items: center;

--- a/crates/ruscker-admin/assets/tailwind/input.css
+++ b/crates/ruscker-admin/assets/tailwind/input.css
@@ -1146,14 +1146,16 @@ textarea.spec-form-input { resize: vertical; min-height: 64px; }
 .editor-card--preview { padding-bottom: 14px; }
 
 /* Public landing header/footer logo bars (admin-managed) */
+/* Center logo bar (#468): left/right buckets now live in the chrome, so this
+   bar only ever holds the `center` group — centre it with flex. (The old
+   3-column grid `1fr auto 1fr` left a lone center child stuck in the first
+   1fr column, i.e. off to the left.) */
 .landing-logo-bar {
-  display: grid; grid-template-columns: 1fr auto 1fr; align-items: center;
+  display: flex; align-items: center; justify-content: center;
   gap: 16px; padding-top: 12px; padding-bottom: 12px;
 }
 .landing-logo-group { display: flex; align-items: center; gap: 16px; flex-wrap: wrap; }
-.landing-logo-left { justify-self: start; }
-.landing-logo-center { justify-self: center; }
-.landing-logo-right { justify-self: end; }
+.landing-logo-center { justify-content: center; }
 .landing-logo-bar img { display: block; width: auto; object-fit: contain; }
 .landing-logo-bar--footer {
   border-top: 0.5px solid var(--border, rgba(120,120,120,0.25));

--- a/crates/ruscker-admin/assets/tailwind/input.css
+++ b/crates/ruscker-admin/assets/tailwind/input.css
@@ -1114,6 +1114,37 @@ textarea.spec-form-input { resize: vertical; min-height: 64px; }
 .seg-control button.is-active { background: var(--color-teal-600); color: #fff; }
 .seg-control .ti { font-size: 16px; }
 
+/* ── Landing editor: modern section-card layout (#482 polish) ────── */
+/* Sticky action bar so Save / Open portal stay reachable on a long form. */
+.editor-topbar {
+  position: sticky; top: 0; z-index: 20;
+  display: flex; align-items: flex-end; justify-content: space-between; gap: 16px;
+  background: var(--bg);
+  border-bottom: 0.5px solid var(--border);
+  padding: 14px 0 12px; margin-bottom: 18px;
+}
+/* Each configuration group is a card — icon + title head, then its fields. */
+.editor-card {
+  border: 0.5px solid var(--border);
+  border-radius: 12px;
+  background: var(--surface);
+  padding: 16px 18px 18px;
+  margin-bottom: 14px;
+}
+.editor-card__head { display: flex; align-items: center; gap: 11px; margin-bottom: 16px; }
+.editor-card__icon {
+  display: inline-flex; align-items: center; justify-content: center;
+  width: 32px; height: 32px; flex: none; border-radius: 9px;
+  background: rgba(15, 110, 86, 0.10); color: var(--color-teal-600); font-size: 17px;
+}
+.editor-card__title { font-size: 14px; font-weight: 600; color: var(--text); letter-spacing: -0.01em; line-height: 1.2; }
+.editor-card__desc { font-size: 11.5px; color: var(--text-muted); margin-top: 2px; line-height: 1.35; }
+/* The first legacy sub-title inside a card drops its big standalone top margin. */
+.editor-card .editor-card__head + .spec-form-section-title,
+.editor-card > .spec-form-section-title:first-child { margin-top: 0; }
+/* Preview card sits in the sticky aside; let the frame breathe inside it. */
+.editor-card--preview { padding-bottom: 14px; }
+
 /* Public landing header/footer logo bars (admin-managed) */
 .landing-logo-bar {
   display: grid; grid-template-columns: 1fr auto 1fr; align-items: center;

--- a/crates/ruscker-admin/assets/tailwind/input.css
+++ b/crates/ruscker-admin/assets/tailwind/input.css
@@ -1145,22 +1145,17 @@ textarea.spec-form-input { resize: vertical; min-height: 64px; }
 /* Preview card sits in the sticky aside; let the frame breathe inside it. */
 .editor-card--preview { padding-bottom: 14px; }
 
-/* Public landing header/footer logo bars (admin-managed) */
-/* Center logo bar (#468): left/right buckets now live in the chrome, so this
-   bar only ever holds the `center` group — centre it with flex. (The old
-   3-column grid `1fr auto 1fr` left a lone center child stuck in the first
-   1fr column, i.e. off to the left.) */
-.landing-logo-bar {
-  display: flex; align-items: center; justify-content: center;
-  gap: 16px; padding-top: 12px; padding-bottom: 12px;
+/* Header/footer center logos (#468): absolutely centred within the header
+   bar / footer chrome (their empty middle), so they read as part of the bar
+   itself — not a separate strip below the header / above the footer. The
+   parent (header inner / footer) carries `relative`. */
+.landing-logo-center-abs {
+  position: absolute; left: 50%; top: 50%; transform: translate(-50%, -50%);
+  display: flex; align-items: center; gap: 16px;
+  pointer-events: none;
 }
-.landing-logo-group { display: flex; align-items: center; gap: 16px; flex-wrap: wrap; }
-.landing-logo-center { justify-content: center; }
-.landing-logo-bar img { display: block; width: auto; object-fit: contain; }
-.landing-logo-bar--footer {
-  border-top: 0.5px solid var(--border, rgba(120,120,120,0.25));
-  margin-top: 8px; opacity: 0.92;
-}
+.landing-logo-center-abs a { pointer-events: auto; }
+.landing-logo-center-abs img { display: block; width: auto; object-fit: contain; }
 .image-tile {
   position: relative;
   background: var(--surface);
@@ -1280,6 +1275,7 @@ textarea.spec-form-input { resize: vertical; min-height: 64px; }
 .landing-preview-header-inner {
   display: flex; align-items: center; justify-content: space-between; gap: 8px;
   padding: 10px 12px;
+  position: relative;
 }
 .landing-preview-title {
   font-size: 13px; font-weight: 500;
@@ -1322,14 +1318,11 @@ textarea.spec-form-input { resize: vertical; min-height: 64px; }
 .lp-head-side { display: flex; align-items: center; gap: 5px; min-width: 0; }
 .lp-logo { display: block; width: auto; object-fit: contain; }
 .lp-mark { width: 14px; height: 14px; flex: none; }
-.landing-preview-centerbar {
-  display: flex; align-items: center; justify-content: center; gap: 8px;
-  padding: 5px 12px; border-top: 0.5px solid var(--border-soft);
-}
 .landing-preview-footer {
   display: flex; align-items: center; justify-content: space-between; gap: 8px;
   padding: 6px 12px; border-top: 0.5px solid var(--border);
   font-size: 9px; color: var(--text-muted);
+  position: relative;
 }
 .landing-preview-footer .lp-version { opacity: 0.7; }
 

--- a/crates/ruscker-admin/assets/tailwind/input.css
+++ b/crates/ruscker-admin/assets/tailwind/input.css
@@ -1276,7 +1276,7 @@ textarea.spec-form-input { resize: vertical; min-height: 64px; }
   border-bottom: 0.5px solid var(--border);
 }
 .landing-preview-header-inner {
-  display: flex; align-items: flex-end; justify-content: space-between;
+  display: flex; align-items: center; justify-content: space-between; gap: 8px;
   padding: 10px 12px;
 }
 .landing-preview-title {
@@ -1316,6 +1316,20 @@ textarea.spec-form-input { resize: vertical; min-height: 64px; }
   border: 0.5px solid var(--border);
   border-radius: 4px;
 }
+/* Live preview: logos in the header/footer chrome + a faithful footer. */
+.lp-head-side { display: flex; align-items: center; gap: 5px; min-width: 0; }
+.lp-logo { display: block; width: auto; object-fit: contain; }
+.lp-mark { width: 14px; height: 14px; flex: none; }
+.landing-preview-centerbar {
+  display: flex; align-items: center; justify-content: center; gap: 8px;
+  padding: 5px 12px; border-top: 0.5px solid var(--border-soft);
+}
+.landing-preview-footer {
+  display: flex; align-items: center; justify-content: space-between; gap: 8px;
+  padding: 6px 12px; border-top: 0.5px solid var(--border);
+  font-size: 9px; color: var(--text-muted);
+}
+.landing-preview-footer .lp-version { opacity: 0.7; }
 
 /* ─── Audit log viewer ───────────────────────────────────────── */
 .audit-filter-bar {

--- a/crates/ruscker-admin/src/routes/landing.rs
+++ b/crates/ruscker-admin/src/routes/landing.rs
@@ -101,6 +101,7 @@ struct LogoView {
     src: String,
     link: Option<String>,
     height: u32,
+    margin: Option<u32>,
 }
 
 impl<'a> LandingPage<'a> {
@@ -142,6 +143,7 @@ impl<'a> LandingPage<'a> {
                 src: self.logo_src(l),
                 link: l.link.clone(),
                 height: l.height.unwrap_or(default_h),
+                margin: l.margin,
             })
             .collect()
     }

--- a/crates/ruscker-admin/templates/_layout.html
+++ b/crates/ruscker-admin/templates/_layout.html
@@ -34,8 +34,10 @@
    landing inject operator logos integrated into the footer chrome (#468):
    left on the far side, right trailing the Ruscker version+mark. They
    default to empty, so other layouts keep the plain right-aligned lockup. #}
-<footer class="mt-auto border-t border-[color:var(--border)] py-4 px-6 text-xs text-[color:var(--text-muted)] flex items-center justify-between gap-3">
+<footer class="mt-auto border-t border-[color:var(--border)] py-4 px-6 text-xs text-[color:var(--text-muted)] flex items-center justify-between gap-3 relative">
   <div class="flex items-center gap-3">{% block footer_logos_left %}{% endblock %}</div>
+  {# Footer-center logos: absolutely centred over the footer (#468). #}
+  {% block footer_logos_center %}{% endblock %}
   <div class="flex items-center gap-3">
     <a class="opacity-60 hover:opacity-100 transition-opacity"
        href="https://github.com/StrategicProjects/ruscker/releases/tag/v{{ crate::APP_VERSION }}"

--- a/crates/ruscker-admin/templates/admin/landing.html
+++ b/crates/ruscker-admin/templates/admin/landing.html
@@ -478,12 +478,12 @@
               </template>
               <div class="landing-preview-count">N</div>
             </div>
-          </div>
-          {# Header center bar — separate row, only when center logos exist. #}
-          <div class="landing-preview-centerbar" x-show="logos.some(l => l.url && l.slot === 'header' && l.align === 'center')">
-            <template x-for="(logo, i) in logos.filter(l => l.url && l.slot === 'header' && l.align === 'center')" :key="i">
-              <img class="lp-logo" :src="assetUrl(logo.url)" :style="'height:' + Math.min((logo.height || 24), 16) + 'px'" alt="">
-            </template>
+            {# Header-center logos: absolutely centred within the header bar. #}
+            <div class="landing-logo-center-abs" x-show="logos.some(l => l.url && l.slot === 'header' && l.align === 'center')">
+              <template x-for="(logo, i) in logos.filter(l => l.url && l.slot === 'header' && l.align === 'center')" :key="i">
+                <img class="lp-logo" :src="assetUrl(logo.url)" :style="'height:' + Math.min((logo.height || 24), 16) + 'px'" alt="">
+              </template>
+            </div>
           </div>
         </div>
 
@@ -497,15 +497,14 @@
           </div>
         </div>
 
-        {# Footer center bar — separate row above the footer. #}
-        <div class="landing-preview-centerbar" x-show="logos.some(l => l.url && l.slot === 'footer' && l.align === 'center')">
-          <template x-for="(logo, i) in logos.filter(l => l.url && l.slot === 'footer' && l.align === 'center')" :key="i">
-            <img class="lp-logo" :src="assetUrl(logo.url)" :style="'height:' + Math.min((logo.height || 20), 12) + 'px'" alt="">
-          </template>
-        </div>
-
-        {# Footer: left logos · right logos + version + Ruscker mark (#468). #}
+        {# Footer: left · center (absolutely centred) · right + version + mark (#468). #}
         <div class="landing-preview-footer">
+          {# Footer-center logos: absolutely centred within the footer. #}
+          <div class="landing-logo-center-abs" x-show="logos.some(l => l.url && l.slot === 'footer' && l.align === 'center')">
+            <template x-for="(logo, i) in logos.filter(l => l.url && l.slot === 'footer' && l.align === 'center')" :key="i">
+              <img class="lp-logo" :src="assetUrl(logo.url)" :style="'height:' + Math.min((logo.height || 20), 12) + 'px'" alt="">
+            </template>
+          </div>
           <div class="lp-head-side">
             <template x-for="(logo, i) in logos.filter(l => l.url && l.slot === 'footer' && l.align === 'left')" :key="i">
               <img class="lp-logo" :src="assetUrl(logo.url)" :style="'height:' + Math.min((logo.height || 20), 12) + 'px'" alt="">

--- a/crates/ruscker-admin/templates/admin/landing.html
+++ b/crates/ruscker-admin/templates/admin/landing.html
@@ -6,8 +6,8 @@
 
 <div x-data="ruscker.landingForm({{ form_initial_json() }}, {{ logo_images_json() }})" x-cloak>
 
-  {# ── Header ───────────────────────────────────────────────── #}
-  <div class="flex items-end justify-between mb-5 pb-3 border-b border-[color:var(--border)]">
+  {# ── Sticky action bar (title + Open portal + Save) ───────── #}
+  <div class="editor-topbar">
     <div>
       <div class="text-[11px] text-[color:var(--text-faint)] uppercase tracking-wide">
         {{ self.t("admin-landing-crumb") }}
@@ -53,9 +53,16 @@
          texts, SEO, custom blocks), NOT an arbitrary-CSS editor. #}
       <div class="spec-form-help" style="margin-bottom:12px">{{ self.t("admin-landing-scope-help") }}</div>
 
-      {# ── Header title + subtitle (#468). Blank ⇒ falls back to the
+      {# ── Card: Header title + subtitle (#468). Blank ⇒ falls back to the
          config proxy.title / default subtitle. #}
-      <div class="spec-form-section-title">{{ self.t("admin-landing-header") }}</div>
+      <section class="editor-card">
+        <div class="editor-card__head">
+          <span class="editor-card__icon"><i class="ti ti-heading" aria-hidden="true"></i></span>
+          <div>
+            <div class="editor-card__title">{{ self.t("admin-landing-header") }}</div>
+            <div class="editor-card__desc">{{ self.t("admin-landing-card-header-desc") }}</div>
+          </div>
+        </div>
       <div class="spec-form-field">
         <label class="spec-form-label">{{ self.t("admin-landing-portal-title") }}</label>
         <input type="text" name="title" x-model="form.title" maxlength="120"
@@ -68,6 +75,18 @@
                placeholder="{{ self.t("landing-subtitle") }}" class="spec-form-input">
         <div class="spec-form-help">{{ self.t("admin-landing-portal-subtitle-help") }}</div>
       </div>
+
+      </section>
+
+      {# ── Card: Appearance — header colours + per-theme palettes. #}
+      <section class="editor-card">
+        <div class="editor-card__head">
+          <span class="editor-card__icon"><i class="ti ti-palette" aria-hidden="true"></i></span>
+          <div>
+            <div class="editor-card__title">{{ self.t("admin-landing-card-appearance") }}</div>
+            <div class="editor-card__desc">{{ self.t("admin-landing-card-appearance-desc") }}</div>
+          </div>
+        </div>
 
       <div class="spec-form-section-title">{{ self.t("admin-landing-colors") }}</div>
 
@@ -214,10 +233,18 @@
         </div>
       </div>
 
-      {# ── Header / footer logos (visual identity, grouped with Colors #471) #}
-      <div class="spec-form-section-title">{{ self.t("admin-landing-logos") }}</div>
+      </section>
+
+      {# ── Card: Header / footer logos (#468). #}
+      <section class="editor-card">
+        <div class="editor-card__head">
+          <span class="editor-card__icon"><i class="ti ti-photo" aria-hidden="true"></i></span>
+          <div>
+            <div class="editor-card__title">{{ self.t("admin-landing-logos") }}</div>
+            <div class="editor-card__desc">{{ self.t("admin-landing-logos-help") }}</div>
+          </div>
+        </div>
       <div class="spec-form-field">
-        <div class="spec-form-help" style="margin-bottom:8px">{{ self.t("admin-landing-logos-help") }}</div>
         {# Submitted as one hidden JSON field; the rows below edit the array. #}
         <input type="hidden" name="logos_json" :value="JSON.stringify(logos)">
         <template x-for="(logo, i) in logos" :key="i">
@@ -283,6 +310,18 @@
         </button>
       </div>
 
+      </section>
+
+      {# ── Card: Content — intro text (default + per-locale). #}
+      <section class="editor-card">
+        <div class="editor-card__head">
+          <span class="editor-card__icon"><i class="ti ti-align-left" aria-hidden="true"></i></span>
+          <div>
+            <div class="editor-card__title">{{ self.t("admin-landing-card-content") }}</div>
+            <div class="editor-card__desc">{{ self.t("admin-landing-card-content-desc") }}</div>
+          </div>
+        </div>
+
       <div class="spec-form-section-title">{{ self.t("admin-landing-intro") }}</div>
 
       <div class="spec-form-field">
@@ -323,6 +362,18 @@
         </div>
       </div>
 
+      </section>
+
+      {# ── Card: SEO & analytics. #}
+      <section class="editor-card">
+        <div class="editor-card__head">
+          <span class="editor-card__icon"><i class="ti ti-search" aria-hidden="true"></i></span>
+          <div>
+            <div class="editor-card__title">{{ self.t("admin-landing-card-meta") }}</div>
+            <div class="editor-card__desc">{{ self.t("admin-landing-card-meta-desc") }}</div>
+          </div>
+        </div>
+
       <div class="spec-form-section-title">{{ self.t("admin-landing-seo") }}</div>
       <div class="spec-form-field">
         <label class="spec-form-label">{{ self.t("admin-landing-seo-title") }}</label>
@@ -362,7 +413,17 @@
         <div class="spec-form-help">{{ self.t("admin-landing-analytics-origins-help") }}</div>
       </div>
 
-      <div class="spec-form-section-title">{{ self.t("admin-landing-style") }}</div>
+      </section>
+
+      {# ── Card: Advanced — custom CSS. #}
+      <section class="editor-card">
+        <div class="editor-card__head">
+          <span class="editor-card__icon"><i class="ti ti-code" aria-hidden="true"></i></span>
+          <div>
+            <div class="editor-card__title">{{ self.t("admin-landing-style") }}</div>
+            <div class="editor-card__desc">{{ self.t("admin-landing-card-style-desc") }}</div>
+          </div>
+        </div>
       <div class="spec-form-field">
         <label class="spec-form-label">{{ self.t("admin-landing-custom-css") }}</label>
         <textarea name="custom_css" rows="6" x-model="form.custom_css"
@@ -370,12 +431,19 @@
                   class="spec-form-input spec-form-input--mono">{{ form.custom_css }}</textarea>
         <div class="spec-form-help">{{ self.t("admin-landing-custom-css-help") }}</div>
       </div>
+      </section>
 
     </form>
 
     {# ── RIGHT: live preview ──────────────────────────────── #}
-    <aside class="spec-form-preview">
-      <div class="spec-form-section-title">{{ self.t("admin-landing-preview") }}</div>
+    <aside class="spec-form-preview" style="top:96px">
+      <div class="editor-card editor-card--preview">
+        <div class="editor-card__head">
+          <span class="editor-card__icon"><i class="ti ti-eye" aria-hidden="true"></i></span>
+          <div>
+            <div class="editor-card__title">{{ self.t("admin-landing-preview") }}</div>
+          </div>
+        </div>
 
       <div class="landing-preview-frame">
         <div class="landing-preview-header"
@@ -408,6 +476,7 @@
 
       <div class="spec-form-help" style="margin-top:8px">
         {{ self.t("admin-landing-preview-help") }}
+      </div>
       </div>
     </aside>
 

--- a/crates/ruscker-admin/templates/admin/landing.html
+++ b/crates/ruscker-admin/templates/admin/landing.html
@@ -163,7 +163,7 @@
           <div class="spec-form-field">
             <label class="spec-form-label">{{ self.t("admin-landing-theme-bg") }}</label>
             <div class="color-input">
-              <input type="color" x-model="form.theme_light_bg" :value="form.theme_light_bg || '#fafaf7'">
+              <input type="color" :value="form.theme_light_bg || '#fafaf7'" @input="form.theme_light_bg = $event.target.value">
               <input type="text" name="theme_light_bg" x-model="form.theme_light_bg" placeholder="#fafaf7" class="spec-form-input spec-form-input--mono">
               <button type="button" @click="form.theme_light_bg = ''" class="admin-nav-link" title="{{ self.t("admin-landing-clear") }}"><i class="ti ti-x" aria-hidden="true"></i></button>
             </div>
@@ -171,7 +171,7 @@
           <div class="spec-form-field">
             <label class="spec-form-label">{{ self.t("admin-landing-theme-text") }}</label>
             <div class="color-input">
-              <input type="color" x-model="form.theme_light_text" :value="form.theme_light_text || '#1a1a1a'">
+              <input type="color" :value="form.theme_light_text || '#1a1a1a'" @input="form.theme_light_text = $event.target.value">
               <input type="text" name="theme_light_text" x-model="form.theme_light_text" placeholder="#1a1a1a" class="spec-form-input spec-form-input--mono">
               <button type="button" @click="form.theme_light_text = ''" class="admin-nav-link" title="{{ self.t("admin-landing-clear") }}"><i class="ti ti-x" aria-hidden="true"></i></button>
             </div>
@@ -179,7 +179,7 @@
           <div class="spec-form-field">
             <label class="spec-form-label">{{ self.t("admin-landing-theme-accent") }}</label>
             <div class="color-input">
-              <input type="color" x-model="form.theme_light_accent" :value="form.theme_light_accent || '#0f6e56'">
+              <input type="color" :value="form.theme_light_accent || '#0f6e56'" @input="form.theme_light_accent = $event.target.value">
               <input type="text" name="theme_light_accent" x-model="form.theme_light_accent" placeholder="#0f6e56" class="spec-form-input spec-form-input--mono">
               <button type="button" @click="form.theme_light_accent = ''" class="admin-nav-link" title="{{ self.t("admin-landing-clear") }}"><i class="ti ti-x" aria-hidden="true"></i></button>
             </div>
@@ -190,7 +190,7 @@
           <div class="spec-form-field">
             <label class="spec-form-label">{{ self.t("admin-landing-theme-bg") }}</label>
             <div class="color-input">
-              <input type="color" x-model="form.theme_dark_bg" :value="form.theme_dark_bg || '#161616'">
+              <input type="color" :value="form.theme_dark_bg || '#161616'" @input="form.theme_dark_bg = $event.target.value">
               <input type="text" name="theme_dark_bg" x-model="form.theme_dark_bg" placeholder="#161616" class="spec-form-input spec-form-input--mono">
               <button type="button" @click="form.theme_dark_bg = ''" class="admin-nav-link" title="{{ self.t("admin-landing-clear") }}"><i class="ti ti-x" aria-hidden="true"></i></button>
             </div>
@@ -198,7 +198,7 @@
           <div class="spec-form-field">
             <label class="spec-form-label">{{ self.t("admin-landing-theme-text") }}</label>
             <div class="color-input">
-              <input type="color" x-model="form.theme_dark_text" :value="form.theme_dark_text || '#f0f0f0'">
+              <input type="color" :value="form.theme_dark_text || '#f0f0f0'" @input="form.theme_dark_text = $event.target.value">
               <input type="text" name="theme_dark_text" x-model="form.theme_dark_text" placeholder="#f0f0f0" class="spec-form-input spec-form-input--mono">
               <button type="button" @click="form.theme_dark_text = ''" class="admin-nav-link" title="{{ self.t("admin-landing-clear") }}"><i class="ti ti-x" aria-hidden="true"></i></button>
             </div>
@@ -206,7 +206,7 @@
           <div class="spec-form-field">
             <label class="spec-form-label">{{ self.t("admin-landing-theme-accent") }}</label>
             <div class="color-input">
-              <input type="color" x-model="form.theme_dark_accent" :value="form.theme_dark_accent || '#0f6e56'">
+              <input type="color" :value="form.theme_dark_accent || '#0f6e56'" @input="form.theme_dark_accent = $event.target.value">
               <input type="text" name="theme_dark_accent" x-model="form.theme_dark_accent" placeholder="#0f6e56" class="spec-form-input spec-form-input--mono">
               <button type="button" @click="form.theme_dark_accent = ''" class="admin-nav-link" title="{{ self.t("admin-landing-clear") }}"><i class="ti ti-x" aria-hidden="true"></i></button>
             </div>
@@ -246,12 +246,14 @@
                    class="spec-form-input" style="flex:1;min-width:8rem" title="{{ self.t("admin-landing-logo-link") }}">
             <input type="number" x-model.number="logo.height" min="8" max="240" placeholder="32"
                    class="spec-form-input" style="width:4.5rem" title="{{ self.t("admin-landing-logo-height") }}">
+            <input type="number" x-model.number="logo.margin" min="0" max="120" placeholder="0"
+                   class="spec-form-input" style="width:4.5rem" title="{{ self.t("admin-landing-logo-margin") }}">
             <button type="button" class="admin-nav-link" @click="logos.splice(i, 1)"
                     title="{{ self.t("admin-landing-clear") }}"><i class="ti ti-trash" aria-hidden="true"></i></button>
           </div>
         </template>
         <button type="button" class="admin-nav-link mt-2"
-                @click="logos.push({ url: '', slot: 'header', align: 'left', link: null, height: 32 })">
+                @click="logos.push({ url: '', slot: 'header', align: 'left', link: null, height: 32, margin: null })">
           <i class="ti ti-plus" aria-hidden="true"></i> {{ self.t("admin-landing-logo-add") }}
         </button>
       </div>

--- a/crates/ruscker-admin/templates/admin/landing.html
+++ b/crates/ruscker-admin/templates/admin/landing.html
@@ -449,17 +449,41 @@
         <div class="landing-preview-header"
              :style="(form.header_bg ? `background:${form.header_bg};` : '') + (form.header_fg ? `color:${form.header_fg};` : '')">
           <div class="landing-preview-header-inner">
-            <div>
-              {# Live preview (#468): title binds to the form, falling back
-                 to the config title; subtitle is optional (hidden when blank). #}
-              <div class="landing-preview-title">
-                <span x-show="(form.title || '').trim()" x-text="form.title"></span>
-                <span x-show="!(form.title || '').trim()">{{ portal_title }}</span>
+            <div class="lp-head-side">
+              {# Header-left logos replace the Ruscker mark (faithful to #468);
+                 a small mark shows when none are set. #}
+              <template x-for="(logo, i) in logos.filter(l => l.url && l.slot === 'header' && l.align === 'left')" :key="i">
+                <img class="lp-logo" :src="assetUrl(logo.url)" :style="'height:' + Math.min((logo.height || 24), 16) + 'px'" alt="">
+              </template>
+              <svg class="lp-mark" x-show="!logos.some(l => l.url && l.slot === 'header' && l.align === 'left')" viewBox="0 0 80 80" aria-hidden="true">
+                <polygon points="14,52 40,40 66,52 40,64" fill="#0F6E56"/>
+                <polygon points="14,40 40,28 66,40 40,52" fill="#1D9E75"/>
+                <polygon points="14,28 40,16 66,28 40,40" fill="#5DCAA5"/>
+              </svg>
+              <div>
+                {# Live preview (#468): title binds to the form, falling back
+                   to the config title; subtitle is optional (hidden when blank). #}
+                <div class="landing-preview-title">
+                  <span x-show="(form.title || '').trim()" x-text="form.title"></span>
+                  <span x-show="!(form.title || '').trim()">{{ portal_title }}</span>
+                </div>
+                <div class="landing-preview-sub" x-show="(form.subtitle || '').trim()"
+                     x-text="form.subtitle" x-cloak></div>
               </div>
-              <div class="landing-preview-sub" x-show="(form.subtitle || '').trim()"
-                   x-text="form.subtitle" x-cloak></div>
             </div>
-            <div class="landing-preview-count">N</div>
+            <div class="lp-head-side">
+              {# Header-right logos trail the chrome (the count stands in for it). #}
+              <template x-for="(logo, i) in logos.filter(l => l.url && l.slot === 'header' && l.align === 'right')" :key="i">
+                <img class="lp-logo" :src="assetUrl(logo.url)" :style="'height:' + Math.min((logo.height || 24), 16) + 'px'" alt="">
+              </template>
+              <div class="landing-preview-count">N</div>
+            </div>
+          </div>
+          {# Header center bar — separate row, only when center logos exist. #}
+          <div class="landing-preview-centerbar" x-show="logos.some(l => l.url && l.slot === 'header' && l.align === 'center')">
+            <template x-for="(logo, i) in logos.filter(l => l.url && l.slot === 'header' && l.align === 'center')" :key="i">
+              <img class="lp-logo" :src="assetUrl(logo.url)" :style="'height:' + Math.min((logo.height || 24), 16) + 'px'" alt="">
+            </template>
           </div>
         </div>
 
@@ -470,6 +494,33 @@
           <div class="landing-preview-mockfilter"></div>
           <div class="landing-preview-mockgrid">
             <div></div><div></div><div></div><div></div>
+          </div>
+        </div>
+
+        {# Footer center bar — separate row above the footer. #}
+        <div class="landing-preview-centerbar" x-show="logos.some(l => l.url && l.slot === 'footer' && l.align === 'center')">
+          <template x-for="(logo, i) in logos.filter(l => l.url && l.slot === 'footer' && l.align === 'center')" :key="i">
+            <img class="lp-logo" :src="assetUrl(logo.url)" :style="'height:' + Math.min((logo.height || 20), 12) + 'px'" alt="">
+          </template>
+        </div>
+
+        {# Footer: left logos · right logos + version + Ruscker mark (#468). #}
+        <div class="landing-preview-footer">
+          <div class="lp-head-side">
+            <template x-for="(logo, i) in logos.filter(l => l.url && l.slot === 'footer' && l.align === 'left')" :key="i">
+              <img class="lp-logo" :src="assetUrl(logo.url)" :style="'height:' + Math.min((logo.height || 20), 12) + 'px'" alt="">
+            </template>
+          </div>
+          <div class="lp-head-side">
+            <template x-for="(logo, i) in logos.filter(l => l.url && l.slot === 'footer' && l.align === 'right')" :key="i">
+              <img class="lp-logo" :src="assetUrl(logo.url)" :style="'height:' + Math.min((logo.height || 20), 12) + 'px'" alt="">
+            </template>
+            <span class="lp-version">v{{ crate::APP_VERSION }}</span>
+            <svg class="lp-mark" style="width:11px;height:11px" viewBox="0 0 80 80" aria-hidden="true">
+              <polygon points="14,52 40,40 66,52 40,64" fill="#0F6E56"/>
+              <polygon points="14,40 40,28 66,40 40,52" fill="#1D9E75"/>
+              <polygon points="14,28 40,16 66,28 40,40" fill="#5DCAA5"/>
+            </svg>
           </div>
         </div>
       </div>

--- a/crates/ruscker-admin/templates/admin/landing.html
+++ b/crates/ruscker-admin/templates/admin/landing.html
@@ -221,35 +221,60 @@
         {# Submitted as one hidden JSON field; the rows below edit the array. #}
         <input type="hidden" name="logos_json" :value="JSON.stringify(logos)">
         <template x-for="(logo, i) in logos" :key="i">
-          <div class="landing-logo-row">
-            <img :src="assetUrl(logo.url)" alt="" class="landing-logo-thumb" x-show="logo.url">
-            {# Shared gallery picker (#451): writes only this row's `url`,
-               leaving slot/align/link/height intact. The field stays
-               editable for an external/manual URL. #}
-            <button type="button" class="admin-login-btn" style="padding:6px 10px;font-size:12px;white-space:nowrap"
-                    @click="openImagePicker((v) => { logo.url = v }, logo.url)">
-              <i class="ti ti-photo" aria-hidden="true"></i>
-              {{ self.t("spec-form-choose-image") }}
-            </button>
-            <input type="text" x-model="logo.url"
-                   placeholder="/assets/img/logo.png" class="spec-form-input spec-form-input--mono" style="flex:2;min-width:10rem">
-            <select x-model="logo.slot" class="theme-select">
-              <option value="header">{{ self.t("admin-landing-logo-header") }}</option>
-              <option value="footer">{{ self.t("admin-landing-logo-footer") }}</option>
-            </select>
-            <select x-model="logo.align" class="theme-select">
-              <option value="left">{{ self.t("admin-landing-logo-left") }}</option>
-              <option value="center">{{ self.t("admin-landing-logo-center") }}</option>
-              <option value="right">{{ self.t("admin-landing-logo-right") }}</option>
-            </select>
-            <input type="url" x-model="logo.link" placeholder="https://…"
-                   class="spec-form-input" style="flex:1;min-width:8rem" title="{{ self.t("admin-landing-logo-link") }}">
-            <input type="number" x-model.number="logo.height" min="8" max="240" placeholder="32"
-                   class="spec-form-input" style="width:4.5rem" title="{{ self.t("admin-landing-logo-height") }}">
-            <input type="number" x-model.number="logo.margin" min="0" max="120" placeholder="0"
-                   class="spec-form-input" style="width:4.5rem" title="{{ self.t("admin-landing-logo-margin") }}">
-            <button type="button" class="admin-nav-link" @click="logos.splice(i, 1)"
-                    title="{{ self.t("admin-landing-clear") }}"><i class="ti ti-trash" aria-hidden="true"></i></button>
+          <div class="landing-logo-card">
+            <div class="landing-logo-card__head">
+              {# Preview thumbnail, or a placeholder icon when no URL yet. #}
+              <img :src="assetUrl(logo.url)" alt="" class="landing-logo-thumb" x-show="logo.url">
+              <span class="landing-logo-thumb landing-logo-thumb--empty" x-show="!logo.url"><i class="ti ti-photo" aria-hidden="true"></i></span>
+              {# Image field: shared gallery picker (#451) writes only `url`,
+                 leaving the other fields intact; the input stays editable
+                 for an external/manual URL. #}
+              <div class="landing-logo-field" style="flex:1;min-width:0">
+                <label>{{ self.t("admin-landing-logo-image") }}</label>
+                <div class="landing-logo-image-row">
+                  <button type="button" class="admin-login-btn landing-logo-pick"
+                          @click="openImagePicker((v) => { logo.url = v }, logo.url)">
+                    <i class="ti ti-photo" aria-hidden="true"></i>
+                    {{ self.t("spec-form-choose-image") }}
+                  </button>
+                  <input type="text" x-model="logo.url" placeholder="/assets/img/logo.png"
+                         class="spec-form-input spec-form-input--mono" style="flex:1;min-width:0">
+                </div>
+              </div>
+              <button type="button" class="landing-logo-card__remove admin-nav-link" @click="logos.splice(i, 1)"
+                      title="{{ self.t("admin-landing-clear") }}"><i class="ti ti-trash" aria-hidden="true"></i></button>
+            </div>
+            <div class="landing-logo-card__grid">
+              {# Slot — segmented pill (header / footer). #}
+              <div class="landing-logo-field">
+                <label>{{ self.t("admin-landing-logo-slot-label") }}</label>
+                <div class="seg-control" role="group">
+                  <button type="button" :class="{ 'is-active': logo.slot === 'header' }" @click="logo.slot = 'header'">{{ self.t("admin-landing-logo-header") }}</button>
+                  <button type="button" :class="{ 'is-active': logo.slot === 'footer' }" @click="logo.slot = 'footer'">{{ self.t("admin-landing-logo-footer") }}</button>
+                </div>
+              </div>
+              {# Alignment — segmented icon pill (left / center / right). #}
+              <div class="landing-logo-field">
+                <label>{{ self.t("admin-landing-logo-align-label") }}</label>
+                <div class="seg-control" role="group">
+                  <button type="button" :class="{ 'is-active': logo.align === 'left' }" @click="logo.align = 'left'" title="{{ self.t("admin-landing-logo-left") }}"><i class="ti ti-align-left" aria-hidden="true"></i></button>
+                  <button type="button" :class="{ 'is-active': logo.align === 'center' }" @click="logo.align = 'center'" title="{{ self.t("admin-landing-logo-center") }}"><i class="ti ti-align-center" aria-hidden="true"></i></button>
+                  <button type="button" :class="{ 'is-active': logo.align === 'right' }" @click="logo.align = 'right'" title="{{ self.t("admin-landing-logo-right") }}"><i class="ti ti-align-right" aria-hidden="true"></i></button>
+                </div>
+              </div>
+              <div class="landing-logo-field">
+                <label>{{ self.t("admin-landing-logo-link") }}</label>
+                <input type="url" x-model="logo.link" placeholder="https://…" class="spec-form-input">
+              </div>
+              <div class="landing-logo-field">
+                <label>{{ self.t("admin-landing-logo-height") }}</label>
+                <input type="number" x-model.number="logo.height" min="8" max="240" placeholder="32" class="spec-form-input">
+              </div>
+              <div class="landing-logo-field">
+                <label>{{ self.t("admin-landing-logo-margin") }}</label>
+                <input type="number" x-model.number="logo.margin" min="0" max="120" placeholder="0" class="spec-form-input">
+              </div>
+            </div>
           </div>
         </template>
         <button type="button" class="admin-nav-link mt-2"

--- a/crates/ruscker-admin/templates/landing.html
+++ b/crates/ruscker-admin/templates/landing.html
@@ -6,7 +6,7 @@
 {% macro logos(items) %}
   {% for l in items %}
     {% match l.link %}{% when Some with (href) %}<a href="{{ href }}" target="_blank" rel="noopener" class="inline-flex items-center">{% when None %}{% endmatch %}
-    <img src="{{ l.src }}" alt="" loading="lazy" style="height:{{ l.height }}px">
+    <img src="{{ l.src }}" alt="" loading="lazy" style="height:{{ l.height }}px{% match l.margin %}{% when Some with (m) %};margin:{{ m }}px{% when None %}{% endmatch %}">
     {% match l.link %}{% when Some with (href) %}</a>{% when None %}{% endmatch %}
   {% endfor %}
 {% endmacro %}

--- a/crates/ruscker-admin/templates/landing.html
+++ b/crates/ruscker-admin/templates/landing.html
@@ -34,7 +34,7 @@
 
 <header class="border-b border-[color:var(--border)]"
         {% if !header_style.is_empty() %}style="{{ header_style }}"{% endif %}>
-  <div class="max-w-6xl mx-auto px-6 py-5 flex items-center justify-between gap-6">
+  <div class="max-w-6xl mx-auto px-6 py-5 flex items-center justify-between gap-6 relative">
     <div class="flex items-center gap-3">
       {# Header-left identity. When the operator configured header-left
          logo(s) (#468) they REPLACE the Ruscker mark — the title/subtitle
@@ -65,6 +65,12 @@
         {% if !header_subtitle.is_empty() %}<p class="text-xs opacity-70 mt-1">{{ header_subtitle }}</p>{% endif %}
       </div>
     </div>
+    {# Header-center logo(s) (#468): absolutely centred within the header
+       bar (the empty middle between the title and the chrome), so they read
+       as part of the header — not a separate strip below it. #}
+    {% if self.has_logos_at("header", "center") %}
+    <div class="landing-logo-center-abs">{% call logos(self.logo_view("header", "center", 28)) %}{% endcall %}</div>
+    {% endif %}
     {# Chrome cluster (theme/language/account) with header-right logo(s)
        trailing it (#468) — kept in one flex child so the group stays
        right-aligned within the header's justify-between. #}
@@ -76,17 +82,6 @@
     </div>
   </div>
 </header>
-
-{# Header center logos (admin-managed) — left/right buckets now integrate
-   into the header chrome above (#468); only `center` keeps the separate
-   bar below the header. #}
-{% if self.has_logos_at("header", "center") %}
-<div class="landing-logo-bar px-6 max-w-6xl mx-auto w-full">
-  <div class="landing-logo-group landing-logo-center">
-    {% call logos(self.logo_view("header", "center", 32)) %}{% endcall %}
-  </div>
-</div>
-{% endif %}
 
 {# Custom HTML blocks — `top` slot (after the header). Rendered
    verbatim; admin-trusted (see /admin/blocks). Kept outside the
@@ -280,16 +275,6 @@
 <section class="landing-block landing-block--bottom px-6 max-w-6xl mx-auto w-full">{{ b.html|safe }}</section>
 {% endfor %}
 
-{# Footer center logos (admin-managed) — left/right buckets now integrate
-   into the global footer (#468, see the footer_logos_* block overrides
-   below); only `center` keeps the separate bar above the footer. #}
-{% if self.has_logos_at("footer", "center") %}
-<div class="landing-logo-bar landing-logo-bar--footer px-6 max-w-6xl mx-auto w-full">
-  <div class="landing-logo-group landing-logo-center">
-    {% call logos(self.logo_view("footer", "center", 28)) %}{% endcall %}
-  </div>
-</div>
-{% endif %}
 
 <script src="{{ base }}/assets/js/alpine.min.js?v={{ crate::APP_VERSION }}" defer></script>
 <script>
@@ -402,9 +387,10 @@ window.ruscker.landing = () => ({
 
 {% endblock %}
 
-{# Footer-left / footer-right logos integrate into the global footer
-   (_layout.html): left on the far side, right trailing the Ruscker
-   version+mark. Defined OUTSIDE `content` so they only fill the layout's
-   footer slots — not render inline here too (#468). #}
+{# Footer-left / center / right logos integrate into the global footer
+   (_layout.html): left on the far side, center absolutely centred, right
+   trailing the Ruscker version+mark. Defined OUTSIDE `content` so they only
+   fill the layout's footer slots — not render inline here too (#468). #}
 {% block footer_logos_left %}{% if self.has_logos_at("footer", "left") %}{% call logos(self.logo_view("footer", "left", 24)) %}{% endcall %}{% endif %}{% endblock %}
+{% block footer_logos_center %}{% if self.has_logos_at("footer", "center") %}<div class="landing-logo-center-abs">{% call logos(self.logo_view("footer", "center", 20)) %}{% endcall %}</div>{% endif %}{% endblock %}
 {% block footer_logos_right %}{% if self.has_logos_at("footer", "right") %}{% call logos(self.logo_view("footer", "right", 20)) %}{% endcall %}{% endif %}{% endblock %}

--- a/crates/ruscker-config/src/schema.rs
+++ b/crates/ruscker-config/src/schema.rs
@@ -506,6 +506,10 @@ pub struct LandingLogo {
     /// Render height in pixels (per-logo size). Falls back to a default
     /// when unset.
     pub height: Option<u32>,
+    /// Outer margin in pixels applied around the logo, for spacing from
+    /// adjacent chrome (the title, the buttons, the version) or from a
+    /// neighbouring logo. Unset ⇒ no extra margin.
+    pub margin: Option<u32>,
 }
 
 /// A custom HTML block on the public landing (admin-authored,

--- a/docs/YAML_SCHEMA.md
+++ b/docs/YAML_SCHEMA.md
@@ -183,6 +183,7 @@ proxy:
         align: left                     # `left` | `center` | `right`
         link: https://org.example       # optional click-through
         height: 40                      # render height in px
+        margin: 12                      # optional outer margin in px
 
     # Sign-in visibility (anonymous viewers only)
     show-admin-link: true              # default true; false hides the entrance
@@ -220,9 +221,10 @@ Field reference:
 |---|---|---|---|
 | `url` | string | required | Image URL — `/assets/img/...` (uploaded), a built-in (`/assets/showcase/...`, `/assets/brand/...`), or an absolute URL. |
 | `slot` | enum | required | `header` or `footer` — where the logo renders. |
-| `align` | enum | required | `left`, `center`, or `right` within the slot. Logos sharing a slot+alignment render side by side. |
+| `align` | enum | required | `left`, `center`, or `right` within the slot. `left`/`right` integrate into the chrome: header-`left` replaces the Ruscker mark, header-`right` trails the buttons, footer-`left` sits far-left, footer-`right` trails the version+mark. `center` renders in a separate bar. Logos sharing a slot+alignment render side by side. |
 | `link` | URL | none | Optional click-through — when set, the logo becomes an `<a>`. |
 | `height` | px | default | Per-logo render height in pixels; falls back to a built-in default when unset. |
+| `margin` | px | none | Optional outer margin in pixels around the logo, for spacing from adjacent chrome or a neighbouring logo. |
 
 `blocks[]` subfields:
 


### PR DESCRIPTION
## Resumo

Modernização do editor do Portal (`/admin/landing`) — layout, logos e cores. Closes #482.

### 1. Redesign da página em **cards de seção** + barra sticky
O editor era um formulário corrido com 9 títulos de seção crus. Agora:
- As 9 seções viram **6 cards rotulados** (Cabeçalho · Aparência = cores do cabeçalho + paleta por tema · Logos · Conteúdo = intro + por idioma · SEO e Analytics · Estilo/CSS). Cada card tem **ícone + título + descrição**; seções relacionadas mantêm seus sub-títulos internos.
- **Barra de ação sticky** (`.editor-topbar`): título, "Abrir portal" e **Salvar** sempre acessíveis ao rolar o form longo.
- A **prévia ao vivo** vira um card combinando e gruda abaixo da barra.

### 2. Editor de logos em cards rotulados
Linhas de logo crus → **card por logo**: preview 44px, campo "Imagem" rotulado, e grid com **Posição** / **Alinhamento** (controles segmentados em pílula, com ícones de alinhamento e ativo em teal), Link, Altura (px), Margem (px) — tudo com label visível.

### 3. Margin por logo
Campo opcional `margin` (px) por logo (`LandingLogo::margin`, JSON, sem migration).

### 4. Swatches de cor não ficam mais pretos
Cor vazia (= default do tema) fazia o `<input type=color>` mostrar preto. Removido `x-model` dos 6 swatches → `:value="form.X || '<default>'"` + `@input`.

## Smoke real
- 6 cards + preview renderizam com títulos/ícones; topbar `position:sticky`; CSS compilado tem `.editor-card`/`.editor-topbar`/`.seg-control`.
- **Save smoke: 200, todos os `name=` presentes** (só apresentação, form inalterado).
- Margin renderiza set/unset; 6 swatches usam `:value`+`@input`.
- Gate: `cargo test` (verde) + `clippy -D warnings` + `i18n-check` OK.

> Nota: em dev local lembre do **hard-refresh** (Cmd+Shift+R) — o `styles.css?v=` não muda sem bump de versão, então o navegador serve o CSS antigo do cache. Em release a versão bumpa e resolve sozinho.

🤖 Generated with [Claude Code](https://claude.com/claude-code)