### PR TITLE
chore(release): bump workspace version 0.1.35 → 0.1.36

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2845,7 +2845,7 @@ dependencies = [
 
 [[package]]
 name = "ruscker-admin"
-version = "0.1.35"
+version = "0.1.36"
 dependencies = [
  "aes-gcm",
  "anyhow",
@@ -2892,7 +2892,7 @@ dependencies = [
 
 [[package]]
 name = "ruscker-cli"
-version = "0.1.35"
+version = "0.1.36"
 dependencies = [
  "anyhow",
  "clap",
@@ -2912,7 +2912,7 @@ dependencies = [
 
 [[package]]
 name = "ruscker-config"
-version = "0.1.35"
+version = "0.1.36"
 dependencies = [
  "chrono",
  "ordered-float",
@@ -2927,7 +2927,7 @@ dependencies = [
 
 [[package]]
 name = "ruscker-core"
-version = "0.1.35"
+version = "0.1.36"
 dependencies = [
  "async-trait",
  "chrono",
@@ -2940,7 +2940,7 @@ dependencies = [
 
 [[package]]
 name = "ruscker-docker"
-version = "0.1.35"
+version = "0.1.36"
 dependencies = [
  "anyhow",
  "async-stream",
@@ -2959,7 +2959,7 @@ dependencies = [
 
 [[package]]
 name = "ruscker-proxy"
-version = "0.1.35"
+version = "0.1.36"
 dependencies = [
  "anyhow",
  "axum",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -10,7 +10,7 @@ members = [
 ]
 
 [workspace.package]
-version = "0.1.35"
+version = "0.1.36"
 edition = "2021"
 rust-version = "1.85"
 license = "Apache-2.0"

--- a/book/src/faq.md
+++ b/book/src/faq.md
@@ -80,7 +80,7 @@ the **sign-in session** paths to a single upstream — see
 
 ### Is it production-ready?
 
-Yes. The current release is **v0.1.35** — Phases 0–7 are complete and
+Yes. The current release is **v0.1.36** — Phases 0–7 are complete and
 the proxy is production-ready and horizontally scalable.
 Releases are multi-arch and cosign-signed; see the
 [release notes](./news.md) and the [Roadmap](./roadmap.md).

--- a/book/src/introduction.md
+++ b/book/src/introduction.md
@@ -40,7 +40,7 @@ proper admin panel, a monitoring dashboard, and load balancing.
 
 ## In production
 
-Ruscker is on **v0.1.35** and runs in production today. Where the
+Ruscker is on **v0.1.36** and runs in production today. Where the
 JVM-based stack it replaced idled at hundreds of megabytes, Ruscker
 idles in the low tens:
 

--- a/book/src/news.md
+++ b/book/src/news.md
@@ -9,6 +9,25 @@ the [GitHub releases page](https://github.com/StrategicProjects/ruscker/releases
 
 ---
 
+## v0.1.36 — 2026-06-01
+
+A favicon fix for Safari and a cleaner uninstall.
+
+**Admin**
+- Every page now ships the **same favicon set** — the standalone login
+  and setup screens previously linked only the SVG icon, which Safari can
+  ignore (leaving a dark placeholder when moving between admin and the
+  landing). The icon links live in one shared partial, and a dedicated
+  monochrome `safari-pinned-tab.svg` backs the Safari pinned-tab icon.
+
+**Packaging**
+- `apt purge ruscker` now removes `/etc/ruscker` too (config + the admin
+  token / keys in `ruscker.env`), so a purge leaves no trace. The
+  installation chapter documents the full **uninstall & reset** matrix
+  (remove vs purge vs purge+install vs a data-only DB wipe).
+
+---
+
 ## v0.1.35 — 2026-06-01
 
 Live dashboard fixes behind a reverse proxy, plus smarter share images.

--- a/book/src/roadmap.md
+++ b/book/src/roadmap.md
@@ -1,6 +1,6 @@
 # Roadmap
 
-Ruscker is at **v0.1.35** — Phases 0 through 7 are done and the proxy is
+Ruscker is at **v0.1.36** — Phases 0 through 7 are done and the proxy is
 production-ready and horizontally scalable. Phase 8 (external auth) is
 the main optional, demand-driven work left. For what changed in each
 release, see the [release notes](./news.md).
@@ -71,7 +71,7 @@ can serve any session; one scaler leader via Postgres advisory locks,
 with failover. A runnable 2-instance compose harness lives in
 `examples/ha/`. See [Deployment shapes](./architecture.md#deployment-shapes).
 
-### Post-phase polish → **v0.1.4 – v0.1.35**
+### Post-phase polish → **v0.1.4 – v0.1.36**
 
 Incremental improvements shipped after Phase 7.
 

--- a/docs/SECURITY.md
+++ b/docs/SECURITY.md
@@ -5,7 +5,7 @@ Status: living document. Tracks the Phase 5 security audit
 **[accepted limitation]**, or **[deferred]**. File references use
 `crate/path:symbol` so they survive line-number drift.
 
-> **Scope.** This covers v0.1.35: single-operator install, Ruscker
+> **Scope.** This covers v0.1.36: single-operator install, Ruscker
 > behind a TLS-terminating reverse proxy, Docker on the same host.
 > Multi-tenant / shared-team auth (OIDC, RBAC) is out of scope until
 > Phase 8.


### PR DESCRIPTION
Corte da **v0.1.36**. Bump + `Cargo.lock` + `news.md` + refs de versão.

Conteúdo (mergeado desde a v0.1.35):
- **#496** (#495) favicon consistente em todas as páginas (fix Safari admin↔landing) + `safari-pinned-tab.svg`
- **#494** `apt purge` limpa `/etc/ruscker` (zero traço) + matriz uninstall/reset no book
- **#492/#493** docs (roadmap recente + next-steps pra discussão)

Após merge: tag `v0.1.36` → `release.yml` publica `.deb`/musl/ghcr cosign-signed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)