### PR TITLE
feat(admin): drag-and-drop YAML import + credential/image counts in the result

### DIFF
--- a/crates/ruscker-admin/assets/i18n/en/landing.ftl
+++ b/crates/ruscker-admin/assets/i18n/en/landing.ftl
@@ -413,6 +413,8 @@ admin-import-submit = Import
 admin-import-cancel = Cancel
 admin-import-ok = Import complete: { $created } created, { $updated } updated, { $unchanged } unchanged.
 admin-import-ok-warnings = { $warnings } validation warning(s) — review embedded credentials and empty names.
+admin-import-ok-assets = { $creds } credential(s) and { $logos } image(s) imported into the panel.
+admin-import-drop = Drag your application.yml here or click to browse
 admin-import-err = Import failed: { $msg }
 
 # Gradient builder

--- a/crates/ruscker-admin/assets/i18n/es/landing.ftl
+++ b/crates/ruscker-admin/assets/i18n/es/landing.ftl
@@ -413,6 +413,8 @@ admin-import-submit = Importar
 admin-import-cancel = Cancelar
 admin-import-ok = Import completo: { $created } creados, { $updated } actualizados, { $unchanged } sin cambios.
 admin-import-ok-warnings = { $warnings } advertencia(s) de validación — revise credenciales embebidas y nombres vacíos.
+admin-import-ok-assets = { $creds } credencial(es) y { $logos } imagen(es) importadas al panel.
+admin-import-drop = Arrastra el application.yml aquí o haz clic para seleccionar
 admin-import-err = Error en el import: { $msg }
 
 # Gradient builder

--- a/crates/ruscker-admin/assets/i18n/fr/landing.ftl
+++ b/crates/ruscker-admin/assets/i18n/fr/landing.ftl
@@ -413,6 +413,8 @@ admin-import-submit = Importer
 admin-import-cancel = Annuler
 admin-import-ok = Import terminé : { $created } créés, { $updated } mis à jour, { $unchanged } inchangés.
 admin-import-ok-warnings = { $warnings } avertissement(s) de validation — vérifiez les identifiants intégrés et les noms vides.
+admin-import-ok-assets = { $creds } identifiant(s) et { $logos } image(s) importés dans le panneau.
+admin-import-drop = Glissez votre application.yml ici ou cliquez pour parcourir
 admin-import-err = Échec de l import : { $msg }
 
 # Gradient builder

--- a/crates/ruscker-admin/assets/i18n/pt/landing.ftl
+++ b/crates/ruscker-admin/assets/i18n/pt/landing.ftl
@@ -417,6 +417,8 @@ admin-import-submit = Importar
 admin-import-cancel = Cancelar
 admin-import-ok = Import concluído: { $created } criados, { $updated } atualizados, { $unchanged } inalterados.
 admin-import-ok-warnings = { $warnings } aviso(s) de validação — revise as credenciais embutidas e nomes vazios.
+admin-import-ok-assets = { $creds } credencial(is) e { $logos } imagem(ns) importadas para o painel.
+admin-import-drop = Arraste o application.yml aqui ou clique para selecionar
 admin-import-err = Falha no import: { $msg }
 
 # Gradient builder

