### PR TITLE
feat(admin): access-counter follow-ups — daily sparkline + API per-request counting (#549)

### DIFF
--- a/crates/ruscker-admin/assets/tailwind/input.css
+++ b/crates/ruscker-admin/assets/tailwind/input.css
@@ -822,11 +822,19 @@ body {
   text-align: right;
   white-space: nowrap;
 }
-/* Access counter column (#549) — tabular figures so totals line up. */
+/* Access counter column (#549) — tabular figures so totals line up,
+   with a faint daily-usage sparkline beside the total. */
 .admin-table .access-cell {
   font-variant-numeric: tabular-nums;
   color: var(--text-muted);
+  white-space: nowrap;
 }
+.admin-table .access-cell .access-num { display: inline-block; min-width: 2ch; }
+.admin-table .access-cell .sparkline-wrap {
+  display: inline-block; vertical-align: middle; margin-left: 8px;
+  color: var(--color-teal-600);
+}
+.admin-table .access-cell .sparkline { display: block; opacity: 0.8; }
 .pill {
   display: inline-flex; align-items: center;
   padding: 2px 8px;

--- a/crates/ruscker-admin/src/db/spec_access.rs
+++ b/crates/ruscker-admin/src/db/spec_access.rs
@@ -69,6 +69,85 @@ pub async fn totals(db: &ConfigDb) -> Result<HashMap<String, i64>> {
     Ok(rows.into_iter().collect())
 }
 
+/// Per-spec daily series for the last `days` days (oldest → newest),
+/// 0-filled for days with no access. Drives the admin sparkline (#549
+/// follow-up). Specs with no access in the window are absent.
+pub async fn recent_series(db: &ConfigDb, days: usize) -> Result<HashMap<String, Vec<i64>>> {
+    let today = chrono::Utc::now().date_naive();
+    // Day keys oldest → newest, e.g. [d-13, …, d-1, d] for days=14.
+    let keys: Vec<String> = (0..days)
+        .rev()
+        .map(|i| {
+            (today - chrono::Duration::days(i as i64))
+                .format("%Y-%m-%d")
+                .to_string()
+        })
+        .collect();
+    let since = keys.first().cloned().unwrap_or_default();
+
+    let rows: Vec<(String, String, i64)> = match db {
+        ConfigDb::Sqlite(pool) => {
+            sqlx::query_as("SELECT spec_id, day, count FROM spec_access WHERE day >= ?")
+                .bind(&since)
+                .fetch_all(pool)
+                .await
+                .context("spec access series (sqlite)")?
+        }
+        ConfigDb::Postgres(pool) => {
+            sqlx::query_as("SELECT spec_id, day, count FROM spec_access WHERE day >= $1")
+                .bind(&since)
+                .fetch_all(pool)
+                .await
+                .context("spec access series (postgres)")?
+        }
+    };
+
+    let mut grouped: HashMap<String, HashMap<String, i64>> = HashMap::new();
+    for (spec_id, day, count) in rows {
+        grouped.entry(spec_id).or_default().insert(day, count);
+    }
+    let out = grouped
+        .into_iter()
+        .map(|(spec, daymap)| {
+            let series = keys
+                .iter()
+                .map(|k| daymap.get(k).copied().unwrap_or(0))
+                .collect();
+            (spec, series)
+        })
+        .collect();
+    Ok(out)
+}
+
+/// Render a tiny inline-SVG line sparkline from a daily series. Returns
+/// an empty string when there's nothing to show (all-zero or empty), so
+/// the template can skip it. The SVG is generated here from plain numbers
+/// — no user input — so it's safe to render unescaped.
+pub fn sparkline_svg(values: &[i64]) -> String {
+    if values.len() < 2 || values.iter().all(|&v| v == 0) {
+        return String::new();
+    }
+    let (w, h, pad) = (64.0_f64, 18.0_f64, 1.5_f64);
+    let max = (*values.iter().max().unwrap_or(&1)).max(1) as f64;
+    let step = w / (values.len() - 1) as f64;
+    let points = values
+        .iter()
+        .enumerate()
+        .map(|(i, &v)| {
+            let x = i as f64 * step;
+            let y = h - pad - (v as f64 / max) * (h - 2.0 * pad);
+            format!("{x:.1},{y:.1}")
+        })
+        .collect::<Vec<_>>()
+        .join(" ");
+    format!(
+        "<svg viewBox=\"0 0 {w:.0} {h:.0}\" width=\"{w:.0}\" height=\"{h:.0}\" \
+         class=\"sparkline\" aria-hidden=\"true\"><polyline fill=\"none\" \
+         stroke=\"currentColor\" stroke-width=\"1.5\" stroke-linejoin=\"round\" \
+         stroke-linecap=\"round\" points=\"{points}\"/></svg>"
+    )
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
@@ -91,5 +170,24 @@ mod tests {
         assert_eq!(totals.get("a"), Some(&3));
         assert_eq!(totals.get("b"), Some(&1));
         assert_eq!(totals.get("never"), None, "unseen spec absent from totals");
+    }
+
+    #[tokio::test]
+    async fn recent_series_aligns_to_days_and_zero_fills() {
+        let db = mem_db().await;
+        record(&db, "a").await.unwrap();
+        record(&db, "a").await.unwrap();
+        let series = recent_series(&db, 7).await.unwrap();
+        let a = series.get("a").expect("a present");
+        assert_eq!(a.len(), 7);
+        assert_eq!(*a.last().unwrap(), 2, "today's bucket is the last value");
+        assert!(a[..6].iter().all(|&v| v == 0), "earlier days zero-filled");
+    }
+
+    #[test]
+    fn sparkline_empty_when_flat_else_polyline() {
+        assert_eq!(sparkline_svg(&[]), "");
+        assert_eq!(sparkline_svg(&[0, 0, 0]), "");
+        assert!(sparkline_svg(&[0, 1, 3, 2]).contains("<polyline"));
     }
 }

--- a/crates/ruscker-admin/src/routes/admin/specs.rs
+++ b/crates/ruscker-admin/src/routes/admin/specs.rs
@@ -100,6 +100,10 @@ pub struct SpecRow {
     /// SUM, not a column on `specs`. `0` when never accessed.
     #[sqlx(default)]
     pub access_count: i64,
+    /// Inline-SVG daily-usage sparkline (#549 follow-up), rendered from the
+    /// last days' buckets. Empty when there's no usage to draw.
+    #[sqlx(default)]
+    pub trend_svg: String,
 }
 
 /// Post-import flash, carried back via query params on the
@@ -218,10 +222,20 @@ async fn index(
         }
     };
 
-    // Access totals (#549) — a `spec_access` SUM per spec; absent ⇒ 0.
+    // Access totals (#549) — a `spec_access` SUM per spec; absent ⇒ 0 —
+    // and the last 14 days' series for the sparkline.
     let access = crate::db::spec_access::totals(database)
         .await
         .unwrap_or_default();
+    let series = crate::db::spec_access::recent_series(database, 14)
+        .await
+        .unwrap_or_default();
+    let spark = |id: &str| {
+        series
+            .get(id)
+            .map(|s| crate::db::spec_access::sparkline_svg(s))
+            .unwrap_or_default()
+    };
 
     // Featured flag lives in `config_json`, not a column — fill it from a
     // single `list_all` pass so the table's star toggle (#521) shows state.
@@ -237,6 +251,7 @@ async fn index(
         for row in &mut specs {
             row.featured = featured.contains(&row.id);
             row.access_count = access.get(&row.id).copied().unwrap_or(0);
+            row.trend_svg = spark(&row.id);
         }
     }
 
@@ -272,6 +287,7 @@ async fn index(
                 config_only: true,
                 featured: s.is_featured(),
                 access_count: access.get(&s.id).copied().unwrap_or(0),
+                trend_svg: spark(&s.id),
             });
         }
     }

