### PR TITLE
fix(admin): stream SSE through reverse proxies (X-Accel-Buffering: no) (#485)

### DIFF
--- a/crates/ruscker-admin/src/routes/admin/dashboard.rs
+++ b/crates/ruscker-admin/src/routes/admin/dashboard.rs
@@ -30,7 +30,6 @@ use axum::{
     Router,
 };
 use chrono::Utc;
-use futures_util::stream::Stream;
 use ruscker_core::{Replica, ReplicaId, ReplicaState};
 use std::convert::Infallible;
 use std::sync::{Arc, LazyLock};
@@ -448,11 +447,26 @@ fn format_bytes(bytes: u64) -> String {
 /// blip just resumes the cadence — there's no event-id /
 /// last-event-id handshake to manage, and replaying a snapshot
 /// is idempotent on the client side anyway.
+/// Headers that keep an SSE response *streaming* through a reverse proxy
+/// instead of being buffered. `X-Accel-Buffering: no` tells nginx (and
+/// compatible proxies) not to buffer this response, and `Cache-Control:
+/// no-cache` keeps intermediaries from caching the stream. Without these,
+/// nginx buffers the event stream and the live dashboard appears frozen
+/// behind a reverse proxy (e.g. a `/box` subpath mount) — the WebSocket
+/// pump has `proxy_buffering off`, but a plain SSE response doesn't.
+fn sse_no_buffer_headers() -> [(axum::http::HeaderName, &'static str); 2] {
+    use axum::http::header::{HeaderName, CACHE_CONTROL};
+    [
+        (CACHE_CONTROL, "no-cache"),
+        (HeaderName::from_static("x-accel-buffering"), "no"),
+    ]
+}
+
 async fn events(
     _: AdminSession,
     State(state): State<AppState>,
     loc: Locale,
-) -> Sse<impl Stream<Item = Result<Event, Infallible>>> {
+) -> impl IntoResponse {
     use async_stream::stream;
     let stream = stream! {
         // Emit the first snapshot immediately so the client
@@ -474,7 +488,8 @@ async fn events(
             yield Ok::<_, Infallible>(Event::default().data(body));
         }
     };
-    Sse::new(stream).keep_alive(KeepAlive::new().interval(SSE_KEEPALIVE_INTERVAL))
+    let sse = Sse::new(stream).keep_alive(KeepAlive::new().interval(SSE_KEEPALIVE_INTERVAL));
+    (sse_no_buffer_headers(), sse)
 }
 
 /// Per-replica logs page. Fetches the last [`LOGS_TAIL`] lines
@@ -590,9 +605,8 @@ async fn logs_stream(
 
     use futures_util::StreamExt;
     let event_stream = line_stream.map(|line| Ok::<_, Infallible>(Event::default().data(line)));
-    Sse::new(event_stream)
-        .keep_alive(KeepAlive::new().interval(SSE_KEEPALIVE_INTERVAL))
-        .into_response()
+    let sse = Sse::new(event_stream).keep_alive(KeepAlive::new().interval(SSE_KEEPALIVE_INTERVAL));
+    (sse_no_buffer_headers(), sse).into_response()
 }
 
 /// Resolve a `{replica_id}` path param to a `ReplicaId`,


### PR DESCRIPTION
## Resumo

Conserta o **Painel ao vivo congelando atrás de nginx/subpath** (#485). Closes #485.

O dashboard já tem SSE (snapshot a cada 5s, adiciona replicas novos), mas o handler não mandava `X-Accel-Buffering: no` e o nginx (default `proxy_buffering on`) bufferizava o event-stream → painel parecia congelado no cast (`/box`).

## Mudança
- `sse_no_buffer_headers()` → `X-Accel-Buffering: no` + `Cache-Control: no-cache` nas **duas** respostas SSE (`events` + `logs_stream`). nginx honra esse header por-resposta **mesmo com `proxy_buffering on`** → conserta pra qualquer deploy, sem mexer no nginx.
- `events` agora retorna `impl IntoResponse` (pra carregar os headers); removido o import `Stream` órfão.

## Smoke real
`/admin/dashboard/events` responde com `x-accel-buffering: no` ✅. Gate: `cargo test` + `clippy -D warnings` verdes.

> Quick-fix de deploy (pra quem já roda v0.1.34 sem o header): `proxy_buffering off;` no location `/box/` do nginx.

🤖 Generated with [Claude Code](https://claude.com/claude-code)