### PR TITLE
fix(admin): hide Advanced section for external Link/Package specs

### DIFF
--- a/crates/ruscker-admin/templates/admin/spec_form.html
+++ b/crates/ruscker-admin/templates/admin/spec_form.html
@@ -429,7 +429,11 @@
 
       {# ── Advanced (collapsible): API, scaling, resources, lifecycle.
            Every field is optional — leaving it blank keeps the schema
-           default, so casual operators never have to open this. ──── #}
+           default, so casual operators never have to open this.
+           Container-only: an external Link/Package (kind External) has no
+           image or runtime to tune, so the whole section is hidden for it
+           — only container-backed kinds (app/api/talk/report) see it. ── #}
+      <template x-if="needsContainer()">
       <div class="spec-form-advanced">
         <button type="button" class="spec-form-advanced-toggle"
                 :class="advancedOpen ? 'is-open' : ''"
@@ -832,6 +836,7 @@
           </div>
         </div>
       </div>
+      </template>
       </section>
     </form>
 


### PR DESCRIPTION
The spec form's **Advanced** collapse is entirely container/runtime configuration — API ports, runtime tuning, registry credentials, scaling, resource limits, volumes, routing, lifecycle. For a **kind=External** card (display type **Link** or **Package**) there is no image or container to run, so none of it applies. Today the toggle and all those fields still render for links.

Wrap the whole `spec-form-advanced` block in `x-if="needsContainer()"` (true for app/api/talk/report, false for link/package). External Link/Package specs now show only their **External link** card and the shared Identity/Visual/Metadata cards — no misleading runtime knobs.

Verified: rendered `/admin/specs/new` HTML now nests the `spec-form-advanced` div inside `<template x-if="needsContainer()">`. Build green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)