### PR TITLE
security: revoke live sessions on role change / delete / password reset (#544)

### DIFF
--- a/crates/ruscker-admin/src/admin_sessions_pg.rs
+++ b/crates/ruscker-admin/src/admin_sessions_pg.rs
@@ -326,6 +326,23 @@ impl AdminSessionStore for PostgresAdminSessionStore {
             },
         );
     }
+
+    async fn revoke_by_actor(&self, actor: &str) {
+        // Authoritative delete of every session for this user (#544).
+        if let Err(e) = sqlx::query("DELETE FROM admin_sessions WHERE actor = $1")
+            .bind(actor)
+            .execute(&self.pool)
+            .await
+        {
+            warn!(error = ?e, "admin session revoke-by-actor DELETE failed");
+        }
+        // Evict this node's positive cache entries for the actor so it
+        // stops serving them immediately; negative tombstones and other
+        // users' entries stay. Sibling nodes ride the cache_ttl window,
+        // same as logout.
+        self.cache
+            .retain(|_, e| e.info.as_ref().and_then(|i| i.actor.as_deref()) != Some(actor));
+    }
 }
 
 // ── Tests ─────────────────────────────────────────────────────────────

--- a/crates/ruscker-admin/src/auth.rs
+++ b/crates/ruscker-admin/src/auth.rs
@@ -215,6 +215,13 @@ pub trait AdminSessionStore: Send + Sync + std::fmt::Debug {
 
     /// Invalidate a session (logout / forced revoke).
     async fn remove(&self, id: &str);
+
+    /// Invalidate **every** live session belonging to `actor` (the DB
+    /// username). Called when a user is demoted, deleted, or has their
+    /// password reset, so a stale session can't keep the old (possibly
+    /// elevated) role until it expires (#544). Break-glass token
+    /// sessions (`actor == None`) are never matched.
+    async fn revoke_by_actor(&self, actor: &str);
 }
 
 /// Single-node admin session store. The default; replaced by
@@ -285,6 +292,13 @@ impl AdminSessionStore for InMemoryAdminSessionStore {
 
     async fn remove(&self, id: &str) {
         self.sessions.remove(id);
+    }
+
+    async fn revoke_by_actor(&self, actor: &str) {
+        // Drop every entry whose actor matches; token sessions (None)
+        // never match a username, so they're left alone.
+        self.sessions
+            .retain(|_, e| e.actor.as_deref() != Some(actor));
     }
 }
 
@@ -601,6 +615,29 @@ mod tests {
         assert!(
             s.validate(&id).await.is_none(),
             "removed (logged-out) session is invalid"
+        );
+    }
+
+    #[tokio::test]
+    async fn admin_sessions_revoke_by_actor() {
+        let s = InMemoryAdminSessionStore::default_policy();
+        // Two sessions for alice (e.g. two browsers), one for bob, one token.
+        let a1 = s.create(Role::Admin, Some("alice".into())).await;
+        let a2 = s.create(Role::Admin, Some("alice".into())).await;
+        let bob = s.create(Role::Editor, Some("bob".into())).await;
+        let token = s.create(Role::Admin, None).await;
+
+        s.revoke_by_actor("alice").await;
+
+        assert!(s.validate(&a1).await.is_none(), "alice session 1 revoked");
+        assert!(s.validate(&a2).await.is_none(), "alice session 2 revoked");
+        assert!(
+            s.validate(&bob).await.is_some(),
+            "another user's session is untouched"
+        );
+        assert!(
+            s.validate(&token).await.is_some(),
+            "break-glass token session (actor=None) is never matched"
         );
     }
 

--- a/crates/ruscker-admin/src/routes/admin/users.rs
+++ b/crates/ruscker-admin/src/routes/admin/users.rs
@@ -212,7 +212,13 @@ async fn set_role(
         return redirect_flash("last-admin");
     }
     match db::users::set_role(pool, &username, new_role, Some(admin.actor())).await {
-        Ok(()) => redirect_flash("saved"),
+        Ok(()) => {
+            // Kick the user's live sessions so the new role takes effect
+            // now, not after the cookie expires (#544) — a demotion must
+            // drop elevated access immediately.
+            state.admin_sessions.revoke_by_actor(&username).await;
+            redirect_flash("saved")
+        }
         Err(e) => {
             tracing::warn!(error = ?e, %username, "set role failed");
             redirect_flash("bad-input")
@@ -240,7 +246,11 @@ async fn reset_password(
     // Admin-assigned password ⇒ prompt the user to change it next login.
     match db::users::set_password(pool, &username, &form.password, true, Some(admin.actor())).await
     {
-        Ok(()) => redirect_flash("saved"),
+        Ok(()) => {
+            // A password reset must invalidate existing sessions (#544).
+            state.admin_sessions.revoke_by_actor(&username).await;
+            redirect_flash("saved")
+        }
         Err(e) => {
             tracing::warn!(error = ?e, %username, "reset password failed");
             redirect_flash("bad-input")
@@ -261,7 +271,11 @@ async fn delete(
         return redirect_flash("last-admin");
     }
     match db::users::delete(pool, &username, Some(admin.actor())).await {
-        Ok(()) => redirect_flash("deleted"),
+        Ok(()) => {
+            // A deleted user must lose access now, not at session expiry (#544).
+            state.admin_sessions.revoke_by_actor(&username).await;
+            redirect_flash("deleted")
+        }
         Err(e) => {
             tracing::warn!(error = ?e, %username, "delete user failed");
             redirect_flash("bad-input")


### PR DESCRIPTION
Closes #544.

The admin session store baked the role into the session at login and never re-read it from the DB, so **demoting, deleting, or resetting a user's password left their existing session valid — with the old role — until it expired (~24h)**. De-provisioning and mistake-correction had a 24h lag.

## Change
- New trait method `AdminSessionStore::revoke_by_actor(actor)`:
  - **in-memory** — `retain` out every entry whose `actor` matches; break-glass token sessions (`actor == None`) are never matched.
  - **Postgres** — `DELETE FROM admin_sessions WHERE actor = $1`, then evict this node's positive cache entries for that actor (sibling nodes ride the existing `cache_ttl`, exactly like logout).
- Called on success from `set_role` (demotion takes effect now), `reset_password` (a reset kicks live sessions), and user `delete` (a removed user loses access now) in `routes/admin/users.rs`.

## Verification
- **Unit test** (`admin_sessions_revoke_by_actor`): alice's two sessions are revoked; another user's session and a token session (`actor=None`) are untouched.
- **Real smoke** (rebuilt binary): a **deleted** user and a **demoted** editor both go from `200` to `303` (bounced to login) on the very next request.
- `cargo test -p ruscker-admin` green, `clippy -D warnings` clean, i18n parity OK.

Complements #517 (RBAC/ownership).

🤖 Generated with [Claude Code](https://claude.com/claude-code)