--- a/crates/ruscker-admin/src/routes/proxy.rs
+++ b/crates/ruscker-admin/src/routes/proxy.rs
@@ -584,6 +584,12 @@ async fn forward(
         set_sticky_cookie(&cookies, &state.cookie_key, &session, is_https);
     }
 
+    // API specs aren't sticky, so count each forwarded call here (#549
+    // follow-up). One per request — for an API, each call *is* the access.
+    if spec.kind() == SpecKind::Api {
+        record_access(&state, &spec.id).await;
+    }
+
     let resp = with_cors(resp, cors_on);
     // Keep the in-flight count up until the response body is fully streamed
     // to the client, not just until this handler returns (#424).

--- a/crates/ruscker-admin/templates/admin/specs.html
+++ b/crates/ruscker-admin/templates/admin/specs.html
@@ -105,7 +105,10 @@
           {% if spec.config_only %}
           <td class="text-[color:var(--text-faint)]">—</td>
           <td class="text-[color:var(--text-faint)]">—</td>
-          <td class="access-cell">{% if spec.access_count > 0 %}{{ spec.access_count }}{% else %}<span class="text-[color:var(--text-faint)]">0</span>{% endif %}</td>
+          <td class="access-cell">
+            <span class="access-num">{% if spec.access_count > 0 %}{{ spec.access_count }}{% else %}<span class="text-[color:var(--text-faint)]">0</span>{% endif %}</span>
+            {% if !spec.trend_svg.is_empty() %}<span class="sparkline-wrap" title="{{ self.t("admin-specs-col-access-help") }}">{{ spec.trend_svg|safe }}</span>{% endif %}
+          </td>
           <td class="actions-cell">
             {# Featured star (#521) — read-only for config-defined specs (the
                flag lives in the YAML file). Inline SVG, not a font glyph: the
