### PR TITLE
docs: README screenshots + site audit fixes (idle footprint, stale alt-text)

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,6 +17,10 @@ is megabytes, not hundreds of megabytes, and startup is instant.
 📖 **Documentation: <https://strategicprojects.github.io/ruscker/>**
 (install · migrating from ShinyProxy · configuration · admin · deploy).
 
+<p align="center">
+  <img src="book/src/images/landing.png" alt="The Ruscker landing page: a portal of app cards with a Featured carousel at the top, plus search and type/access filters." width="860">
+</p>
+
 ## How it works
 
 Visitors and API clients hit one Ruscker process. It serves the landing
@@ -44,7 +48,7 @@ dashboard, and load balancing on top.
 |                        | ShinyProxy   | Shiny Server Free | **Ruscker**          |
 |------------------------|--------------|-------------------|----------------------|
 | Runtime                | JVM          | R process         | single Rust binary   |
-| Idle memory            | 300–500 MB   | —                 | **~16 MB**           |
+| Idle memory            | 300–500 MB   | —                 | **~14 MB**           |
 | Dependencies           | JVM          | R                 | none (static binary) |
 | Web admin panel        | ✗            | ✗                 | ✓                    |
 | Live monitoring dashboard | ✗         | ✗                 | ✓                    |
@@ -82,7 +86,7 @@ low tens:
 
 [cosign-signed]: https://strategicprojects.github.io/ruscker/installation.html#verifying-release-artifacts
 
-> **~540 MB → ~16 MB idle** — roughly a 30× cut, on the same machine
+> **~540 MB → ~14 MB idle** — roughly a 38× cut, on the same machine
 > serving the same apps. A real 31-spec config migrated with **no
 > unsupported features**, and apps spawn on demand.
 
@@ -111,6 +115,16 @@ What's in the box:
 300+ unit + integration tests run green on `cargo test` (no Docker
 required); extra feature-gated suites exercise a real Docker daemon
 (`docker-it`) and a full proxy + WebSocket end-to-end run (`e2e`).
+
+<p align="center">
+  <img src="book/src/images/admin-apps.png" alt="The admin Apps table: each spec row with kind/state, and a featured star in the Actions column to toggle landing-page highlighting inline." width="860">
+  <br><em>Apps catalogue — every spec field editable from the web UI, no YAML.</em>
+</p>
+
+<p align="center">
+  <img src="book/src/images/admin-dashboard.png" alt="The live monitoring dashboard: aggregate cards plus a per-replica table with CPU sparklines, memory, sessions and stop/restart/logs actions, streamed over SSE." width="860">
+  <br><em>Live monitoring dashboard — per-replica CPU/memory over Server-Sent Events.</em>
+</p>
 
 ## Install
 

--- a/book/src/roadmap.md
+++ b/book/src/roadmap.md
@@ -5,7 +5,7 @@ production-ready and horizontally scalable. Phase 8 (external auth) is
 the main optional, demand-driven work left. For what changed in each
 release, see the [release notes](./news.md).
 
-![Roadmap timeline: phases 0–7 are done — 0 to 5 shipped in v0.1.0 (scaffolding, landing page, persistence + admin CRUD, proxy + Docker backend, monitoring dashboard, production polish); phase 6 (multi-host scheduling, app visibility, sub-path mounting) across v0.1.1–v0.1.2; phase 7 (HA / multi-instance) in v0.1.1. The latest release v0.1.31 adds demo forks, URL-rewrite modernization, unified credentials, media library, portal logos, and security + perf fixes. Phase 8 (external auth) is planned and optional.](images/roadmap.svg)
+![Roadmap timeline: phases 0–7 are done — 0 to 5 shipped in v0.1.0 (scaffolding, landing page, persistence + admin CRUD, proxy + Docker backend, monitoring dashboard, production polish); phase 6 (multi-host scheduling, app visibility, sub-path mounting) across v0.1.1–v0.1.2; phase 7 (HA / multi-instance) in v0.1.1. Post-1.0 point releases add demo forks, URL-rewrite modernization, unified credentials, the media library, portal logos, admin UX polish, and security + perf fixes. Phase 8 (external auth) is planned and optional.](images/roadmap.svg)
 
 ## Shipped
 


### PR DESCRIPTION
A general staleness pass over the documentation site and README, plus README screenshots — prompted by a `traefik/whoami` question.

## README
- **Added UI screenshots**: the landing page (hero), the admin Apps table, and the live monitoring dashboard (reusing the PNGs added under `book/src/images/`).
- **Idle footprint** `~16 MB` → **`~14 MB`** (the real measured figure, corrected in the book in PR #465) and the cut **30× → 38×**, so the README matches the book.

## Book
- **`roadmap.md`** — the timeline image's alt text said *"The latest release v0.1.31 adds…"*; reworded to *"Post-1.0 point releases add…"* so it doesn't pin a stale version (the page body already says v0.1.45).

## Audit result (no other changes needed)
A full read of `book/src/*.md` + `README.md` + `docs/*.md` against current truth (auto-Docker default, 13-card showcase seed, no `welcome` spec, Homebrew tap, v0.1.45, featured star in Actions, 3-band form, centered carousel) found **everything else accurate**. No broken internal links, no "coming soon" for shipped features, no references to removed features.

## On `traefik/whoami`
Verified: it is **not** a removed feature. `quickstart.md` uses `traefik/whoami` deliberately as a tiny stateless echo image — a "nothing to build" hello-world for the manual-config path. It still works. Left as-is; happy to swap it for a more on-brand minimal image or restructure the quickstart to lead with the `--db` showcase seed if preferred (see PR discussion).

🤖 Generated with [Claude Code](https://claude.com/claude-code)