### PR TITLE
feat(admin): read-only Groups page (#503)

### DIFF
--- a/crates/ruscker-admin/assets/i18n/en/landing.ftl
+++ b/crates/ruscker-admin/assets/i18n/en/landing.ftl
@@ -647,3 +647,13 @@ spec-form-featured = Feature this app
 spec-form-featured-help = Shows the app in the Featured carousel at the top of the landing (when the toggle is on).
 admin-landing-show-highlights = Show Featured carousel
 admin-landing-show-highlights-help = Shows the carousel of featured apps above the filters. Hidden when nothing is featured.
+
+# Groups page (#503, read-only)
+admin-nav-groups = Groups
+admin-groups-title = Groups
+admin-groups-subtitle = Groups derived from apps (access-groups) and users — read-only. Edit on the user or the app.
+admin-groups-members = Members
+admin-groups-apps = Apps
+admin-groups-empty = No groups yet. Groups appear when you set access-groups on an app or groups on a user.
+admin-groups-no-members = No members
+admin-groups-no-apps = No app restricted to this group

--- a/crates/ruscker-admin/assets/i18n/es/landing.ftl
+++ b/crates/ruscker-admin/assets/i18n/es/landing.ftl
@@ -647,3 +647,13 @@ spec-form-featured = Destacar esta app
 spec-form-featured-help = Muestra la app en el carrusel de Destacados arriba de la landing (si la opción está activada).
 admin-landing-show-highlights = Mostrar Destacados
 admin-landing-show-highlights-help = Muestra el carrusel de apps destacadas encima de los filtros. Se oculta si no hay ninguna destacada.
+
+# Groups page (#503, read-only)
+admin-nav-groups = Grupos
+admin-groups-title = Grupos
+admin-groups-subtitle = Grupos derivados de los apps (access-groups) y usuarios — solo lectura. Edita en el usuario o el app.
+admin-groups-members = Miembros
+admin-groups-apps = Apps
+admin-groups-empty = Aún no hay grupos. Aparecen cuando defines access-groups en un app o grupos en un usuario.
+admin-groups-no-members = Sin miembros
+admin-groups-no-apps = Ningún app restringido a este grupo

--- a/crates/ruscker-admin/assets/i18n/fr/landing.ftl
+++ b/crates/ruscker-admin/assets/i18n/fr/landing.ftl
@@ -647,3 +647,13 @@ spec-form-featured = Mettre cette app en avant
 spec-form-featured-help = Affiche l'app dans le carrousel « À la une » en haut de la landing (si l'option est activée).
 admin-landing-show-highlights = Afficher « À la une »
 admin-landing-show-highlights-help = Affiche le carrousel des apps en avant au-dessus des filtres. Masqué si rien n'est mis en avant.
+
+# Groups page (#503, read-only)
+admin-nav-groups = Groupes
+admin-groups-title = Groupes
+admin-groups-subtitle = Groupes dérivés des apps (access-groups) et des utilisateurs — lecture seule. Modifiez sur l'utilisateur ou l'app.
+admin-groups-members = Membres
+admin-groups-apps = Apps
+admin-groups-empty = Aucun groupe pour l'instant. Les groupes apparaissent quand vous définissez access-groups sur une app ou des groupes sur un utilisateur.
+admin-groups-no-members = Aucun membre
+admin-groups-no-apps = Aucune app restreinte à ce groupe

--- a/crates/ruscker-admin/assets/i18n/pt/landing.ftl
+++ b/crates/ruscker-admin/assets/i18n/pt/landing.ftl
@@ -651,3 +651,13 @@ spec-form-featured = Destacar este app
 spec-form-featured-help = Mostra o app no carrossel de Destaques no topo da landing (quando a opção estiver ligada).
 admin-landing-show-highlights = Mostrar Destaques
 admin-landing-show-highlights-help = Exibe o carrossel de apps em destaque acima dos filtros. Some se nada estiver em destaque.
+
+# Groups page (#503, read-only)
+admin-nav-groups = Grupos
+admin-groups-title = Grupos
+admin-groups-subtitle = Grupos derivados dos apps (access-groups) e usuários — somente leitura. Edite no usuário ou no app.
+admin-groups-members = Membros
+admin-groups-apps = Apps
+admin-groups-empty = Nenhum grupo ainda. Grupos aparecem quando você define access-groups num app ou grupos num usuário.
+admin-groups-no-members = Sem membros
+admin-groups-no-apps = Nenhum app restrito a este grupo

--- a/crates/ruscker-admin/assets/tailwind/input.css
+++ b/crates/ruscker-admin/assets/tailwind/input.css
@@ -1194,6 +1194,28 @@ textarea.spec-form-input { resize: vertical; min-height: 64px; }
 /* Preview card sits in the sticky aside; let the frame breathe inside it. */
 .editor-card--preview { padding-bottom: 14px; }
 
