### PR TITLE
chore(release): bump workspace version 0.1.33 → 0.1.34

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2845,7 +2845,7 @@ dependencies = [
 
 [[package]]
 name = "ruscker-admin"
-version = "0.1.33"
+version = "0.1.34"
 dependencies = [
  "aes-gcm",
  "anyhow",
@@ -2892,7 +2892,7 @@ dependencies = [
 
 [[package]]
 name = "ruscker-cli"
-version = "0.1.33"
+version = "0.1.34"
 dependencies = [
  "anyhow",
  "clap",
@@ -2912,7 +2912,7 @@ dependencies = [
 
 [[package]]
 name = "ruscker-config"
-version = "0.1.33"
+version = "0.1.34"
 dependencies = [
  "chrono",
  "ordered-float",
@@ -2927,7 +2927,7 @@ dependencies = [
 
 [[package]]
 name = "ruscker-core"
-version = "0.1.33"
+version = "0.1.34"
 dependencies = [
  "async-trait",
  "chrono",
@@ -2940,7 +2940,7 @@ dependencies = [
 
 [[package]]
 name = "ruscker-docker"
-version = "0.1.33"
+version = "0.1.34"
 dependencies = [
  "anyhow",
  "async-stream",
@@ -2959,7 +2959,7 @@ dependencies = [
 
 [[package]]
 name = "ruscker-proxy"
-version = "0.1.33"
+version = "0.1.34"
 dependencies = [
  "anyhow",
  "axum",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -10,7 +10,7 @@ members = [
 ]
 
 [workspace.package]
-version = "0.1.33"
+version = "0.1.34"
 edition = "2021"
 rust-version = "1.85"
 license = "Apache-2.0"

--- a/book/src/faq.md
+++ b/book/src/faq.md
@@ -80,7 +80,7 @@ the **sign-in session** paths to a single upstream — see
 
 ### Is it production-ready?
 
-Yes. The current release is **v0.1.33** — Phases 0–7 are complete and
+Yes. The current release is **v0.1.34** — Phases 0–7 are complete and
 the proxy is production-ready and horizontally scalable.
 Releases are multi-arch and cosign-signed; see the
 [release notes](./news.md) and the [Roadmap](./roadmap.md).

--- a/book/src/introduction.md
+++ b/book/src/introduction.md
@@ -40,7 +40,7 @@ proper admin panel, a monitoring dashboard, and load balancing.
 
 ## In production
 
-Ruscker is on **v0.1.33** and runs in production today. Where the
+Ruscker is on **v0.1.34** and runs in production today. Where the
 JVM-based stack it replaced idled at hundreds of megabytes, Ruscker
 idles in the low tens:
 

--- a/book/src/news.md
+++ b/book/src/news.md
@@ -9,6 +9,38 @@ the [GitHub releases page](https://github.com/StrategicProjects/ruscker/releases
 
 ---
 
+## v0.1.34 — 2026-06-01
+
+Docker connects out of the box, per-theme colours, and a modernised
+Portal editor.
+
+**Runtime**
+- Ruscker now **auto-connects to Docker** when the daemon socket is
+  reachable — `serve` spawns app containers with no `--docker` flag.
+  Pass `--no-docker` to run landing-only, or keep `--docker` to make a
+  failed connect fatal (useful for a remote daemon).
+- Showcase demos seed with `min-replicas: 0`, so a fresh install no
+  longer pre-spawns every demo container at boot — they cold-start on
+  first click.
+
+**Portal**
+- **Per-theme colours**: set the background, text and accent for the
+  light and dark themes independently in the landing editor. Blank keeps
+  the built-in default.
+- **Logos integrate into the chrome**: a header-left logo replaces the
+  Ruscker mark, header-right sits after the buttons, footer-right trails
+  the version, and a center logo is centred within the header/footer bar
+  itself. Each logo also takes an optional **margin**.
+
+**Admin**
+- The **landing editor** is reorganised into labelled section cards with
+  a sticky Save bar; logos are edited as cards with segmented
+  position/alignment pickers; the live preview now mirrors the real
+  portal chrome (logos + footer). Theme colour swatches show the theme
+  default instead of black when unset.
+
+---
+
 ## v0.1.33 — 2026-06-01
 
 A bulk image cleanup on the disk panel, plus a documentation fix.

--- a/book/src/roadmap.md
+++ b/book/src/roadmap.md
@@ -1,6 +1,6 @@
 # Roadmap
 
-Ruscker is at **v0.1.33** — Phases 0 through 7 are done and the proxy is
+Ruscker is at **v0.1.34** — Phases 0 through 7 are done and the proxy is
 production-ready and horizontally scalable. Phase 8 (external auth) is
 the main optional, demand-driven work left. For what changed in each
 release, see the [release notes](./news.md).
@@ -71,7 +71,7 @@ can serve any session; one scaler leader via Postgres advisory locks,
 with failover. A runnable 2-instance compose harness lives in
 `examples/ha/`. See [Deployment shapes](./architecture.md#deployment-shapes).
 
-### Post-phase polish → **v0.1.4 – v0.1.33**
+### Post-phase polish → **v0.1.4 – v0.1.34**
 
 Incremental improvements shipped after Phase 7.
 

--- a/docs/SECURITY.md
+++ b/docs/SECURITY.md
@@ -5,7 +5,7 @@ Status: living document. Tracks the Phase 5 security audit
 **[accepted limitation]**, or **[deferred]**. File references use
 `crate/path:symbol` so they survive line-number drift.
 
-> **Scope.** This covers v0.1.33: single-operator install, Ruscker
+> **Scope.** This covers v0.1.34: single-operator install, Ruscker
 > behind a TLS-terminating reverse proxy, Docker on the same host.
 > Multi-tenant / shared-team auth (OIDC, RBAC) is out of scope until
 > Phase 8.


### PR DESCRIPTION
Corte da **v0.1.34**. Bump de `[workspace.package] version` + `Cargo.lock` + entrada no `news.md` + refs de versão no book/docs.

Conteúdo (tudo já mergeado em main desde a v0.1.33):
- **#479** (#477) auto-conecta Docker por default + `--no-docker`
- **#476** (#475) cores por tema (light/dark bg/text/accent)
- **#480** (#468) logos integrados ao chrome (header/footer) + center centralizado na barra
- **#481** (#478) showcase `min-replicas: 0` (sem pré-spawn na fresh install)
- **#483** (#482) editor do Portal modernizado: cards de seção, editor de logos em cards, margin por logo, swatches com default do tema, prévia fiel

Após merge: tag `v0.1.34` → `release.yml` publica `.deb`/musl/ghcr cosign-signed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)