### PR TITLE
feat(landing): Featured carousel of highlighted apps (#506)

### DIFF
--- a/crates/ruscker-admin/assets/i18n/en/landing.ftl
+++ b/crates/ruscker-admin/assets/i18n/en/landing.ftl
@@ -640,3 +640,10 @@ admin-landing-theme-dark = Dark theme
 admin-landing-theme-bg = Background
 admin-landing-theme-text = Text
 admin-landing-theme-accent = Accent
+
+# Featured carousel (#506)
+highlights-title = Featured
+spec-form-featured = Feature this app
+spec-form-featured-help = Shows the app in the Featured carousel at the top of the landing (when the toggle is on).
+admin-landing-show-highlights = Show Featured carousel
+admin-landing-show-highlights-help = Shows the carousel of featured apps above the filters. Hidden when nothing is featured.

--- a/crates/ruscker-admin/assets/i18n/es/landing.ftl
+++ b/crates/ruscker-admin/assets/i18n/es/landing.ftl
@@ -640,3 +640,10 @@ admin-landing-theme-dark = Tema oscuro
 admin-landing-theme-bg = Fondo
 admin-landing-theme-text = Texto
 admin-landing-theme-accent = Acento
+
+# Featured carousel (#506)
+highlights-title = Destacados
+spec-form-featured = Destacar esta app
+spec-form-featured-help = Muestra la app en el carrusel de Destacados arriba de la landing (si la opción está activada).
+admin-landing-show-highlights = Mostrar Destacados
+admin-landing-show-highlights-help = Muestra el carrusel de apps destacadas encima de los filtros. Se oculta si no hay ninguna destacada.

--- a/crates/ruscker-admin/assets/i18n/fr/landing.ftl
+++ b/crates/ruscker-admin/assets/i18n/fr/landing.ftl
@@ -640,3 +640,10 @@ admin-landing-theme-dark = Thème sombre
 admin-landing-theme-bg = Fond
 admin-landing-theme-text = Texte
 admin-landing-theme-accent = Accent
+
+# Featured carousel (#506)
+highlights-title = À la une
+spec-form-featured = Mettre cette app en avant
+spec-form-featured-help = Affiche l'app dans le carrousel « À la une » en haut de la landing (si l'option est activée).
+admin-landing-show-highlights = Afficher « À la une »
+admin-landing-show-highlights-help = Affiche le carrousel des apps en avant au-dessus des filtres. Masqué si rien n'est mis en avant.

--- a/crates/ruscker-admin/assets/i18n/pt/landing.ftl
+++ b/crates/ruscker-admin/assets/i18n/pt/landing.ftl
@@ -644,3 +644,10 @@ admin-landing-theme-dark = Tema escuro
 admin-landing-theme-bg = Fundo
 admin-landing-theme-text = Texto
 admin-landing-theme-accent = Acento
+
+# Featured carousel (#506)
+highlights-title = Destaques
+spec-form-featured = Destacar este app
+spec-form-featured-help = Mostra o app no carrossel de Destaques no topo da landing (quando a opção estiver ligada).
+admin-landing-show-highlights = Mostrar Destaques
+admin-landing-show-highlights-help = Exibe o carrossel de apps em destaque acima dos filtros. Some se nada estiver em destaque.

--- a/crates/ruscker-admin/assets/tailwind/input.css
+++ b/crates/ruscker-admin/assets/tailwind/input.css
@@ -355,6 +355,25 @@ body {
   max-width: 12ch; overflow: hidden; text-overflow: ellipsis; white-space: nowrap;
   backdrop-filter: blur(2px);
 }
