### PR TITLE
feat(admin): pull an absent image from the spec editor with live progress (#498, slice B)

### DIFF
--- a/crates/ruscker-admin/assets/i18n/en/landing.ftl
+++ b/crates/ruscker-admin/assets/i18n/en/landing.ftl
@@ -222,6 +222,8 @@ spec-form-image-absent = Not on the server — pulled on first launch
 spec-form-image-unresolved = Has an env variable — resolved at pull time
 spec-form-image-no-backend = Docker not connected — can't check
 spec-form-image-error = Image check failed
+spec-form-image-pull = Pull
+spec-form-image-pulling = Pulling…
 spec-form-seats = Sessions/container
 spec-form-lifetime = Max lifetime (min)
 spec-form-lifetime-help = 360 = 6 hours

--- a/crates/ruscker-admin/assets/i18n/es/landing.ftl
+++ b/crates/ruscker-admin/assets/i18n/es/landing.ftl
@@ -222,6 +222,8 @@ spec-form-image-absent = Ausente — se descarga en el primer acceso
 spec-form-image-unresolved = Tiene una variable de entorno — se resuelve al hacer pull
 spec-form-image-no-backend = Docker no conectado — no se puede verificar
 spec-form-image-error = Error al verificar la imagen
+spec-form-image-pull = Descargar
+spec-form-image-pulling = Descargando…
 spec-form-seats = Sesiones/contenedor
 spec-form-lifetime = Vida máx. (min)
 spec-form-lifetime-help = 360 = 6 horas

--- a/crates/ruscker-admin/assets/i18n/fr/landing.ftl
+++ b/crates/ruscker-admin/assets/i18n/fr/landing.ftl
@@ -222,6 +222,8 @@ spec-form-image-absent = Absente — récupérée au premier lancement
 spec-form-image-unresolved = Contient une variable d'environnement — résolue au pull
 spec-form-image-no-backend = Docker non connecté — vérification impossible
 spec-form-image-error = Échec de la vérification de l'image
+spec-form-image-pull = Récupérer
+spec-form-image-pulling = Récupération…
 spec-form-seats = Sessions/conteneur
 spec-form-lifetime = Durée max. (min)
 spec-form-lifetime-help = 360 = 6 heures

--- a/crates/ruscker-admin/assets/i18n/pt/landing.ftl
+++ b/crates/ruscker-admin/assets/i18n/pt/landing.ftl
@@ -226,6 +226,8 @@ spec-form-image-absent = Ausente — será puxada no primeiro acesso
 spec-form-image-unresolved = Contém variável de ambiente — resolvida no pull
 spec-form-image-no-backend = Docker não conectado — não dá para verificar
 spec-form-image-error = Falha ao verificar a imagem
+spec-form-image-pull = Puxar
+spec-form-image-pulling = Puxando…
 spec-form-seats = Sessões/container
 spec-form-lifetime = Vida máx. (min)
 spec-form-lifetime-help = 360 = 6 horas

--- a/crates/ruscker-admin/src/routes/admin/spec_form.rs
+++ b/crates/ruscker-admin/src/routes/admin/spec_form.rs
@@ -44,6 +44,7 @@ pub fn routes() -> Router<AppState> {
         )
         .route("/admin/specs/{id}/duplicate", get(duplicate_form))
         .route("/admin/specs/image-check", get(image_check))
+        .route("/admin/specs/image-pull", get(image_pull))
         .route("/admin/specs/{id}", post(update))
         .route("/admin/specs/{id}/delete", post(delete))
 }
@@ -96,6 +97,88 @@ async fn image_check(
         "no-backend"
     };
     Json(ImageCheckResult { status })
