### PR TITLE
fix(admin): style Media search + type filter to match the other controls

### DIFF
--- a/crates/ruscker-admin/templates/admin/_layout.html
+++ b/crates/ruscker-admin/templates/admin/_layout.html
@@ -279,6 +279,17 @@ window.ruscker.imagePicker = (filenames) => ({
     border-radius: 8px; background: var(--surface, #fff); color: var(--text-primary);
   }
   .admin-table-search:focus { outline: none; border-color: var(--accent, #2563eb); }
+  /* Companion <select> matching .admin-table-search, so a search + filter
+     pair (e.g. the Media gallery) looks like one consistent control. */
+  .admin-table-select {
+    font-size: 13px; padding: 7px 30px 7px 11px;
+    border: 0.5px solid var(--color-border-tertiary, rgba(120,120,120,0.3));
+    border-radius: 8px; background-color: var(--surface, #fff); color: var(--text-primary);
+    appearance: none; -webkit-appearance: none; cursor: pointer;
+    background-image: url("data:image/svg+xml;utf8,<svg xmlns='http://www.w3.org/2000/svg' width='12' height='12' viewBox='0 0 24 24' fill='none' stroke='%23888' stroke-width='2' stroke-linecap='round' stroke-linejoin='round'><path d='M6 9l6 6 6-6'/></svg>");
+    background-repeat: no-repeat; background-position: right 10px center; background-size: 12px;
+  }
+  .admin-table-select:focus { outline: none; border-color: var(--accent, #2563eb); }
   th.admin-th-sort { cursor: pointer; user-select: none; white-space: nowrap; }
   th.admin-th-sort::after { content: '↕'; opacity: .3; margin-left: 5px; font-size: 10px; }
   th.admin-th-sort[data-sort-dir='asc']::after  { content: '↑'; opacity: .9; }

--- a/crates/ruscker-admin/templates/admin/images.html
+++ b/crates/ruscker-admin/templates/admin/images.html
@@ -73,14 +73,12 @@
     <div class="mb-4 flex flex-wrap items-center gap-2">
       <input type="search" x-model="q"
              placeholder="{{ self.t("admin-images-search") }}"
-             class="admin-input flex-1 min-w-0 max-w-xs text-sm"
-             style="padding:6px 10px">
+             class="admin-table-search">
       {# Type filter — options derived from the images actually present
          (typically SVG + WebP), so it adapts and never offers an empty
          filter. Hidden when there's only one type. #}
       <template x-if="types().length > 1">
-        <select x-model="type" class="admin-input text-sm theme-select"
-                style="padding:6px 10px;width:auto"
+        <select x-model="type" class="admin-table-select"
                 aria-label="{{ self.t("admin-images-type-all") }}">
           <option value="">{{ self.t("admin-images-type-all") }}</option>
           <template x-for="t in types()" :key="t">


### PR DESCRIPTION
The Media gallery's filter controls didn't match the rest of the admin:

- the **search box** used a `.admin-input` class that doesn't exist in the stylesheet, so it rendered essentially unstyled;
- the **type select** used the pill-shaped `.theme-select` (form style), unlike the data-table search boxes.

Both now use the shared data-table look: the search reuses **`.admin-table-search`**, and a new companion **`.admin-table-select`** (same 0.5px border, 8px radius, surface background, focus accent, plus a chevron) styles the type filter — so the search + type pair reads as one consistent control, matching the searchable tables elsewhere.

Both classes live in `admin/_layout.html`, so every admin page shares them. Verified the rendered `/admin/media` now carries `class="admin-table-search"` + `class="admin-table-select"` (no more `admin-input`/`theme-select`). Build green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)