### PR TITLE
feat(packaging): enable the admin catalog (--db) by default in the systemd unit

### DIFF
--- a/book/src/deploying.md
+++ b/book/src/deploying.md
@@ -10,8 +10,10 @@ with an existing ShinyProxy.
 sudo apt install ./ruscker_<version>_amd64.deb
 ```
 
-Put your apps in `/etc/ruscker/application.yml` and your secrets in
-`/etc/ruscker/ruscker.env` (read by the unit):
+Manage your **apps, landing page and users in the admin panel** at
+`/admin` — the unit runs with `--db`, so the catalog is live out of the
+box. `application.yml` only carries **deployment** settings; put your
+**secrets** in `/etc/ruscker/ruscker.env` (read by the unit):
 
 ```ini
 RUSCKER_ADMIN_TOKEN=...        # openssl rand -hex 32
@@ -23,7 +25,14 @@ DOCKER_REGISTRY_PASSWORD=...   # referenced as ${DOCKER_REGISTRY_PASSWORD} in th
 ## 2. Enable the container backend
 
 The shipped unit serves landing + admin + proxy but not the `--docker`
-backend. Enable it with a drop-in (so upgrades don't clobber it):
+backend. The easy path is the helper, which writes the drop-in for you
+(preserving your `--bind`/`--config`/`--db`):
+
+```sh
+sudo ruscker-enable-docker
+```
+
+Or do it by hand with a drop-in (so upgrades don't clobber it):
 
 ```sh
 sudo systemctl edit ruscker

--- a/book/src/installation.md
+++ b/book/src/installation.md
@@ -21,10 +21,13 @@ This:
 - installs `/usr/bin/ruscker`,
 - creates a `ruscker` system user,
 - installs a hardened `ruscker.service` unit and enables + starts it,
-- drops an example config at `/etc/ruscker/application.yml` and a
+- drops a minimal config at `/etc/ruscker/application.yml` and a
   secrets file at `/etc/ruscker/ruscker.env`,
 - **generates a unique admin token on first install and prints it
-  once** (there is no default password).
+  once** (there is no default password),
+- runs with the **admin catalog enabled** (`--db
+  /var/lib/ruscker/ruscker.db`), so the admin panel works out of the box
+  and a set of showcase apps seeds on first boot.
 
 ```sh
 systemctl status ruscker
@@ -32,10 +35,16 @@ curl http://localhost:8080/healthz
 sudo grep RUSCKER_ADMIN_TOKEN /etc/ruscker/ruscker.env   # your admin token
 ```
 
-Edit `/etc/ruscker/application.yml`, put secrets in
-`/etc/ruscker/ruscker.env`, then `sudo systemctl restart ruscker`. See
-[Deploying in production](./deploying.md) to enable the `--docker`
-backend and put it behind nginx.
+Log in at `/admin` with the printed token to manage **apps, the landing
+page and users** — that's where day-to-day configuration lives (stored
+in the catalog DB, not the YAML). `application.yml` holds **deployment**
+settings; put secrets in `/etc/ruscker/ruscker.env`. After editing either
+file, `sudo systemctl restart ruscker`.
+
+To actually run the demo apps (and your own containers) enable the Docker
+backend: `sudo ruscker-enable-docker`. See [Deploying in
+production](./deploying.md) for nginx + TLS, and
+[Configuration](./configuration.md) for what lives where.
 
 ### Uninstall & reset
 

--- a/packaging/application.example.yml
+++ b/packaging/application.example.yml
@@ -1,7 +1,10 @@
 # Ruscker configuration — installed at /etc/ruscker/application.yml.
 #
-# This is a minimal, working starting point. Edit it for your apps,
-# then `systemctl restart ruscker`. Full schema reference:
+# This file holds DEPLOYMENT settings only. Your apps, landing page and
+# users are managed in the admin panel at /admin (the systemd unit runs
+# with --db, so the catalog is live out of the box) — you don't need to
+# add specs here. It stays as the ShinyProxy-compatible import format and
+# for GitOps if you prefer YAML. Full schema reference:
 # https://github.com/StrategicProjects/ruscker/blob/main/docs/YAML_SCHEMA.md
 #
 # NEVER put secrets here. Use ${ENV_VAR} interpolation and set the

--- a/packaging/systemd/ruscker.service
+++ b/packaging/systemd/ruscker.service
@@ -15,10 +15,13 @@ Group=ruscker
 # RUSCKER_MASTER_KEY, RUSCKER_COOKIE_KEY, DOCKER_REGISTRY_PASSWORD, …
 # The leading `-` makes systemd tolerate the file being absent/empty.
 EnvironmentFile=-/etc/ruscker/ruscker.env
-# Default command: landing + admin + proxy. Add `--docker` to enable
-# the container backend (see /usr/share/doc/ruscker/README.Debian),
-# and `--db /var/lib/ruscker/ruscker.db` to persist the admin catalog.
-ExecStart=/usr/bin/ruscker serve --config /etc/ruscker/application.yml --bind 0.0.0.0:8080
+# Default command: landing + admin + proxy, with the SQLite catalog at
+# /var/lib/ruscker/ruscker.db — so the admin panel works and the showcase
+# apps seed on first boot, no YAML editing required. Add `--docker` to
+# enable the container backend (the `ruscker` user then also needs Docker
+# access — run `sudo ruscker-enable-docker`, see
+# /usr/share/doc/ruscker/README.Debian).
+ExecStart=/usr/bin/ruscker serve --config /etc/ruscker/application.yml --bind 0.0.0.0:8080 --db /var/lib/ruscker/ruscker.db
 Restart=on-failure
 RestartSec=5s
 


### PR DESCRIPTION
Makes a fresh `.deb` install match the DB-first story the docs now tell.

## The gap
The shipped `ruscker.service` ran:
```
ExecStart=/usr/bin/ruscker serve --config /etc/ruscker/application.yml --bind 0.0.0.0:8080
```
No `--db` → on a default install the **admin panel returns 503** and the **showcase seed never runs**; apps could only come from `application.yml`. That directly contradicts the quickstart + configuration docs ("manage apps in the admin panel; the portal seeds itself").

## Change
- Add `--db /var/lib/ruscker/ruscker.db` to the default `ExecStart`. Safe: the unit already has `StateDirectory=ruscker` + `ReadWritePaths=/var/lib/ruscker`, and `ruscker-enable-docker` already reads the effective ExecStart and adds/keeps `--db`, so enabling Docker composes cleanly.
- **`--docker` stays opt-in** — granting the `ruscker` user Docker-socket access is a deliberate security trade-off (`sudo ruscker-enable-docker`).
- Docs (`installation.md`, `deploying.md`) + the packaged `application.example.yml` header updated to the two-layer framing: apps/landing/users in the admin panel; `application.yml` = deployment settings + ShinyProxy import.

## Result on a fresh install
Admin panel live out of the box (gated by the auto-generated token), 13 showcase cards seeded, landing populated — no YAML editing. The operator enables Docker when ready to actually spawn app containers.

## Verified
- `application.example.yml` still validates. `mdbook build` clean. ExecStart confirmed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)