### PR TITLE
feat(admin): selective YAML import — preview apps and choose which to import (#557)

### DIFF
--- a/crates/ruscker-admin/assets/i18n/en/landing.ftl
+++ b/crates/ruscker-admin/assets/i18n/en/landing.ftl
@@ -668,3 +668,17 @@ admin-specs-col-featured = Featured
 admin-specs-featured-on = Featured — click to remove
 admin-specs-featured-off = Not featured — click to feature
 admin-specs-featured-readonly = Featured is set in the config file
+
+# Selective import (#557)
+admin-import-preview-title = Confirm import
+admin-import-preview-help = Pick which apps to import
+admin-import-apps-label = apps
+admin-import-warnings-label = warnings
+admin-import-preview-none = The file contains no apps.
+admin-import-select-all = Select all
+admin-import-col-status = Status
+admin-import-badge-new = New
+admin-import-badge-new-help = Will be created (not in the panel)
+admin-import-badge-update = Updates
+admin-import-badge-update-help = Overwrites an app already in the panel
+admin-import-confirm = Import selected

--- a/crates/ruscker-admin/assets/i18n/es/landing.ftl
+++ b/crates/ruscker-admin/assets/i18n/es/landing.ftl
@@ -668,3 +668,17 @@ admin-specs-col-featured = Destacado
 admin-specs-featured-on = Destacado — clic para quitar
 admin-specs-featured-off = No destacado — clic para destacar
 admin-specs-featured-readonly = El destacado se define en el archivo de config
+
+# Importacion selectiva (#557)
+admin-import-preview-title = Confirmar importación
+admin-import-preview-help = Elige qué apps importar
+admin-import-apps-label = apps
+admin-import-warnings-label = avisos
+admin-import-preview-none = El archivo no contiene ninguna app.
+admin-import-select-all = Seleccionar todo
+admin-import-col-status = Estado
+admin-import-badge-new = Nuevo
+admin-import-badge-new-help = Se creará (no está en el panel)
+admin-import-badge-update = Actualiza
+admin-import-badge-update-help = Sobrescribe una app ya existente en el panel
+admin-import-confirm = Importar seleccionados

--- a/crates/ruscker-admin/assets/i18n/fr/landing.ftl
+++ b/crates/ruscker-admin/assets/i18n/fr/landing.ftl
@@ -668,3 +668,17 @@ admin-specs-col-featured = À la une
 admin-specs-featured-on = En avant — cliquer pour retirer
 admin-specs-featured-off = Pas en avant — cliquer pour mettre en avant
 admin-specs-featured-readonly = Le statut « à la une » vient du fichier de config
+
+# Import selectif (#557)
+admin-import-preview-title = Confirmer l'import
+admin-import-preview-help = Choisissez les apps à importer
+admin-import-apps-label = apps
+admin-import-warnings-label = avertissements
+admin-import-preview-none = Le fichier ne contient aucune app.
+admin-import-select-all = Tout sélectionner
+admin-import-col-status = Statut
+admin-import-badge-new = Nouveau
+admin-import-badge-new-help = Sera créé (absent du panneau)
+admin-import-badge-update = Met à jour
+admin-import-badge-update-help = Écrase une app déjà dans le panneau
+admin-import-confirm = Importer la sélection

--- a/crates/ruscker-admin/assets/i18n/pt/landing.ftl
+++ b/crates/ruscker-admin/assets/i18n/pt/landing.ftl
@@ -672,3 +672,17 @@ admin-specs-col-featured = Destaque
 admin-specs-featured-on = Destacado — clique para remover
 admin-specs-featured-off = Não destacado — clique para destacar
 admin-specs-featured-readonly = Destaque definido no arquivo de config
+
+# Importacao seletiva (#557)
+admin-import-preview-title = Confirmar importação
+admin-import-preview-help = Marque quais apps importar
+admin-import-apps-label = apps
+admin-import-warnings-label = avisos
+admin-import-preview-none = O arquivo não contém nenhum app.
+admin-import-select-all = Selecionar todos
+admin-import-col-status = Situação
+admin-import-badge-new = Novo
+admin-import-badge-new-help = Será criado (não existe no painel)
+admin-import-badge-update = Atualiza
+admin-import-badge-update-help = Sobrescreve um app já existente no painel
+admin-import-confirm = Importar selecionados

--- a/crates/ruscker-admin/src/db/specs.rs
+++ b/crates/ruscker-admin/src/db/specs.rs
@@ -105,6 +105,70 @@ pub async fn import_all(db: &ConfigDb, config: &Config) -> Result<ImportReport> 
     }
 }
 