+/* Groups page (#503, read-only) — one card per derived group. */
+.groups-grid {
+  display: grid; grid-template-columns: repeat(auto-fill, minmax(280px, 1fr));
+  gap: 14px;
+}
+.group-col { margin-top: 12px; }
+.group-col-title {
+  font-size: 11px; font-weight: 600; color: var(--text-muted);
+  text-transform: uppercase; letter-spacing: 0.04em; margin-bottom: 6px;
+}
+.group-pills { display: flex; flex-wrap: wrap; gap: 6px; }
+.group-pill {
+  display: inline-flex; align-items: center; gap: 5px;
+  font-size: 12px; color: var(--text); text-decoration: none;
+  background: var(--surface-soft); border: 0.5px solid var(--border);
+  border-radius: 999px; padding: 4px 10px;
+  transition: border-color 0.12s, background 0.12s;
+}
+.group-pill:hover { border-color: var(--color-teal-600); background: var(--surface); }
+.group-pill .ti { font-size: 13px; color: var(--text-muted); }
+.group-empty { font-size: 12px; color: var(--text-faint); font-style: italic; }
+
 /* Header/footer center logos (#468): absolutely centred within the header
    bar / footer chrome (their empty middle), so they read as part of the bar
    itself — not a separate strip below the header / above the footer. The

--- a/crates/ruscker-admin/src/routes/admin.rs
+++ b/crates/ruscker-admin/src/routes/admin.rs
@@ -27,6 +27,7 @@ pub mod blocks;
 pub mod credentials;
 pub mod dashboard;
 pub mod disk;
+pub mod groups;
 pub mod images;
 pub mod landing;
 pub mod logs;
@@ -59,6 +60,7 @@ pub fn routes() -> Router<AppState> {
         .merge(landing::routes())
         .merge(blocks::routes())
         .merge(audit::routes())
+        .merge(groups::routes())
         .merge(logs::routes())
         .merge(users::routes())
 }

--- a/crates/ruscker-admin/src/routes/admin/groups.rs
+++ b/crates/ruscker-admin/src/routes/admin/groups.rs
@@ -1,0 +1,114 @@
+//! Admin > Groups (read-only, #503).
+//!
+//! Groups in Ruscker are **derived**, not a first-class entity: a group is
+//! any name that appears in a user's memberships or a spec's `access-groups`.
+//! This page surfaces them — for each group, its member users and the apps it
+//! gates — so an operator can spot typos / orphan groups and see who can use
+//! what. No CRUD: memberships are edited on the user, app access on the spec.
+
+use askama::Template;
+use axum::{extract::State, response::Response, routing::get, Router};
+use std::collections::{BTreeMap, BTreeSet};
+
+use crate::auth::{RequireAdmin, Role};
+use crate::i18n::{Locale, Locales};
+use crate::theme::Theme;
+use crate::AppState;
+
+pub fn routes() -> Router<AppState> {
+    Router::new().route("/admin/groups", get(index))
+}
+
+/// One app reference inside a group (id + display name).
+struct AppRef {
+    id: String,
+    name: String,
+}
+
+/// A derived group with its members and the apps it gates.
+struct GroupView {
+    name: String,
+    members: Vec<String>,
+    apps: Vec<AppRef>,
+}
+
+#[derive(Template)]
+#[template(path = "admin/groups.html")]
+struct GroupsPage<'a> {
+    locale: Locale,
+    theme: Theme,
+    locales: &'a Locales,
+    locales_all: &'static [Locale],
+    /// Mount prefix for base-path-correct URLs (#294).
+    base: std::sync::Arc<str>,
+    nav_section: &'static str,
+    /// Current session role (always Admin here) — drives nav gating.
+    role: Role,
+    groups: Vec<GroupView>,
+}
+
+impl GroupsPage<'_> {
+    fn t(&self, key: &str) -> String {
+        self.locales.t(self.locale, key, None)
+    }
+}
+
+async fn index(
+    _: RequireAdmin,
+    State(state): State<AppState>,
+    loc: Locale,
+    theme: Theme,
+) -> Response {
+    // group name → (member usernames, apps id→name). BTree everywhere so the
+    // page is deterministically ordered (groups, members, apps) with no dups.
+    let mut map: BTreeMap<String, (BTreeSet<String>, BTreeMap<String, String>)> = BTreeMap::new();
+
+    // Users contribute members.
+    if let Some(db) = state.db.as_ref() {
+        if let Ok(users) = crate::db::users::list_all(db).await {
+            for u in users {
+                for g in u.groups {
+                    map.entry(g).or_default().0.insert(u.username.clone());
+                }
+            }
+        }
+    }
+
+    // Specs contribute apps (by `access-groups`).
+    let specs = crate::catalog::effective_specs(state.db.as_ref(), &state.config).await;
+    for s in &specs {
+        if let Some(groups) = s.access_groups.as_ref() {
+            let name = s.display_name.clone().unwrap_or_else(|| s.id.clone());
+            for g in groups {
+                map.entry(g.clone())
+                    .or_default()
+                    .1
+                    .insert(s.id.clone(), name.clone());
+            }
+        }
+    }
+
+    let groups = map
+        .into_iter()
+        .map(|(name, (members, apps))| GroupView {
+            name,
+            members: members.into_iter().collect(),
+            apps: apps
+                .into_iter()
+                .map(|(id, name)| AppRef { id, name })
+                .collect(),
+        })
+        .collect();
+
+    let page = GroupsPage {
+        locale: loc,
+        theme,
+        locales: &state.locales,
+        locales_all: &Locale::ALL,
+        base: state.base_path.clone(),
+        nav_section: "groups",
+        role: Role::Admin,
+        groups,
+    };
+    super::render(&page)
+}

--- a/crates/ruscker-admin/templates/admin/_layout.html
+++ b/crates/ruscker-admin/templates/admin/_layout.html
@@ -92,6 +92,12 @@
       <span>{{ self.t("admin-nav-users") }}</span>
     </a>
     {% endif %}
+    {% if role.can_access_section("groups") %}
+    <a href="{{ base }}/admin/groups" class="admin-nav-link {% if nav_section == "groups" %}is-active{% endif %}">
+      <i class="ti ti-users-group" aria-hidden="true"></i>
+      <span>{{ self.t("admin-nav-groups") }}</span>
+    </a>
+    {% endif %}
     {% if role.can_access_section("logs") %}
     <a href="{{ base }}/admin/logs" class="admin-nav-link {% if nav_section == "logs" %}is-active{% endif %}">
       <i class="ti ti-terminal-2" aria-hidden="true"></i>

--- a/crates/ruscker-admin/templates/admin/groups.html
+++ b/crates/ruscker-admin/templates/admin/groups.html
@@ -1,0 +1,53 @@
+{% extends "admin/_layout.html" %}
+
+{% block title %}{{ self.t("admin-groups-title") }} · Ruscker{% endblock %}
+
+{% block content %}
+
+<div class="flex items-end justify-between mb-5 pb-3 border-b border-[color:var(--border)]">
+  <div>
+    <h1 class="text-xl font-medium tracking-tight">{{ self.t("admin-groups-title") }}</h1>
+    <p class="text-xs text-[color:var(--text-muted)] mt-1">{{ self.t("admin-groups-subtitle") }}</p>
+  </div>
+  <div class="text-xs text-[color:var(--text-faint)]">{{ groups.len() }}</div>
+</div>
+
+{% if groups.is_empty() %}
+  <div class="spec-form-empty-hint" style="max-width:44rem">
+    <i class="ti ti-users-group" aria-hidden="true"></i>
+    {{ self.t("admin-groups-empty") }}
+  </div>
+{% else %}
+  <div class="groups-grid">
+    {% for g in groups %}
+    <section class="editor-card group-card">
+      <div class="editor-card__head">
+        <span class="editor-card__icon"><i class="ti ti-users-group" aria-hidden="true"></i></span>
+        <div><div class="editor-card__title">{{ g.name }}</div></div>
+      </div>
+      <div class="group-col">
+        <div class="group-col-title">{{ self.t("admin-groups-members") }} · {{ g.members.len() }}</div>
+        {% if g.members.is_empty() %}
+          <span class="group-empty">{{ self.t("admin-groups-no-members") }}</span>
+        {% else %}
+          <div class="group-pills">
+            {% for m in g.members %}<a href="{{ base }}/admin/users" class="group-pill"><i class="ti ti-user" aria-hidden="true"></i> {{ m }}</a>{% endfor %}
+          </div>
+        {% endif %}
+      </div>
+      <div class="group-col">
+        <div class="group-col-title">{{ self.t("admin-groups-apps") }} · {{ g.apps.len() }}</div>
+        {% if g.apps.is_empty() %}
+          <span class="group-empty">{{ self.t("admin-groups-no-apps") }}</span>
+        {% else %}
+          <div class="group-pills">
+            {% for a in g.apps %}<a href="{{ base }}/admin/specs/{{ a.id }}/edit" class="group-pill"><i class="ti ti-app-window" aria-hidden="true"></i> {{ a.name }}</a>{% endfor %}
+          </div>
+        {% endif %}
+      </div>
+    </section>
+    {% endfor %}
+  </div>
+{% endif %}
+
+{% endblock %}


### PR DESCRIPTION
## Resumo
Grupos no Ruscker são **derivados** (não entidade de 1ª classe) — um grupo é qualquer nome em `users.groups` ou no `access-groups` de um spec. Nova página admin-only **`/admin/groups`** que os mostra: para cada grupo, **membros** (usuários) + **apps** que ele restringe. Closes #503 (fatia read-only).

## Mudanças
- `routes/admin/groups.rs`: deriva grupos de `users::list_all` + `catalog::effective_specs`; ordenado/dedup (BTree). Pills linkam pro user list / spec editor.
- Admin-only (catch-all do `can_access_section`); link no nav + empty-state.
- **Read-only** de propósito: edita membros no usuário, acesso de app no spec — CRUD fica adiado (evita fonte-de-verdade dupla + risco de compat ShinyProxy).

## Smoke real
spec com `access-groups: analysts, admins` + user em `analysts` → deriva ambos os grupos (app sob cada um, membro bob sob analysts), nav link ok, empty-state quando não há grupo.

Gates: `cargo test` (24) + `clippy -D warnings` + `i18n-check` verdes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)