### PR TITLE
fix(admin): featured star vanished when toggled on — inline SVG instead of missing glyph

### DIFF
--- a/crates/ruscker-admin/assets/tailwind/input.css
+++ b/crates/ruscker-admin/assets/tailwind/input.css
@@ -1246,6 +1246,7 @@ textarea.spec-form-input { resize: vertical; min-height: 64px; }
 .star-toggle:disabled { cursor: default; }
 .star-toggle.is-readonly { cursor: default; }
 .star-toggle .ti { font-size: 16px; }
+.star-toggle .star-ico { width: 17px; height: 17px; display: block; }
 
 /* Header/footer center logos (#468): absolutely centred within the header
    bar / footer chrome (their empty middle), so they read as part of the bar

--- a/crates/ruscker-admin/templates/admin/specs.html
+++ b/crates/ruscker-admin/templates/admin/specs.html
@@ -108,7 +108,17 @@
           {# Featured star (#521) — read-only for config-defined specs (the
              flag lives in the YAML file). Sits next to the actions column. #}
           <td class="star-cell">
-            <span class="star-toggle is-readonly" title="{{ self.t("admin-specs-featured-readonly") }}"><i class="ti {% if spec.featured %}ti-star-filled is-on{% else %}ti-star{% endif %}" aria-hidden="true"></i></span>
+            {# Inline SVG star (not a font glyph): the served tabler subset
+               has no `ti-star-filled`, so a filled state rendered empty.
+               `fill` toggles solid/outline; `currentColor` picks up the
+               amber `.is-on` color. #}
+            <span class="star-toggle is-readonly{% if spec.featured %} is-on{% endif %}" title="{{ self.t("admin-specs-featured-readonly") }}">
+              <svg viewBox="0 0 24 24" class="star-ico" aria-hidden="true"
+                   fill="{% if spec.featured %}currentColor{% else %}none{% endif %}"
+                   stroke="currentColor" stroke-width="1.5" stroke-linejoin="round">
+                <path d="M12 17.27L18.18 21l-1.64-7.03L22 9.24l-7.19-.61L12 2 9.19 8.63 2 9.24l5.46 4.73L5.82 21z"/>
+              </svg>
+            </span>
           </td>
           <td class="actions-cell">
             {# Duplicate a YAML/config spec into a new, editable DB spec. #}
@@ -140,7 +150,14 @@
                               .then(d => { on = d.featured })
                               .catch(() => { on = prev })
                               .finally(() => { busy = false })">
-              <i class="ti" :class="on ? 'ti-star-filled' : 'ti-star'" aria-hidden="true"></i>
+              {# Inline SVG star — `:fill` flips solid (featured) ↔ outline.
+                 Avoids the missing `ti-star-filled` font glyph that made the
+                 filled state render empty. #}
+              <svg viewBox="0 0 24 24" class="star-ico" aria-hidden="true"
+                   :fill="on ? 'currentColor' : 'none'"
+                   stroke="currentColor" stroke-width="1.5" stroke-linejoin="round">
+                <path d="M12 17.27L18.18 21l-1.64-7.03L22 9.24l-7.19-.61L12 2 9.19 8.63 2 9.24l5.46 4.73L5.82 21z"/>
+              </svg>
             </button>
           </td>
           <td class="actions-cell">


### PR DESCRIPTION
## The bug
Toggling an app's featured star made it **disappear** instead of becoming solid (reported on cast). Root cause: the served tabler-icons subset (`crates/ruscker-admin/assets/icons/tabler-icons.min.css`) defines only `.ti-star` (outline) — **not `.ti-star-filled`**. The bundled woff2 is the outline family, so the "featured" state (`ti-star-filled`) mapped to no glyph and rendered empty.

This affected the star regardless of the column/Alpine fix in #527 — the earlier smoke only checked HTML structure, not the rendered glyph.

## Fix
Replace the font glyph with an **inline SVG star** whose `fill` toggles:
- live toggle button: `:fill="on ? 'currentColor' : 'none'"`
- read-only config-spec variant: `fill="{% if spec.featured %}currentColor{% else %}none{% endif %}"`

`currentColor` keeps the amber `.is-on` color, and `stroke="currentColor"` draws the outline when not filled. No dependency on which icons the font subset includes. Added `.star-toggle .star-ico` sizing to the CSS.

## Verification
- Rendered HTML: **0** `ti-star-filled` left; 15 `star-ico` SVGs with a `:fill` binding.
- Toggle endpoint flips `featured` true↔false; star fills/empties accordingly.
- clippy + i18n-check green.

## Note on cast
cast was still on **v0.1.40** when tested (auto-update hadn't picked up v0.1.41), so the star also appeared in the old column and didn't react — that part is fixed by #527 (v0.1.41). This PR fixes the filled-glyph, which #527 didn't cover. A version carrying **both** (next release) is needed on cast for the star to look + behave right.

🤖 Generated with [Claude Code](https://claude.com/claude-code)