+}
+
+#[derive(Deserialize)]
+struct ImagePullQuery {
+    image: String,
+    /// Name of a stored registry credential (the form's picker) for a
+    /// private image. Empty ⇒ anonymous pull (public images).
+    #[serde(default)]
+    credential: String,
+}
+
+/// `GET /admin/specs/image-pull?image=…&credential=…` — pull an absent
+/// image now, streaming the daemon's progress over SSE so the editor's
+/// Pull button (#498, slice B) can show it. Reuses the same pull path as
+/// a spawn. A terminal `done` event lets the client close the stream and
+/// re-check presence (success ⇒ present, failure ⇒ still absent + the
+/// `error: …` line). Editor-gated.
+async fn image_pull(
+    _: RequireEditor,
+    State(state): State<AppState>,
+    Query(q): Query<ImagePullQuery>,
+) -> Response {
+    use axum::http::header::{HeaderName, CACHE_CONTROL};
+    use axum::response::sse::{Event, KeepAlive, Sse};
+    use futures_util::StreamExt;
+
+    let image = q.image.trim().to_string();
+    if image.is_empty() || image.contains("${") {
+        return (
+            StatusCode::BAD_REQUEST,
+            "image name required (and must be free of ${…})",
+        )
+            .into_response();
+    }
+    let Some(backend) = state.backend.clone() else {
+        return (StatusCode::SERVICE_UNAVAILABLE, "Docker backend not connected").into_response();
+    };
+    let creds = resolve_pull_creds(&state, &q.credential).await;
+    let line_stream = match backend.pull_image(&image, creds.as_ref(), None).await {
+        Ok(s) => s,
+        Err(e) => {
+            tracing::warn!(image, error = ?e, "image pull start failed");
+            return (StatusCode::BAD_GATEWAY, format!("pull failed: {e}")).into_response();
+        }
+    };
+    // Progress lines as default events, then one terminal `done` event so
+    // the client closes the EventSource (no auto-reconnect → re-pull).
+    let progress = line_stream.map(|line| Ok::<_, std::convert::Infallible>(Event::default().data(line)));
+    let done = futures_util::stream::once(async {
+        Ok::<_, std::convert::Infallible>(Event::default().event("done").data(""))
+    });
+    let sse = Sse::new(progress.chain(done))
+        .keep_alive(KeepAlive::new().interval(std::time::Duration::from_secs(15)));
+    // `X-Accel-Buffering: no` so nginx streams the pull instead of buffering.
+    (
+        [
+            (CACHE_CONTROL, "no-cache"),
+            (HeaderName::from_static("x-accel-buffering"), "no"),
+        ],
+        sse,
+    )
+        .into_response()
+}
+
+/// Resolve a stored registry credential by name for [`image_pull`].
+/// `None` (empty name / no DB / no master key / not found) ⇒ anonymous.
+async fn resolve_pull_creds(
+    state: &AppState,
+    credential: &str,
+) -> Option<ruscker_core::RegistryCredentials> {
+    let name = credential.trim();
+    if name.is_empty() {
+        return None;
+    }
+    let pool = state.db.as_ref()?;
+    if !state.master_key.is_configured() {
+        return None;
+    }
+    crate::db::credentials::resolve(pool, &state.master_key, name)
+        .await
+        .ok()
+        .flatten()
 }
 
 // ── Form payload ────────────────────────────────────────────────

