### PR TITLE
feat(packaging): purge removes /etc/ruscker; document uninstall & reset

### DIFF
--- a/book/src/installation.md
+++ b/book/src/installation.md
@@ -37,6 +37,31 @@ Edit `/etc/ruscker/application.yml`, put secrets in
 [Deploying in production](./deploying.md) to enable the `--docker`
 backend and put it behind nginx.
 
+### Uninstall & reset
+
+Pick the scope you want:
+
+| Goal | Command | What's left |
+|---|---|---|
+| **Remove the software**, keep config + data | `sudo apt remove ruscker` | `/etc/ruscker` (config, admin token, keys) and `/var/lib/ruscker` (catalog DB) — a reinstall resumes where you left off. |
+| **Remove everything** (no trace) | `sudo apt purge ruscker` | Nothing. Drops the catalog DB **and** `/etc/ruscker` — including `application.yml` and the admin token / master key in `ruscker.env`. |
+| **Reset to a brand-new install** | `sudo apt purge ruscker && sudo apt install ./ruscker_<version>-1_amd64.deb` | A pristine box: the default `application.yml` (no custom title/specs) and a freshly generated admin token, exactly like a first install. |
+| **Wipe the data only**, keep config | stop, remove the DB, start (below) | Config + token unchanged; the catalog is empty, so migrations re-run and the showcase cards re-seed on next boot. |
+
+To wipe just the catalog (a "fresh portal" without uninstalling):
+
+```sh
+sudo systemctl stop ruscker
+sudo rm -f /var/lib/ruscker/ruscker.db          # + -wal/-shm if present
+sudo systemctl start ruscker
+```
+
+> The catalog DB lives in `/var/lib/ruscker`; your config and secrets
+> live in `/etc/ruscker`. `purge` clears both; removing the DB clears
+> only the catalog. The portal **title** comes from `proxy.title` in
+> `application.yml`, so it survives a data-only wipe — only a `purge` (or
+> editing the file) changes it.
+
 ## Static musl tarball
 
 For hosts without a package manager, or for quick installs without a

--- a/packaging/debian/postrm
+++ b/packaging/debian/postrm
@@ -1,14 +1,21 @@
 #!/bin/sh
 # postrm — cargo-deb injects the systemd cleanup at the marker below. On
-# purge we also drop the state directory. The `ruscker` system user is
+# purge we drop the state directory AND the config directory, so a purge
+# leaves no Ruscker trace behind. The `ruscker` system user is
 # intentionally left behind (Debian policy discourages removing system
-# users), and config files are conf-files that dpkg removes on purge.
+# users).
 set -e
 
 #DEBHELPER#
 
 if [ "$1" = "purge" ]; then
+    # The catalog DB, images, audit log, showcase-seed marker, etc.
     rm -rf /var/lib/ruscker
+    # dpkg removes the conffiles themselves (application.yml, ruscker.env)
+    # on purge, but can leave behind `.dpkg-{bak,old,dist}` variants and
+    # the now-empty directory. Drop the whole dir so nothing — including
+    # the admin token / master key in ruscker.env — survives a purge.
+    rm -rf /etc/ruscker
 fi
 
 exit 0


### PR DESCRIPTION
## Resumo

"Remover qualquer traço do Ruscker" é o trabalho do `apt purge`, mas o `postrm` só apagava `/var/lib/ruscker` e contava com o dpkg pra limpar os conffiles de `/etc/ruscker` — o que pode deixar `.dpkg-{bak,old,dist}` e o diretório vazio. Agora o purge faz `rm -rf /etc/ruscker` explícito → **zero traços** (inclui o token de admin / master key no `ruscker.env`).

## Mudanças
- `packaging/debian/postrm`: no `purge`, remove `/var/lib/ruscker` **e** `/etc/ruscker`.
- `book/src/installation.md`: tabela **"Uninstall & reset"** — remove (mantém config+dados) · purge (zero traço) · purge+install (instalação nova) · wipe só do DB (catálogo limpo, config/token intactos). Esclarece que o **título do portal vem do `proxy.title`** (`application.yml`) e por isso sobrevive a um reset só-de-dados — só `purge` ou editar o arquivo muda.

## Verificação
`sh -n postrm` ✓; `mdbook build` ✓; o purge só remove `/etc/ruscker` no branch `purge` (remove/upgrade mantêm config).

Responde à dúvida: por que um reset de dados ainda mostra "Ruscker @ <algo>" — porque o título mora no config, não no DB.

🤖 Generated with [Claude Code](https://claude.com/claude-code)