### PR TITLE
feat(admin): import spec logos into the Media library (#560 A)

### DIFF
--- a/crates/ruscker-admin/assets/i18n/en/landing.ftl
+++ b/crates/ruscker-admin/assets/i18n/en/landing.ftl
@@ -264,7 +264,7 @@ admin-images-delete = Delete
 admin-images-delete-confirm = Delete this image? Specs referencing the filename will fall back to the tinted cover.
 admin-images-inuse = In use
 admin-images-inuse-help = Used by a card or a landing logo
-admin-images-delete-confirm-inuse = This image is IN USE (a card or the landing). Delete anyway?
+admin-images-delete-confirm-inuse = This image is IN USE. Deleting it resets the apps that use it to the default Ruscker logo (the card will not break). Delete?
 admin-images-search = Search images…
 admin-images-no-match = No images match your search.
 

--- a/crates/ruscker-admin/assets/i18n/es/landing.ftl
+++ b/crates/ruscker-admin/assets/i18n/es/landing.ftl
@@ -264,7 +264,7 @@ admin-images-delete = Eliminar
 admin-images-delete-confirm = ¿Eliminar esta imagen? Las specs que referencian el archivo mostrarán el cover tintado.
 admin-images-inuse = En uso
 admin-images-inuse-help = Usada en una tarjeta o un logo de la landing
-admin-images-delete-confirm-inuse = Esta imagen está EN USO (una tarjeta o la landing). ¿Eliminar igualmente?
+admin-images-delete-confirm-inuse = Esta imagen está EN USO. Al eliminarla, los apps que la usan vuelven al logo predeterminado de Ruscker (la tarjeta no se rompe). ¿Eliminar?
 admin-images-search = Buscar imágenes…
 admin-images-no-match = Ninguna imagen coincide con la búsqueda.
 

--- a/crates/ruscker-admin/assets/i18n/fr/landing.ftl
+++ b/crates/ruscker-admin/assets/i18n/fr/landing.ftl
@@ -264,7 +264,7 @@ admin-images-delete = Supprimer
 admin-images-delete-confirm = Supprimer cette image ? Les specs qui référencent le fichier afficheront le cover teinté.
 admin-images-inuse = Utilisé
 admin-images-inuse-help = Utilisé par une carte ou un logo de la landing
-admin-images-delete-confirm-inuse = Cette image est UTILISÉE (une carte ou la landing). Supprimer quand même ?
+admin-images-delete-confirm-inuse = Cette image est UTILISÉE. La supprimer rétablit le logo Ruscker par défaut sur les apps concernées (la carte ne casse pas). Supprimer ?
 admin-images-search = Rechercher des images…
 admin-images-no-match = Aucune image ne correspond à la recherche.
 

--- a/crates/ruscker-admin/assets/i18n/pt/landing.ftl
+++ b/crates/ruscker-admin/assets/i18n/pt/landing.ftl
@@ -268,7 +268,7 @@ admin-images-delete = Excluir
 admin-images-delete-confirm = Excluir essa imagem? Specs que referenciam o arquivo passarão a mostrar o cover tintado.
 admin-images-inuse = Em uso
 admin-images-inuse-help = Usada num card ou nos logos da landing
-admin-images-delete-confirm-inuse = Esta imagem está EM USO (um card ou a landing). Deletar mesmo assim?
+admin-images-delete-confirm-inuse = Esta imagem está EM USO. Se deletar, os apps que a usam voltam ao logo padrão do Ruscker (o card não quebra). Deletar?
 admin-images-search = Buscar imagens…
 admin-images-no-match = Nenhuma imagem corresponde à busca.
 

--- a/crates/ruscker-admin/src/db/images.rs
+++ b/crates/ruscker-admin/src/db/images.rs
@@ -194,6 +194,24 @@ pub async fn list_all(db: &ConfigDb) -> Result<Vec<ImageMeta>> {
         .collect())
 }
 
