### PR TITLE
feat(landing): paged Featured carousel — max 3 + chevrons, no scrollbar (#516)

### DIFF
--- a/crates/ruscker-admin/assets/i18n/en/landing.ftl
+++ b/crates/ruscker-admin/assets/i18n/en/landing.ftl
@@ -657,3 +657,6 @@ admin-groups-apps = Apps
 admin-groups-empty = No groups yet. Groups appear when you set access-groups on an app or groups on a user.
 admin-groups-no-members = No members
 admin-groups-no-apps = No app restricted to this group
+
+highlights-prev = Previous
+highlights-next = Next

--- a/crates/ruscker-admin/assets/i18n/es/landing.ftl
+++ b/crates/ruscker-admin/assets/i18n/es/landing.ftl
@@ -657,3 +657,6 @@ admin-groups-apps = Apps
 admin-groups-empty = Aún no hay grupos. Aparecen cuando defines access-groups en un app o grupos en un usuario.
 admin-groups-no-members = Sin miembros
 admin-groups-no-apps = Ningún app restringido a este grupo
+
+highlights-prev = Anteriores
+highlights-next = Siguientes

--- a/crates/ruscker-admin/assets/i18n/fr/landing.ftl
+++ b/crates/ruscker-admin/assets/i18n/fr/landing.ftl
@@ -657,3 +657,6 @@ admin-groups-apps = Apps
 admin-groups-empty = Aucun groupe pour l'instant. Les groupes apparaissent quand vous définissez access-groups sur une app ou des groupes sur un utilisateur.
 admin-groups-no-members = Aucun membre
 admin-groups-no-apps = Aucune app restreinte à ce groupe
+
+highlights-prev = Précédents
+highlights-next = Suivants

--- a/crates/ruscker-admin/assets/i18n/pt/landing.ftl
+++ b/crates/ruscker-admin/assets/i18n/pt/landing.ftl
@@ -661,3 +661,6 @@ admin-groups-apps = Apps
 admin-groups-empty = Nenhum grupo ainda. Grupos aparecem quando você define access-groups num app ou grupos num usuário.
 admin-groups-no-members = Sem membros
 admin-groups-no-apps = Nenhum app restrito a este grupo
+
+highlights-prev = Anteriores
+highlights-next = Próximos

--- a/crates/ruscker-admin/assets/tailwind/input.css
+++ b/crates/ruscker-admin/assets/tailwind/input.css
@@ -362,21 +362,35 @@ body {
 /* Featured carousel (#506) — a horizontal scroll rail of full cards. The
    card keeps its fixed width, so 1–3 fit per viewport and the rest scroll. */
 .highlights { margin-bottom: 22px; }
+.highlights-head {
+  display: flex; align-items: center; justify-content: space-between;
+  gap: 12px; margin-bottom: 10px;
+}
 .highlights-title {
   display: flex; align-items: center; gap: 6px;
   font-size: 13px; font-weight: 600; color: var(--text);
-  letter-spacing: -0.01em; margin-bottom: 10px;
+  letter-spacing: -0.01em;
 }
 .highlights-title .ti { color: var(--color-teal-600); font-size: 15px; }
-.highlights-rail {
+.highlights-nav { display: flex; gap: 6px; }
+.highlights-arrow {
+  display: inline-flex; align-items: center; justify-content: center;
+  width: 28px; height: 28px; border-radius: 8px;
+  border: 0.5px solid var(--border); background: var(--surface);
+  color: var(--text-muted); cursor: pointer;
+  transition: border-color 0.12s, color 0.12s, opacity 0.12s;
+}
+.highlights-arrow:hover:not(:disabled) { border-color: var(--color-teal-600); color: var(--text); }
+.highlights-arrow:disabled { opacity: 0.35; cursor: default; }
+.highlights-arrow .ti { font-size: 16px; }
+/* Viewport caps at 3 cards and clips; the track pages via translateX — no
+   horizontal scrollbar (#516). */
+.highlights-viewport { overflow: hidden; max-width: calc(3 * var(--card-w) + 28px); }
+.highlights-track {
   display: flex; gap: 14px;
-  overflow-x: auto; scroll-snap-type: x proximity;
-  padding-bottom: 8px; scrollbar-width: thin;
+  transition: transform 0.32s cubic-bezier(0.4, 0, 0.2, 1);
 }
-.highlights-rail > .rcard {
-  flex: 0 0 auto;            /* keep the fixed card width; never stretch */
-  scroll-snap-align: start;
-}
+.highlights-track > .rcard { flex: 0 0 auto; }
 .b-app     { background: #06d6a0; color: #04553f; }
 .b-talk    { background: #ffd166; color: #5a4400; }
 .b-report  { background: #ef476f; color: #ffffff; }

--- a/crates/ruscker-admin/templates/landing.html
+++ b/crates/ruscker-admin/templates/landing.html
@@ -106,9 +106,20 @@
      scroll). Filter bindings are intentionally omitted: the rail always
      shows the featured set, independent of the filters below. #}
   {% if show_highlights && self.has_featured() %}
-  <section class="highlights" aria-label="{{ self.t("highlights-title") }}">
-    <div class="highlights-title"><i class="ti ti-star" aria-hidden="true"></i> {{ self.t("highlights-title") }}</div>
-    <div class="highlights-rail">
+  <section class="highlights" x-data="ruscker.highlights()" x-init="$nextTick(() => measure())"
+           @resize.window.debounce.150ms="measure()" aria-label="{{ self.t("highlights-title") }}">
+    <div class="highlights-head">
+      <div class="highlights-title"><i class="ti ti-star" aria-hidden="true"></i> {{ self.t("highlights-title") }}</div>
+      {# Chevrons appear only when there's more than one page (>3 featured). #}
+      <div class="highlights-nav" x-show="pages > 1" x-cloak>
+        <button type="button" class="highlights-arrow" @click="prev()" :disabled="page === 0"
+                aria-label="{{ self.t("highlights-prev") }}"><i class="ti ti-chevron-left" aria-hidden="true"></i></button>
+        <button type="button" class="highlights-arrow" @click="next()" :disabled="page >= pages - 1"
+                aria-label="{{ self.t("highlights-next") }}"><i class="ti ti-chevron-right" aria-hidden="true"></i></button>
+      </div>
+    </div>
+    <div class="highlights-viewport">
+      <div class="highlights-track" x-ref="track" :style="trackStyle()">
       {% for card in cards %}
         {% if card.featured %}
         <a class="rcard {% if !card.active %}inactive{% endif %}"
@@ -153,6 +164,7 @@
         </a>
         {% endif %}
       {% endfor %}
+      </div>
     </div>
   </section>
   {% endif %}
@@ -443,6 +455,35 @@ window.ruscker.landing = () => ({
     list.sort((a, b) =>
       (a.dataset.name || '').localeCompare(b.dataset.name || ''));
     this._nameRanks = new Map(list.map((el, i) => [el, i]));
+  },
+});
+
+// Featured carousel (#516): page through the featured cards, max 3 per
+// view, via chevrons — no horizontal scrollbar (the viewport clips, the
+// track translates). Re-measures on resize.
+window.ruscker.highlights = () => ({
+  page: 0,
+  perPage: 3,
+  pages: 1,
+  step: 270, // card width + gap; refined by measure()
+  measure() {
+    const track = this.$refs.track;
+    if (!track || !track.children.length) return;
+    const total = track.children.length;
+    const cardW = track.children[0].getBoundingClientRect().width || 256;
+    const styles = getComputedStyle(track);
+    const gap = parseFloat(styles.columnGap || styles.gap) || 14;
+    this.step = cardW + gap;
+    const vpW = track.parentElement.getBoundingClientRect().width;
+    // Max 3 visible; fewer on narrow viewports.
+    this.perPage = Math.max(1, Math.min(3, Math.floor((vpW + gap) / this.step)));
+    this.pages = Math.max(1, Math.ceil(total / this.perPage));
+    if (this.page > this.pages - 1) this.page = this.pages - 1;
+  },
+  prev() { if (this.page > 0) this.page--; },
+  next() { if (this.page < this.pages - 1) this.page++; },
+  trackStyle() {
+    return 'transform: translateX(' + (-this.page * this.perPage * this.step) + 'px)';
   },
 });
 </script>


### PR DESCRIPTION
Refina o carrossel do #506:

- **Máx 3 cards** visíveis (viewport `overflow:hidden`, `max-width` = 3 cards).
- **Chevrons ‹ ›** que paginam (`translateX` no track), aparecem **só quando > 3** destaques (`x-show="pages > 1"`) e desabilitam nas pontas.
- **Sem scrollbar horizontal.**
- Componente Alpine `ruscker.highlights` mede a largura do card → calcula `perPage`(≤3)/`pages`, re-mede no resize.

## Smoke real
4 specs featured → head + 2 chevrons + viewport(overflow hidden, max 3 cards) + track com os 4 cards; classe antiga `highlights-rail` removida. Gates verdes. (Paginação é Alpine client-side.)

🤖 Generated with [Claude Code](https://claude.com/claude-code)