--- a/crates/ruscker-admin/src/routes/admin/specs.rs
+++ b/crates/ruscker-admin/src/routes/admin/specs.rs
@@ -122,6 +122,12 @@ pub struct SpecsQuery {
     pub unchanged: Option<usize>,
     #[serde(default)]
     pub warnings: Option<usize>,
+    /// Inline registry passwords lifted into the credential store (#560 B).
+    #[serde(default)]
+    pub creds: Option<usize>,
+    /// Spec logos copied into the Media library (#560 A).
+    #[serde(default)]
+    pub logos: Option<usize>,
     /// Error message (URL-encoded) when `import=err`.
     #[serde(default)]
     pub msg: Option<String>,
@@ -204,6 +210,17 @@ fn build_flash(locales: &Locales, loc: Locale, q: &SpecsQuery) -> Option<Flash> 
             args.set("updated", q.updated.unwrap_or(0) as i64);
             args.set("unchanged", q.unchanged.unwrap_or(0) as i64);
             let mut text = locales.t(loc, "admin-import-ok", Some(&args));
+            // #560 A/B: note how many logos went to the Media library and how
+            // many inline passwords were lifted into the credential store.
+            let creds = q.creds.unwrap_or(0);
+            let logos = q.logos.unwrap_or(0);
+            if creds > 0 || logos > 0 {
+                let mut aargs = FluentArgs::new();
+                aargs.set("creds", creds as i64);
+                aargs.set("logos", logos as i64);
+                text.push(' ');
+                text.push_str(&locales.t(loc, "admin-import-ok-assets", Some(&aargs)));
+            }
             let warnings = q.warnings.unwrap_or(0);
             if warnings > 0 {
                 let mut wargs = FluentArgs::new();
@@ -498,8 +515,8 @@ async fn import_confirm(
                 "selective YAML import via admin"
             );
             Redirect::to(&format!(
-                "/admin/specs?import=ok&created={}&updated={}&unchanged={}&warnings=0",
-                r.created, r.updated, r.unchanged
+                "/admin/specs?import=ok&created={}&updated={}&unchanged={}&warnings=0&creds={}&logos={}",
+                r.created, r.updated, r.unchanged, creds, logos
             ))
             .into_response()
         }

--- a/crates/ruscker-admin/templates/admin/specs.html
+++ b/crates/ruscker-admin/templates/admin/specs.html
@@ -31,11 +31,29 @@
 {% endmatch %}
 
 <dialog id="import-modal" class="import-dialog">
-  <form method="post" action="{{ base }}/admin/specs/import" enctype="multipart/form-data" class="import-form">
-    <h2 class="text-base font-medium mb-1">{{ self.t("admin-import-title") }}</h2>
-    <p class="text-xs text-[color:var(--text-muted)] mb-3">{{ self.t("admin-import-help") }}</p>
-    <label class="block text-xs mb-1">{{ self.t("admin-import-file") }}</label>
-    <input type="file" name="file" accept=".yml,.yaml" required class="import-file" />
+  <form method="post" action="{{ base }}/admin/specs/import" enctype="multipart/form-data" class="import-form"
+        x-data="{ name: '', drag: false }">
+    <h2 class="import-h2">{{ self.t("admin-import-title") }}</h2>
+    <p class="import-sub">{{ self.t("admin-import-help") }}</p>
+
+    {# Custom dropzone: hides the native file input (whose "Choose file"
+       button can't be localized — it follows the browser UI language) and
+       renders our own PT/EN/ES/FR prompt. Clicking the <label> opens the
+       picker natively; a drop sets the hidden input's `files`. #}
+    <label class="import-dropzone" :class="{ 'is-drag': drag }"
+           @dragover.prevent="drag = true" @dragleave.prevent="drag = false"
+           @drop.prevent="drag = false; if ($event.dataTransfer.files.length) { $refs.file.files = $event.dataTransfer.files; name = $refs.file.files[0].name }">
+      <input type="file" name="file" accept=".yml,.yaml" required x-ref="file" class="import-dz-input"
+             @change="name = $refs.file.files.length ? $refs.file.files[0].name : ''" />
+      <svg class="import-dz-ico" viewBox="0 0 24 24" fill="none" stroke="currentColor"
+           stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true">
+        <path d="M21 15v4a2 2 0 0 1-2 2H5a2 2 0 0 1-2-2v-4"/>
+        <path d="M7 10l5-5 5 5"/><path d="M12 5v12"/>
+      </svg>
+      <p class="import-dz-prompt" x-show="!name">{{ self.t("admin-import-drop") }}</p>
+      <p class="import-dz-file" x-show="name" x-text="name" x-cloak></p>
+      <p class="import-dz-hint">{{ self.t("admin-import-file") }}</p>
+    </label>
     <div class="flex justify-end gap-2 mt-4">
       <button type="button" class="admin-nav-link" style="font-size:12px"
               onclick="document.getElementById('import-modal').close()">
@@ -63,12 +81,38 @@
     background: var(--surface, #fff); color: var(--text-primary);
   }
   .import-dialog::backdrop { background: rgba(0,0,0,0.35); }
-  .import-form { padding: 20px; }
-  .import-file {
-    width: 100%; font-size: 12px; padding: 8px;
-    border: 0.5px dashed var(--color-border-tertiary, rgba(120,120,120,0.3));
-    border-radius: 8px;
+  .import-form { padding: 22px; }
+  [x-cloak] { display: none !important; }
+  .import-h2 { font-size: 15px; font-weight: 600; margin-bottom: 4px; }
+  .import-sub {
+    font-size: 12px; line-height: 1.5; margin-bottom: 16px;
+    color: var(--text-muted);
   }
+  .import-dropzone {
+    display: flex; flex-direction: column; align-items: center; justify-content: center;
+    gap: 7px; text-align: center; cursor: pointer; position: relative;
+    padding: 30px 20px; border-radius: 12px;
+    border: 1.5px dashed var(--color-border-tertiary, rgba(120,120,120,0.35));
+    background: var(--surface-soft, rgba(120,120,120,0.04));
+    transition: border-color .15s ease, background .15s ease, transform .15s ease;
+  }
+  .import-dropzone:hover {
+    border-color: var(--accent, #2563eb);
+    background: color-mix(in srgb, var(--accent, #2563eb) 5%, transparent);
+  }
+  .import-dropzone.is-drag {
+    border-color: var(--accent, #2563eb); border-style: solid;
+    background: color-mix(in srgb, var(--accent, #2563eb) 9%, transparent);
+    transform: scale(1.01);
+  }
+  /* visually hidden but still label-triggerable + form-validatable */
+  .import-dz-input { position: absolute; width: 1px; height: 1px; opacity: 0; pointer-events: none; }
+  .import-dz-ico { width: 34px; height: 34px; color: var(--accent, #2563eb); opacity: .85; }
+  .import-dropzone.is-drag .import-dz-ico { animation: import-bounce .55s ease infinite alternate; }
+  @keyframes import-bounce { to { transform: translateY(-3px); } }
+  .import-dz-prompt { font-size: 13px; font-weight: 500; color: var(--text-primary); }
+  .import-dz-file { font-size: 13px; font-weight: 600; color: var(--accent, #2563eb); word-break: break-all; }
+  .import-dz-hint { font-size: 11px; color: var(--text-faint, var(--text-muted)); }
 </style>
 
 {% if specs.is_empty() %}


### PR DESCRIPTION
## Drag-and-drop import zone (localized)

The import modal used a bare `<input type="file">`, whose **"Choose file"** button is rendered by the browser in **its own UI language** — so it showed English even with the panel in Portuguese. Replaced it with a custom dropzone:

- a styled `<label>` that opens the native picker on click,
- accepts a **dropped** `.yml`/`.yaml` (sets the hidden input's `files`),
- highlights + animates the icon on drag-over,
- shows the **selected filename**,
- fully localized prompt (`admin-import-drop`) in pt/en/es/fr.

The hidden input stays `name="file"` + `required`, so server-side handling and form validation are unchanged.

## Result message now counts credentials + images

After a selective import, the success flash only reported specs:
`Import concluído: 31 criados, 0 atualizados, 0 inalterados.`

It now appends what else came in:
`… 3 credencial(is) e 12 imagem(ns) importadas para o painel.`

- **credentials**: inline registry passwords lifted into the encrypted store (#560 B),
- **images**: spec logos copied into the Media library (#560 A).

The counts (already computed, previously only logged) ride the redirect query (`creds`/`logos`) and render via a new `admin-import-ok-assets` message. Only shown when at least one is non-zero.

## Verification

Smoke (local server): opened `/admin/specs` → modal renders the dropzone in PT; posted a selective import of a spec carrying `template-properties.logo: /assets/img/applogo.svg` + an inline registry password → redirect `…&creds=1&logos=1`, the image landed in the `images` table, the credential in `credentials`, and the flash read *"… 1 credencial(is) e 1 imagem(ns) importadas para o painel."* Confirmed the **real** `box-apps.yml` carries logos as `template-properties.logo`, the exact field the importer reads.

Gates green: `cargo build`, `cargo clippy -p ruscker-admin`, `cargo test -p ruscker-admin` (273+), `./scripts/i18n-check.sh`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)