### PR TITLE
feat(admin): search box + sortable columns on admin tables

### DIFF
--- a/crates/ruscker-admin/assets/i18n/en/landing.ftl
+++ b/crates/ruscker-admin/assets/i18n/en/landing.ftl
@@ -415,6 +415,8 @@ admin-import-ok = Import complete: { $created } created, { $updated } updated, {
 admin-import-ok-warnings = { $warnings } validation warning(s) — review embedded credentials and empty names.
 admin-import-ok-assets = { $creds } credential(s) and { $logos } image(s) imported into the panel.
 admin-import-drop = Drag your application.yml here or click to browse
+admin-table-search = Search…
+admin-table-no-results = No results
 admin-import-err = Import failed: { $msg }
 
 # Gradient builder

--- a/crates/ruscker-admin/assets/i18n/es/landing.ftl
+++ b/crates/ruscker-admin/assets/i18n/es/landing.ftl
@@ -415,6 +415,8 @@ admin-import-ok = Import completo: { $created } creados, { $updated } actualizad
 admin-import-ok-warnings = { $warnings } advertencia(s) de validación — revise credenciales embebidas y nombres vacíos.
 admin-import-ok-assets = { $creds } credencial(es) y { $logos } imagen(es) importadas al panel.
 admin-import-drop = Arrastra el application.yml aquí o haz clic para seleccionar
+admin-table-search = Buscar…
+admin-table-no-results = Sin resultados
 admin-import-err = Error en el import: { $msg }
 
 # Gradient builder

--- a/crates/ruscker-admin/assets/i18n/fr/landing.ftl
+++ b/crates/ruscker-admin/assets/i18n/fr/landing.ftl
@@ -415,6 +415,8 @@ admin-import-ok = Import terminé : { $created } créés, { $updated } mis à jo
 admin-import-ok-warnings = { $warnings } avertissement(s) de validation — vérifiez les identifiants intégrés et les noms vides.
 admin-import-ok-assets = { $creds } identifiant(s) et { $logos } image(s) importés dans le panneau.
 admin-import-drop = Glissez votre application.yml ici ou cliquez pour parcourir
+admin-table-search = Rechercher…
+admin-table-no-results = Aucun résultat
 admin-import-err = Échec de l import : { $msg }
 
 # Gradient builder

--- a/crates/ruscker-admin/assets/i18n/pt/landing.ftl
+++ b/crates/ruscker-admin/assets/i18n/pt/landing.ftl
@@ -419,6 +419,8 @@ admin-import-ok = Import concluído: { $created } criados, { $updated } atualiza
 admin-import-ok-warnings = { $warnings } aviso(s) de validação — revise as credenciais embutidas e nomes vazios.
 admin-import-ok-assets = { $creds } credencial(is) e { $logos } imagem(ns) importadas para o painel.
 admin-import-drop = Arraste o application.yml aqui ou clique para selecionar
+admin-table-search = Buscar…
+admin-table-no-results = Nenhum resultado
 admin-import-err = Falha no import: { $msg }
 
 # Gradient builder

--- a/crates/ruscker-admin/templates/admin/_layout.html
+++ b/crates/ruscker-admin/templates/admin/_layout.html
@@ -259,5 +259,111 @@ window.ruscker.imagePicker = (filenames) => ({
   </a>
 </footer>
 
+{# ── Shared table enhancer (search + column sort) ──────────────────
+   Progressive enhancement, zero deps: any `<table data-enhance>` in the
+   admin gets a search box above it and clickable, sortable headers
+   (skip a header with `data-nosort`, e.g. the actions column). Runs on
+   every admin page so each data table opts in with one attribute. The
+   localized labels are injected once here so the script stays static. #}
+<script>
+  window.RUSCKER_TABLE_I18N = {
+    search: "{{ self.t("admin-table-search") }}",
+    noResults: "{{ self.t("admin-table-no-results") }}"
+  };
+</script>
+<style>
+  .admin-table-toolbar { margin: 0 0 10px; }
+  .admin-table-search {
+    width: 100%; max-width: 320px; font-size: 13px; padding: 7px 11px;
+    border: 0.5px solid var(--color-border-tertiary, rgba(120,120,120,0.3));
+    border-radius: 8px; background: var(--surface, #fff); color: var(--text-primary);
+  }
+  .admin-table-search:focus { outline: none; border-color: var(--accent, #2563eb); }
+  th.admin-th-sort { cursor: pointer; user-select: none; white-space: nowrap; }
+  th.admin-th-sort::after { content: '↕'; opacity: .3; margin-left: 5px; font-size: 10px; }
+  th.admin-th-sort[data-sort-dir='asc']::after  { content: '↑'; opacity: .9; }
+  th.admin-th-sort[data-sort-dir='desc']::after { content: '↓'; opacity: .9; }
+  .admin-table-empty { text-align: center; padding: 18px; color: var(--text-muted); font-size: 13px; }
+</style>
+<script>
+(function () {
+  var I18N = window.RUSCKER_TABLE_I18N || { search: 'Search', noResults: 'No results' };
+
+  function compare(a, b) {
+    var na = parseFloat(a.replace(/[^0-9.\-]/g, '')), nb = parseFloat(b.replace(/[^0-9.\-]/g, ''));
+    var aNum = a !== '' && /[0-9]/.test(a) && !isNaN(na);
+    var bNum = b !== '' && /[0-9]/.test(b) && !isNaN(nb);
+    if (aNum && bNum) return na - nb;
+    return a.localeCompare(b, undefined, { numeric: true, sensitivity: 'base' });
+  }
+
+  function enhance(table) {
+    var tbody = table.tBodies[0];
+    var headRow = table.tHead && table.tHead.rows[0];
+    if (!tbody || !headRow) return;
+
+    function dataRows() {
+      return Array.prototype.filter.call(tbody.rows, function (r) { return !r.dataset.tableEmpty; });
+    }
+    function cellVal(row, idx) {
+      var c = row.cells[idx];
+      if (!c) return '';
+      return c.dataset.sortValue !== undefined ? c.dataset.sortValue : c.textContent.trim();
+    }
+
+    // search toolbar
+    var wrap = document.createElement('div');
+    wrap.className = 'admin-table-toolbar';
+    var input = document.createElement('input');
+    input.type = 'search';
+    input.className = 'admin-table-search';
+    input.setAttribute('aria-label', I18N.search);
+    input.placeholder = I18N.search;
+    wrap.appendChild(input);
+    table.parentNode.insertBefore(wrap, table);
+
+    // empty-state row
+    var emptyRow = document.createElement('tr');
+    emptyRow.dataset.tableEmpty = '1';
+    emptyRow.style.display = 'none';
+    var emptyCell = document.createElement('td');
+    emptyCell.colSpan = headRow.cells.length;
+    emptyCell.className = 'admin-table-empty';
+    emptyCell.textContent = I18N.noResults;
+    emptyRow.appendChild(emptyCell);
+    tbody.appendChild(emptyRow);
+
+    function applyFilter() {
+      var q = input.value.trim().toLowerCase(), visible = 0;
+      dataRows().forEach(function (r) {
+        var match = !q || r.textContent.toLowerCase().indexOf(q) !== -1;
+        r.style.display = match ? '' : 'none';
+        if (match) visible++;
+      });
+      emptyRow.style.display = visible ? 'none' : '';
+    }
+    input.addEventListener('input', applyFilter);
+
+    // sortable headers
+    Array.prototype.forEach.call(headRow.cells, function (th, idx) {
+      if (th.hasAttribute('data-nosort')) return;
+      th.classList.add('admin-th-sort');
+      th.addEventListener('click', function () {
+        var asc = th.dataset.sortDir !== 'asc';
+        Array.prototype.forEach.call(headRow.cells, function (h) { if (h !== th) delete h.dataset.sortDir; });
+        th.dataset.sortDir = asc ? 'asc' : 'desc';
+        dataRows()
+          .sort(function (a, b) { return compare(cellVal(a, idx), cellVal(b, idx)) * (asc ? 1 : -1); })
+          .forEach(function (r) { tbody.insertBefore(r, emptyRow); });
+      });
+    });
+  }
+
+  document.addEventListener('DOMContentLoaded', function () {
+    document.querySelectorAll('table[data-enhance]').forEach(enhance);
+  });
+})();
+</script>
+
 </body>
 </html>

--- a/crates/ruscker-admin/templates/admin/credentials.html
+++ b/crates/ruscker-admin/templates/admin/credentials.html
@@ -92,14 +92,14 @@
     {{ self.t("admin-creds-empty") }}
   </div>
 {% else %}
-  <table class="admin-table mt-6">
+  <table class="admin-table mt-6" data-enhance>
     <thead>
       <tr>
         <th>{{ self.t("admin-creds-col-name") }}</th>
         <th>{{ self.t("admin-creds-col-registry") }}</th>
         <th>{{ self.t("admin-creds-col-username") }}</th>
         <th>{{ self.t("admin-creds-col-created") }}</th>
-        <th class="actions-cell">{{ self.t("admin-specs-col-actions") }}</th>
+        <th class="actions-cell" data-nosort>{{ self.t("admin-specs-col-actions") }}</th>
       </tr>
     </thead>
     <tbody>

--- a/crates/ruscker-admin/templates/admin/disk.html
+++ b/crates/ruscker-admin/templates/admin/disk.html
@@ -52,14 +52,14 @@
   {% if containers.is_empty() %}
   <p class="text-sm text-[color:var(--text-faint)] py-4">{{ self.t("admin-disk-no-containers") }}</p>
   {% else %}
-  <table class="w-full text-sm disk-table" style="border-collapse:collapse">
+  <table class="w-full text-sm disk-table" style="border-collapse:collapse" data-enhance>
     <thead>
       <tr class="text-left text-[color:var(--text-muted)]" style="border-bottom:0.5px solid var(--border)">
         <th class="py-2">{{ self.t("admin-disk-col-container") }}</th>
         <th>{{ self.t("admin-disk-col-app") }}</th>
         <th>{{ self.t("admin-disk-col-image") }}</th>
         <th>{{ self.t("admin-disk-col-status") }}</th>
-        <th style="text-align:right">{{ self.t("admin-users-col-actions") }}</th>
+        <th style="text-align:right" data-nosort>{{ self.t("admin-users-col-actions") }}</th>
       </tr>
     </thead>
     <tbody>
@@ -115,14 +115,14 @@
   {% if images.is_empty() %}
   <p class="text-sm text-[color:var(--text-faint)] py-4">{{ self.t("admin-disk-no-images") }}</p>
   {% else %}
-  <table class="w-full text-sm disk-table" style="border-collapse:collapse">
+  <table class="w-full text-sm disk-table" style="border-collapse:collapse" data-enhance>
     <thead>
       <tr class="text-left text-[color:var(--text-muted)]" style="border-bottom:0.5px solid var(--border)">
         <th class="py-2">{{ self.t("admin-disk-col-image") }}</th>
         <th>{{ self.t("admin-disk-col-id") }}</th>
         <th style="text-align:right">{{ self.t("admin-disk-col-size") }}</th>
         <th>{{ self.t("admin-disk-col-usage") }}</th>
-        <th style="text-align:right">{{ self.t("admin-users-col-actions") }}</th>
+        <th style="text-align:right" data-nosort>{{ self.t("admin-users-col-actions") }}</th>
       </tr>
     </thead>
     <tbody>

--- a/crates/ruscker-admin/templates/admin/specs.html
+++ b/crates/ruscker-admin/templates/admin/specs.html
@@ -121,7 +121,7 @@
     <pre class="mt-3 inline-block text-[11px] text-left bg-[color:var(--surface-soft)] px-3 py-2 rounded">ruscker import application.yml --db &lt;path&gt;</pre>
   </div>
 {% else %}
-  <table class="admin-table">
+  <table class="admin-table" data-enhance>
     <thead>
       <tr>
         <th>{{ self.t("admin-specs-col-id") }}</th>
@@ -131,7 +131,7 @@
         <th>{{ self.t("admin-specs-col-updated") }}</th>
         <th>{{ self.t("admin-specs-col-version") }}</th>
         <th title="{{ self.t("admin-specs-col-access-help") }}">{{ self.t("admin-specs-col-access") }}</th>
-        <th class="actions-cell">{{ self.t("admin-specs-col-actions") }}</th>
+        <th class="actions-cell" data-nosort>{{ self.t("admin-specs-col-actions") }}</th>
       </tr>
     </thead>
     <tbody>

--- a/crates/ruscker-admin/templates/admin/users.html
+++ b/crates/ruscker-admin/templates/admin/users.html
@@ -70,14 +70,14 @@
 </form>
 
 {# ── Existing users ────────────────────────────────────────────── #}
-<table class="w-full text-sm" style="border-collapse:collapse">
+<table class="w-full text-sm" style="border-collapse:collapse" data-enhance>
   <thead>
     <tr class="text-left text-[color:var(--text-muted)]" style="border-bottom:0.5px solid var(--border)">
       <th class="py-2">{{ self.t("admin-users-col-user") }}</th>
       <th>{{ self.t("admin-users-col-role") }}</th>
       <th>{{ self.t("admin-users-col-groups") }}</th>
       <th>{{ self.t("admin-users-col-created") }}</th>
-      <th style="text-align:right">{{ self.t("admin-users-col-actions") }}</th>
+      <th style="text-align:right" data-nosort>{{ self.t("admin-users-col-actions") }}</th>
     </tr>
   </thead>
   <tbody>


### PR DESCRIPTION
Adds an **app/data search box** and **click-to-sort columns** to the admin tables, as requested.

## How it works

A small, dependency-free enhancer in `admin/_layout.html` runs on every admin page and upgrades any `<table data-enhance>`:

- inserts a **search input** above the table that filters rows by text (case-insensitive, matches any cell);
- makes each column header **clickable to sort** — ascending ↔ descending, numeric-aware (so version/access/size sort as numbers, names as text); a header marked `data-nosort` (the **Actions** column) stays inert;
- shows a localized **"no results"** row when a filter matches nothing.

Labels (`Buscar…` / `Nenhum resultado`, + en/es/fr) are injected once via `window.RUSCKER_TABLE_I18N`, so the script stays static and cached with the page.

## Tables covered

✅ Apps (`/admin/specs`), Users, Credentials, and **both** disk-panel tables (containers + images).

Intentionally **excluded**:
- the **dashboard** replica table — it re-renders rows live over SSE, which would fight client-side sort/filter state;
- the **import preview** — a one-shot confirm list, not a data table.

## Verification

Rendered `/admin/specs` carries `data-enhance` on the table, the enhancer script, and `RUSCKER_TABLE_I18N` with the translated strings; users/credentials/disk tables likewise marked. Build + i18n-check green. (Sort/filter behavior is client-side; structure verified server-side.)

🤖 Generated with [Claude Code](https://claude.com/claude-code)