### PR TITLE
fix(admin): enforce user-form rules in the browser + clearer errors

### DIFF
--- a/crates/ruscker-admin/assets/i18n/en/landing.ftl
+++ b/crates/ruscker-admin/assets/i18n/en/landing.ftl
@@ -105,7 +105,7 @@ admin-users-subtitle = Create and manage who can sign in, and at which level.
 admin-users-new = New user
 admin-users-create = Create
 admin-users-initial-password = Initial password
-admin-users-initial-password-hint = The user must change it on first login.
+admin-users-initial-password-hint = At least 8 characters. The user must change it on first login.
 admin-users-role = Role
 admin-users-col-user = User
 admin-users-col-role = Role
@@ -127,7 +127,9 @@ admin-users-flash-created = User created.
 admin-users-flash-saved = Changes saved.
 admin-users-flash-deleted = User removed.
 admin-users-flash-last-admin = Can't remove or demote the last administrator.
-admin-users-flash-bad-input = Invalid input (empty username or password under 8 characters).
+admin-users-flash-bad-input = Invalid input: the username may contain only letters, digits and _ . @ - , and the password needs at least 8 characters.
+admin-users-username-rule = Letters, digits and _ . @ - only (no spaces or accents).
+admin-users-password-rule = At least 8 characters.
 admin-users-flash-exists = A user with that name already exists.
 
 # Admin dashboard

--- a/crates/ruscker-admin/assets/i18n/es/landing.ftl
+++ b/crates/ruscker-admin/assets/i18n/es/landing.ftl
@@ -105,7 +105,7 @@ admin-users-subtitle = Crea y gestiona quién accede al panel y con qué nivel.
 admin-users-new = Nuevo usuario
 admin-users-create = Crear
 admin-users-initial-password = Contraseña inicial
-admin-users-initial-password-hint = El usuario deberá cambiarla en el primer acceso.
+admin-users-initial-password-hint = Mínimo 8 caracteres. El usuario deberá cambiarla en el primer acceso.
 admin-users-role = Nivel
 admin-users-col-user = Usuario
 admin-users-col-role = Nivel
@@ -127,7 +127,9 @@ admin-users-flash-created = Usuario creado.
 admin-users-flash-saved = Cambios guardados.
 admin-users-flash-deleted = Usuario eliminado.
 admin-users-flash-last-admin = No se puede eliminar ni degradar al último administrador.
-admin-users-flash-bad-input = Datos inválidos (usuario vacío o contraseña de menos de 8 caracteres).
+admin-users-flash-bad-input = Datos inválidos: el usuario solo puede tener letras, números y _ . @ - , y la contraseña necesita al menos 8 caracteres.
+admin-users-username-rule = Solo letras, números y _ . @ - (sin espacios ni acentos).
+admin-users-password-rule = Mínimo 8 caracteres.
 admin-users-flash-exists = Ya existe un usuario con ese nombre.
 
 # Admin dashboard

--- a/crates/ruscker-admin/assets/i18n/fr/landing.ftl
+++ b/crates/ruscker-admin/assets/i18n/fr/landing.ftl
@@ -105,7 +105,7 @@ admin-users-subtitle = Créez et gérez qui peut se connecter, et à quel niveau
 admin-users-new = Nouvel utilisateur
 admin-users-create = Créer
 admin-users-initial-password = Mot de passe initial
-admin-users-initial-password-hint = L'utilisateur devra le changer à la première connexion.
+admin-users-initial-password-hint = Au moins 8 caractères. L’utilisateur devra la changer à la première connexion.
 admin-users-role = Niveau
 admin-users-col-user = Utilisateur
 admin-users-col-role = Niveau
@@ -127,7 +127,9 @@ admin-users-flash-created = Utilisateur créé.
 admin-users-flash-saved = Modifications enregistrées.
 admin-users-flash-deleted = Utilisateur supprimé.
 admin-users-flash-last-admin = Impossible de supprimer ou rétrograder le dernier administrateur.
-admin-users-flash-bad-input = Données invalides (identifiant vide ou mot de passe de moins de 8 caractères).
+admin-users-flash-bad-input = Données invalides : le nom d’utilisateur ne peut contenir que des lettres, chiffres et _ . @ - , et le mot de passe doit comporter au moins 8 caractères.
+admin-users-username-rule = Lettres, chiffres et _ . @ - uniquement (sans espaces ni accents).
+admin-users-password-rule = Au moins 8 caractères.
 admin-users-flash-exists = Un utilisateur portant ce nom existe déjà.
 
 # Admin dashboard

--- a/crates/ruscker-admin/assets/i18n/pt/landing.ftl
+++ b/crates/ruscker-admin/assets/i18n/pt/landing.ftl
@@ -109,7 +109,7 @@ admin-users-subtitle = Crie e gerencie quem acessa o painel e com qual nível.
 admin-users-new = Novo usuário
 admin-users-create = Criar
 admin-users-initial-password = Senha inicial
