### PR TITLE
fix(admin): put the featured star inside the Actions column, not its own column

### DIFF
--- a/crates/ruscker-admin/assets/tailwind/input.css
+++ b/crates/ruscker-admin/assets/tailwind/input.css
@@ -1238,7 +1238,7 @@ textarea.spec-form-input { resize: vertical; min-height: 64px; }
 .star-toggle {
   display: inline-flex; align-items: center; justify-content: center;
   width: 28px; height: 28px; border: 0; background: none; border-radius: 6px;
-  color: var(--text-faint); cursor: pointer;
+  color: var(--text-faint); cursor: pointer; vertical-align: middle;
   transition: color 0.12s, background 0.12s;
 }
 .star-toggle:hover:not(:disabled):not(.is-readonly) { color: #eab308; background: var(--surface-soft); }

--- a/crates/ruscker-admin/templates/admin/specs.html
+++ b/crates/ruscker-admin/templates/admin/specs.html
@@ -86,7 +86,6 @@
         <th>{{ self.t("admin-specs-col-state") }}</th>
         <th>{{ self.t("admin-specs-col-updated") }}</th>
         <th>{{ self.t("admin-specs-col-version") }}</th>
-        <th class="star-cell" title="{{ self.t("admin-specs-col-featured") }}"><i class="ti ti-star" aria-hidden="true"></i></th>
         <th class="actions-cell">{{ self.t("admin-specs-col-actions") }}</th>
       </tr>
     </thead>
@@ -105,13 +104,12 @@
           {% if spec.config_only %}
           <td class="text-[color:var(--text-faint)]">—</td>
           <td class="text-[color:var(--text-faint)]">—</td>
-          {# Featured star (#521) — read-only for config-defined specs (the
-             flag lives in the YAML file). Sits next to the actions column. #}
-          <td class="star-cell">
-            {# Inline SVG star (not a font glyph): the served tabler subset
-               has no `ti-star-filled`, so a filled state rendered empty.
-               `fill` toggles solid/outline; `currentColor` picks up the
-               amber `.is-on` color. #}
+          <td class="actions-cell">
+            {# Featured star (#521) — read-only for config-defined specs (the
+               flag lives in the YAML file). Inline SVG, not a font glyph: the
+               served tabler subset has no `ti-star-filled`, so a filled state
+               rendered empty. `fill` toggles solid/outline; `currentColor`
+               picks up the amber `.is-on` color. #}
             <span class="star-toggle is-readonly{% if spec.featured %} is-on{% endif %}" title="{{ self.t("admin-specs-featured-readonly") }}">
               <svg viewBox="0 0 24 24" class="star-ico" aria-hidden="true"
                    fill="{% if spec.featured %}currentColor{% else %}none{% endif %}"
@@ -119,8 +117,6 @@
                 <path d="M12 17.27L18.18 21l-1.64-7.03L22 9.24l-7.19-.61L12 2 9.19 8.63 2 9.24l5.46 4.73L5.82 21z"/>
               </svg>
             </span>
-          </td>
-          <td class="actions-cell">
             {# Duplicate a YAML/config spec into a new, editable DB spec. #}
             <a href="{{ base }}/admin/specs/{{ spec.id }}/duplicate"
                class="admin-nav-link"
@@ -132,12 +128,12 @@
           {% else %}
           <td class="text-[color:var(--text-muted)]">{{ spec.updated_at.format("%d/%m/%Y %H:%M") }}</td>
           <td class="text-[color:var(--text-muted)]">v{{ spec.version }}</td>
-          {# Featured star (#521): inline toggle, solid when featured. Sits
-             next to the actions column. #}
-          <td class="star-cell">
-            {# URL + titles ride in `data-*` (HTML-escaped) and are read via
-               `$el.dataset` — never interpolated into the JS handler, so a
-               spec id from an import can't break out of the string. #}
+          <td class="actions-cell">
+            {# Featured star (#521): inline toggle, solid when featured, right
+               in the actions column. URL + titles ride in `data-*`
+               (HTML-escaped), read via `$el.dataset` — never interpolated
+               into the JS handler. Inline SVG star (`:fill` flips solid ↔
+               outline) avoids the missing `ti-star-filled` font glyph. #}
             <button type="button" class="star-toggle" x-data="{ on: {{ spec.featured }}, busy: false }"
                     data-toggle-url="{{ base }}/admin/specs/{{ spec.id }}/featured/toggle"
                     data-title-on="{{ self.t("admin-specs-featured-on") }}"
@@ -150,17 +146,12 @@
                               .then(d => { on = d.featured })
                               .catch(() => { on = prev })
                               .finally(() => { busy = false })">
-              {# Inline SVG star — `:fill` flips solid (featured) ↔ outline.
-                 Avoids the missing `ti-star-filled` font glyph that made the
-                 filled state render empty. #}
               <svg viewBox="0 0 24 24" class="star-ico" aria-hidden="true"
                    :fill="on ? 'currentColor' : 'none'"
                    stroke="currentColor" stroke-width="1.5" stroke-linejoin="round">
                 <path d="M12 17.27L18.18 21l-1.64-7.03L22 9.24l-7.19-.61L12 2 9.19 8.63 2 9.24l5.46 4.73L5.82 21z"/>
               </svg>
             </button>
-          </td>
-          <td class="actions-cell">
             <a href="{{ base }}/admin/specs/{{ spec.id }}/edit"
                class="admin-nav-link"
                title="{{ self.t("admin-specs-edit") }}">


### PR DESCRIPTION
The featured star was in a **separate column** immediately before Actions (from #527). The actual ask was for it to live **inside** the Actions cell, next to the edit/duplicate icons.

## Change
- Removed the dedicated `star-cell` column: the `<th>` and both per-row `<td class="star-cell">` cells.
- Render the star as the **first control inside `actions-cell`**:
  - DB specs → the live toggle button,
  - config-defined specs → the read-only star.
- Added `vertical-align: middle` to `.star-toggle` so it aligns with the inline action links.

## Verification
- Rendered HTML: **0** `star-cell` `<th>`/`<td>` remain; all **15** `actions-cell`s contain the star, rendered **before** the edit link.
- Toggle endpoint still flips `featured` (returns `{"featured":true}`); SVG star fills/empties.
- clippy + i18n-check green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)