### PR TITLE
feat(landing): center the Featured carousel + move chevrons outside the cards

### DIFF
--- a/crates/ruscker-admin/assets/tailwind/input.css
+++ b/crates/ruscker-admin/assets/tailwind/input.css
@@ -363,7 +363,7 @@ body {
    card keeps its fixed width, so 1–3 fit per viewport and the rest scroll. */
 .highlights { margin-bottom: 22px; }
 .highlights-head {
-  display: flex; align-items: center; justify-content: space-between;
+  display: flex; align-items: center; justify-content: center;
   gap: 12px; margin-bottom: 10px;
 }
 .highlights-title {
@@ -372,38 +372,37 @@ body {
   letter-spacing: -0.01em;
 }
 .highlights-title .ti { color: var(--color-teal-600); font-size: 15px; }
-/* Circular prev/next controls overlaid on the card row, vertically centered
-   on the left/right edges (Material-Tailwind style). Absolutely positioned
-   inside the viewport, so the overflow:hidden box pins them to the visible
-   cards regardless of how many (1–3) fit. */
+/* Centered stage: the card row sits between the prev/next chevrons, which
+   live in the side gutters (OUTSIDE the cards), vertically centered. The
+   whole block is centered on the page. */
+.highlights-stage {
+  display: flex; align-items: center; justify-content: center; gap: 12px;
+}
+/* Circular prev/next controls in the gutters beside the card row. */
 .highlights-arrow {
-  position: absolute; top: 50%; transform: translateY(-50%); z-index: 3;
+  flex: 0 0 auto;
   display: inline-flex; align-items: center; justify-content: center;
   width: 36px; height: 36px; border-radius: 9999px;
-  border: 0.5px solid var(--border);
-  background: color-mix(in srgb, var(--surface) 86%, transparent);
-  -webkit-backdrop-filter: blur(4px); backdrop-filter: blur(4px);
-  color: var(--text); cursor: pointer;
-  box-shadow: 0 2px 8px rgba(0, 0, 0, 0.14);
+  border: 0.5px solid var(--border); background: var(--surface);
+  color: var(--text-muted); cursor: pointer;
+  box-shadow: 0 1px 3px rgba(0, 0, 0, 0.08);
   transition: background 0.12s, border-color 0.12s, color 0.12s,
               opacity 0.12s, box-shadow 0.12s;
 }
-.highlights-arrow--prev { left: 8px; }
-.highlights-arrow--next { right: 8px; }
 .highlights-arrow:hover:not(:disabled) {
   border-color: var(--color-teal-600); color: var(--color-teal-600);
-  box-shadow: 0 3px 12px rgba(0, 0, 0, 0.18);
+  box-shadow: 0 2px 6px rgba(0, 0, 0, 0.12);
 }
 /* Keep both chevrons present at the ends, just faded + inert (MT-style). */
 .highlights-arrow:disabled { opacity: 0.3; pointer-events: none; }
 .highlights-arrow .ti { font-size: 18px; }
 /* Viewport caps at 3 cards and clips; the track pages via translateX — no
-   horizontal scrollbar (#516). `position: relative` anchors the overlaid
-   chevrons. Vertical padding (with horizontal 0) gives the card's hover
-   lift + dark top border headroom so `overflow: hidden` doesn't shave it
-   off, while still clipping the rail at the left/right edges. */
+   horizontal scrollbar (#516). Vertical padding (with horizontal 0) gives the
+   card's hover lift + dark top border headroom so `overflow: hidden` doesn't
+   shave it off, while still clipping the rail at the left/right edges.
+   `min-width: 0` lets it shrink below 3 cards on narrow viewports. */
 .highlights-viewport {
-  position: relative; overflow: hidden;
+  overflow: hidden; min-width: 0;
   max-width: calc(3 * var(--card-w) + 28px);
   padding: 6px 0;
 }

--- a/crates/ruscker-admin/templates/landing.html
+++ b/crates/ruscker-admin/templates/landing.html
@@ -111,18 +111,15 @@
     <div class="highlights-head">
       <div class="highlights-title"><i class="ti ti-star" aria-hidden="true"></i> {{ self.t("highlights-title") }}</div>
     </div>
-    {# Chevrons overlay the card row, vertically centered on the left/right
-       edges (Material-Tailwind style). Shown only when there's more than one
-       page. They live inside the viewport so its overflow:hidden box keeps
-       them pinned to the visible cards. #}
-    <div class="highlights-viewport">
+    {# Centered stage: the chevrons sit OUTSIDE the card row in the side
+       gutters, vertically centered (flex row, justify-center). The whole
+       block is centered on the page. Shown only when there's >1 page. #}
+    <div class="highlights-stage">
       <button type="button" class="highlights-arrow highlights-arrow--prev"
               x-show="pages > 1" x-cloak @click="prev()" :disabled="page === 0"
               aria-label="{{ self.t("highlights-prev") }}"><i class="ti ti-chevron-left" aria-hidden="true"></i></button>
-      <button type="button" class="highlights-arrow highlights-arrow--next"
-              x-show="pages > 1" x-cloak @click="next()" :disabled="page >= pages - 1"
-              aria-label="{{ self.t("highlights-next") }}"><i class="ti ti-chevron-right" aria-hidden="true"></i></button>
-      <div class="highlights-track" x-ref="track" :style="trackStyle()">
+      <div class="highlights-viewport">
+        <div class="highlights-track" x-ref="track" :style="trackStyle()">
       {% for card in cards %}
         {% if card.featured %}
         <a class="rcard {% if !card.active %}inactive{% endif %}"
@@ -167,7 +164,11 @@
         </a>
         {% endif %}
       {% endfor %}
+        </div>
       </div>
+      <button type="button" class="highlights-arrow highlights-arrow--next"
+              x-show="pages > 1" x-cloak @click="next()" :disabled="page >= pages - 1"
+              aria-label="{{ self.t("highlights-next") }}"><i class="ti ti-chevron-right" aria-hidden="true"></i></button>
     </div>
   </section>
   {% endif %}


### PR DESCRIPTION
Follow-up to the carousel restyle (#535): **center the featured-cards block on the page** and **move the prev/next chevrons outside the cards**, into the side gutters.

## Changes
- **`landing.html`** — wrapped `prev · viewport · next` in a new `.highlights-stage` flex row; the chevrons are now siblings of the viewport (in the gutters), not overlaid inside it.
- **`input.css`** —
  - `.highlights-stage { display: flex; align-items: center; justify-content: center; gap: 12px }` — centers the rail on the page and puts the chevrons beside it, vertically centered.
  - `.highlights-arrow` is now a static flex item: dropped `position: absolute`/`top`/`translate`/`z-index`, the translucent blur background and the `--prev`/`--next` offsets; it's a plain circular surface button.
  - `.highlights-head` → `justify-content: center` so the "★ Destaques" title centers above the cards.
  - `.highlights-viewport` keeps `overflow: hidden` + the `6px 0` hover-clip headroom and gains `min-width: 0` to shrink below 3 cards on narrow screens.

## Verification
- Rendered structure: `stage > [prev, viewport>track, next]` in order; **no** arrow inside the viewport.
- Served CSS: `.highlights-stage`/`.highlights-head` are centered flex; `.highlights-arrow` no longer has `position: absolute`.
- clippy + i18n-check green.

> Structural + compiled-CSS verification only (no headless browser). Worth a live eyeball for the gutter spacing and centering across widths.

🤖 Generated with [Claude Code](https://claude.com/claude-code)