### PR TITLE
ci(release): auto-publish Homebrew formula to the tap on release

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -347,3 +347,93 @@ jobs:
             --notes-file notes.md \
             --generate-notes \
             $pre
+
+  # --------------------------------------------------------------------
+  # Keep the Homebrew tap in lockstep with the release so
+  #   brew install strategicprojects/tap/ruscker
+  # always tracks the latest version (it used to drift — bumped by hand
+  # and forgotten). Renders the canonical formula
+  # (packaging/homebrew/ruscker.rb, the template) with this release's
+  # version + the three sha256 (two Linux tarballs from the release
+  # `.sha256` assets, the macOS source tarball computed here) and pushes
+  # it to StrategicProjects/homebrew-tap as Formula/ruscker.rb.
+  #
+  # Skipped for pre-releases. Needs a PAT with `contents:write` on the
+  # tap repo, stored as the `HOMEBREW_TAP_TOKEN` secret. If the secret
+  # is absent the job logs a warning and no-ops — it never fails a
+  # release.
+  # --------------------------------------------------------------------
+  homebrew:
+    needs: [meta, release]
+    if: needs.meta.outputs.prerelease == 'false'
+    runs-on: ubuntu-24.04
+    steps:
+      - name: Gate on tap token
+        id: gate
+        env:
+          TAP_TOKEN: ${{ secrets.HOMEBREW_TAP_TOKEN }}
+        run: |
+          if [ -n "${TAP_TOKEN}" ]; then
+            echo "ok=true" >> "$GITHUB_OUTPUT"
+          else
+            echo "::warning::HOMEBREW_TAP_TOKEN not set — skipping Homebrew tap update for ${GITHUB_REF_NAME}"
+            echo "ok=false" >> "$GITHUB_OUTPUT"
+          fi
+
+      - name: Checkout (for the canonical formula template)
+        if: steps.gate.outputs.ok == 'true'
+        uses: actions/checkout@v6
+
+      - name: Render formula from the release artifacts
+        if: steps.gate.outputs.ok == 'true'
+        env:
+          GH_TOKEN: ${{ github.token }}
+          # Via env (not inline `${{ }}`) so a crafted tag name can't be
+          # interpolated into the shell. `version` is `${tag#v}` from meta.
+          V: ${{ needs.meta.outputs.version }}
+        run: |
+          set -euo pipefail
+          v="$V"
+          tag="v${v}"
+          # Linux checksums: straight from the release `.sha256` assets.
+          amd=$(gh release download "$tag" --repo "$GITHUB_REPOSITORY" \
+                  -p "ruscker-${v}-linux-amd64.tar.gz.sha256" -O - | awk '{print $1}')
+          arm=$(gh release download "$tag" --repo "$GITHUB_REPOSITORY" \
+                  -p "ruscker-${v}-linux-arm64.tar.gz.sha256" -O - | awk '{print $1}')
+          # macOS builds from source: the GitHub auto-generated tag tarball.
+          src=$(curl -fsSL "https://github.com/${GITHUB_REPOSITORY}/archive/refs/tags/${tag}.tar.gz" \
+                  | sha256sum | awk '{print $1}')
+          echo "macos=$src arm64=$arm amd64=$amd"
+          f=packaging/homebrew/ruscker.rb
+          # Bump version + the three sha256 in place. Each sha256 is matched
+          # by the URL line that precedes it (slurp mode), so the right
+          # checksum lands on the right platform block.
+          perl -0pi -e "s/version \"[0-9][^\"]*\"/version \"${v}\"/" "$f"
+          perl -0pi -e "s{(archive/refs/tags/v#\{version\}\.tar\.gz\"\n\s*sha256 \")[0-9a-f]{64}}{\${1}${src}}" "$f"
+          perl -0pi -e "s{(linux-arm64\.tar\.gz\"\n\s*sha256 \")[0-9a-f]{64}}{\${1}${arm}}" "$f"
+          perl -0pi -e "s{(linux-amd64\.tar\.gz\"\n\s*sha256 \")[0-9a-f]{64}}{\${1}${amd}}" "$f"
+          echo "--- rendered formula ---"; grep -nE 'version |sha256 ' "$f"
+          cp "$f" "${RUNNER_TEMP}/ruscker.rb"
+
+      - name: Publish to the tap
+        if: steps.gate.outputs.ok == 'true'
+        env:
+          TAP_TOKEN: ${{ secrets.HOMEBREW_TAP_TOKEN }}
+          V: ${{ needs.meta.outputs.version }}
+        run: |
+          set -euo pipefail
+          v="$V"
+          git clone --depth 1 \
+            "https://x-access-token:${TAP_TOKEN}@github.com/StrategicProjects/homebrew-tap.git" tap
+          mkdir -p tap/Formula
+          cp "${RUNNER_TEMP}/ruscker.rb" tap/Formula/ruscker.rb
+          cd tap
+          git config user.name "github-actions[bot]"
+          git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
+          git add Formula/ruscker.rb
+          if git diff --cached --quiet; then
+            echo "tap already at ${v} — nothing to push"
+          else
+            git commit -m "ruscker ${v}"
+            git push
+          fi