+/// Import only the specs whose id is in `ids` (selective import, #557).
+/// Unlike [`import_all`], it touches **only the chosen specs** (plus an
+/// audit row) — never the landing customization or the proxy/server
+/// settings — so importing a subset of apps can't clobber a portal the
+/// operator configured in the panel. Mirrors `import_all`'s
+/// per-spec upsert + transaction.
+pub async fn import_selected(
+    db: &ConfigDb,
+    config: &Config,
+    ids: &[String],
+) -> Result<ImportReport> {
+    use std::collections::HashSet;
+    let want: HashSet<&str> = ids.iter().map(String::as_str).collect();
+    let now = Utc::now();
+    match db {
+        ConfigDb::Sqlite(pool) => {
+            let mut tx = pool.begin().await.context("begin import tx")?;
+            let mut report = ImportReport::default();
+            for spec in config
+                .proxy
+                .specs
+                .iter()
+                .filter(|s| want.contains(s.id.as_str()))
+            {
+                tally(&mut report, upsert_in_tx(&mut tx, spec, now).await?);
+            }
+            sqlx::query(
+                "INSERT INTO audit_log (actor, action, target, diff_json, occurred_at)
+                 VALUES (NULL, 'spec.import', NULL, ?, ?)",
+            )
+            .bind(import_diff(&report)?)
+            .bind(now)
+            .execute(&mut *tx)
+            .await
+            .context("audit import")?;
+            tx.commit().await.context("commit import tx")?;
+            Ok(report)
+        }
+        ConfigDb::Postgres(pool) => {
+            let mut tx = pool.begin().await.context("begin import tx")?;
+            let mut report = ImportReport::default();
+            for spec in config
+                .proxy
+                .specs
+                .iter()
+                .filter(|s| want.contains(s.id.as_str()))
+            {
+                tally(&mut report, upsert_in_tx_pg(&mut tx, spec, now).await?);
+            }
+            sqlx::query(
+                "INSERT INTO audit_log (actor, action, target, diff_json, occurred_at)
+                 VALUES (NULL, 'spec.import', NULL, $1, $2)",
+            )
+            .bind(import_diff(&report)?)
+            .bind(now)
+            .execute(&mut *tx)
+            .await
+            .context("audit import")?;
+            tx.commit().await.context("commit import tx")?;
+            Ok(report)
+        }
+    }
+}
+
 #[derive(Debug, PartialEq, Eq)]
 pub enum UpsertOutcome {
     Created,
@@ -656,6 +720,30 @@ mod tests {
         .await
         .unwrap();
         assert_eq!(audit_count.0, 2);
+    }
+
+    #[tokio::test]
+    async fn import_selected_imports_only_the_chosen_subset() {
+        let db = ConfigDb::Sqlite(open_memory().await.unwrap());
+        let cfg = Config::from_yaml(&fixture_yaml()).unwrap();
+        assert!(cfg.proxy.specs.len() >= 2, "fixture needs ≥2 specs");
+        let chosen = cfg.proxy.specs[0].id.clone();
+        let other = cfg.proxy.specs[1].id.clone();
+
+        let r = import_selected(&db, &cfg, std::slice::from_ref(&chosen))
+            .await
+            .unwrap();
+        assert_eq!(r.created, 1, "only the one selected spec is imported");
+        assert_eq!(r.updated + r.unchanged, 0);
+
+        assert!(
+            fetch_one(&db, &chosen).await.unwrap().is_some(),
+            "chosen spec landed in the DB"
+        );
+        assert!(
+            fetch_one(&db, &other).await.unwrap().is_none(),
+            "unselected spec was NOT imported"
+        );
     }
 
     #[tokio::test]

--- a/crates/ruscker-admin/src/routes/admin/specs.rs
+++ b/crates/ruscker-admin/src/routes/admin/specs.rs
@@ -30,6 +30,7 @@ pub fn routes() -> Router<AppState> {
     Router::new()
         .route("/admin/specs", get(index))
         .route("/admin/specs/import", post(import))
+        .route("/admin/specs/import/confirm", post(import_confirm))
         .route(
             "/admin/specs/{id}/featured/toggle",
             post(toggle_featured),
@@ -152,6 +153,41 @@ struct SpecsPage<'a> {
 }
 
 impl<'a> SpecsPage<'a> {
+    fn t(&self, key: &str) -> String {
+        self.locales.t(self.locale, key, None)
+    }
+}
+
+/// One row in the import preview (#557).
+struct ImportRow {
+    id: String,
+    display_name: String,
+    kind: &'static str,
+    /// `true` ⇒ the import would **update** a spec already in the DB;
+    /// `false` ⇒ it's **new**.
+    exists: bool,
+}
+
+#[derive(Template)]
+#[template(path = "admin/import_preview.html")]
+struct ImportPreviewPage<'a> {
+    locale: Locale,
+    theme: Theme,
+    locales: &'a Locales,
+    locales_all: &'static [Locale],
+    base: std::sync::Arc<str>,
+    nav_section: &'static str,
+    role: Role,
+    /// The apps the uploaded YAML carries, in file order.
+    rows: Vec<ImportRow>,
+    /// The original YAML, round-tripped through a hidden field so the
+    /// confirm step is stateless (`${VAR}` stays literal — #260).
+    raw_yaml: String,
+    /// Validation warnings across the whole file (shown as a count).
+    warning_count: usize,
+}
+
+impl<'a> ImportPreviewPage<'a> {
     fn t(&self, key: &str) -> String {
         self.locales.t(self.locale, key, None)
     }
@@ -316,9 +352,15 @@ async fn index(
 /// No separate dry-run/preview step yet (issue #8 wants one) —
 /// import is idempotent and never deletes, so re-importing is
 /// safe; a preview is a follow-up.
+/// Step 1 of the import (#557): parse the uploaded YAML and render a
+/// **preview** — the list of apps it carries, each marked new vs updates,
+/// with a checkbox — so the operator confirms which to import. Nothing is
+/// written to the DB here.
 async fn import(
-    _: RequireEditor,
+    editor: RequireEditor,
     State(state): State<AppState>,
+    loc: Locale,
+    theme: Theme,
     mut multipart: Multipart,
 ) -> Response {
     let Some(pool) = state.db.as_ref() else {
@@ -349,31 +391,112 @@ async fn import(
         return redirect_err("no file selected");
     };
 
-    // Parse (env-interpolation + raw-text credential scan happen
-    // inside from_yaml; parse failure → error flash).
+    // Parse (env-interpolation + raw-text credential scan happen inside
+    // from_yaml; parse failure → error flash).
     let config = match ruscker_config::Config::from_yaml(&raw) {
         Ok(c) => c,
         Err(e) => return redirect_err(&format!("YAML parse failed: {e}")),
     };
-    // Validation warnings (embedded creds, empty names, dup ids…)
-    // — surfaced as a count; non-fatal, import still proceeds.
     let report = ruscker_config::validate::run(&config);
     let warning_count = report.warnings.len() + config.raw_warnings.len();
 
-    match crate::db::specs::import_all(pool, &config).await {
+    // Which ids already exist in the DB (→ "updates", vs "new").
+    let existing: std::collections::HashSet<String> = crate::db::specs::list_all(pool)
+        .await
+        .unwrap_or_default()
+        .into_iter()
+        .map(|s| s.id)
+        .collect();
+
+    let rows: Vec<ImportRow> = config
+        .proxy
+        .specs
+        .iter()
+        .map(|s| ImportRow {
+            exists: existing.contains(&s.id),
+            kind: match s.kind() {
+                ruscker_config::SpecKind::Shiny => "shiny",
+                ruscker_config::SpecKind::InteractiveApp => "interactive",
+                ruscker_config::SpecKind::Api => "api",
+                ruscker_config::SpecKind::External => "external",
+            },
+            display_name: s.display_name.clone().unwrap_or_default(),
+            id: s.id.clone(),
+        })
+        .collect();
+
+    let page = ImportPreviewPage {
+        locale: loc,
+        theme,
+        locales: &state.locales,
+        locales_all: &Locale::ALL,
+        base: state.base_path.clone(),
+        nav_section: "specs",
+        role: editor.role,
+        rows,
+        raw_yaml: raw,
+        warning_count,
+    };
+    super::render(&page)
+}
+
+/// Step 2 of the import (#557): import only the **checked** specs. The
+/// preview form re-posts the original YAML (hidden) plus one `ids` field
+/// per selected spec, as multipart so repeated `ids` collect cleanly.
+async fn import_confirm(
+    _: RequireEditor,
+    State(state): State<AppState>,
+    mut multipart: Multipart,
+) -> Response {
+    let Some(pool) = state.db.as_ref() else {
+        return (StatusCode::SERVICE_UNAVAILABLE, "no db").into_response();
+    };
+    let mut raw: Option<String> = None;
+    let mut ids: Vec<String> = Vec::new();
+    loop {
+        match multipart.next_field().await {
+            Ok(Some(field)) => {
+                let name = field.name().map(str::to_string);
+                match name.as_deref() {
+                    Some("yaml") => raw = field.text().await.ok(),
+                    Some("ids") => {
+                        if let Ok(v) = field.text().await {
+                            ids.push(v);
+                        }
+                    }
+                    _ => {}
+                }
+            }
+            Ok(None) => break,
+            Err(e) => return redirect_err(&format!("multipart parse: {e}")),
+        }
+    }
+    let Some(raw) = raw else {
+        return redirect_err("missing config");
+    };
+    // Nothing checked → no-op, back to the list with a zero flash.
+    if ids.is_empty() {
+        return Redirect::to("/admin/specs?import=ok&created=0&updated=0&unchanged=0&warnings=0")
+            .into_response();
+    }
+    let config = match ruscker_config::Config::from_yaml(&raw) {
+        Ok(c) => c,
+        Err(e) => return redirect_err(&format!("YAML parse failed: {e}")),
+    };
+    match crate::db::specs::import_selected(pool, &config, &ids).await {
         Ok(r) => {
             tracing::info!(
                 created = r.created, updated = r.updated, unchanged = r.unchanged,
-                warnings = warning_count, "YAML import via admin"
+                selected = ids.len(), "selective YAML import via admin"
             );
             Redirect::to(&format!(
-                "/admin/specs?import=ok&created={}&updated={}&unchanged={}&warnings={}",
-                r.created, r.updated, r.unchanged, warning_count
+                "/admin/specs?import=ok&created={}&updated={}&unchanged={}&warnings=0",
+                r.created, r.updated, r.unchanged
             ))
             .into_response()
         }
         Err(e) => {
-            tracing::error!(error = ?e, "import_all failed");
+            tracing::error!(error = ?e, "import_selected failed");
             redirect_err(&format!("import failed: {e}"))
         }
     }

--- a/crates/ruscker-admin/templates/admin/import_preview.html
+++ b/crates/ruscker-admin/templates/admin/import_preview.html
@@ -1,0 +1,80 @@
+{% extends "admin/_layout.html" %}
+
+{% block title %}{{ self.t("admin-import-preview-title") }} · Ruscker{% endblock %}
+
+{% block content %}
+
+<div class="flex items-end justify-between mb-5">
+  <div>
+    <h1 class="text-xl font-medium tracking-tight">{{ self.t("admin-import-preview-title") }}</h1>
+    <p class="text-xs text-[color:var(--text-muted)] mt-1">
+      {{ self.t("admin-import-preview-help") }}
+      — {{ rows.len() }} {{ self.t("admin-import-apps-label") }}{% if warning_count > 0 %} ·
+      <span style="color:var(--color-lock)">{{ warning_count }} {{ self.t("admin-import-warnings-label") }}</span>{% endif %}
+    </p>
+  </div>
+</div>
+
+{% if rows.is_empty() %}
+  <div class="card-surface rounded-lg p-12 text-center text-sm text-[color:var(--text-muted)]">
+    <p>{{ self.t("admin-import-preview-none") }}</p>
+    <a href="{{ base }}/admin/specs" class="admin-nav-link mt-3 inline-block">{{ self.t("admin-import-cancel") }}</a>
+  </div>
+{% else %}
+<form method="post" action="{{ base }}/admin/specs/import/confirm" enctype="multipart/form-data">
+  {# Original YAML round-tripped so the confirm is stateless. ${VAR} stays
+     literal end-to-end (#260) — no secret is resolved here. #}
+  <textarea name="yaml" hidden>{{ raw_yaml }}</textarea>
+
+  <table class="admin-table">
+    <thead>
+      <tr>
+        <th class="import-check-cell">
+          <input type="checkbox" checked
+                 title="{{ self.t("admin-import-select-all") }}"
+                 onclick="document.querySelectorAll('input[name=ids]').forEach(function(c){c.checked=this.checked}.bind(this))">
+        </th>
+        <th>{{ self.t("admin-specs-col-id") }}</th>
+        <th>{{ self.t("admin-specs-col-name") }}</th>
+        <th>{{ self.t("admin-specs-col-kind") }}</th>
+        <th>{{ self.t("admin-import-col-status") }}</th>
+      </tr>
+    </thead>
+    <tbody>
+      {% for row in rows %}
+      <tr>
+        <td class="import-check-cell">
+          <input type="checkbox" name="ids" value="{{ row.id }}" checked>
+        </td>
+        <td class="id-cell">{{ row.id }}</td>
+        <td>{% if row.display_name.is_empty() %}<span class="text-[color:var(--text-faint)]">—</span>{% else %}{{ row.display_name }}{% endif %}</td>
+        <td><span class="pill pill-kind-{{ row.kind }}">{{ row.kind }}</span></td>
+        <td>
+          {% if row.exists %}
+            <span class="pill" title="{{ self.t("admin-import-badge-update-help") }}">{{ self.t("admin-import-badge-update") }}</span>
+          {% else %}
+            <span class="pill pill-kind-app" title="{{ self.t("admin-import-badge-new-help") }}">{{ self.t("admin-import-badge-new") }}</span>
+          {% endif %}
+        </td>
+      </tr>
+      {% endfor %}
+    </tbody>
+  </table>
+
+  <div class="flex items-center justify-end gap-2 mt-4">
+    <a href="{{ base }}/admin/specs" class="admin-nav-link" style="font-size:12px">
+      {{ self.t("admin-import-cancel") }}
+    </a>
+    <button type="submit" class="admin-login-btn" style="padding:6px 12px;font-size:12px">
+      <i class="ti ti-file-import" aria-hidden="true"></i>
+      {{ self.t("admin-import-confirm") }}
+    </button>
+  </div>
+</form>
+{% endif %}
+
+<style>
+  .import-check-cell { width: 1%; text-align: center; }
+</style>
+
+{% endblock %}


### PR DESCRIPTION
Closes #557 (slices A+B). YAML import was **all-or-nothing** — `import_all` brought in every spec in the file. Now it's a **preview → confirm** flow.

## Flow
1. **Preview** (`POST /admin/specs/import`) — parses the upload and renders the **list of apps** it carries: a checkbox per app + id / name / kind + a **New** vs **Updates** badge (cross-referenced against the DB) + the file's validation-warning count. **Nothing is written.**
2. **Confirm** (`POST /admin/specs/import/confirm`) — imports **only the checked** specs via the new `db::specs::import_selected`. Unlike `import_all`, it touches **only those specs** (+ an audit row) — never the landing customization or proxy/server settings — so a partial app import can't clobber a portal configured in the panel.

The original YAML round-trips through a hidden field so the confirm is **stateless**; `${VAR}` stays literal end-to-end (#260) — no secret is resolved. A **select-all** toggle defaults everything checked; the confirm uses multipart so repeated `ids` collect cleanly (no extra deps).

## Verification
- Unit: `import_selected_imports_only_the_chosen_subset` (the chosen spec lands, the others don't).
- Real smoke: a 3-app upload lists all three with checkboxes + New badges; confirming **two** imports exactly those two — the third is absent from the DB.
- Gates: `cargo test -p ruscker-admin` green, `clippy --all-targets` clean, i18n parity OK (pt/en/es/fr).

## Not in this PR (slice C)
Per-app validation-warning detail in the list, an overwrite warning on Updates rows, and an "import everything" shortcut. The CLI's `import` (full import via `import_all`) is unchanged.

🤖 Generated with [Claude Code](https://claude.com/claude-code)