+/// The filename for an image id, without deleting — so a caller can find
+/// what references it before removing it (#560).
+pub async fn filename_for(db: &ConfigDb, id: &str) -> Result<Option<String>> {
+    let row: Option<(String,)> = match db {
+        ConfigDb::Sqlite(pool) => sqlx::query_as("SELECT filename FROM images WHERE id = ?")
+            .bind(id)
+            .fetch_optional(pool)
+            .await
+            .context("lookup image filename (sqlite)")?,
+        ConfigDb::Postgres(pool) => sqlx::query_as("SELECT filename FROM images WHERE id = $1")
+            .bind(id)
+            .fetch_optional(pool)
+            .await
+            .context("lookup image filename (postgres)")?,
+    };
+    Ok(row.map(|(f,)| f))
+}
+
 /// Delete an image by id. Returns the deleted row's filename (so the
 /// caller can invalidate caches keyed by it, #301), or `None` if no
 /// such image existed. Audit row is written when a row was removed.

--- a/crates/ruscker-admin/src/routes/admin/images.rs
+++ b/crates/ruscker-admin/src/routes/admin/images.rs
@@ -346,6 +346,16 @@ async fn upload_inline(
     inline_err(StatusCode::BAD_REQUEST, "no file field in upload")
 }
 
+/// Asset path of the built-in Ruscker mark — what a card falls back to
+/// when its image is deleted (#560), so it never renders a broken image.
+/// Seeded into Media as a built-in (#433), so it's always available.
+const RUSCKER_DEFAULT_LOGO: &str = "/assets/img/ruscker-mark.svg";
+
+/// True when a `logo`/`cover` value points at `filename`.
+fn references_image(value: &str, filename: &str) -> bool {
+    value == filename || value.contains(&format!("/assets/img/{filename}"))
+}
+
 async fn delete(
     editor: RequireEditor,
     State(state): State<AppState>,
@@ -354,12 +364,56 @@ async fn delete(
     let Some(pool) = state.db.as_ref() else {
         return (StatusCode::SERVICE_UNAVAILABLE, "no db").into_response();
     };
-    match db::images::delete_one(pool, &id, Some(editor.actor())).await {
-        Ok(filename) => {
-            // Drop the cached thumbnail of the deleted image (#301).
-            if let Some(name) = filename {
-                crate::routes::assets::invalidate_thumb(&name);
+
+    // Find the filename first, so we can fix up any app that used it before
+    // it's gone — otherwise that card would render a broken image (#560).
+    let filename = match db::images::filename_for(pool, &id).await {
+        Ok(Some(f)) => f,
+        Ok(None) => return Redirect::to("/admin/media").into_response(), // already gone
+        Err(err) => {
+            tracing::error!(error = ?err, id, "image lookup failed");
+            return (StatusCode::INTERNAL_SERVER_ERROR, "lookup failed").into_response();
+        }
+    };
+
+    // Reset every spec that used the image: a referencing `logo` falls back
+    // to the Ruscker mark; a referencing `cover` is cleared (kind tint).
+    let mut reset = 0usize;
+    if let Ok(specs) = db::specs::list_all(pool).await {
+        for spec in specs {
+            let logo_hit = spec
+                .template_properties
+                .get_str("logo")
+                .is_some_and(|v| references_image(v, &filename));
+            let cover_hit = spec
+                .template_properties
+                .get_str("cover")
+                .is_some_and(|v| references_image(v, &filename));
+            if !logo_hit && !cover_hit {
+                continue;
             }
+            let mut spec = spec;
+            if logo_hit {
+                spec.template_properties
+                    .set_str("logo", RUSCKER_DEFAULT_LOGO);
+            }
+            if cover_hit {
+                spec.template_properties.remove("cover");
+            }
+            if let Err(e) = db::specs::upsert_one(pool, &spec, Some(editor.actor())).await {
+                tracing::warn!(spec = %spec.id, error = ?e, "reset spec image on delete failed");
+            } else {
+                reset += 1;
+            }
+        }
+    }
+
+    match db::images::delete_one(pool, &id, Some(editor.actor())).await {
+        Ok(name) => {
+            if let Some(n) = name {
+                crate::routes::assets::invalidate_thumb(&n);
+            }
+            tracing::info!(id, %filename, reset, "image deleted; apps reset to default logo");
             Redirect::to("/admin/media").into_response()
         }
         Err(err) => {

--- a/crates/ruscker-admin/src/routes/admin/specs.rs
+++ b/crates/ruscker-admin/src/routes/admin/specs.rs
@@ -628,11 +628,12 @@ fn local_img_filename(value: &str) -> Option<String> {
         || v.starts_with("http://")
         || v.starts_with("https://")
         || v.starts_with("data:")
+        || v.contains("..")
     {
         return None;
     }
     let f = v.rsplit('/').next().unwrap_or(v);
-    if f.is_empty() || f.contains("..") {
+    if f.is_empty() {
         return None;
     }
     Some(f.to_string())

--- a/crates/ruscker-admin/src/routes/admin/specs.rs
+++ b/crates/ruscker-admin/src/routes/admin/specs.rs
@@ -490,9 +490,11 @@ async fn import_confirm(
     let creds = extract_inline_credentials(&state, &mut config, &ids, editor.actor()).await;
     match crate::db::specs::import_selected(pool, &config, &ids).await {
         Ok(r) => {
+            // #560 A: bring the specs' --images-dir logos into the Media library.
+            let logos = import_referenced_logos(&state, &config, &ids, editor.actor()).await;
             tracing::info!(
                 created = r.created, updated = r.updated, unchanged = r.unchanged,
-                selected = ids.len(), credentials = creds,
+                selected = ids.len(), credentials = creds, logos = logos,
                 "selective YAML import via admin"
             );
             Redirect::to(&format!(
@@ -617,6 +619,89 @@ async fn extract_inline_credentials(
     created
 }
 
+/// Extract a local image filename from a spec `logo` value, or `None` for
+/// external URLs / data URIs / empty. Accepts `/assets/img/<file>` or a
+/// bare `<file>`; rejects path-traversal.
+fn local_img_filename(value: &str) -> Option<String> {
+    let v = value.trim();
+    if v.is_empty()
+        || v.starts_with("http://")
+        || v.starts_with("https://")
+        || v.starts_with("data:")
+    {
+        return None;
+    }
+    let f = v.rsplit('/').next().unwrap_or(v);
+    if f.is_empty() || f.contains("..") {
+        return None;
+    }
+    Some(f.to_string())
+}
+
+/// #560 A: copy each **selected** spec's local logo file (served today from
+/// `--images-dir`) into the Media library, so it's manageable there — the
+/// reported "shows on the card but not in Media" gap. Needs `--images-dir`
+/// set and the file present; external-URL logos and files already in Media
+/// are skipped. The YAML carries only the filename, so the bytes come from
+/// the server's `images_dir`. Returns how many images were added.
+async fn import_referenced_logos(
+    state: &AppState,
+    config: &ruscker_config::Config,
+    ids: &[String],
+    actor: &str,
+) -> usize {
+    use std::collections::HashSet;
+    let (Some(db), Some(dir)) = (state.db.as_ref(), state.images_dir.as_ref()) else {
+        return 0;
+    };
+    let want: HashSet<&str> = ids.iter().map(String::as_str).collect();
+    let mut imported = 0usize;
+    let mut seen: HashSet<String> = HashSet::new();
+    for spec in config
+        .proxy
+        .specs
+        .iter()
+        .filter(|s| want.contains(s.id.as_str()))
+    {
+        let Some(logo) = spec.template_properties.get_str("logo") else {
+            continue;
+        };
+        let Some(filename) = local_img_filename(logo) else {
+            continue;
+        };
+        if !seen.insert(filename.clone()) {
+            continue; // already handled this file in this import
+        }
+        // Already in the Media DB? then it's not a --images-dir-only file.
+        if crate::db::images::fetch_by_filename(db, &filename)
+            .await
+            .ok()
+            .flatten()
+            .is_some()
+        {
+            continue;
+        }
+        let bytes = match std::fs::read(dir.join(&filename)) {
+            Ok(b) => b,
+            Err(_) => continue, // not on disk → nothing to copy
+        };
+        match crate::images::process_upload(&filename, None, bytes) {
+            Ok(processed) => {
+                if crate::db::images::insert(db, processed, Some(actor))
+                    .await
+                    .is_ok()
+                {
+                    imported += 1;
+                }
+            }
+            Err(e) => {
+                tracing::warn!(file = %filename, error = ?e, "import: logo → Media failed")
+            }
+        }
+    }
+    imported
+}
+
 fn redirect_err(msg: &str) -> Response {
     // Keep the message short + URL-safe enough for a query param.
     let encoded: String = msg
@@ -633,7 +718,20 @@ fn redirect_err(msg: &str) -> Response {
 
 #[cfg(test)]
 mod tests {
-    use super::sanitize_cred_name;
+    use super::{local_img_filename, sanitize_cred_name};
+
+    #[test]
+    fn local_img_filename_extracts_or_skips() {
+        assert_eq!(
+            local_img_filename("/assets/img/logo.svg").as_deref(),
+            Some("logo.svg")
+        );
+        assert_eq!(local_img_filename("bare.png").as_deref(), Some("bare.png"));
+        assert_eq!(local_img_filename("https://x.org/a.png"), None);
+        assert_eq!(local_img_filename("data:image/png;base64,AA"), None);
+        assert_eq!(local_img_filename(""), None);
+        assert_eq!(local_img_filename("/assets/img/../../etc/passwd"), None);
+    }
 
     #[test]
     fn sanitize_cred_name_slugs_and_falls_back() {

--- a/crates/ruscker-config/src/schema.rs
+++ b/crates/ruscker-config/src/schema.rs
@@ -834,6 +834,19 @@ impl TemplateProperties {
         self.0.get(key).and_then(|v| v.as_str())
     }
 
+    /// Set a string property (e.g. reset a card `logo` to a default).
+    pub fn set_str(&mut self, key: &str, value: &str) {
+        self.0.insert(
+            key.to_string(),
+            serde_yaml_ng::Value::String(value.to_string()),
+        );
+    }
+
+    /// Remove a property (e.g. clear a `cover` whose image was deleted).
+    pub fn remove(&mut self, key: &str) {
+        self.0.remove(key);
+    }
+
     pub fn type_field(&self) -> Option<&str> {
         self.get_str("type")
     }


### PR DESCRIPTION
## #560 Part A — import spec logos into the Media library

When importing a ShinyProxy `application.yml`, spec logos that point at a
local file (`logo: foo.svg` or `/assets/img/foo.svg`) are now copied into
the Media library so they show up in `/admin/media`, not just on the card.

- `import_referenced_logos` reads each selected spec's logo from
  `--images-dir`, runs it through `process_upload` + `images::insert`.
- `local_img_filename` extracts the filename and rejects URLs / data URIs /
  empty / traversal-looking values (whole-value `..` check, defense-in-depth).

## Safe Media deletion — in-use images fall back, don't break

Deleting a Media image that a spec references used to leave a dangling card.
Now the delete handler scans every spec and, before removing the image row:

- a **logo** hit is reset to the Ruscker default mark
  (`/assets/img/ruscker-mark.svg`),
- a **cover** hit is cleared.

The in-use confirm dialog is reworded in all four locales to say the apps
using the image will revert to the default Ruscker logo (the card won't
break).

- `db::images::filename_for(id)` resolves the filename for the cross-ref.
- `TemplateProperties::set_str` / `remove` rewrite the logo/cover keys.
- `references_image()` matches a bare filename or `/assets/img/<file>`.

Smoke: created an image, referenced it from a spec's `logo`, deleted it →
the spec's logo became `/assets/img/ruscker-mark.svg` and the image row was
gone. Gates green (clippy + i18n-check + build).

🤖 Generated with [Claude Code](https://claude.com/claude-code)