--- a/crates/ruscker-admin/templates/admin/specs.html
+++ b/crates/ruscker-admin/templates/admin/specs.html
@@ -84,9 +84,9 @@
         <th>{{ self.t("admin-specs-col-name") }}</th>
         <th>{{ self.t("admin-specs-col-kind") }}</th>
         <th>{{ self.t("admin-specs-col-state") }}</th>
-        <th class="star-cell" title="{{ self.t("admin-specs-col-featured") }}"><i class="ti ti-star" aria-hidden="true"></i></th>
         <th>{{ self.t("admin-specs-col-updated") }}</th>
         <th>{{ self.t("admin-specs-col-version") }}</th>
+        <th class="star-cell" title="{{ self.t("admin-specs-col-featured") }}"><i class="ti ti-star" aria-hidden="true"></i></th>
         <th class="actions-cell">{{ self.t("admin-specs-col-actions") }}</th>
       </tr>
     </thead>
@@ -102,34 +102,14 @@
           </td>
           <td><span class="pill pill-kind-{{ spec.kind }}">{{ spec.kind }}</span></td>
           <td><span class="pill pill-state-{{ spec.state }}">{{ spec.state }}</span></td>
-          {# Featured star (#521): toggle inline; solid when featured. Config
-             specs are read-only here (the flag lives in the YAML file). #}
-          <td class="star-cell">
-            {% if spec.config_only %}
-              <span class="star-toggle is-readonly" title="{{ self.t("admin-specs-featured-readonly") }}"><i class="ti {% if spec.featured %}ti-star-filled is-on{% else %}ti-star{% endif %}" aria-hidden="true"></i></span>
-            {% else %}
-              {# URL + titles ride in `data-*` (HTML-escaped) and are read via
-                 `$el.dataset` — never interpolated into the JS handler, so a
-                 spec id from an import can't break out of the string. #}
-              <button type="button" class="star-toggle" x-data="{ on: {{ spec.featured }}, busy: false }"
-                      data-toggle-url="{{ base }}/admin/specs/{{ spec.id }}/featured/toggle"
-                      data-title-on="{{ self.t("admin-specs-featured-on") }}"
-                      data-title-off="{{ self.t("admin-specs-featured-off") }}"
-                      :class="on ? 'is-on' : ''" :disabled="busy"
-                      :title="on ? $el.dataset.titleOn : $el.dataset.titleOff"
-                      @click="busy = true; const prev = on; on = !on;
-                              fetch($el.dataset.toggleUrl, { method: 'POST' })
-                                .then(r => r.ok ? r.json() : Promise.reject())
-                                .then(d => { on = d.featured })
-                                .catch(() => { on = prev })
-                                .finally(() => { busy = false })">
-                <i class="ti" :class="on ? 'ti-star-filled' : 'ti-star'" aria-hidden="true"></i>
-              </button>
-            {% endif %}
-          </td>
           {% if spec.config_only %}
           <td class="text-[color:var(--text-faint)]">—</td>
           <td class="text-[color:var(--text-faint)]">—</td>
+          {# Featured star (#521) — read-only for config-defined specs (the
+             flag lives in the YAML file). Sits next to the actions column. #}
+          <td class="star-cell">
+            <span class="star-toggle is-readonly" title="{{ self.t("admin-specs-featured-readonly") }}"><i class="ti {% if spec.featured %}ti-star-filled is-on{% else %}ti-star{% endif %}" aria-hidden="true"></i></span>
+          </td>
           <td class="actions-cell">
             {# Duplicate a YAML/config spec into a new, editable DB spec. #}
             <a href="{{ base }}/admin/specs/{{ spec.id }}/duplicate"
@@ -142,6 +122,27 @@
           {% else %}
           <td class="text-[color:var(--text-muted)]">{{ spec.updated_at.format("%d/%m/%Y %H:%M") }}</td>
           <td class="text-[color:var(--text-muted)]">v{{ spec.version }}</td>
+          {# Featured star (#521): inline toggle, solid when featured. Sits
+             next to the actions column. #}
+          <td class="star-cell">
+            {# URL + titles ride in `data-*` (HTML-escaped) and are read via
+               `$el.dataset` — never interpolated into the JS handler, so a
+               spec id from an import can't break out of the string. #}
+            <button type="button" class="star-toggle" x-data="{ on: {{ spec.featured }}, busy: false }"
+                    data-toggle-url="{{ base }}/admin/specs/{{ spec.id }}/featured/toggle"
+                    data-title-on="{{ self.t("admin-specs-featured-on") }}"
+                    data-title-off="{{ self.t("admin-specs-featured-off") }}"
+                    :class="on ? 'is-on' : ''" :disabled="busy"
+                    :title="on ? $el.dataset.titleOn : $el.dataset.titleOff"
+                    @click="busy = true; const prev = on; on = !on;
+                            fetch($el.dataset.toggleUrl, { method: 'POST' })
+                              .then(r => r.ok ? r.json() : Promise.reject())
+                              .then(d => { on = d.featured })
+                              .catch(() => { on = prev })
+                              .finally(() => { busy = false })">
+              <i class="ti" :class="on ? 'ti-star-filled' : 'ti-star'" aria-hidden="true"></i>
+            </button>
+          </td>
           <td class="actions-cell">
             <a href="{{ base }}/admin/specs/{{ spec.id }}/edit"
                class="admin-nav-link"
@@ -160,5 +161,9 @@
     </tbody>
   </table>
 {% endif %}
+
+{# Alpine powers the inline featured-star toggle (#521). Without it the
+   `x-data`/`:class` button never initializes and the star renders empty. #}
+<script src="{{ base }}/assets/js/alpine.min.js?v={{ crate::APP_VERSION }}" defer></script>
 
 {% endblock %}


### PR DESCRIPTION
Closes the "brew never gets updated" gap. The Homebrew formula drifted for ~32 releases (canonical stuck at **v0.1.8**, the published tap at **v0.1.0**) because the bump was manual and kept being forgotten.

## What this adds
A `homebrew` job in `release.yml` that runs after the GitHub Release is published (`needs: [meta, release]`), only for **non-prereleases**:
1. Checks out the repo to use `packaging/homebrew/ruscker.rb` as the **template**.
2. Computes the three `sha256`:
   - `linux-amd64` / `linux-arm64` from the release `*.sha256` assets,
   - the macOS **source tarball** (`archive/refs/tags/vX.tar.gz`) inline.
3. `perl`-substitutes `version` + the three checksums (each matched by its preceding URL line, so the right sha lands on the right platform block).
4. Clones `StrategicProjects/homebrew-tap` and pushes the rendered `Formula/ruscker.rb` (no-op if unchanged).

## Operational notes
- **Requires a one-time secret:** `HOMEBREW_TAP_TOKEN` — a PAT (fine-grained or classic) with `contents:write` on `StrategicProjects/homebrew-tap`. **If the secret is absent the job logs a warning and no-ops — it never fails a release.**
- The canonical `packaging/homebrew/ruscker.rb` is treated as the structure/template; CI fills version+shas at release time, so the **tap** always tracks the latest release even if the canonical literals are stale.
- Security: the tag-derived `version` is passed through `env:` rather than inline `${{ }}` (ref-injection hardening).

## Verification
- `release.yml` parses as valid YAML.
- Ran the exact `perl` substitution sequence locally against the real formula with dummy version/shas → each checksum landed in the correct block and the rendered file passed `ruby -c`.

> Note: v0.1.40 was already published to the tap manually; this job takes over from v0.1.41 onward (once the secret is set).

🤖 Generated with [Claude Code](https://claude.com/claude-code)