### PR TITLE
fix(admin): point mask-icon at the monochrome mark (#489)

### DIFF
--- a/crates/ruscker-admin/templates/_layout.html
+++ b/crates/ruscker-admin/templates/_layout.html
@@ -12,7 +12,7 @@
 <link rel="icon" type="image/png" sizes="32x32" href="{{ base }}/favicon-32.png">
 <link rel="icon" type="image/svg+xml" href="{{ base }}/favicon.svg">
 <link rel="apple-touch-icon" href="{{ base }}/apple-touch-icon.png">
-<link rel="mask-icon" href="{{ base }}/assets/brand/mark.svg" color="#0f6e56">
+<link rel="mask-icon" href="{{ base }}/assets/brand/mark-mono-black.svg" color="#0f6e56">
 
 <link rel="preload" href="{{ base }}/assets/fonts/jost-latin-400-normal.woff2" as="font" type="font/woff2" crossorigin>
 <link rel="preload" href="{{ base }}/assets/fonts/jost-latin-500-normal.woff2" as="font" type="font/woff2" crossorigin>

--- a/crates/ruscker-admin/templates/admin/_layout.html
+++ b/crates/ruscker-admin/templates/admin/_layout.html
@@ -12,7 +12,7 @@
 <link rel="icon" type="image/png" sizes="32x32" href="{{ base }}/favicon-32.png">
 <link rel="icon" type="image/svg+xml" href="{{ base }}/favicon.svg">
 <link rel="apple-touch-icon" href="{{ base }}/apple-touch-icon.png">
-<link rel="mask-icon" href="{{ base }}/assets/brand/mark.svg" color="#0f6e56">
+<link rel="mask-icon" href="{{ base }}/assets/brand/mark-mono-black.svg" color="#0f6e56">
 
 <link rel="preload" href="{{ base }}/assets/fonts/jost-latin-400-normal.woff2" as="font" type="font/woff2" crossorigin>
 <link rel="preload" href="{{ base }}/assets/fonts/jost-latin-500-normal.woff2" as="font" type="font/woff2" crossorigin>


### PR DESCRIPTION
## Resumo

O `<link rel="mask-icon">` (Safari pinned tab) apontava pro `mark.svg` **colorido**; mask-icon exige SVG **monocromático** (o Safari recolore via `color=`). Troca pros dois layouts pro `mark-mono-black.svg` já existente. Closes #489.

## Smoke real
Landing renderiza `<link rel="mask-icon" href="/assets/brand/mark-mono-black.svg" color="#0f6e56">`; asset serve 200 `image/svg+xml`. i18n OK, build limpo.

> Nota: isto NÃO é a "bola preta" do cast (essa era o `/favicon.ico` da raiz do castlab, fix de deploy). É um nit de correção descoberto na investigação.

🤖 Generated with [Claude Code](https://claude.com/claude-code)