-admin-users-initial-password-hint = O usuário será obrigado a trocá-la no primeiro acesso.
+admin-users-initial-password-hint = Mínimo de 8 caracteres. O usuário será obrigado a trocá-la no primeiro acesso.
 admin-users-role = Nível
 admin-users-col-user = Usuário
 admin-users-col-role = Nível
@@ -131,7 +131,9 @@ admin-users-flash-created = Usuário criado.
 admin-users-flash-saved = Alterações salvas.
 admin-users-flash-deleted = Usuário removido.
 admin-users-flash-last-admin = Não é possível remover ou rebaixar o último administrador.
-admin-users-flash-bad-input = Dados inválidos (usuário vazio ou senha com menos de 8 caracteres).
+admin-users-flash-bad-input = Dados inválidos: o usuário só pode ter letras, números e _ . @ - , e a senha precisa de ao menos 8 caracteres.
+admin-users-username-rule = Apenas letras, números e _ . @ - (sem espaços nem acentos).
+admin-users-password-rule = Mínimo de 8 caracteres.
 admin-users-flash-exists = Já existe um usuário com esse nome.
 
 # Admin dashboard

--- a/crates/ruscker-admin/templates/admin/users.html
+++ b/crates/ruscker-admin/templates/admin/users.html
@@ -31,7 +31,8 @@
   <div class="flex flex-wrap items-end gap-3">
     <label class="admin-login-field" style="margin:0;flex:1 1 180px">
       <span class="admin-login-label">{{ self.t("admin-login-username-label") }}</span>
-      <input type="text" name="username" required autocapitalize="none" placeholder="jane">
+      <input type="text" name="username" required autocapitalize="none" placeholder="jane"
+             pattern="[A-Za-z0-9_.@\-]+" title="{{ self.t("admin-users-username-rule") }}">
     </label>
     <label class="admin-login-field" style="margin:0">
       <span class="admin-login-label">{{ self.t("admin-users-initial-password") }}</span>
@@ -40,8 +41,8 @@
          the page — no Alpine dependency, so it works even if Alpine is
          absent (cf. the #433 images-gallery regression). #}
       <span style="position:relative;display:block">
-        <input type="password" name="password" required autocomplete="new-password"
-               placeholder="••••••••" style="padding-right:2.2rem">
+        <input type="password" name="password" required minlength="8" autocomplete="new-password"
+               placeholder="••••••••" title="{{ self.t("admin-users-password-rule") }}" style="padding-right:2.2rem">
         <button type="button" tabindex="-1" class="pw-reveal"
                 title="{{ self.t("admin-pw-reveal") }}"
                 style="position:absolute;right:8px;top:50%;transform:translateY(-50%);background:none;border:0;cursor:pointer;color:var(--text-muted);line-height:0;padding:0">
@@ -111,7 +112,8 @@
           <form method="post" action="{{ base }}/admin/users/{{ u.username }}/password"
                 style="display:inline-flex;gap:4px;align-items:center" autocomplete="off">
             <span style="position:relative;display:inline-block">
-              <input type="password" name="password" placeholder="{{ self.t("admin-users-new-password") }}"
+              <input type="password" name="password" required minlength="8" placeholder="{{ self.t("admin-users-new-password") }}"
+                     title="{{ self.t("admin-users-password-rule") }}"
                      style="width:140px;padding-right:1.8rem" autocomplete="new-password">
               <button type="button" tabindex="-1" class="pw-reveal"
                       title="{{ self.t("admin-pw-reveal") }}"


### PR DESCRIPTION
## Symptom

"None of the passwords I recently created worked." On investigation, the box DB had **only the `admin` account** — the other accounts were never created. A successful create writes an audit event; there were none for the missing users, so creation was **rejected**, not mis-hashed.

## Root cause

The create-user form's inputs were only `required` — no `minlength`/`pattern`. So a **password under 8 characters** or a **username with spaces/accents** (common for Brazilian names) passed the browser, hit the server's `is_valid_username(..) || password.len() < 8` guard, and bounced with a generic `bad-input` flash. The account was never created, so the later login failed — looking like "the password doesn't work."

## Fix (client-side guard + clearer copy; no backend change)

- `minlength="8"` on both password fields (create **and** per-user reset).
- `pattern="[A-Za-z0-9_.@\-]+"` + `title` on the username — the browser blocks the bad submit with a precise message.
- Field `title`s + the password hint now state the rules ("At least 8 characters", "Letters, digits and _ . @ - only…").
- The server-side `bad-input` flash now also names the username charset rule.

The server validation is unchanged — this just stops the silent pass-through and explains *why* an input is rejected.

## Verification

Local smoke: form HTML now carries `minlength="8"`/`pattern`; a short password is rejected server-side (0 users); a valid `andre.leite` / `senha1234` creates the account, and logging in with it authenticates (redirecting to the forced first-login password change). Build + i18n-check green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)