### PR TITLE
feat(landing): show the card's subject as a pill next to the type (#507)

### DIFF
--- a/crates/ruscker-admin/assets/tailwind/input.css
+++ b/crates/ruscker-admin/assets/tailwind/input.css
@@ -337,11 +337,23 @@ body {
 .tint-api     { background: radial-gradient(120% 92% at 50% 36%, #ffffff 0%, #ffffff 16%, #c7ebf3 100%); }
 .tint-link    { background: radial-gradient(120% 92% at 50% 36%, #ffffff 0%, #ffffff 16%, #ccd9f0 100%); }
 
+/* Type + subject badges, grouped top-left over the cover (#507). */
+.rbadges {
+  position: absolute; top: 8px; left: 8px; z-index: 2;
+  display: flex; align-items: center; gap: 4px;
+  max-width: calc(100% - 44px);  /* leave room for the lock top-right */
+}
 .rbadge {
-  position: absolute; top: 8px; left: 8px;
   font-size: 9px; font-weight: 500;
   padding: 3px 9px; border-radius: 999px;
-  letter-spacing: 0.4px; z-index: 2;
+  letter-spacing: 0.4px;
+}
+/* Subject pill — neutral, frosted, truncates long subjects. */
+.rbadge--subject {
+  background: rgba(20, 20, 20, 0.62); color: #fff;
+  letter-spacing: 0.2px;
+  max-width: 12ch; overflow: hidden; text-overflow: ellipsis; white-space: nowrap;
+  backdrop-filter: blur(2px);
 }
 .b-app     { background: #06d6a0; color: #04553f; }
 .b-talk    { background: #ffd166; color: #5a4400; }

--- a/crates/ruscker-admin/templates/admin/spec_form.html
+++ b/crates/ruscker-admin/templates/admin/spec_form.html
@@ -793,7 +793,11 @@
           <template x-if="!form.logo">
             <span class="rcover-fallback" x-text="form.id || '—'"></span>
           </template>
-          <span class="rbadge" :class="'b-' + form.display_type" x-text="badgeText()"></span>
+          <div class="rbadges">
+            <span class="rbadge" :class="'b-' + form.display_type" x-text="badgeText()"></span>
+            {# Live subject ("tema") pill — mirrors the landing card (#507). #}
+            <span class="rbadge rbadge--subject" x-show="(form.subject || '').trim()" x-text="form.subject" :title="form.subject" x-cloak></span>
+          </div>
           <span class="rlock">
             <i class="ti" :class="isOpenAccess()
                 ? 'ti-lock-open text-[color:var(--color-lock-open)]'

--- a/crates/ruscker-admin/templates/landing.html
+++ b/crates/ruscker-admin/templates/landing.html
@@ -225,7 +225,12 @@
             <span class="rcover-fallback">{{ card.id }}</span>
           {% endmatch %}
 
-          <span class="rbadge b-{{ card.display_type.key() }}">{{ self.t(card.display_type.abbr_key()) }}</span>
+          <div class="rbadges">
+            <span class="rbadge b-{{ card.display_type.key() }}">{{ self.t(card.display_type.abbr_key()) }}</span>
+            {# Subject ("tema") pill next to the type — neutral so it doesn't
+               compete with the coloured type badge (#507). #}
+            {% if let Some(subj) = card.subject %}<span class="rbadge rbadge--subject" title="{{ subj }}">{{ subj }}</span>{% endif %}
+          </div>
           <span class="rlock">
             <i class="ti ti-{% if card.access_open %}lock-open text-[color:var(--color-lock-open)]{% else %}lock text-[color:var(--color-lock)]{% endif %} text-[12px]" aria-hidden="true"></i>
           </span>


### PR DESCRIPTION
## Resumo
O **subject** ("tema", `template-properties.subject`) já alimentava o filtro mas não aparecia no card. Agora é uma **pill neutra ao lado do badge de tipo**, no cover. Closes #507.

## Mudanças
- Wrapper `.rbadges` (flex) agrupa o badge de tipo (colorido) + a pill `.rbadge--subject` (neutra/frosted, truncada) quando o card tem subject.
- Prévia ao vivo do spec form espelha, ligada a `form.subject`.

## Confirmações (item do issue)
- O **filtro de subject já auto-popula** dos subjects distintos — verificado: criar um spec `subject=Analytics` adiciona `<option value="Analytics">` no filtro **e** a pill no card. ✅
- Showcase já tem subjects (ex. "Documentação") → pills aparecem.

Gates: `cargo test` (24) + `clippy -D warnings` + `i18n-check` verdes. Só template + CSS.

🤖 Generated with [Claude Code](https://claude.com/claude-code)