### PR TITLE
feat(admin): filter the Media gallery by file type

### DIFF
--- a/crates/ruscker-admin/assets/i18n/en/landing.ftl
+++ b/crates/ruscker-admin/assets/i18n/en/landing.ftl
@@ -273,6 +273,7 @@ admin-images-inuse = In use
 admin-images-inuse-help = Used by a card or a landing logo
 admin-images-delete-confirm-inuse = This image is IN USE. Deleting it resets the apps that use it to the default Ruscker logo (the card will not break). Delete?
 admin-images-search = Search images…
+admin-images-type-all = All types
 admin-images-no-match = No images match your search.
 
 # Admin credentials

--- a/crates/ruscker-admin/assets/i18n/es/landing.ftl
+++ b/crates/ruscker-admin/assets/i18n/es/landing.ftl
@@ -273,6 +273,7 @@ admin-images-inuse = En uso
 admin-images-inuse-help = Usada en una tarjeta o un logo de la landing
 admin-images-delete-confirm-inuse = Esta imagen está EN USO. Al eliminarla, los apps que la usan vuelven al logo predeterminado de Ruscker (la tarjeta no se rompe). ¿Eliminar?
 admin-images-search = Buscar imágenes…
+admin-images-type-all = Todos los tipos
 admin-images-no-match = Ninguna imagen coincide con la búsqueda.
 
 # Admin credentials

--- a/crates/ruscker-admin/assets/i18n/fr/landing.ftl
+++ b/crates/ruscker-admin/assets/i18n/fr/landing.ftl
@@ -273,6 +273,7 @@ admin-images-inuse = Utilisé
 admin-images-inuse-help = Utilisé par une carte ou un logo de la landing
 admin-images-delete-confirm-inuse = Cette image est UTILISÉE. La supprimer rétablit le logo Ruscker par défaut sur les apps concernées (la carte ne casse pas). Supprimer ?
 admin-images-search = Rechercher des images…
+admin-images-type-all = Tous les types
 admin-images-no-match = Aucune image ne correspond à la recherche.
 
 # Admin credentials

--- a/crates/ruscker-admin/assets/i18n/pt/landing.ftl
+++ b/crates/ruscker-admin/assets/i18n/pt/landing.ftl
@@ -277,6 +277,7 @@ admin-images-inuse = Em uso
 admin-images-inuse-help = Usada num card ou nos logos da landing
 admin-images-delete-confirm-inuse = Esta imagem está EM USO. Se deletar, os apps que a usam voltam ao logo padrão do Ruscker (o card não quebra). Deletar?
 admin-images-search = Buscar imagens…
+admin-images-type-all = Todos os tipos
 admin-images-no-match = Nenhuma imagem corresponde à busca.
 
 # Admin credentials

--- a/crates/ruscker-admin/templates/admin/images.html
+++ b/crates/ruscker-admin/templates/admin/images.html
@@ -70,11 +70,24 @@
      leaving `q`/`filtered` undefined and no tiles). The browser un-escapes
      `&quot;` back to `"` before Alpine parses it. #}
   <div x-data="ruscker.mediaGallery({{ self.images_json() }})" x-cloak>
-    <div class="mb-4">
+    <div class="mb-4 flex flex-wrap items-center gap-2">
       <input type="search" x-model="q"
              placeholder="{{ self.t("admin-images-search") }}"
-             class="admin-input w-full max-w-xs text-sm"
+             class="admin-input flex-1 min-w-0 max-w-xs text-sm"
              style="padding:6px 10px">
+      {# Type filter — options derived from the images actually present
+         (typically SVG + WebP), so it adapts and never offers an empty
+         filter. Hidden when there's only one type. #}
+      <template x-if="types().length > 1">
+        <select x-model="type" class="admin-input text-sm theme-select"
+                style="padding:6px 10px;width:auto"
+                aria-label="{{ self.t("admin-images-type-all") }}">
+          <option value="">{{ self.t("admin-images-type-all") }}</option>
+          <template x-for="t in types()" :key="t">
+            <option :value="t" x-text="t.toUpperCase()"></option>
+          </template>
+        </select>
+      </template>
     </div>
 
     <section class="image-gallery">
@@ -148,11 +161,27 @@
   window.ruscker.mediaGallery = (items) => ({
     all: Array.isArray(items) ? items : [],
     q: '',
+    type: '',
     shown: 24,
     page: 24,
+    // File extension, lowercased (e.g. "svg", "webp"). Drives the type
+    // filter, whose options are derived from what's actually present —
+    // raster uploads are stored as WebP, so png/jpeg never appear.
+    ext(name) {
+      const i = (name || '').lastIndexOf('.');
+      return i >= 0 ? name.slice(i + 1).toLowerCase() : '';
+    },
+    types() {
+      return [...new Set(this.all.map((i) => this.ext(i.filename)).filter(Boolean))].sort();
+    },
     filtered() {
       const t = this.q.trim().toLowerCase();
-      return t ? this.all.filter((i) => i.filename.toLowerCase().includes(t)) : this.all;
+      const ty = this.type;
+      return this.all.filter(
+        (i) =>
+          (!t || i.filename.toLowerCase().includes(t)) &&
+          (!ty || this.ext(i.filename) === ty)
+      );
     },
     // Prefix the base path on a root-absolute asset/action URL so the
     // gallery works under `--base-path /box` (#270) — these URLs are


### PR DESCRIPTION
Adds a **type filter** to the Media library, next to the existing filename search.

- A dropdown whose options are **derived from the images actually present** (lowercased file extension), not a fixed png/jpeg list — raster uploads are re-encoded to **WebP**, so in practice it offers **SVG + WebP** and adapts to whatever is in the library.
- Hidden when only one type exists (no point in a single-option filter).
- Combines with the text search (both narrow the set); options are shown uppercased; default is **All types**.

Pure client-side in the `mediaGallery` Alpine component — no backend change.

Verification: rendered `/admin/media` carries the `x-model="type"` select, the `types()`/`ext()` helpers, and the `types().length > 1` guard; the showcase-only (SVG) seed keeps the filter hidden as designed. Build + `cargo test -p ruscker-admin` + i18n-check green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)