### PR TITLE
chore(release): bump workspace version 0.1.39 → 0.1.40

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2845,7 +2845,7 @@ dependencies = [
 
 [[package]]
 name = "ruscker-admin"
-version = "0.1.39"
+version = "0.1.40"
 dependencies = [
  "aes-gcm",
  "anyhow",
@@ -2892,7 +2892,7 @@ dependencies = [
 
 [[package]]
 name = "ruscker-cli"
-version = "0.1.39"
+version = "0.1.40"
 dependencies = [
  "anyhow",
  "clap",
@@ -2912,7 +2912,7 @@ dependencies = [
 
 [[package]]
 name = "ruscker-config"
-version = "0.1.39"
+version = "0.1.40"
 dependencies = [
  "chrono",
  "ordered-float",
@@ -2927,7 +2927,7 @@ dependencies = [
 
 [[package]]
 name = "ruscker-core"
-version = "0.1.39"
+version = "0.1.40"
 dependencies = [
  "async-trait",
  "chrono",
@@ -2940,7 +2940,7 @@ dependencies = [
 
 [[package]]
 name = "ruscker-docker"
-version = "0.1.39"
+version = "0.1.40"
 dependencies = [
  "anyhow",
  "async-stream",
@@ -2959,7 +2959,7 @@ dependencies = [
 
 [[package]]
 name = "ruscker-proxy"
-version = "0.1.39"
+version = "0.1.40"
 dependencies = [
  "anyhow",
  "axum",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -10,7 +10,7 @@ members = [
 ]
 
 [workspace.package]
-version = "0.1.39"
+version = "0.1.40"
 edition = "2021"
 rust-version = "1.85"
 license = "Apache-2.0"

--- a/book/src/faq.md
+++ b/book/src/faq.md
@@ -80,7 +80,7 @@ the **sign-in session** paths to a single upstream — see
 
 ### Is it production-ready?
 
-Yes. The current release is **v0.1.39** — Phases 0–7 are complete and
+Yes. The current release is **v0.1.40** — Phases 0–7 are complete and
 the proxy is production-ready and horizontally scalable.
 Releases are multi-arch and cosign-signed; see the
 [release notes](./news.md) and the [Roadmap](./roadmap.md).

--- a/book/src/introduction.md
+++ b/book/src/introduction.md
@@ -40,7 +40,7 @@ proper admin panel, a monitoring dashboard, and load balancing.
 
 ## In production
 
-Ruscker is on **v0.1.39** and runs in production today. Where the
+Ruscker is on **v0.1.40** and runs in production today. Where the
 JVM-based stack it replaced idled at hundreds of megabytes, Ruscker
 idles in the low tens:
 

--- a/book/src/news.md
+++ b/book/src/news.md
@@ -9,6 +9,23 @@ the [GitHub releases page](https://github.com/StrategicProjects/ruscker/releases
 
 ---
 
+## v0.1.40 — 2026-06-02
+
+Two admin UX touches for managing apps.
+
+**Admin**
+- **Inline featured star** in the Apps table: toggle an app's Featured
+  flag straight from the list with a single click — solid star when on,
+  outline when off — without opening each app's editor.
+- **App form reorganized into three bands** so the layout maps to
+  intent: Identity (the essentials), a visible **Metadata & visibility**
+  band (Featured, access groups/users, updated date), and the
+  **Advanced** collapse for runtime knobs. Per-session tuning
+  (`seats-per-container`, `max-lifetime`) moved into Advanced; the
+  Container card is now just "which image to run".
+
+---
+
 ## v0.1.39 — 2026-06-02
 
 Polish for the Featured carousel and subject pills.

--- a/book/src/roadmap.md
+++ b/book/src/roadmap.md
@@ -1,6 +1,6 @@
 # Roadmap
 
-Ruscker is at **v0.1.39** — Phases 0 through 7 are done and the proxy is
+Ruscker is at **v0.1.40** — Phases 0 through 7 are done and the proxy is
 production-ready and horizontally scalable. Phase 8 (external auth) is
 the main optional, demand-driven work left. For what changed in each
 release, see the [release notes](./news.md).
@@ -71,7 +71,7 @@ can serve any session; one scaler leader via Postgres advisory locks,
 with failover. A runnable 2-instance compose harness lives in
 `examples/ha/`. See [Deployment shapes](./architecture.md#deployment-shapes).
 
-### Post-phase polish → **v0.1.4 – v0.1.39**
+### Post-phase polish → **v0.1.4 – v0.1.40**
 
 Incremental improvements shipped after Phase 7.
 

--- a/docs/SECURITY.md
+++ b/docs/SECURITY.md
@@ -5,7 +5,7 @@ Status: living document. Tracks the Phase 5 security audit
 **[accepted limitation]**, or **[deferred]**. File references use
 `crate/path:symbol` so they survive line-number drift.
 
-> **Scope.** This covers v0.1.39: single-operator install, Ruscker
+> **Scope.** This covers v0.1.40: single-operator install, Ruscker
 > behind a TLS-terminating reverse proxy, Docker on the same host.
 > Multi-tenant / shared-team auth (OIDC, RBAC) is out of scope until
 > Phase 8.


### PR DESCRIPTION
Release **v0.1.40** — admin UX.

## Included
- **#521 / #522** — inline featured star in the Apps table (toggle Featured from the list; XSS-hardened via `data-*`).
- **#523 / #524** — app form reorganized into 3 bands: Identity / Metadata & visibility (Featured, access, updated) / Advanced runtime; `seats`/`max-lifetime` demoted into Advanced.

## Release mechanics
- `[workspace.package] version` 0.1.39 → 0.1.40; `Cargo.lock` refreshed (6 crates).
- `news.md` entry added; version refs bumped in `faq.md`, `introduction.md`, `roadmap.md`, `docs/SECURITY.md`.
- After merge, an annotated `v0.1.40` tag triggers `release.yml` (.deb + musl + cosign-signed ghcr image + GitHub release).

🤖 Generated with [Claude Code](https://claude.com/claude-code)