### PR TITLE
fix(packaging): drop the obsolete welcome starter spec from the default config

### DIFF
--- a/packaging/application.example.yml
+++ b/packaging/application.example.yml
@@ -14,17 +14,13 @@ proxy:
   # and only the public landing + proxy are served.
   authentication: none
 
-  specs:
-    # A simple external-link card so the landing page isn't empty out
-    # of the box. Replace with your own apps / APIs.
-    - id: welcome
-      display-name: "Welcome to Ruscker"
-      description: "Edit /etc/ruscker/application.yml to add your apps."
-      template-properties:
-        type: package
-        state: active
-        link: https://github.com/StrategicProjects/ruscker
-
+  # Apps and APIs live in the database and are managed in the admin
+  # panel. On first run Ruscker auto-seeds a set of showcase cards, so
+  # the landing page is never empty out of the box — no starter spec is
+  # needed here (an old `welcome` placeholder used to live here; it just
+  # duplicated a DB card and showed up as a read-only CONFIG row in the
+  # admin, so it was dropped). Add your own apps below, or via the admin.
+  specs: []
     # Example containerized app (commented). Requires the --docker
     # backend — add `--docker` to ExecStart in the systemd unit and
     # give the `ruscker` user Docker access (see README.Debian).


### PR DESCRIPTION
## The bug
After a **fresh purge + reinstall**, the admin Apps table showed a read-only **`welcome` / CONFIG** row (and the portal showed a duplicate "Welcome to Ruscker" card). It wasn't added by #521 — it comes from the `welcome` external-link spec shipped in `packaging/application.example.yml`, which installs to `/etc/ruscker/application.yml` and is surfaced in the admin by the config-defined-rows feature (#303).

## Why it's obsolete
That starter card existed "so the landing page isn't empty out of the box." That rationale predates the **DB-first showcase seed (#205)**: `db::showcase::seed_if_unseeded` runs on every fresh DB at startup (`db.rs:98`) and fills the landing with real showcase cards. So the `welcome` placeholder is redundant — and actively confusing, because it duplicates a card and clutters the admin with a CONFIG row a clean install shouldn't have.

## The fix
Replace the `welcome` spec with an empty `specs: []` (commented examples retained) and a comment explaining the DB seed handles first-run content.

## Verification (fresh DB + this config)
- `ruscker validate packaging/application.example.yml` → **0 specs, 0 warnings**, exit 0.
- Public landing: **0** occurrences of `welcome`; renders the seeded showcase cards.
- DB after startup: 13 showcase specs seeded (`bokeh dash fastapi jupyter plumber quarto rmarkdown rstudio ruscker-docs shiny shiny-for-python streamlit voila`), `welcome` count **0**, `showcase.seeded` marker present.

## Operator note
This fixes **future** fresh installs. An existing deployment whose `/etc/ruscker/application.yml` still has the `welcome` spec needs it removed there (edit the file + `systemctl restart ruscker`, or re-run the fresh-install flow after this ships).

🤖 Generated with [Claude Code](https://claude.com/claude-code)