### PR TITLE
docs(book): Homebrew install section + featured-star / 3-band form in admin guide

### DIFF
--- a/book/src/admin.md
+++ b/book/src/admin.md
@@ -56,15 +56,24 @@ replica; open its logs. Shows a banner when started without
 
 ### Apps
 The list of specs — apps, APIs and external links — with create, edit
-and delete. The add/edit form has a type selector, a **live card
-preview**, and a **logo picker** that pulls from the media library (no
-need to type `/assets/img/...` by hand). A **"?" help popover** on every
-field explains what it does.
+and delete. Each row has a **featured star** next to the actions: click
+it to toggle whether the app appears in the landing page's *Featured*
+carousel, inline, without opening the editor (solid = featured).
 
-Under a collapsible **Advanced** section, every remaining spec option is
+The add/edit form is organised into three bands so the layout maps to
+intent: **Identity** (id, name, description), a **Metadata & visibility**
+band (the featured flag, access groups/users, subject, logo and cover),
+and a collapsible **Advanced** band for runtime knobs. It has a type
+selector, a **live card preview**, and a **logo picker** that pulls from
+the media library (no need to type `/assets/img/...` by hand). A **"?"
+help popover** on every field explains what it does.
+
+Under the collapsible **Advanced** band, every remaining spec option is
 editable too — so an app can be configured end-to-end from the web UI,
 without touching YAML:
 
+- **Runtime** — seats per container, session lifetime, inner container
+  port and platform.
 - **API** (for `type: api`) — container port, rate limit, docs/health
   paths, permissive CORS.
 - **Scaling** — min/max replicas and concurrent requests per replica.

--- a/book/src/installation.md
+++ b/book/src/installation.md
@@ -78,6 +78,25 @@ ruscker --version
 The binary has no shared-library dependencies and runs on any
 glibc-free or glibc Linux system.
 
+## Homebrew (macOS / Linux)
+
+For a local install — handy on a macOS workstation for development — use
+the tap:
+
+```sh
+brew install strategicprojects/tap/ruscker
+ruscker --version
+```
+
+On Linux the formula pulls the static musl binary from the matching
+release; on macOS it builds from source (so a Rust toolchain is fetched
+as a build dependency). Each release auto-publishes its formula to the
+tap, so `brew upgrade` tracks the latest version.
+
+> Ruscker spawns **Linux containers**, so the `--docker` backend needs a
+> Linux Docker host. A macOS Homebrew install is meant for running the
+> portal locally and for development, not for hosting app containers.
+
 ## Docker
 
 ```sh


### PR DESCRIPTION
Brings the site docs in line with v0.1.40/v0.1.41.

## `installation.md`
Adds a **Homebrew** section — the overview pages linked "brew" but the install guide had no instructions:
```sh
brew install strategicprojects/tap/ruscker
```
Documents that the formula builds from source on macOS (Rust pulled as a build dep) and pulls the musl tarball on Linux, that each release auto-publishes the formula to the tap, and that a macOS install is for local/dev use (Ruscker spawns Linux containers, so `--docker` needs a Linux host).

## `admin.md` (Apps section)
- Documents the **inline featured star**: toggle an app into the landing *Featured* carousel straight from the list row (next to the actions), no editor needed.
- Documents the **3-band form** (Identity / Metadata & visibility / Advanced) from #523, and adds a **Runtime** bullet to the Advanced list for the seats/session-lifetime knobs that moved there.

## Notes
- Version strings + `news.md` were already bumped in the release PR (#530); this is the prose/structure follow-up the version bump didn't cover.
- `book/src/{architecture,security,configuration}.md` are `{{#include}}` wrappers over `docs/*.md` and were not touched.
- `mdbook build` is clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)