+
+/* Featured carousel (#506) — a horizontal scroll rail of full cards. The
+   card keeps its fixed width, so 1–3 fit per viewport and the rest scroll. */
+.highlights { margin-bottom: 22px; }
+.highlights-title {
+  display: flex; align-items: center; gap: 6px;
+  font-size: 13px; font-weight: 600; color: var(--text);
+  letter-spacing: -0.01em; margin-bottom: 10px;
+}
+.highlights-title .ti { color: var(--color-teal-600); font-size: 15px; }
+.highlights-rail {
+  display: flex; gap: 14px;
+  overflow-x: auto; scroll-snap-type: x proximity;
+  padding-bottom: 8px; scrollbar-width: thin;
+}
+.highlights-rail > .rcard {
+  flex: 0 0 auto;            /* keep the fixed card width; never stretch */
+  scroll-snap-align: start;
+}
 .b-app     { background: #06d6a0; color: #04553f; }
 .b-talk    { background: #ffd166; color: #5a4400; }
 .b-report  { background: #ef476f; color: #ffffff; }
@@ -826,6 +845,14 @@ body {
   padding: 8px 10px;
 }
 .spec-form-empty-hint .ti { font-size: 14px; flex: none; }
+/* Checkbox row (e.g. the Featured / Show-highlights toggles, #506). */
+.spec-form-check {
+  display: inline-flex; align-items: center; gap: 8px;
+  font-size: 13px; color: var(--text); cursor: pointer;
+}
+.spec-form-check input[type="checkbox"] {
+  width: 15px; height: 15px; accent-color: var(--color-teal-600); cursor: pointer;
+}
 .spec-form-input {
   width: 100%;
   background: var(--surface);

--- a/crates/ruscker-admin/migrations-pg/0013_landing_show_highlights.sql
+++ b/crates/ruscker-admin/migrations-pg/0013_landing_show_highlights.sql
@@ -1,0 +1,2 @@
+-- Postgres twin of migrations/0013 (#506). Idempotent.
+ALTER TABLE landing_customization ADD COLUMN IF NOT EXISTS show_highlights BOOLEAN;

--- a/crates/ruscker-admin/migrations/0013_landing_show_highlights.sql
+++ b/crates/ruscker-admin/migrations/0013_landing_show_highlights.sql
@@ -1,0 +1,4 @@
+-- Show the "Featured" carousel of highlighted apps above the filters
+-- (#506). NULL → default on; the carousel still only renders when at
+-- least one spec is featured.
+ALTER TABLE landing_customization ADD COLUMN show_highlights INTEGER;

--- a/crates/ruscker-admin/src/db/landing.rs
+++ b/crates/ruscker-admin/src/db/landing.rs
@@ -34,11 +34,12 @@ pub async fn fetch(db: &ConfigDb) -> Result<LandingCustomization> {
         Option<String>, // title
         Option<String>, // subtitle
         Option<String>, // theme_colors_json
+        Option<bool>,   // show_highlights
     );
     let sql = "SELECT header_bg, header_fg, intro, intro_locales_json,
                 seo_title, seo_description, og_image,
                 analytics_html, analytics_origins, custom_css, logos_json,
-                title, subtitle, theme_colors_json
+                title, subtitle, theme_colors_json, show_highlights
            FROM landing_customization WHERE id = 1";
     let row: Option<Row> = match db {
         ConfigDb::Sqlite(pool) => sqlx::query_as(sql).fetch_optional(pool).await,
@@ -62,6 +63,7 @@ pub async fn fetch(db: &ConfigDb) -> Result<LandingCustomization> {
             title,
             subtitle,
             theme_colors_json,
+            show_highlights,
         )) => {
             let intro_locales =
                 serde_json::from_str(&locales_json).context("parse intro_locales_json")?;
@@ -100,6 +102,7 @@ pub async fn fetch(db: &ConfigDb) -> Result<LandingCustomization> {
                 title,
                 subtitle,
                 theme_colors,
+                show_highlights,
             })
         }
     }
@@ -167,7 +170,7 @@ pub(crate) async fn update_in_tx(
                 intro_locales_json = ?, seo_title = ?, seo_description = ?,
                 og_image = ?, analytics_html = ?, analytics_origins = ?,
                 custom_css = ?, logos_json = ?, title = ?, subtitle = ?,
-                theme_colors_json = ?, updated_at = ?
+                theme_colors_json = ?, show_highlights = ?, updated_at = ?
           WHERE id = 1",
     )
     .bind(none_if_empty(&lc.header_bg))
@@ -184,6 +187,7 @@ pub(crate) async fn update_in_tx(
     .bind(none_if_empty(&lc.title))
     .bind(none_if_empty(&lc.subtitle))
     .bind(&theme_colors_json)
+    .bind(lc.show_highlights)
     .bind(now)
     .execute(&mut **tx)
     .await
@@ -221,7 +225,8 @@ pub(crate) async fn update_in_tx_pg(
                 intro_locales_json = $4, seo_title = $5, seo_description = $6,
                 og_image = $7, analytics_html = $8, analytics_origins = $9,
                 custom_css = $10, logos_json = $11, title = $12,
-                subtitle = $13, theme_colors_json = $14, updated_at = $15
+                subtitle = $13, theme_colors_json = $14,
+                show_highlights = $15, updated_at = $16
           WHERE id = 1",
     )
     .bind(none_if_empty(&lc.header_bg))
@@ -238,6 +243,7 @@ pub(crate) async fn update_in_tx_pg(
     .bind(none_if_empty(&lc.title))
     .bind(none_if_empty(&lc.subtitle))
     .bind(&theme_colors_json)
+    .bind(lc.show_highlights)
     .bind(now)
     .execute(&mut **tx)
     .await

--- a/crates/ruscker-admin/src/routes/admin/landing.rs
+++ b/crates/ruscker-admin/src/routes/admin/landing.rs
@@ -115,6 +115,10 @@ pub struct LandingForm {
     /// logos.
     #[serde(default)]
     pub logos_json: String,
+    /// "Featured" carousel toggle (#506) — an HTML checkbox: present ("on")
+    /// when checked, absent when not (hence `#[serde(default)]`).
+    #[serde(default)]
+    pub show_highlights: String,
 }
 
 impl LandingForm {
@@ -145,6 +149,12 @@ impl LandingForm {
             analytics_origins: lc.analytics_origins.clone().unwrap_or_default(),
             custom_css: lc.custom_css.clone().unwrap_or_default(),
             logos_json: serde_json::to_string(&lc.logos).unwrap_or_else(|_| "[]".into()),
+            // Pre-check the box from the stored value (defaults to on).
+            show_highlights: if lc.effective_show_highlights() {
+                "on".into()
+            } else {
+                String::new()
+            },
         }
     }
 
@@ -194,6 +204,8 @@ impl LandingForm {
             // `show-admin-link` is a YAML deploy policy (#156), not an
             // editor field — never persisted from the form.
             show_admin_link: None,
+            // "Featured" carousel toggle (#506) — checkbox present ⇒ on.
+            show_highlights: Some(!self.show_highlights.trim().is_empty()),
             logos: parse_logos(&self.logos_json),
         }
     }

--- a/crates/ruscker-admin/src/routes/admin/spec_form.rs
+++ b/crates/ruscker-admin/src/routes/admin/spec_form.rs
@@ -198,6 +198,9 @@ pub struct SpecForm {
     /// "active" | "inactive"
     pub state: String,
     pub subject: String,
+    /// "Featured" carousel flag (#506) — an HTML checkbox: present ("on")
+    /// when checked, absent when not.
+    pub featured: String,
     pub logo: String,
     /// Card-cover CSS background (`template-properties.cover`):
     /// a solid color or a gradient string. Empty ⇒ fall back to
@@ -319,6 +322,8 @@ impl SpecForm {
                 .map(str::to_string)
                 .unwrap_or_else(|| "active".into()),
             subject: tp.get_str("subject").map(str::to_string).unwrap_or_default(),
+            // Pre-check the "Featured" box from the spec (#506).
+            featured: if spec.is_featured() { "on".into() } else { String::new() },
             logo: tp.get_str("logo").map(str::to_string).unwrap_or_default(),
             cover: tp.get_str("cover").map(str::to_string).unwrap_or_default(),
             updated: tp.get_str("updated").map(str::to_string).unwrap_or_default(),
@@ -512,6 +517,9 @@ impl SpecForm {
             id: self.id.trim().to_string(),
             display_name: empty_to_none(&self.display_name),
             description: empty_to_none(&self.description),
+            // "Featured" carousel flag (#506) — checkbox present ⇒ true;
+            // absent ⇒ None (so a normal spec carries no `featured` noise).
+            featured: (!self.featured.trim().is_empty()).then_some(true),
             container_image,
             seats_per_container: parse_opt(&self.seats_per_container),
             max_lifetime: parse_opt(&self.max_lifetime),

--- a/crates/ruscker-admin/src/routes/landing.rs
+++ b/crates/ruscker-admin/src/routes/landing.rs
@@ -91,6 +91,9 @@ struct LandingPage<'a> {
     /// deploy policy from `landing-customization.show-admin-link`
     /// (default true); false hides the admin entrance on public portals.
     show_admin_link: bool,
+    /// Whether the "Featured" carousel may render (#506). The template also
+    /// checks that at least one card is featured via [`Self::has_featured`].
+    show_highlights: bool,
 }
 
 /// A landing logo resolved for rendering: `src` already carries the mount
@@ -116,6 +119,12 @@ impl<'a> LandingPage<'a> {
     /// whether to render a slot's chrome insert (header-left replaces the
     /// Ruscker mark; header-right sits after the chrome cluster; the
     /// `center` bucket still renders as a separate bar). See #468.
+    /// Any featured card? Gates the "Featured" carousel together with
+    /// `show_highlights` (#506).
+    fn has_featured(&self) -> bool {
+        self.cards.iter().any(|c| c.featured)
+    }
+
     fn has_logos_at(&self, slot: &str, align: &str) -> bool {
         self.logos.iter().any(|l| l.slot == slot && l.align == align)
     }
@@ -344,6 +353,8 @@ async fn index(
             .proxy
             .landing_customization
             .effective_show_admin_link(),
+        // Carousel toggle from the DB-backed editor (#506).
+        show_highlights: lc.effective_show_highlights(),
     };
     let mut resp = render(&page);
     // Widen *this page's* CSP so the analytics script can load/report.

--- a/crates/ruscker-admin/src/view_model.rs
+++ b/crates/ruscker-admin/src/view_model.rs
@@ -210,6 +210,8 @@ pub struct CardCtx<'a> {
     /// verbatim from `template-properties.subject` and rendered as-is
     /// in the UI — operators choose their own taxonomy.
     pub subject: Option<&'a str>,
+    /// Highlighted in the landing's "Featured" carousel (#506).
+    pub featured: bool,
     /// Card logo URL. Stored base-agnostic; a root-absolute value
     /// (e.g. `/assets/img/x.png`) is prefixed with the portal base
     /// path at construction (#294) so it resolves under `--base-path`.
@@ -280,6 +282,7 @@ impl<'a> CardCtx<'a> {
             access_open,
             active,
             subject,
+            featured: spec.is_featured(),
             logo,
             cover,
             updated_raw,

--- a/crates/ruscker-admin/templates/admin/landing.html
+++ b/crates/ruscker-admin/templates/admin/landing.html
@@ -75,6 +75,15 @@
                placeholder="{{ self.t("landing-subtitle") }}" class="spec-form-input">
         <div class="spec-form-help">{{ self.t("admin-landing-portal-subtitle-help") }}</div>
       </div>
+      {# "Featured" carousel toggle (#506) — plain checkbox; the carousel
+         only shows when this is on AND at least one app is featured. #}
+      <div class="spec-form-field">
+        <label class="spec-form-check">
+          <input type="checkbox" name="show_highlights" value="on" {% if !form.show_highlights.is_empty() %}checked{% endif %}>
+          <span>{{ self.t("admin-landing-show-highlights") }}</span>
+        </label>
+        <div class="spec-form-help">{{ self.t("admin-landing-show-highlights-help") }}</div>
+      </div>
 
       </section>
 

--- a/crates/ruscker-admin/templates/admin/spec_form.html
+++ b/crates/ruscker-admin/templates/admin/spec_form.html
@@ -124,6 +124,16 @@
                   class="spec-form-input">{{ form.description }}</textarea>
       </div>
 
+      {# Featured carousel flag (#506) — plain checkbox; native submit sends
+         `featured=on` only when checked. #}
+      <div class="spec-form-field">
+        <label class="spec-form-check">
+          <input type="checkbox" name="featured" value="on" {% if !form.featured.is_empty() %}checked{% endif %}>
+          <span>{{ self.t("spec-form-featured") }}</span>
+        </label>
+        <div class="spec-form-help">{{ self.t("spec-form-featured-help") }}</div>
+      </div>
+
       </section>
 
       {# ── Card: Visual ───────────────────────────────────────── #}

--- a/crates/ruscker-admin/templates/landing.html
+++ b/crates/ruscker-admin/templates/landing.html
@@ -100,6 +100,63 @@
     </p>
   {% endif %}
 
+  {# ── Featured carousel (#506) — only when the toggle is on AND at least
+     one app is featured; otherwise it vanishes. A horizontal scroll rail
+     of the full cards (fixed width ⇒ 1–3 per row by viewport, the rest
+     scroll). Filter bindings are intentionally omitted: the rail always
+     shows the featured set, independent of the filters below. #}
+  {% if show_highlights && self.has_featured() %}
+  <section class="highlights" aria-label="{{ self.t("highlights-title") }}">
+    <div class="highlights-title"><i class="ti ti-star" aria-hidden="true"></i> {{ self.t("highlights-title") }}</div>
+    <div class="highlights-rail">
+      {% for card in cards %}
+        {% if card.featured %}
+        <a class="rcard {% if !card.active %}inactive{% endif %}"
+           href="{% if card.active %}{{ card.href }}{% else %}#{% endif %}">
+          <div class="rcover">
+            {% match card.cover %}
+              {% when Some with (cover) %}<div class="rcover-bg" style="background: {{ cover }};"></div>
+              {% when None %}<div class="rcover-bg tint-{{ card.display_type.key() }}"></div>
+            {% endmatch %}
+            {% match card.logo %}{% when Some with (logo) %}
+              <img src="{{ logo }}" alt="" loading="lazy" onerror="this.style.display='none'"
+                   class="rcover-img{% if logo.ends_with(".svg") %} rcover-img--contain{% endif %}">
+            {% when None %}
+              <span class="rcover-fallback">{{ card.id }}</span>
+            {% endmatch %}
+            <div class="rbadges">
+              <span class="rbadge b-{{ card.display_type.key() }}">{{ self.t(card.display_type.abbr_key()) }}</span>
+              {% if let Some(subj) = card.subject %}<span class="rbadge rbadge--subject" title="{{ subj }}">{{ subj }}</span>{% endif %}
+            </div>
+            <span class="rlock">
+              <i class="ti ti-{% if card.access_open %}lock-open text-[color:var(--color-lock-open)]{% else %}lock text-[color:var(--color-lock)]{% endif %} text-[12px]" aria-hidden="true"></i>
+            </span>
+          </div>
+          <div class="rbody">
+            <div class="rtitle">{{ card.display_name }}</div>
+            <div class="rdesc">{{ card.description }}</div>
+            <div class="rmeta">
+              <span class="rmeta-left">
+                <span class="status-dot {{ card.status.dot_class() }}" title="{{ self.t(card.status.title_key()) }}"></span>
+                {% match card.status.label_key() %}
+                  {% when Some with (key) %}
+                    {% match card.updated_short.as_deref() %}
+                      {% when Some with (d) %}{{ self.t_with(key, "date", d) }}
+                      {% when None %}{{ self.t(key) }}
+                    {% endmatch %}
+                  {% when None %}<span class="text-[color:var(--text-faint)]" title="{{ self.t(card.status.title_key()) }}">—</span>
+                {% endmatch %}
+              </span>
+              <i class="ti ti-arrow-right arrow-go" aria-hidden="true"></i>
+            </div>
+          </div>
+        </a>
+        {% endif %}
+      {% endfor %}
+    </div>
+  </section>
+  {% endif %}
+
   {# ── Filter row 1: search + theme select + sort + status ───── #}
   <div class="flex flex-wrap gap-2.5 items-center mb-3.5">
     <label class="search-pill flex-1 min-w-[180px]">

--- a/crates/ruscker-config/src/schema.rs
+++ b/crates/ruscker-config/src/schema.rs
@@ -431,6 +431,12 @@ pub struct LandingCustomization {
     #[serde(default, rename = "show-admin-link")]
     pub show_admin_link: Option<bool>,
 
+    /// Show the "Featured" carousel of highlighted apps above the filters
+    /// (#506). Default true; the carousel still only renders when at least
+    /// one spec is `featured`. Admin-managed via the landing editor.
+    #[serde(default, rename = "show-highlights")]
+    pub show_highlights: Option<bool>,
+
     /// Logos rendered in the public landing header / footer, each with a
     /// slot, alignment, optional click-through link and per-logo height.
     /// Admin-managed via the landing editor; survives import/export.
@@ -481,6 +487,12 @@ impl ThemePalette {
 }
 
 impl LandingCustomization {
+    /// Resolve [`Self::show_highlights`] — defaults to `true`. The carousel
+    /// itself only shows when at least one spec is featured (#506).
+    pub fn effective_show_highlights(&self) -> bool {
+        self.show_highlights.unwrap_or(true)
+    }
+
     /// Resolve [`Self::show_admin_link`] — defaults to `true` so the
     /// landing keeps the anonymous "Sign in" entrance unless an
     /// operator opts out.
@@ -567,6 +579,12 @@ pub struct Spec {
 
     /// Description shown on the card. Inline HTML is permitted.
     pub description: Option<String>,
+
+    /// Highlight this app in the landing's "Featured" carousel (#506).
+    /// Ruscker extension (not in ShinyProxy). `None`/`false` ⇒ normal card.
+    /// The carousel only renders when `landing-customization.show-highlights`
+    /// is on AND at least one spec is featured.
+    pub featured: Option<bool>,
 
     /// Docker image reference. If absent, this spec is a "link card"
     /// (external URL only, no container management).
@@ -966,6 +984,12 @@ impl Spec {
         self.access_groups
             .as_deref()
             .is_some_and(|gs| gs.iter().any(|g| groups.iter().any(|h| h == g)))
+    }
+
+    /// Whether this app is highlighted in the landing's "Featured"
+    /// carousel (#506). `None`/`false` ⇒ normal card.
+    pub fn is_featured(&self) -> bool {
+        self.featured.unwrap_or(false)
     }
 
     /// Effective minimum replicas (default 1 for containerized, 0 for
@@ -1585,6 +1609,7 @@ proxy:
             id: "pkg".to_string(),
             display_name: None,
             description: None,
+            featured: None,
             container_image: None,
             seats_per_container: None,
             max_lifetime: None,
@@ -1632,6 +1657,7 @@ proxy:
             id: "app".to_string(),
             display_name: None,
             description: None,
+            featured: None,
             container_image: Some("foo/bar:latest".to_string()),
             seats_per_container: None,
             max_lifetime: None,
@@ -1679,6 +1705,7 @@ proxy:
             id: "api".to_string(),
             display_name: None,
             description: None,
+            featured: None,
             container_image: Some("foo/api:latest".to_string()),
             seats_per_container: None,
             max_lifetime: None,

--- a/docs/YAML_SCHEMA.md
+++ b/docs/YAML_SCHEMA.md
@@ -212,6 +212,7 @@ Field reference:
 | `analytics-origins` | string | none | Space-separated origins added to the landing CSP (`script-src`/`connect-src`/`img-src`). |
 | `custom-css` | string | none | **Trusted** raw CSS, injected as a `<style>` late in the landing `<head>` so it overrides the built-in styles. |
 | `show-admin-link` | bool | `true` | When `false`, anonymous visitors don't see the "Sign in" entrance. Logged-in users still see their panel link. |
+| `show-highlights` | bool | `true` | Show the "Featured" carousel above the filters. The carousel still only renders when at least one spec is `featured`. |
 | `logos[]` | list | `[]` | Header/footer logos (see below). |
 | `blocks[]` | list | `[]` | Custom HTML blocks (see below). |
 
@@ -604,6 +605,12 @@ Free-form key-value bag. The current landing template uses:
 | `icon` | `lock` \| `lock_open` | Access level |
 | `type` | `app` \| `package` \| `talk` \| `report` \| `api` | Badge category |
 | `subject` | string | Subject/topic of the app — drives the **Subject** filter facet on the landing |
+
+> **`featured`** (a top-level spec field, not a template-property): set
+> `featured: true` to highlight the app in the landing's **Featured**
+> carousel above the filters. The carousel shows only when
+> `landing-customization.show-highlights` is on (the default) and at least
+> one spec is featured. Default `false`.
 | `updated` | string | Display date (DD/MM/YYYY) |
 | `state` | `active` \| `inactive` | Whether to enable card |
 | `link` | URL | External URL for non-container specs |


### PR DESCRIPTION
## Resumo
Faixa de **Destaques** acima dos filtros — só aparece quando o toggle está ligado **E** há ≥1 app destacado; senão **some**. Closes #506.

## Mudanças
- **Schema:** `Spec.featured` (extensão Ruscker) + `is_featured()`; `LandingCustomization.show-highlights` + `effective_show_highlights()` (default on). **Migration 0013** (`show_highlights` — sqlite INTEGER / pg BOOLEAN); o flag do spec vai no `config_json` (sem migration de spec).
- **Editor:** spec form ganha checkbox "Destacar este app"; Portal ganha "Mostrar Destaques".
- **Landing:** `CardCtx.featured`; `show_highlights` + `has_featured()` gatam a seção. Carrossel = **scroll rail horizontal** dos cards (largura fixa ⇒ 1–3 por viewport, resto rola); sem bindings de filtro (sempre mostra o set destacado).
- i18n (×4) + docs YAML_SCHEMA.

## Smoke real
- featured spec → carrossel aparece ✅; nada featured → some ✅; toggle off → some mesmo com featured ✅
- Gates: `cargo test` (24) + `clippy -D warnings` + `i18n-check` verdes; **pg migration validada** (`postgres-it`: `pg_migrations_apply_and_match_sqlite_tables` ok).

🤖 Generated with [Claude Code](https://claude.com/claude-code)