### PR TITLE
feat(admin): inline featured star in the Apps table (#521)

### DIFF
--- a/crates/ruscker-admin/assets/i18n/en/landing.ftl
+++ b/crates/ruscker-admin/assets/i18n/en/landing.ftl
@@ -660,3 +660,9 @@ admin-groups-no-apps = No app restricted to this group
 
 highlights-prev = Previous
 highlights-next = Next
+
+# Featured star toggle in the Apps table (#521)
+admin-specs-col-featured = Featured
+admin-specs-featured-on = Featured — click to remove
+admin-specs-featured-off = Not featured — click to feature
+admin-specs-featured-readonly = Featured is set in the config file

--- a/crates/ruscker-admin/assets/i18n/es/landing.ftl
+++ b/crates/ruscker-admin/assets/i18n/es/landing.ftl
@@ -660,3 +660,9 @@ admin-groups-no-apps = Ningún app restringido a este grupo
 
 highlights-prev = Anteriores
 highlights-next = Siguientes
+
+# Featured star toggle in the Apps table (#521)
+admin-specs-col-featured = Destacado
+admin-specs-featured-on = Destacado — clic para quitar
+admin-specs-featured-off = No destacado — clic para destacar
+admin-specs-featured-readonly = El destacado se define en el archivo de config

--- a/crates/ruscker-admin/assets/i18n/fr/landing.ftl
+++ b/crates/ruscker-admin/assets/i18n/fr/landing.ftl
@@ -660,3 +660,9 @@ admin-groups-no-apps = Aucune app restreinte à ce groupe
 
 highlights-prev = Précédents
 highlights-next = Suivants
+
+# Featured star toggle in the Apps table (#521)
+admin-specs-col-featured = À la une
+admin-specs-featured-on = En avant — cliquer pour retirer
+admin-specs-featured-off = Pas en avant — cliquer pour mettre en avant
+admin-specs-featured-readonly = Le statut « à la une » vient du fichier de config

--- a/crates/ruscker-admin/assets/i18n/pt/landing.ftl
+++ b/crates/ruscker-admin/assets/i18n/pt/landing.ftl
@@ -664,3 +664,9 @@ admin-groups-no-apps = Nenhum app restrito a este grupo
 
 highlights-prev = Anteriores
 highlights-next = Próximos
+
+# Featured star toggle in the Apps table (#521)
+admin-specs-col-featured = Destaque
+admin-specs-featured-on = Destacado — clique para remover
+admin-specs-featured-off = Não destacado — clique para destacar
+admin-specs-featured-readonly = Destaque definido no arquivo de config

--- a/crates/ruscker-admin/assets/tailwind/input.css
+++ b/crates/ruscker-admin/assets/tailwind/input.css
@@ -1233,6 +1233,20 @@ textarea.spec-form-input { resize: vertical; min-height: 64px; }
 .group-pill .ti { font-size: 13px; color: var(--text-muted); }
 .group-empty { font-size: 12px; color: var(--text-faint); font-style: italic; }
 
+/* Featured-star toggle in the Apps table (#521). */
+.star-cell { width: 1%; text-align: center; white-space: nowrap; }
+.star-toggle {
+  display: inline-flex; align-items: center; justify-content: center;
+  width: 28px; height: 28px; border: 0; background: none; border-radius: 6px;
+  color: var(--text-faint); cursor: pointer;
+  transition: color 0.12s, background 0.12s;
+}
+.star-toggle:hover:not(:disabled):not(.is-readonly) { color: #eab308; background: var(--surface-soft); }
+.star-toggle.is-on { color: #eab308; }       /* amber when featured */
+.star-toggle:disabled { cursor: default; }
+.star-toggle.is-readonly { cursor: default; }
+.star-toggle .ti { font-size: 16px; }
+
 /* Header/footer center logos (#468): absolutely centred within the header
    bar / footer chrome (their empty middle), so they read as part of the bar
    itself — not a separate strip below the header / above the footer. The

--- a/crates/ruscker-admin/src/routes/admin/specs.rs
+++ b/crates/ruscker-admin/src/routes/admin/specs.rs
@@ -6,11 +6,11 @@
 
 use askama::Template;
 use axum::{
-    extract::{DefaultBodyLimit, Multipart, Query, State},
+    extract::{DefaultBodyLimit, Multipart, Path, Query, State},
     http::StatusCode,
     response::{IntoResponse, Redirect, Response},
     routing::{get, post},
-    Router,
+    Json, Router,
 };
 use chrono::{DateTime, Utc};
 use serde::Deserialize;
@@ -30,7 +30,48 @@ pub fn routes() -> Router<AppState> {
     Router::new()
         .route("/admin/specs", get(index))
         .route("/admin/specs/import", post(import))
+        .route(
+            "/admin/specs/{id}/featured/toggle",
+            post(toggle_featured),
+        )
         .layer(DefaultBodyLimit::max(IMPORT_BODY_LIMIT))
+}
+
+#[derive(serde::Serialize)]
+struct ToggleResult {
+    featured: bool,
+}
+
+/// `POST /admin/specs/{id}/featured/toggle` — flip a spec's `featured`
+/// flag from the Apps table's star (#521), without opening the editor.
+/// Editor-gated; returns the new state as JSON for the optimistic UI.
+async fn toggle_featured(
+    editor: RequireEditor,
+    State(state): State<AppState>,
+    Path(id): Path<String>,
+) -> Response {
+    let Some(db) = state.db.as_ref() else {
+        return (StatusCode::SERVICE_UNAVAILABLE, "no db").into_response();
+    };
+    let mut spec = match crate::db::specs::fetch_one(db, &id).await {
+        Ok(Some(s)) => s,
+        Ok(None) => return (StatusCode::NOT_FOUND, "spec not found").into_response(),
+        Err(e) => {
+            tracing::error!(id, error = ?e, "fetch spec for toggle failed");
+            return (StatusCode::INTERNAL_SERVER_ERROR, "db error").into_response();
+        }
+    };
+    let now_featured = !spec.is_featured();
+    // None when off so a normal spec carries no `featured` noise in JSON.
+    spec.featured = now_featured.then_some(true);
+    if let Err(e) = crate::db::specs::upsert_one(db, &spec, Some(editor.actor())).await {
+        tracing::error!(id, error = ?e, "save featured toggle failed");
+        return (StatusCode::INTERNAL_SERVER_ERROR, "save failed").into_response();
+    }
+    Json(ToggleResult {
+        featured: now_featured,
+    })
+    .into_response()
 }
 
 /// One row out of the `specs` table, picked for the list view.
@@ -50,6 +91,11 @@ pub struct SpecRow {
     /// `SELECT` (which doesn't have the column) still maps.
     #[sqlx(default)]
     pub config_only: bool,
+    /// Highlighted in the landing's Featured carousel (#506). Not a column
+    /// — `featured` lives in `config_json`; the index fills this in from a
+    /// `list_all` pass so the table's star toggle (#521) reflects state.
+    #[sqlx(default)]
+    pub featured: bool,
 }
 
 /// Post-import flash, carried back via query params on the
@@ -168,6 +214,22 @@ async fn index(
         }
     };
 
+    // Featured flag lives in `config_json`, not a column — fill it from a
+    // single `list_all` pass so the table's star toggle (#521) shows state.
+    {
+        use std::collections::HashSet;
+        let featured: HashSet<String> = crate::db::specs::list_all(database)
+            .await
+            .unwrap_or_default()
+            .iter()
+            .filter(|s| s.is_featured())
+            .map(|s| s.id.clone())
+            .collect();
+        for row in &mut specs {
+            row.featured = featured.contains(&row.id);
+        }
+    }
+
     // Append specs that exist only in the YAML `--config` (not the DB) as
     // read-only "config-defined" rows (#303). They run + show on the
     // landing, so showing them here avoids the "where did my spec go?"
@@ -198,6 +260,7 @@ async fn index(
                 updated_at: Utc::now(), // not shown for config rows
                 version: 0,
                 config_only: true,
+                featured: s.is_featured(),
             });
         }
     }

--- a/crates/ruscker-admin/templates/admin/specs.html
+++ b/crates/ruscker-admin/templates/admin/specs.html
@@ -84,6 +84,7 @@
         <th>{{ self.t("admin-specs-col-name") }}</th>
         <th>{{ self.t("admin-specs-col-kind") }}</th>
         <th>{{ self.t("admin-specs-col-state") }}</th>
+        <th class="star-cell" title="{{ self.t("admin-specs-col-featured") }}"><i class="ti ti-star" aria-hidden="true"></i></th>
         <th>{{ self.t("admin-specs-col-updated") }}</th>
         <th>{{ self.t("admin-specs-col-version") }}</th>
         <th class="actions-cell">{{ self.t("admin-specs-col-actions") }}</th>
@@ -101,6 +102,25 @@
           </td>
           <td><span class="pill pill-kind-{{ spec.kind }}">{{ spec.kind }}</span></td>
           <td><span class="pill pill-state-{{ spec.state }}">{{ spec.state }}</span></td>
+          {# Featured star (#521): toggle inline; solid when featured. Config
+             specs are read-only here (the flag lives in the YAML file). #}
+          <td class="star-cell">
+            {% if spec.config_only %}
+              <span class="star-toggle is-readonly" title="{{ self.t("admin-specs-featured-readonly") }}"><i class="ti {% if spec.featured %}ti-star-filled is-on{% else %}ti-star{% endif %}" aria-hidden="true"></i></span>
+            {% else %}
+              <button type="button" class="star-toggle" x-data="{ on: {{ spec.featured }}, busy: false }"
+                      :class="on ? 'is-on' : ''" :disabled="busy"
+                      :title="on ? '{{ self.t("admin-specs-featured-on") }}' : '{{ self.t("admin-specs-featured-off") }}'"
+                      @click="busy = true; const prev = on; on = !on;
+                              fetch('{{ base }}/admin/specs/{{ spec.id }}/featured/toggle', { method: 'POST' })
+                                .then(r => r.ok ? r.json() : Promise.reject())
+                                .then(d => { on = d.featured })
+                                .catch(() => { on = prev })
+                                .finally(() => { busy = false })">
+                <i class="ti" :class="on ? 'ti-star-filled' : 'ti-star'" aria-hidden="true"></i>
+              </button>
+            {% endif %}
+          </td>
           {% if spec.config_only %}
           <td class="text-[color:var(--text-faint)]">—</td>
           <td class="text-[color:var(--text-faint)]">—</td>

--- a/crates/ruscker-admin/templates/admin/specs.html
+++ b/crates/ruscker-admin/templates/admin/specs.html
@@ -108,11 +108,17 @@
             {% if spec.config_only %}
               <span class="star-toggle is-readonly" title="{{ self.t("admin-specs-featured-readonly") }}"><i class="ti {% if spec.featured %}ti-star-filled is-on{% else %}ti-star{% endif %}" aria-hidden="true"></i></span>
             {% else %}
+              {# URL + titles ride in `data-*` (HTML-escaped) and are read via
+                 `$el.dataset` — never interpolated into the JS handler, so a
+                 spec id from an import can't break out of the string. #}
               <button type="button" class="star-toggle" x-data="{ on: {{ spec.featured }}, busy: false }"
+                      data-toggle-url="{{ base }}/admin/specs/{{ spec.id }}/featured/toggle"
+                      data-title-on="{{ self.t("admin-specs-featured-on") }}"
+                      data-title-off="{{ self.t("admin-specs-featured-off") }}"
                       :class="on ? 'is-on' : ''" :disabled="busy"
-                      :title="on ? '{{ self.t("admin-specs-featured-on") }}' : '{{ self.t("admin-specs-featured-off") }}'"
+                      :title="on ? $el.dataset.titleOn : $el.dataset.titleOff"
                       @click="busy = true; const prev = on; on = !on;
-                              fetch('{{ base }}/admin/specs/{{ spec.id }}/featured/toggle', { method: 'POST' })
+                              fetch($el.dataset.toggleUrl, { method: 'POST' })
                                 .then(r => r.ok ? r.json() : Promise.reject())
                                 .then(d => { on = d.featured })
                                 .catch(() => { on = prev })


### PR DESCRIPTION
## Resumo
Destacar/desdestacar um app (#506) **direto na tabela** de Aplicações — sem abrir app por app. Coluna de **estrela**: sólida (âmbar) quando destacado, contorno quando não; clicar alterna na hora. Closes #521.

## Mudanças
- **`POST /admin/specs/{id}/featured/toggle`** (Editor-gated): `fetch_one` → inverte `featured` → `upsert_one` (com audit) → JSON `{featured}`. Botão **otimista** (Alpine), reverte em erro, **sem reload**.
- Index preenche `SpecRow.featured` de um único `list_all` (`featured` mora no `config_json`, não é coluna). Specs **config-defined** (#303) → estrela **read-only** (flag vem do YAML).

## Smoke real
toggle alterna `config_json` featured `true↔null` e retorna o estado; sem sessão → 303. Reflete no carrossel do operador (mesmo flag #506). Gates: `cargo test` (24) + `clippy -D warnings` + `i18n-check` verdes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)