@@ -130,7 +133,10 @@
           {% else %}
           <td class="text-[color:var(--text-muted)]">{{ spec.updated_at.format("%d/%m/%Y %H:%M") }}</td>
           <td class="text-[color:var(--text-muted)]">v{{ spec.version }}</td>
-          <td class="access-cell">{% if spec.access_count > 0 %}{{ spec.access_count }}{% else %}<span class="text-[color:var(--text-faint)]">0</span>{% endif %}</td>
+          <td class="access-cell">
+            <span class="access-num">{% if spec.access_count > 0 %}{{ spec.access_count }}{% else %}<span class="text-[color:var(--text-faint)]">0</span>{% endif %}</span>
+            {% if !spec.trend_svg.is_empty() %}<span class="sparkline-wrap" title="{{ self.t("admin-specs-col-access-help") }}">{{ spec.trend_svg|safe }}</span>{% endif %}
+          </td>
           <td class="actions-cell">
             {# Featured star (#521): inline toggle, solid when featured, right
                in the actions column. URL + titles ride in `data-*`


### PR DESCRIPTION
Two #549 follow-ups (as picked): a **daily-usage sparkline** in the admin and **API per-request counting**.

## API counting
API specs aren't sticky, so the original PR didn't count them. Now each **forwarded API call** records one access (in `forward()`, after a successful proxy — so errors/503s don't count). For an API, each call *is* the access.

## Daily sparkline
The **Accesses** cell in the Apps table now shows a tiny inline-SVG line of the **last 14 days** next to the total, so you see the trend at a glance.
- `db::spec_access::recent_series(db, days)` — per-spec series, oldest→newest, zero-filled for quiet days.
- `sparkline_svg(&[i64])` — a `<polyline>` built from plain numbers (no user input → safe unescaped); returns empty for all-zero/short series, so specs with no usage just show the count.

## Verification
- Unit: `recent_series_aligns_to_days_and_zero_fills`, `sparkline_empty_when_flat_else_polyline` (+ the existing record/totals test).
- Smoke: 5 hits on a card → **count 5** and a rendered `<polyline class="sparkline">` in the table; quiet specs show no line.
- Gates: `cargo test -p ruscker-admin` green, `clippy --all-targets` clean, i18n parity OK.

## Still open on #549
Public card badge (behind a landing toggle) and a bucket retention/aggregation policy.

🤖 Generated with [Claude Code](https://claude.com/claude-code)