### PR TITLE
chore(release): bump workspace version 0.1.37 → 0.1.38

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2845,7 +2845,7 @@ dependencies = [
 
 [[package]]
 name = "ruscker-admin"
-version = "0.1.37"
+version = "0.1.38"
 dependencies = [
  "aes-gcm",
  "anyhow",
@@ -2892,7 +2892,7 @@ dependencies = [
 
 [[package]]
 name = "ruscker-cli"
-version = "0.1.37"
+version = "0.1.38"
 dependencies = [
  "anyhow",
  "clap",
@@ -2912,7 +2912,7 @@ dependencies = [
 
 [[package]]
 name = "ruscker-config"
-version = "0.1.37"
+version = "0.1.38"
 dependencies = [
  "chrono",
  "ordered-float",
@@ -2927,7 +2927,7 @@ dependencies = [
 
 [[package]]
 name = "ruscker-core"
-version = "0.1.37"
+version = "0.1.38"
 dependencies = [
  "async-trait",
  "chrono",
@@ -2940,7 +2940,7 @@ dependencies = [
 
 [[package]]
 name = "ruscker-docker"
-version = "0.1.37"
+version = "0.1.38"
 dependencies = [
  "anyhow",
  "async-stream",
@@ -2959,7 +2959,7 @@ dependencies = [
 
 [[package]]
 name = "ruscker-proxy"
-version = "0.1.37"
+version = "0.1.38"
 dependencies = [
  "anyhow",
  "axum",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -10,7 +10,7 @@ members = [
 ]
 
 [workspace.package]
-version = "0.1.37"
+version = "0.1.38"
 edition = "2021"
 rust-version = "1.85"
 license = "Apache-2.0"

--- a/book/src/faq.md
+++ b/book/src/faq.md
@@ -80,7 +80,7 @@ the **sign-in session** paths to a single upstream — see
 
 ### Is it production-ready?
 
-Yes. The current release is **v0.1.37** — Phases 0–7 are complete and
+Yes. The current release is **v0.1.38** — Phases 0–7 are complete and
 the proxy is production-ready and horizontally scalable.
 Releases are multi-arch and cosign-signed; see the
 [release notes](./news.md) and the [Roadmap](./roadmap.md).

--- a/book/src/introduction.md
+++ b/book/src/introduction.md
@@ -40,7 +40,7 @@ proper admin panel, a monitoring dashboard, and load balancing.
 
 ## In production
 
-Ruscker is on **v0.1.37** and runs in production today. Where the
+Ruscker is on **v0.1.38** and runs in production today. Where the
 JVM-based stack it replaced idled at hundreds of megabytes, Ruscker
 idles in the low tens:
 

--- a/book/src/news.md
+++ b/book/src/news.md
@@ -9,6 +9,28 @@ the [GitHub releases page](https://github.com/StrategicProjects/ruscker/releases
 
 ---
 
+## v0.1.38 — 2026-06-02
+
+A round of admin & landing UX polish.
+
+**Landing**
+- A **"Featured" carousel** of highlighted apps above the filters. Mark
+  an app `featured` and toggle "Show Featured carousel" in the Portal
+  editor; it only appears when both are set, and is a horizontal rail
+  (1–3 cards per viewport, the rest scroll).
+- Each card now shows its **subject** as a pill next to the type badge.
+
+**Admin**
+- The **Add/Edit App form** is reorganised into labelled section cards
+  with a sticky Save bar, matching the Portal editor.
+- The registry **credential** field is a real selector now, with a clear
+  "no saved credentials" hint when the store is empty.
+- A read-only **Groups** page derives each group's member users and the
+  apps it gates (from `access-groups`), so you can spot typos and see who
+  can use what.
+
+---
+
 ## v0.1.37 — 2026-06-01
 
 Catch a bad image in the editor, not at the first failed launch.

--- a/book/src/roadmap.md
+++ b/book/src/roadmap.md
@@ -1,6 +1,6 @@
 # Roadmap
 
-Ruscker is at **v0.1.37** — Phases 0 through 7 are done and the proxy is
+Ruscker is at **v0.1.38** — Phases 0 through 7 are done and the proxy is
 production-ready and horizontally scalable. Phase 8 (external auth) is
 the main optional, demand-driven work left. For what changed in each
 release, see the [release notes](./news.md).
@@ -71,7 +71,7 @@ can serve any session; one scaler leader via Postgres advisory locks,
 with failover. A runnable 2-instance compose harness lives in
 `examples/ha/`. See [Deployment shapes](./architecture.md#deployment-shapes).
 
-### Post-phase polish → **v0.1.4 – v0.1.37**
+### Post-phase polish → **v0.1.4 – v0.1.38**
 
 Incremental improvements shipped after Phase 7.
 

--- a/docs/SECURITY.md
+++ b/docs/SECURITY.md
@@ -5,7 +5,7 @@ Status: living document. Tracks the Phase 5 security audit
 **[accepted limitation]**, or **[deferred]**. File references use
 `crate/path:symbol` so they survive line-number drift.
 
-> **Scope.** This covers v0.1.37: single-operator install, Ruscker
+> **Scope.** This covers v0.1.38: single-operator install, Ruscker
 > behind a TLS-terminating reverse proxy, Docker on the same host.
 > Multi-tenant / shared-team auth (OIDC, RBAC) is out of scope until
 > Phase 8.


### PR DESCRIPTION
Corte da **v0.1.38**. Bump + `Cargo.lock` + `news.md` + refs de versão.

Conteúdo (lote de UX, desde a v0.1.37):
- **#507** pill do subject no card · **#504** credencial como seletor + empty-state
- **#502** form de apps em cards de seção · **#506** carrossel "Destaques" (+ migration)
- **#505** auditoria/teste de cobertura do import YAML · **#503** página de Grupos (read-only)

Após merge: tag `v0.1.38` → `release.yml` publica `.deb`/musl/ghcr cosign-signed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)