### PR TITLE
chore(release): bump workspace version 0.1.34 → 0.1.35

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2845,7 +2845,7 @@ dependencies = [
 
 [[package]]
 name = "ruscker-admin"
-version = "0.1.34"
+version = "0.1.35"
 dependencies = [
  "aes-gcm",
  "anyhow",
@@ -2892,7 +2892,7 @@ dependencies = [
 
 [[package]]
 name = "ruscker-cli"
-version = "0.1.34"
+version = "0.1.35"
 dependencies = [
  "anyhow",
  "clap",
@@ -2912,7 +2912,7 @@ dependencies = [
 
 [[package]]
 name = "ruscker-config"
-version = "0.1.34"
+version = "0.1.35"
 dependencies = [
  "chrono",
  "ordered-float",
@@ -2927,7 +2927,7 @@ dependencies = [
 
 [[package]]
 name = "ruscker-core"
-version = "0.1.34"
+version = "0.1.35"
 dependencies = [
  "async-trait",
  "chrono",
@@ -2940,7 +2940,7 @@ dependencies = [
 
 [[package]]
 name = "ruscker-docker"
-version = "0.1.34"
+version = "0.1.35"
 dependencies = [
  "anyhow",
  "async-stream",
@@ -2959,7 +2959,7 @@ dependencies = [
 
 [[package]]
 name = "ruscker-proxy"
-version = "0.1.34"
+version = "0.1.35"
 dependencies = [
  "anyhow",
  "axum",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -10,7 +10,7 @@ members = [
 ]
 
 [workspace.package]
-version = "0.1.34"
+version = "0.1.35"
 edition = "2021"
 rust-version = "1.85"
 license = "Apache-2.0"

--- a/book/src/faq.md
+++ b/book/src/faq.md
@@ -80,7 +80,7 @@ the **sign-in session** paths to a single upstream — see
 
 ### Is it production-ready?
 
-Yes. The current release is **v0.1.34** — Phases 0–7 are complete and
+Yes. The current release is **v0.1.35** — Phases 0–7 are complete and
 the proxy is production-ready and horizontally scalable.
 Releases are multi-arch and cosign-signed; see the
 [release notes](./news.md) and the [Roadmap](./roadmap.md).

--- a/book/src/introduction.md
+++ b/book/src/introduction.md
@@ -40,7 +40,7 @@ proper admin panel, a monitoring dashboard, and load balancing.
 
 ## In production
 
-Ruscker is on **v0.1.34** and runs in production today. Where the
+Ruscker is on **v0.1.35** and runs in production today. Where the
 JVM-based stack it replaced idled at hundreds of megabytes, Ruscker
 idles in the low tens:
 

--- a/book/src/news.md
+++ b/book/src/news.md
@@ -9,6 +9,24 @@ the [GitHub releases page](https://github.com/StrategicProjects/ruscker/releases
 
 ---
 
+## v0.1.35 — 2026-06-01
+
+Live dashboard fixes behind a reverse proxy, plus smarter share images.
+
+**Admin**
+- The **live dashboard** now streams through reverse proxies: SSE
+  responses send `X-Accel-Buffering: no`, so new containers show up in
+  real time even behind nginx on a subpath mount (no nginx change
+  needed). Previously the table could appear frozen until a reload.
+- **Social share image (`og:image`) auto-defaults**: when left blank it
+  reuses the header (left) logo, else the Ruscker mark — so a shared
+  link carries the portal's identity without setting it twice. The
+  editor field also gets the gallery picker.
+- The Safari pinned-tab `mask-icon` points at the monochrome mark
+  (correct for a recoloured silhouette).
+
+---
+
 ## v0.1.34 — 2026-06-01
 
 Docker connects out of the box, per-theme colours, and a modernised

--- a/book/src/roadmap.md
+++ b/book/src/roadmap.md
@@ -1,6 +1,6 @@
 # Roadmap
 
-Ruscker is at **v0.1.34** — Phases 0 through 7 are done and the proxy is
+Ruscker is at **v0.1.35** — Phases 0 through 7 are done and the proxy is
 production-ready and horizontally scalable. Phase 8 (external auth) is
 the main optional, demand-driven work left. For what changed in each
 release, see the [release notes](./news.md).
@@ -71,7 +71,7 @@ can serve any session; one scaler leader via Postgres advisory locks,
 with failover. A runnable 2-instance compose harness lives in
 `examples/ha/`. See [Deployment shapes](./architecture.md#deployment-shapes).
 
-### Post-phase polish → **v0.1.4 – v0.1.34**
+### Post-phase polish → **v0.1.4 – v0.1.35**
 
 Incremental improvements shipped after Phase 7.
 

--- a/docs/SECURITY.md
+++ b/docs/SECURITY.md
@@ -5,7 +5,7 @@ Status: living document. Tracks the Phase 5 security audit
 **[accepted limitation]**, or **[deferred]**. File references use
 `crate/path:symbol` so they survive line-number drift.
 
-> **Scope.** This covers v0.1.34: single-operator install, Ruscker
+> **Scope.** This covers v0.1.35: single-operator install, Ruscker
 > behind a TLS-terminating reverse proxy, Docker on the same host.
 > Multi-tenant / shared-team auth (OIDC, RBAC) is out of scope until
 > Phase 8.


### PR DESCRIPTION
Corte da **v0.1.35**. Bump de `[workspace.package] version` + `Cargo.lock` + entrada no `news.md` + refs de versão no book/docs.

Conteúdo (mergeado em main desde a v0.1.34):
- **#486** (#485) dashboard ao vivo atravessa reverse proxy (`X-Accel-Buffering: no`) — corrige o Painel congelado atrás do nginx/`/box`
- **#488** (#487) `og:image` auto-default (logo header-left → marca Ruscker) + picker da galeria
- **#490** (#489) mask-icon (Safari pinned tab) → marca monocromática

Após merge: tag `v0.1.35` → `release.yml` publica `.deb`/musl/ghcr cosign-signed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)