### PR TITLE
feat(admin): reorganize app form into 3 bands (#523)

### DIFF
--- a/crates/ruscker-admin/templates/admin/spec_form.html
+++ b/crates/ruscker-admin/templates/admin/spec_form.html
@@ -124,16 +124,6 @@
                   class="spec-form-input">{{ form.description }}</textarea>
       </div>
 
-      {# Featured carousel flag (#506) — plain checkbox; native submit sends
-         `featured=on` only when checked. #}
-      <div class="spec-form-field">
-        <label class="spec-form-check">
-          <input type="checkbox" name="featured" value="on" {% if !form.featured.is_empty() %}checked{% endif %}>
-          <span>{{ self.t("spec-form-featured") }}</span>
-        </label>
-        <div class="spec-form-help">{{ self.t("spec-form-featured-help") }}</div>
-      </div>
-
       </section>
 
       {# ── Card: Visual ───────────────────────────────────────── #}
@@ -358,32 +348,6 @@
               <span x-text="pull.line" class="spec-form-input--mono" style="opacity:0.75"></span>
             </div>
           </div>
-
-          <div class="grid grid-cols-2 gap-3">
-            <div class="spec-form-field">
-              <div class="spec-form-label-row">
-                <label for="f-seats" class="spec-form-label">{{ self.t("spec-form-seats") }}</label>
-                {% call help(self.t("spec-help-seats")) %}{% endcall %}
-              </div>
-              <input id="f-seats" type="number" name="seats_per_container"
-                     value="{{ form.seats_per_container }}"
-                     min="1"
-                     placeholder="10"
-                     class="spec-form-input">
-            </div>
-            <div class="spec-form-field">
-              <div class="spec-form-label-row">
-                <label for="f-lifetime" class="spec-form-label">{{ self.t("spec-form-lifetime") }}</label>
-                {% call help(self.t("spec-help-lifetime")) %}{% endcall %}
-              </div>
-              <input id="f-lifetime" type="number" name="max_lifetime"
-                     value="{{ form.max_lifetime }}"
-                     min="1"
-                     placeholder="360"
-                     class="spec-form-input">
-              <div class="spec-form-help">{{ self.t("spec-form-lifetime-help") }}</div>
-            </div>
-          </div>
         </section>
       </template>
 
@@ -414,6 +378,41 @@
           <span class="editor-card__icon"><i class="ti ti-adjustments" aria-hidden="true"></i></span>
           <div><div class="editor-card__title">{{ self.t("spec-form-meta") }}</div></div>
         </div>
+
+      {# Featured carousel flag (#506) — plain checkbox; native submit sends
+         `featured=on` only when checked. Lives here (visible metadata band,
+         #523) instead of buried under the runtime "Advanced" collapse. #}
+      <div class="spec-form-field">
+        <label class="spec-form-check">
+          <input type="checkbox" name="featured" value="on" {% if !form.featured.is_empty() %}checked{% endif %}>
+          <span>{{ self.t("spec-form-featured") }}</span>
+        </label>
+        <div class="spec-form-help">{{ self.t("spec-form-featured-help") }}</div>
+      </div>
+
+      {# Access — who may see + reach this app (#155). Promoted out of the
+         runtime "Advanced" collapse (#523): visibility is governance/metadata,
+         not a runtime knob. #}
+      <div class="grid grid-cols-2 gap-3">
+        <div class="spec-form-field">
+          <div class="spec-form-label-row">
+            <label for="f-acl-groups" class="spec-form-label">{{ self.t("spec-form-access-groups") }}</label>
+            {% call help(self.t("spec-help-access-groups")) %}{% endcall %}
+          </div>
+          <input id="f-acl-groups" type="text" name="access_groups"
+                 value="{{ form.access_groups }}" placeholder="staff, ops" class="spec-form-input">
+        </div>
+        <div class="spec-form-field">
+          <div class="spec-form-label-row">
+            <label for="f-acl-users" class="spec-form-label">{{ self.t("spec-form-access-users") }}</label>
+            {% call help(self.t("spec-help-access-users")) %}{% endcall %}
+          </div>
+          <input id="f-acl-users" type="text" name="access_users"
+                 value="{{ form.access_users }}" placeholder="alice, bob" class="spec-form-input">
+        </div>
+      </div>
+      <div class="spec-form-help">{{ self.t("spec-form-access-help") }}</div>
+
       <div class="spec-form-field">
         <div class="spec-form-label-row">
           <label for="f-updated" class="spec-form-label">{{ self.t("spec-form-updated") }}</label>
@@ -497,8 +496,38 @@
             </div>
           </template>
 
-          {# Runtime — inner port, platform, lifecycle #}
+          {# Runtime — seats/session, inner port, platform, lifecycle #}
           <div class="spec-form-subsection">{{ self.t("spec-form-runtime-section") }}</div>
+          {# Seats + max session lifetime — demoted from the always-visible
+             Container card (#523); they're per-session runtime tuning, not
+             "what image to run". Container-only. #}
+          <template x-if="needsContainer()">
+            <div class="grid grid-cols-2 gap-3">
+              <div class="spec-form-field">
+                <div class="spec-form-label-row">
+                  <label for="f-seats" class="spec-form-label">{{ self.t("spec-form-seats") }}</label>
+                  {% call help(self.t("spec-help-seats")) %}{% endcall %}
+                </div>
+                <input id="f-seats" type="number" name="seats_per_container"
+                       value="{{ form.seats_per_container }}"
+                       min="1"
+                       placeholder="10"
+                       class="spec-form-input">
+              </div>
+              <div class="spec-form-field">
+                <div class="spec-form-label-row">
+                  <label for="f-lifetime" class="spec-form-label">{{ self.t("spec-form-lifetime") }}</label>
+                  {% call help(self.t("spec-help-lifetime")) %}{% endcall %}
+                </div>
+                <input id="f-lifetime" type="number" name="max_lifetime"
+                       value="{{ form.max_lifetime }}"
+                       min="1"
+                       placeholder="360"
+                       class="spec-form-input">
+                <div class="spec-form-help">{{ self.t("spec-form-lifetime-help") }}</div>
+              </div>
+            </div>
+          </template>
           <div class="grid grid-cols-2 gap-3">
             <div class="spec-form-field">
               <div class="spec-form-label-row">
@@ -615,28 +644,6 @@
           {% if !form.docker_registry_domain.is_empty() || !form.docker_registry_username.is_empty() %}
           <div class="spec-form-help" style="color:var(--color-lock)">{{ self.t("spec-form-registry-inline-note") }}</div>
           {% endif %}
-
-          {# Access — who may see + reach this app (#155) #}
-          <div class="spec-form-subsection">{{ self.t("spec-form-access-section") }}</div>
-          <div class="grid grid-cols-2 gap-3">
-            <div class="spec-form-field">
-              <div class="spec-form-label-row">
-                <label for="f-acl-groups" class="spec-form-label">{{ self.t("spec-form-access-groups") }}</label>
-                {% call help(self.t("spec-help-access-groups")) %}{% endcall %}
-              </div>
-              <input id="f-acl-groups" type="text" name="access_groups"
-                     value="{{ form.access_groups }}" placeholder="staff, ops" class="spec-form-input">
-            </div>
-            <div class="spec-form-field">
-              <div class="spec-form-label-row">
-                <label for="f-acl-users" class="spec-form-label">{{ self.t("spec-form-access-users") }}</label>
-                {% call help(self.t("spec-help-access-users")) %}{% endcall %}
-              </div>
-              <input id="f-acl-users" type="text" name="access_users"
-                     value="{{ form.access_users }}" placeholder="alice, bob" class="spec-form-input">
-            </div>
-          </div>
-          <div class="spec-form-help">{{ self.t("spec-form-access-help") }}</div>
 
           {# Scaling — replica pool #}
           <div class="spec-form-subsection">{{ self.t("spec-form-scaling-section") }}</div>


### PR DESCRIPTION
Closes #523.

Reorganizes the app create/edit form so the visible structure maps to intent, without touching any field name, validation, or backend.

## Changes (template-only)
- **Identity** → essentials only: `id`, `display_name`, `description`.
- **Metadados** card → now the visible **metadata & visibility** band:
  - `featured` promoted out of Identity.
  - `access-groups` / `access-users` promoted out of the runtime "Advanced" collapse (visibility is governance, not a runtime knob).
  - `updated` stays here.
- **Container** card → just "what image to run". `seats_per_container` + `max_lifetime` demoted into the **Advanced** collapse's Runtime subsection, wrapped in `needsContainer()` so they only render for container kinds.

## Verification
- Round-trip smoke (create → reopen edit): all six relocated fields persist — `featured` ✓, `access_groups="staff, ops"` ✓, `access_users="alice"` ✓, `seats=7` ✓, `max_lifetime=99` ✓, `updated="02/06/2026"` ✓.
- Position assertions: `featured`/`access_*` render **before** the Advanced toggle (visible band); `seats` renders **after** it (inside the collapse).
- Gates: `cargo test -p ruscker-admin` (11 passed), `cargo clippy -p ruscker-admin --all-targets` clean, `i18n-check.sh` parity OK. No new i18n keys.

## Notes
- Per the issue, `subject` was kept in the "Visual" card (right above Metadados) rather than relocated — it's visual categorization and moving it (x-model + datalist) added risk for no real gain. Everything else follows the proposal.

🤖 Generated with [Claude Code](https://claude.com/claude-code)