### PR TITLE
fix(admin): consistent favicon set on every page for Safari (#495)

### DIFF
--- a/crates/ruscker-admin/assets/brand/safari-pinned-tab.svg
+++ b/crates/ruscker-admin/assets/brand/safari-pinned-tab.svg
@@ -1,0 +1,5 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 16 16">
+  <title>Ruscker — Safari pinned tab</title>
+  <path fill="#000000" d="M2.8 5.6 8 3.2 13.2 5.6 8 8Z M2.8 8 8 5.6 13.2 8 8 10.4Z M2.8 10.4 8 8 13.2 10.4 8 12.8Z"/>
+</svg>

--- a/crates/ruscker-admin/src/routes/admin.rs
+++ b/crates/ruscker-admin/src/routes/admin.rs
@@ -687,6 +687,10 @@ pub(crate) fn render<T: Template>(t: &T) -> Response {
 #[cfg(test)]
 mod tests {
     use super::strip_base_prefix;
+    use super::{LoginPage, SetupPage};
+    use crate::i18n::{Locale, Locales};
+    use crate::theme::Theme;
+    use askama::Template;
 
     #[test]
     fn strip_base_prefix_root_is_noop() {
@@ -718,5 +722,50 @@ mod tests {
             "/admin/specs?page=2"
         );
         assert_eq!(strip_base_prefix("/box/?theme=dark", "/box"), "/?theme=dark");
+    }
+
+    // The favicon set lives in the shared `_favicons.html` partial; the
+    // standalone login/setup heads must include it so Safari has the raster
+    // .ico/.png to fall back on (Safari can ignore the SVG favicon and
+    // otherwise keep a stale origin-root icon when moving admin → landing).
+    #[test]
+    fn login_page_includes_raster_favicons() {
+        let locales = Locales::load().expect("load locales");
+        let html = LoginPage {
+            locale: Locale::En,
+            theme: Theme::Auto,
+            locales: &locales,
+            locales_all: &Locale::ALL,
+            base: std::sync::Arc::from(""),
+            error: "",
+            bootstrap: false,
+        }
+        .render()
+        .expect("render login");
+        assert!(html.contains("/favicon.ico"), "login must link /favicon.ico");
+        assert!(
+            html.contains("/favicon-32.png"),
+            "login must link /favicon-32.png"
+        );
+    }
+
+    #[test]
+    fn setup_page_includes_raster_favicons() {
+        let locales = Locales::load().expect("load locales");
+        let html = SetupPage {
+            locale: Locale::En,
+            theme: Theme::Auto,
+            locales: &locales,
+            locales_all: &Locale::ALL,
+            base: std::sync::Arc::from(""),
+            error: "",
+        }
+        .render()
+        .expect("render setup");
+        assert!(html.contains("/favicon.ico"), "setup must link /favicon.ico");
+        assert!(
+            html.contains("/favicon-32.png"),
+            "setup must link /favicon-32.png"
+        );
     }
 }

--- a/crates/ruscker-admin/src/routes/assets.rs
+++ b/crates/ruscker-admin/src/routes/assets.rs
@@ -199,6 +199,10 @@ const BRAND_APP_ICON: &[u8] = include_bytes!("../../assets/brand/ruscker-app-ico
 const FAVICON_ICO: &[u8] = include_bytes!("../../assets/brand/favicon.ico");
 const FAVICON_PNG: &[u8] = include_bytes!("../../assets/brand/favicon-32.png");
 const APPLE_TOUCH_ICON: &[u8] = include_bytes!("../../assets/brand/apple-touch-icon.png");
+// Safari pinned-tab mask icon: a single-layer, 100%-black silhouette on a
+// transparent background (Safari recolours it via the `color` attribute on
+// the `mask-icon` link). A colour or multi-opacity SVG is the wrong input.
+const SAFARI_PINNED_TAB: &[u8] = include_bytes!("../../assets/brand/safari-pinned-tab.svg");
 
 // ── Router ────────────────────────────────────────────────────────
 
@@ -268,6 +272,10 @@ pub fn routes() -> Router<AppState> {
         .route("/favicon.ico", get(|| serve(FAVICON_ICO, ICO)))
         .route("/favicon-32.png", get(|| serve(FAVICON_PNG, PNG)))
         .route("/apple-touch-icon.png", get(|| serve(APPLE_TOUCH_ICON, PNG)))
+        .route(
+            "/safari-pinned-tab.svg",
+            get(|| serve(SAFARI_PINNED_TAB, SVG)),
+        )
         // Operator-uploaded card images. DB first (Phase 2 image
         // library); on miss, fall back to the on-disk `images_dir`
         // (Phase 1 deploy that uses a static folder of files).

--- a/crates/ruscker-admin/templates/_favicons.html
+++ b/crates/ruscker-admin/templates/_favicons.html
@@ -1,0 +1,10 @@
+{# Shared favicon / icon links. Included by every standalone <head> so the
+   set never drifts between pages — Safari can ignore the SVG favicon and
+   otherwise keep a stale origin-root icon, so every page must also offer
+   the raster .ico/.png to fall back on. Requires a `base` field (the mount
+   prefix) on the including page struct. #}
+<link rel="icon" href="{{ base }}/favicon.ico">
+<link rel="icon" type="image/png" sizes="32x32" href="{{ base }}/favicon-32.png">
+<link rel="icon" type="image/svg+xml" href="{{ base }}/favicon.svg">
+<link rel="apple-touch-icon" href="{{ base }}/apple-touch-icon.png">
+<link rel="mask-icon" href="{{ base }}/safari-pinned-tab.svg" color="#0f6e56">

--- a/crates/ruscker-admin/templates/_layout.html
+++ b/crates/ruscker-admin/templates/_layout.html
@@ -8,11 +8,7 @@
 <title>{% block title %}{{ self.t("landing-title") }}{% endblock %}</title>
 {% block head_extra %}{% endblock %}
 
-<link rel="icon" href="{{ base }}/favicon.ico">
-<link rel="icon" type="image/png" sizes="32x32" href="{{ base }}/favicon-32.png">
-<link rel="icon" type="image/svg+xml" href="{{ base }}/favicon.svg">
-<link rel="apple-touch-icon" href="{{ base }}/apple-touch-icon.png">
-<link rel="mask-icon" href="{{ base }}/assets/brand/mark-mono-black.svg" color="#0f6e56">
+{% include "_favicons.html" %}
 
 <link rel="preload" href="{{ base }}/assets/fonts/jost-latin-400-normal.woff2" as="font" type="font/woff2" crossorigin>
 <link rel="preload" href="{{ base }}/assets/fonts/jost-latin-500-normal.woff2" as="font" type="font/woff2" crossorigin>

--- a/crates/ruscker-admin/templates/admin/_layout.html
+++ b/crates/ruscker-admin/templates/admin/_layout.html
@@ -8,11 +8,7 @@
 <meta name="robots" content="noindex,nofollow">
 <title>{% block title %}Admin · Ruscker{% endblock %}</title>
 
-<link rel="icon" href="{{ base }}/favicon.ico">
-<link rel="icon" type="image/png" sizes="32x32" href="{{ base }}/favicon-32.png">
-<link rel="icon" type="image/svg+xml" href="{{ base }}/favicon.svg">
-<link rel="apple-touch-icon" href="{{ base }}/apple-touch-icon.png">
-<link rel="mask-icon" href="{{ base }}/assets/brand/mark-mono-black.svg" color="#0f6e56">
+{% include "_favicons.html" %}
 
 <link rel="preload" href="{{ base }}/assets/fonts/jost-latin-400-normal.woff2" as="font" type="font/woff2" crossorigin>
 <link rel="preload" href="{{ base }}/assets/fonts/jost-latin-500-normal.woff2" as="font" type="font/woff2" crossorigin>

--- a/crates/ruscker-admin/templates/admin/login.html
+++ b/crates/ruscker-admin/templates/admin/login.html
@@ -6,7 +6,7 @@
 <meta name="theme-color" content="#0f6e56">
 <meta name="robots" content="noindex,nofollow">
 <title>{{ self.t("admin-login-title") }} · Ruscker</title>
-<link rel="icon" type="image/svg+xml" href="{{ base }}/favicon.svg">
+{% include "_favicons.html" %}
 <link rel="stylesheet" href="{{ base }}/assets/styles.css?v={{ crate::APP_VERSION }}">
 <link rel="stylesheet" href="{{ base }}/assets/icons/tabler-icons.min.css?v={{ crate::APP_VERSION }}">
 </head>

--- a/crates/ruscker-admin/templates/admin/setup.html
+++ b/crates/ruscker-admin/templates/admin/setup.html
@@ -6,7 +6,7 @@
 <meta name="theme-color" content="#0f6e56">
 <meta name="robots" content="noindex,nofollow">
 <title>{{ self.t("admin-setup-title") }} · Ruscker</title>
-<link rel="icon" type="image/svg+xml" href="{{ base }}/favicon.svg">
+{% include "_favicons.html" %}
 <link rel="stylesheet" href="{{ base }}/assets/styles.css?v={{ crate::APP_VERSION }}">
 <link rel="stylesheet" href="{{ base }}/assets/icons/tabler-icons.min.css?v={{ crate::APP_VERSION }}">
 </head>


### PR DESCRIPTION
## Resumo
Safari ignora o favicon SVG e, sem raster na página, mantém um ícone de origem obsoleto → bola escura ao navegar admin → landing. As páginas standalone `login`/`setup` só declaravam `/favicon.svg`. Closes #495.

## Mudanças
1. Partial compartilhado `templates/_favicons.html` (ico + png-32 + svg + apple-touch + mask-icon).
2. Incluído em `_layout.html`, `admin/_layout.html`, `admin/login.html`, `admin/setup.html` — heads não divergem mais; login/setup agora carregam o raster .ico/.png.
3. Asset `assets/brand/safari-pinned-tab.svg` (mono 100% preto, 1 camada, viewBox 16x16), servido em `/safari-pinned-tab.svg`; `mask-icon` aponta pra ele.
4. Testes renderizam `/admin/login` + `/admin/setup` e validam `/favicon.ico` + `/favicon-32.png`.

## Gates (todos verdes)
- `cargo test -p ruscker-admin favicon` → 2 passed
- `cargo test` → 24 suites ok
- `cargo clippy --all-targets -- -D warnings` → clean
- `./scripts/i18n-check.sh` → OK
- Smoke: `/`, `/admin/login`, `/admin/setup` (com sessão) emitem ico+png+apple+mask; `/safari-pinned-tab.svg` → 200 image/svg+xml.

> Separado do favicon da raiz servido pelo reverse proxy (fix de deploy) — este conserta a consistência das páginas do app.

🤖 Generated with [Claude Code](https://claude.com/claude-code)