### PR TITLE
chore(release): bump workspace version 0.1.54 → 0.1.55

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2845,7 +2845,7 @@ dependencies = [
 
 [[package]]
 name = "ruscker-admin"
-version = "0.1.54"
+version = "0.1.55"
 dependencies = [
  "aes-gcm",
  "anyhow",
@@ -2892,7 +2892,7 @@ dependencies = [
 
 [[package]]
 name = "ruscker-cli"
-version = "0.1.54"
+version = "0.1.55"
 dependencies = [
  "anyhow",
  "clap",
@@ -2912,7 +2912,7 @@ dependencies = [
 
 [[package]]
 name = "ruscker-config"
-version = "0.1.54"
+version = "0.1.55"
 dependencies = [
  "chrono",
  "ordered-float",
@@ -2927,7 +2927,7 @@ dependencies = [
 
 [[package]]
 name = "ruscker-core"
-version = "0.1.54"
+version = "0.1.55"
 dependencies = [
  "async-trait",
  "chrono",
@@ -2940,7 +2940,7 @@ dependencies = [
 
 [[package]]
 name = "ruscker-docker"
-version = "0.1.54"
+version = "0.1.55"
 dependencies = [
  "anyhow",
  "async-stream",
@@ -2959,7 +2959,7 @@ dependencies = [
 
 [[package]]
 name = "ruscker-proxy"
-version = "0.1.54"
+version = "0.1.55"
 dependencies = [
  "anyhow",
  "axum",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -10,7 +10,7 @@ members = [
 ]
 
 [workspace.package]
-version = "0.1.54"
+version = "0.1.55"
 edition = "2021"
 rust-version = "1.85"
 license = "Apache-2.0"

--- a/book/src/faq.md
+++ b/book/src/faq.md
@@ -80,7 +80,7 @@ the **sign-in session** paths to a single upstream — see
 
 ### Is it production-ready?
 
-Yes. The current release is **v0.1.54** — Phases 0–7 are complete and
+Yes. The current release is **v0.1.55** — Phases 0–7 are complete and
 the proxy is production-ready and horizontally scalable.
 Releases are multi-arch and cosign-signed; see the
 [release notes](./news.md) and the [Roadmap](./roadmap.md).

--- a/book/src/introduction.md
+++ b/book/src/introduction.md
@@ -44,7 +44,7 @@ proper admin panel, a monitoring dashboard, and load balancing.
 
 ## In production
 
-Ruscker is on **v0.1.54** and runs in production today. Where the
+Ruscker is on **v0.1.55** and runs in production today. Where the
 JVM-based stack it replaced idled at hundreds of megabytes, Ruscker
 idles in the low tens:
 

--- a/book/src/news.md
+++ b/book/src/news.md
@@ -9,6 +9,19 @@ the [GitHub releases page](https://github.com/StrategicProjects/ruscker/releases
 
 ---
 
+## v0.1.55 — 2026-06-04
+
+Media filename management.
+
+**Admin**
+- Uploading an image whose name already exists no longer **silently
+  overwrites** it — the upload is kept under a free name
+  (`logo.webp` → `logo-2.webp`) and the toast says it was renamed.
+- New **rename** action on each Media tile. The new name keeps the
+  original extension, a taken name is refused, and every card logo/cover
+  and landing logo that referenced the old name is **rewritten** to the
+  new one — so nothing breaks.
+
 ## v0.1.54 — 2026-06-03
 
 Clearer user-account form.

--- a/book/src/roadmap.md
+++ b/book/src/roadmap.md
@@ -1,6 +1,6 @@
 # Roadmap
 
-Ruscker is at **v0.1.54** — Phases 0 through 7 are done and the proxy is
+Ruscker is at **v0.1.55** — Phases 0 through 7 are done and the proxy is
 production-ready and horizontally scalable. Phase 8 (external auth) is
 the main optional, demand-driven work left. For what changed in each
 release, see the [release notes](./news.md).
@@ -71,7 +71,7 @@ can serve any session; one scaler leader via Postgres advisory locks,
 with failover. A runnable 2-instance compose harness lives in
 `examples/ha/`. See [Deployment shapes](./architecture.md#deployment-shapes).
 
-### Post-phase polish → **v0.1.4 – v0.1.54**
+### Post-phase polish → **v0.1.4 – v0.1.55**
 
 Incremental improvements shipped after Phase 7.
 

--- a/docs/SECURITY.md
+++ b/docs/SECURITY.md
@@ -5,7 +5,7 @@ Status: living document. Tracks the Phase 5 security audit
 **[accepted limitation]**, or **[deferred]**. File references use
 `crate/path:symbol` so they survive line-number drift.
 
-> **Scope.** This covers v0.1.54: single-operator install, Ruscker
+> **Scope.** This covers v0.1.55: single-operator install, Ruscker
 > behind a TLS-terminating reverse proxy, Docker on the same host.
 > Multi-tenant / shared-team auth (OIDC, RBAC) is out of scope until
 > Phase 8.


### PR DESCRIPTION
Cuts **v0.1.55**. Since v0.1.54, one PR landed:

- **#571** — Media filename management: a same-named upload is kept under a free name instead of silently overwriting, and a new rename action on each Media tile rewrites every spec/landing reference to the new name.

**Release mechanics**
- `[workspace.package] version` 0.1.54 → 0.1.55, `Cargo.lock` refreshed.
- Version refs bumped in `book/src/{faq,introduction,roadmap}.md` + `docs/SECURITY.md`.
- `news.md` entry added.

Merge → tag `v0.1.55` triggers `release.yml` (`.deb` + musl + cosign-signed ghcr image + GitHub release + Homebrew tap auto-publish).

🤖 Generated with [Claude Code](https://claude.com/claude-code)