### PR TITLE
docs(quickstart): lead with the --db showcase seed (demote the manual traefik/whoami example)

### DIFF
--- a/book/src/quickstart.md
+++ b/book/src/quickstart.md
@@ -1,105 +1,111 @@
-# Quickstart — your first app
+# Quickstart — a portal full of demos
 
-From nothing to a running app behind Ruscker in a few minutes. You need
-**Docker** running locally and the `ruscker` binary (see
+From nothing to a portal of **live demos** in a couple of minutes. You
+need **Docker** running locally and the `ruscker` binary (see
 [Installation](./installation.md) — or just `docker run` the image,
 shown below).
 
-## 1. Write a config
+## 1. Run it (the portal seeds itself)
 
-One spec is enough. Save this as `application.yml` — it serves
-`traefik/whoami`, a tiny stateless echo image, so there's nothing to
-build:
+Ruscker reads a config file, but it can be almost empty — the **database
+seeds the demos**. Save this two-line `application.yml`:
 
 ```yaml
 proxy:
   title: My Ruscker
-  bind-address: 0.0.0.0
-  port: 8080
-  specs:
-    - id: hello
-      display-name: Hello
-      description: A stateless echo server.
-      container-image: traefik/whoami:latest
-      port: 80
 ```
+
+Then start it with an admin token and `--db` (the admin database):
+
+```sh
+RUSCKER_ADMIN_TOKEN=$(openssl rand -hex 32) \
+ruscker serve --config application.yml --bind 127.0.0.1:8080 --db ruscker.db
+```
+
+- Ruscker **auto-connects to Docker** when the daemon socket is
+  reachable, so app containers spawn out of the box. Pass `--no-docker`
+  to run landing-only (then `/app/*` returns 503); pass `--docker` to
+  make a failed connect a fatal error instead of falling back to
+  landing-only (useful for a remote daemon).
+- **On first boot with `--db`, Ruscker seeds 13 showcase cards** — one
+  live demo per supported framework (Shiny, Streamlit, Dash, Voilà,
+  Jupyter, RStudio, …) plus external links for the rest — and seeds the
+  framework logos into the Media library. The seed is idempotent; cards
+  you delete stay deleted on subsequent boots.
+
+![The seeded landing page on first boot: a Featured carousel of highlighted apps above a filterable grid of showcase cards (Shiny, Streamlit, Dash, Jupyter, RStudio, …).](images/landing.png)
+
+Prefer the container image? Mount the Docker socket and a volume for the
+DB (the image is cosign-signed; `:latest` tracks the current release):
+
+```sh
+docker run --rm -p 8080:8080 \
+  -e RUSCKER_ADMIN_TOKEN=$(openssl rand -hex 32) \
+  -v "$PWD/application.yml:/etc/ruscker/application.yml:ro" \
+  -v "$PWD/ruscker.db:/data/ruscker.db" \
+  -v /var/run/docker.sock:/var/run/docker.sock \
+  ghcr.io/strategicprojects/ruscker:latest \
+  serve --config /etc/ruscker/application.yml --bind 0.0.0.0:8080 \
+        --docker --db /data/ruscker.db
+```
+
+## 2. Open it
+
+| URL | What you get |
+|---|---|
+| <http://127.0.0.1:8080/> | the portal — the seeded showcase cards |
+| <http://127.0.0.1:8080/app/shiny/> | a live demo — Ruscker spawns the container on first hit |
+| <http://127.0.0.1:8080/admin> | the admin panel (with `RUSCKER_ADMIN_TOKEN` set) |
+| <http://127.0.0.1:8080/healthz> | liveness (always `200`) |
+
+Click any live-demo card to see on-demand container spawn in action,
+then watch the [admin dashboard](./admin.md) to see the replica start,
+serve, and stop. The first request to an app spawns its container; it's
+reaped automatically once idle.
+
+## 3. Add your own app
+
+Two ways, neither of which needs a restart for the admin route:
+
+- **From the admin panel** (recommended) — go to `/admin` → **Apps** →
+  **Add app**, pick a type, fill the form (there's a live card preview),
+  and **Save**. Everything is editable here — image, ports, scaling,
+  resource limits, access — without touching YAML.
+- **In YAML** — add a spec to your config. A tiny stateless example
+  (`traefik/whoami` is a public echo image, so there's nothing to
+  build):
+
+  ```yaml
+  proxy:
+    title: My Ruscker
+    specs:
+      - id: hello
+        display-name: Hello
+        description: A stateless echo server.
+        container-image: traefik/whoami:latest
+        port: 80
+  ```
+
+  Validate before (re)starting — it catches typos and unsupported
+  features:
+
+  ```sh
+  ruscker validate application.yml
+  # add --strict-compat to flag any ShinyProxy feature Ruscker would ignore
+  ```
 
 The schema is ShinyProxy-compatible, so an existing `application.yml`
 works here too — see [Migrating from ShinyProxy](./migrating.md).
 
-## 2. Validate it
-
-Catch typos and unsupported features before starting:
-
-```sh
-ruscker validate application.yml
-# add --strict-compat to flag any ShinyProxy feature Ruscker would ignore
-```
-
-## 3. Run it
-
-```sh
-ruscker serve --config application.yml --bind 127.0.0.1:8080
-```
-
-Ruscker **auto-connects to Docker** when the daemon socket is reachable, so
-app containers spawn out of the box. Pass `--no-docker` to run landing-only
-(then `/app/*` returns 503); pass `--docker` to make a failed connect a fatal
-error instead of falling back to landing-only (useful for a remote daemon). To
-unlock the admin panel, also pass an admin token and a DB:
-
-```sh
-RUSCKER_ADMIN_TOKEN=$(openssl rand -hex 32) \
-ruscker serve --config application.yml --bind 127.0.0.1:8080 \
-  --docker --db ruscker.db
-```
-
-On first boot with `--db`, Ruscker seeds 13 showcase cards into the
-portal automatically — one live demo per supported framework (Shiny,
-Streamlit, Dash, Voilà, Jupyter, RStudio, …) plus external links for
-the rest. The seed is idempotent; cards you delete stay deleted on
-subsequent boots. Framework logos are also seeded into the Media
-library so they appear in the image picker alongside your own uploads.
-
-Prefer the container image? Mount your config and the Docker socket
-(the image is cosign-signed; `:latest` tracks the current release):
-
-```sh
-docker run --rm -p 8080:8080 \
-  -v "$PWD/application.yml:/etc/ruscker/application.yml:ro" \
-  -v /var/run/docker.sock:/var/run/docker.sock \
-  ghcr.io/strategicprojects/ruscker:latest \
-  serve --config /etc/ruscker/application.yml --bind 0.0.0.0:8080 --docker
-```
-
-## 4. Open it
-
-| URL | What you get |
-|---|---|
-| <http://127.0.0.1:8080/> | the landing page — one card per spec |
-| <http://127.0.0.1:8080/app/hello/> | the app — Ruscker spawns the container on first hit |
-| <http://127.0.0.1:8080/admin> | the admin panel (with `RUSCKER_ADMIN_TOKEN` set) |
-| <http://127.0.0.1:8080/healthz> | liveness (always `200`) |
-
-The first request to `/app/hello/` spawns a container on demand; it's
-reaped automatically once idle.
-
 ## What just happened
 
-Ruscker rendered the landing page from your config, and on the first
-request to the app it asked Docker to start `traefik/whoami`, routed you
-to it, and will reap it when idle. For a real interactive app — Shiny,
-Streamlit, Dash, Voilà, Jupyter, RStudio — the model is the same:
-Ruscker adds sticky sessions and WebSocket forwarding automatically.
-For stateless APIs (Plumber2, FastAPI) it load-balances across replicas
-with no sticky overhead.
-
-If you started with `--db`, the landing page already shows the seeded
-showcase cards. Click any live-demo card to see on-demand container
-spawn in action, then watch the [admin dashboard](./admin.md) to see
-the replica start, serve, and stop.
-
-![The seeded landing page on first boot: a Featured carousel of highlighted apps above a filterable grid of showcase cards (Shiny, Streamlit, Dash, Jupyter, RStudio, …).](images/landing.png)
+Ruscker rendered the landing page, seeded the showcase catalogue into the
+database, and on the first request to an app asked Docker to start its
+container, routed you to it, and will reap it when idle. For interactive
+apps — Shiny, Streamlit, Dash, Voilà, Jupyter, RStudio — Ruscker adds
+sticky sessions and WebSocket forwarding automatically. For stateless
+APIs (Plumber2, FastAPI) it load-balances across replicas with no sticky
+overhead.
 
 See [What Ruscker can serve](./use-cases.md) for the full framework
 list and [Configuration](./configuration.md) for every spec field


### PR DESCRIPTION
Restructures the Quickstart so it **leads with the modern `--db` showcase experience** instead of a hand-written `traefik/whoami` config — addressing the "we don't really use traefik/whoami" feedback by demoting it to an optional example.

## New flow
1. **Run it (the portal seeds itself)** — a two-line `application.yml` (`proxy: title:`) + `--db` boots a portal of **13 live showcase demos**, Docker auto-connected. Landing screenshot right here. The `docker run` form (with a DB volume) is shown alongside.
2. **Open it** — the URL table; click a card → watch the dashboard.
3. **Add your own app** — **admin panel first** (recommended, live preview, no YAML), then the **YAML** option, which is where the minimal `traefik/whoami` echo-image example now lives (clearly framed as "a public echo image, nothing to build").
4. What just happened / Next steps — kept, updated to mention the seeded catalogue.

## Why it's accurate
Verified against the binary:
- `serve` with **no** config file errors out → a config is still required, so the quickstart keeps a (minimal) one.
- `serve --config <2-line file> --db ruscker.db` → **13 showcase specs seeded, 13 cards on the landing**.

`traefik/whoami` mentions dropped from 3 to 1 (now a single optional example). `mdbook build` is clean; internal links/anchors unchanged.

🤖 Generated with [Claude Code](https://claude.com/claude-code)