--- a/crates/ruscker-admin/templates/admin/spec_form.html
+++ b/crates/ruscker-admin/templates/admin/spec_form.html
@@ -301,9 +301,17 @@
               {# On-demand presence check (#498). Pull-free; the badge below
                  reports present / absent / deferred. #}
               <button type="button" class="admin-login-btn" style="padding:7px 11px;font-size:12px;white-space:nowrap"
-                      @click="checkImage()" :disabled="imageCheck.loading || !(form.container_image || '').trim()">
+                      @click="checkImage()" :disabled="imageCheck.loading || pull.running || !(form.container_image || '').trim()">
                 <i class="ti ti-search" aria-hidden="true"></i>
                 {{ self.t("spec-form-image-check") }}
+              </button>
+              {# Pull on demand (#498 slice B) — offered once a check says the
+                 image is absent (but a name is typed). Streams progress below. #}
+              <button type="button" class="admin-login-btn" style="padding:7px 11px;font-size:12px;white-space:nowrap"
+                      x-show="imageCheck.status === 'absent'" x-cloak
+                      @click="pullImage()" :disabled="pull.running">
+                <i class="ti ti-cloud-download" aria-hidden="true"></i>
+                {{ self.t("spec-form-image-pull") }}
               </button>
             </div>
             <div class="spec-form-help" x-show="imageCheck.loading || imageCheck.status" x-cloak style="margin-top:5px">
@@ -313,6 +321,11 @@
               <span x-show="!imageCheck.loading && imageCheck.status === 'unresolved'"><i class="ti ti-variable" aria-hidden="true"></i> {{ self.t("spec-form-image-unresolved") }}</span>
               <span x-show="!imageCheck.loading && imageCheck.status === 'no-backend'"><i class="ti ti-plug-off" aria-hidden="true"></i> {{ self.t("spec-form-image-no-backend") }}</span>
               <span x-show="!imageCheck.loading && imageCheck.status === 'error'"><i class="ti ti-alert-triangle" aria-hidden="true"></i> {{ self.t("spec-form-image-error") }}</span>
+            </div>
+            {# Live pull progress (#498 slice B). #}
+            <div class="spec-form-help" x-show="pull.running || pull.line" x-cloak style="margin-top:5px">
+              <span x-show="pull.running"><i class="ti ti-loader-2" aria-hidden="true"></i> {{ self.t("spec-form-image-pulling") }}</span>
+              <span x-text="pull.line" class="spec-form-input--mono" style="opacity:0.75"></span>
             </div>
           </div>
 
@@ -889,6 +902,31 @@ window.ruscker.specForm = (initial, logoImages) => ({
     } catch (_) {
       this.imageCheck = { status: 'error', loading: false };
     }
+  },
+  // Pull an absent image on demand (#498 slice B), streaming the daemon's
+  // progress over SSE. A terminal `done` event closes the stream; we then
+  // re-check presence so the badge reflects success (present) or failure
+  // (still absent + the last `error:` line).
+  pull: { running: false, line: '' },
+  pullImage() {
+    const image = (this.form.container_image || '').trim();
+    if (!image || this.pull.running) return;
+    this.pull = { running: true, line: '' };
+    const base = window.RUSCKER_BASE || '';
+    const cred = encodeURIComponent(this.form.docker_registry_credential || '');
+    const url = base + '/admin/specs/image-pull?image=' + encodeURIComponent(image) + '&credential=' + cred;
+    const es = new EventSource(url);
+    let finished = false;
+    const finish = () => {
+      if (finished) return;
+      finished = true;
+      es.close();
+      this.pull.running = false;
+      this.checkImage();
+    };
+    es.onmessage = (e) => { if (e.data) this.pull.line = e.data; };
+    es.addEventListener('done', finish);
+    es.onerror = finish;  // stream closed / network / 4xx — re-check tells us
   },
   // Prefix the base path on a root-absolute asset URL (#270). These
   // <img :src> values are set by Alpine at runtime, so the base-path

--- a/crates/ruscker-core/src/lib.rs
+++ b/crates/ruscker-core/src/lib.rs
@@ -392,6 +392,22 @@ pub trait ContainerBackend: Send + Sync {
             .iter()
             .any(|i| image_tag_matches(&i.tags, image)))
     }
+
+    /// Pull `image` (optionally with registry `creds` + a `platform`),
+    /// streaming human-readable progress lines for the editor's Pull
+    /// button (#498, slice B). Default: unsupported — the editor only
+    /// offers Pull when the backend provides it. The Docker backend
+    /// streams `create_image` events.
+    async fn pull_image(
+        &self,
+        _image: &str,
+        _creds: Option<&RegistryCredentials>,
+        _platform: Option<&str>,
+    ) -> CoreResult<LogStream> {
+        Err(CoreError::Backend(
+            "image pull not supported by this backend".into(),
+        ))
+    }
 }
 
 /// Does any of `tags` (an image's `repo:tag` refs) satisfy a request for

--- a/crates/ruscker-docker/src/lib.rs
+++ b/crates/ruscker-docker/src/lib.rs
@@ -735,6 +735,59 @@ impl ContainerBackend for LocalDockerBackend {
         // real daemon failure (#498).
         Ok(self.docker.inspect_image(image).await.is_ok())
     }
+
+    async fn pull_image(
+        &self,
+        image: &str,
+        creds: Option<&ruscker_core::RegistryCredentials>,
+        platform: Option<&str>,
+    ) -> CoreResult<ruscker_core::LogStream> {
+        // Same options/creds path as `ensure_image_pulled`, but the
+        // `create_image` events are surfaced as progress lines instead of
+        // discarded — the editor's Pull button streams them over SSE
+        // (#498, slice B). A registry/auth failure rides through as an
+        // `error: …` line, not a hard error, so the caller can show it.
+        let opts = CreateImageOptions {
+            from_image: Some(image.to_string()),
+            platform: platform.unwrap_or("").to_string(),
+            ..Default::default()
+        };
+        let bollard_creds = creds.map(|c| bollard::auth::DockerCredentials {
+            username: Some(c.username.clone()),
+            password: Some(c.password.clone()),
+            serveraddress: c.server_address.clone(),
+            ..Default::default()
+        });
+        let stream = self
+            .docker
+            .create_image(Some(opts), None, bollard_creds)
+            .map(|ev| match ev {
+                Ok(info) => {
+                    if let Some(err) = info.error_detail {
+                        return format!("error: {}", err.message.unwrap_or_default());
+                    }
+                    let id = info.id.unwrap_or_default();
+                    let status = info.status.unwrap_or_default();
+                    let mut line = String::new();
+                    if !id.is_empty() {
+                        line.push_str(&id);
+                        line.push_str(": ");
+                    }
+                    line.push_str(&status);
+                    // Byte progress, when the daemon reports it (layer pulls).
+                    if let Some(pd) = info.progress_detail {
+                        if let (Some(cur), Some(total)) = (pd.current, pd.total) {
+                            if total > 0 {
+                                line.push_str(&format!(" {cur}/{total}"));
+                            }
+                        }
+                    }
+                    line
+                }
+                Err(e) => format!("error: {e}"),
+            });
+        Ok(Box::pin(stream))
+    }
 }
 
 impl LocalDockerBackend {


### PR DESCRIPTION
## Resumo

Fatia B do #498: quando o check (fatia A) diz que a imagem está **ausente**, um botão **Puxar** baixa na hora e **streama o progresso** do daemon — sem mais descobrir imagem não-puxável só no cold-start que falha.

## Mudanças
- `ContainerBackend::pull_image(image, creds, platform)` → stream de linhas de progresso (default: unsupported; Docker mapeia eventos do `create_image` — status + progresso em bytes, falha de registry/auth como `error: …` — reusando o mesmo caminho de pull do spawn).
- `GET /admin/specs/image-pull?image=…&credential=…` (Editor-gated): SSE dessas linhas + evento terminal `done`, com `X-Accel-Buffering: no` (passa pelo nginx). Credencial do store (picker do form) resolvida pra imagem privada; senão pull anônimo.
- Editor mostra **Puxar** quando o check diz `absent`; um EventSource streama o progresso e o evento terminal re-checa a presença → badge fecha em `present` (sucesso) ou `absent` + linha de erro (falha). Sem auto-reconnect (evita re-pull).

## Smoke real
`hello-world` (ausente) → SSE com `Pulling/Downloading/Extracting/Pull complete/Digest` + `event: done` + header `x-accel-buffering: no` → check vira **present**. ✅

Gates: `cargo test` (24 suites) + `clippy -D warnings` + `i18n-check` verdes.

> Nota: imagens multi-arch podem emitir uma linha `error:` para variantes de plataforma que não casam (o daemon itera o manifest list) — inócuo: o re-check final reflete o estado real (present). A **fatia C** (build de zip+Dockerfile) segue como investigação à parte no #498.

🤖 Generated with [Claude Code](https://claude.com/claude-code)