### PR TITLE
chore(release): bump workspace version 0.1.43 → 0.1.44

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2845,7 +2845,7 @@ dependencies = [
 
 [[package]]
 name = "ruscker-admin"
-version = "0.1.43"
+version = "0.1.44"
 dependencies = [
  "aes-gcm",
  "anyhow",
@@ -2892,7 +2892,7 @@ dependencies = [
 
 [[package]]
 name = "ruscker-cli"
-version = "0.1.43"
+version = "0.1.44"
 dependencies = [
  "anyhow",
  "clap",
@@ -2912,7 +2912,7 @@ dependencies = [
 
 [[package]]
 name = "ruscker-config"
-version = "0.1.43"
+version = "0.1.44"
 dependencies = [
  "chrono",
  "ordered-float",
@@ -2927,7 +2927,7 @@ dependencies = [
 
 [[package]]
 name = "ruscker-core"
-version = "0.1.43"
+version = "0.1.44"
 dependencies = [
  "async-trait",
  "chrono",
@@ -2940,7 +2940,7 @@ dependencies = [
 
 [[package]]
 name = "ruscker-docker"
-version = "0.1.43"
+version = "0.1.44"
 dependencies = [
  "anyhow",
  "async-stream",
@@ -2959,7 +2959,7 @@ dependencies = [
 
 [[package]]
 name = "ruscker-proxy"
-version = "0.1.43"
+version = "0.1.44"
 dependencies = [
  "anyhow",
  "axum",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -10,7 +10,7 @@ members = [
 ]
 
 [workspace.package]
-version = "0.1.43"
+version = "0.1.44"
 edition = "2021"
 rust-version = "1.85"
 license = "Apache-2.0"

--- a/book/src/faq.md
+++ b/book/src/faq.md
@@ -80,7 +80,7 @@ the **sign-in session** paths to a single upstream — see
 
 ### Is it production-ready?
 
-Yes. The current release is **v0.1.43** — Phases 0–7 are complete and
+Yes. The current release is **v0.1.44** — Phases 0–7 are complete and
 the proxy is production-ready and horizontally scalable.
 Releases are multi-arch and cosign-signed; see the
 [release notes](./news.md) and the [Roadmap](./roadmap.md).

--- a/book/src/introduction.md
+++ b/book/src/introduction.md
@@ -40,7 +40,7 @@ proper admin panel, a monitoring dashboard, and load balancing.
 
 ## In production
 
-Ruscker is on **v0.1.43** and runs in production today. Where the
+Ruscker is on **v0.1.44** and runs in production today. Where the
 JVM-based stack it replaced idled at hundreds of megabytes, Ruscker
 idles in the low tens:
 

--- a/book/src/news.md
+++ b/book/src/news.md
@@ -9,6 +9,21 @@ the [GitHub releases page](https://github.com/StrategicProjects/ruscker/releases
 
 ---
 
+## v0.1.44 — 2026-06-02
+
+A refreshed Featured carousel.
+
+**Landing**
+- **New carousel controls.** The prev/next chevrons are now circular
+  buttons overlaid on the card row, vertically centered on the left and
+  right edges (Material-Tailwind style), instead of a pair of buttons in
+  the section header. They stay pinned to the visible cards whether 1, 2
+  or 3 fit, and disappear when everything fits on one page.
+- **Fixed a hover clip.** A featured card's dark top border no longer
+  gets shaved off when you hover it inside the carousel.
+
+---
+
 ## v0.1.43 — 2026-06-02
 
 Another featured-star placement fix.

--- a/book/src/roadmap.md
+++ b/book/src/roadmap.md
@@ -1,6 +1,6 @@
 # Roadmap
 
-Ruscker is at **v0.1.43** — Phases 0 through 7 are done and the proxy is
+Ruscker is at **v0.1.44** — Phases 0 through 7 are done and the proxy is
 production-ready and horizontally scalable. Phase 8 (external auth) is
 the main optional, demand-driven work left. For what changed in each
 release, see the [release notes](./news.md).
@@ -71,7 +71,7 @@ can serve any session; one scaler leader via Postgres advisory locks,
 with failover. A runnable 2-instance compose harness lives in
 `examples/ha/`. See [Deployment shapes](./architecture.md#deployment-shapes).
 
-### Post-phase polish → **v0.1.4 – v0.1.43**
+### Post-phase polish → **v0.1.4 – v0.1.44**
 
 Incremental improvements shipped after Phase 7.
 

--- a/docs/SECURITY.md
+++ b/docs/SECURITY.md
@@ -5,7 +5,7 @@ Status: living document. Tracks the Phase 5 security audit
 **[accepted limitation]**, or **[deferred]**. File references use
 `crate/path:symbol` so they survive line-number drift.
 
-> **Scope.** This covers v0.1.43: single-operator install, Ruscker
+> **Scope.** This covers v0.1.44: single-operator install, Ruscker
 > behind a TLS-terminating reverse proxy, Docker on the same host.
 > Multi-tenant / shared-team auth (OIDC, RBAC) is out of scope until
 > Phase 8.


### PR DESCRIPTION
Release **v0.1.44** — refreshed Featured carousel.

## Included
- **#535** — Material-Tailwind-style carousel controls: circular prev/next chevrons overlaid on the card row, vertically centered on the left/right edges (instead of header buttons), pinned to the visible cards for 1–3 columns. Includes a fix so a card's dark top border isn't clipped on hover inside the carousel.

## Release mechanics
- `[workspace.package] version` 0.1.43 → 0.1.44; `Cargo.lock` refreshed.
- `news.md` entry + version refs bumped (`faq.md`, `introduction.md`, `roadmap.md`, `docs/SECURITY.md`).
- `v0.1.44` tag → `release.yml`; the `homebrew` job auto-publishes the formula to the tap.

🤖 Generated with [Claude Code](https://claude.com/claude-code)