### PR TITLE
docs: lead with Ruscker, drop competitor comparisons (intro + README + alternatives)

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,17 +5,18 @@
        alt="Ruscker" height="56">
 </picture>
 
-A lightweight Rust alternative to **ShinyProxy** and **Shiny Server
-Free**. Serves and load-balances containerized interactive web apps
-(R/Shiny, Streamlit, Dash, Voilà) and stateless HTTP APIs (Plumber2,
-FastAPI) behind a single proxy, with a custom landing page and an
-admin panel.
+**Ruscker** is a high-performance **portal and orchestrator** for
+containerized web workloads. It serves and load-balances
+container-per-session interactive apps (R/Shiny, Streamlit, Dash, Voilà,
+Jupyter, RStudio) and container-per-API stateless HTTP services
+(Plumber2, FastAPI) behind a single proxy, with a custom landing page and
+an admin panel.
 
-It ships as a **single static binary, no JVM** — so the idle footprint
-is megabytes, not hundreds of megabytes, and startup is instant.
+It ships as a **single, ultra-lightweight static binary** with **instant
+startup** — the idle footprint sits in the low tens of megabytes.
 
 📖 **Documentation: <https://strategicprojects.github.io/ruscker/>**
-(install · migrating from ShinyProxy · configuration · admin · deploy).
+(install · migrate · configure · admin · deploy).
 
 <p align="center">
   <img src="book/src/images/landing.png" alt="The Ruscker landing page: a portal of app cards with a Featured carousel at the top, plus search and type/access filters." width="860">
@@ -36,26 +37,18 @@ containers are reaped automatically.
 
 ## Why Ruscker
 
-- **ShinyProxy** is mature but heavy: a JVM that idles at hundreds of
-  MB, slow to start, configured by hand-editing YAML and restarting.
-- **Shiny Server Free** doesn't isolate sessions or scale.
-- **Both** have weak admin UIs ("edit YAML and restart").
+Modern web workloads want speed and minimal overhead. Ruscker delivers
+that without giving up convenience:
 
-Ruscker keeps ShinyProxy's `application.yml` schema (so migration is
-friction-free) and adds a real admin panel, a live monitoring
-dashboard, and load balancing on top.
-
-|                        | ShinyProxy   | Shiny Server Free | **Ruscker**          |
-|------------------------|--------------|-------------------|----------------------|
-| Runtime                | JVM          | R process         | single Rust binary   |
-| Idle memory            | 300–500 MB   | —                 | **~14 MB**           |
-| Dependencies           | JVM          | R                 | none (static binary) |
-| Web admin panel        | ✗            | ✗                 | ✓                    |
-| Live monitoring dashboard | ✗         | ✗                 | ✓                    |
-| Session isolation      | ✓            | ✗                 | ✓                    |
-| Auto-scaling           | manual       | ✗                 | automatic            |
-| Native HTTP APIs       | limited      | ✗                 | ✓ (Plumber/FastAPI)  |
-| ShinyProxy YAML        | —            | —                 | 100% compatible      |
+- **Zero-friction migration** — bring your apps over with a familiar
+  YAML schema, no rewrite.
+- **Single compiled binary** — one artifact to ship and run, with a tiny
+  idle footprint (~14 MB) and instant startup.
+- **Batteries included** — a real admin panel, a live monitoring
+  dashboard, and load balancing, out of the box.
+- **Anything in a container** — interactive apps and stateless HTTP APIs
+  alike, isolated per session or pooled per replica, with an auto-scaler
+  that spawns and reaps containers on demand.
 
 ## What it can serve
 
@@ -80,15 +73,14 @@ tool" cases) is in
 **Production-ready and running in production.** Releases are
 multi-arch (amd64 + arm64) and [cosign-signed]; the
 [releases page](https://github.com/StrategicProjects/ruscker/releases)
-has the current version. Where the JVM-based
-stack it replaced idled at hundreds of megabytes, Ruscker idles in the
-low tens:
+has the current version. Built for efficiency, Ruscker's idle footprint
+sits in the low tens of megabytes:
 
 [cosign-signed]: https://strategicprojects.github.io/ruscker/installation.html#verifying-release-artifacts
 
-> **~540 MB → ~14 MB idle** — roughly a 38× cut, on the same machine
-> serving the same apps. A real 31-spec config migrated with **no
-> unsupported features**, and apps spawn on demand.
+> **~540 MB → ~14 MB idle** — measured on a real production deployment,
+> the same machine serving the same apps. A real 31-spec config migrated
+> with **no unsupported features**, and apps spawn on demand.
 
 What's in the box:
 
@@ -181,7 +173,7 @@ cargo build --release          # rustup fetches the pinned toolchain on first ru
 ## Quickstart
 
 ```bash
-# Validate a config (and check ShinyProxy-feature compatibility)
+# Validate a config (and pre-flight migration compatibility)
 ruscker validate examples/application.yml --strict-compat
 
 # Run the portal + admin + proxy with the Docker backend
@@ -221,7 +213,7 @@ ruscker show    <path>               # render YAML with env vars interpolated
 
 ## YAML compatibility
 
-Ruscker reads ShinyProxy's `application.yml` schema unchanged and adds
+Ruscker reads an existing `application.yml` schema unchanged and adds
 Ruscker-specific fields (API specs, replica pools, landing
 customization) as you go. Migration is typically a one-line change in
 your reverse proxy — point it at Ruscker on the same port and paths.

--- a/book/src/SUMMARY.md
+++ b/book/src/SUMMARY.md
@@ -2,7 +2,7 @@
 
 [Introduction](./introduction.md)
 [What Ruscker can serve](./use-cases.md)
-[Ruscker vs. alternatives](./alternatives.md)
+[Where Ruscker fits](./alternatives.md)
 
 # User guide
 

--- a/book/src/alternatives.md
+++ b/book/src/alternatives.md
@@ -1,72 +1,47 @@
-# Ruscker vs. the alternatives
+# Where Ruscker fits
 
 Ruscker is a **portal-and-orchestrator for container-per-session and
-container-per-API workloads**. That puts it next to a handful of
-established tools — some open source, some commercial, some R-only, some
-notebook-only. This page is an honest map of where Ruscker fits and what
-it replaces.
+container-per-API workloads** — interactive apps that want a fresh
+container per visitor, and stateless HTTP services pooled per replica. If
+your apps run in a container and speak HTTP or WebSocket, Ruscker wraps
+them in a portal, a reverse proxy, sticky sessions, auto-scaling and an
+admin panel — configured by a single YAML file.
 
-The short version: if you run **ShinyProxy** or **Shiny Server** today
-and want the same model without the JVM weight (or without paying for a
-commercial product), Ruscker is a drop-in-shaped fit — it even reads
-ShinyProxy's `application.yml`.
+## What Ruscker is good at
 
-## At a glance
+- **Per-session isolation** — one container per visitor for stateful
+  apps (Shiny, Streamlit, Dash, Voilà, notebooks), so sessions never
+  share state.
+- **Stateless APIs** — pooled per replica with an auto-scaler (Plumber2,
+  FastAPI, and any HTTP service).
+- **Mixed frameworks under one portal** — every app is a card on the
+  landing page; anything in a container is first-class.
+- **A real admin panel** — apps CRUD, a media library, an encrypted
+  credentials store, a live monitoring dashboard, an audit log, and user
+  roles — instead of editing a file and restarting.
+- **Light to run** — a single static binary with a low-tens-of-MB idle
+  footprint and instant startup.
 
-| | **Ruscker** | **ShinyProxy** | **Shiny Server** (open source) | **Posit Connect** | **JupyterHub** |
-|---|---|---|---|---|---|
-| Runtime | Rust — single static binary | JVM (Java / Spring) | C++ / Node | proprietary | Python |
-| Idle footprint | **~14 MB** | ~300–540 MB | moderate | heavy | moderate–heavy |
-| Per-session isolation | ✅ container/session | ✅ container/session | ❌ shared R processes | ✅ | ✅ per-user |
-| Frameworks | Shiny, Streamlit, Dash, Voilà, Plumber, FastAPI — any HTTP/WS container | any container | **R/Shiny only** | R, Python, Quarto, APIs | Jupyter/Python (+ images) |
-| Admin UI | ✅ live dashboard + full CRUD | minimal | edit config + restart | ✅ rich | partial |
-| Multi-host scheduling | ✅ Docker over ssh/tcp | ✅ (Kubernetes / operator) | ❌ | ✅ | ✅ (Kubernetes) |
-| HA / active-active | ✅ (shared Postgres) | ✅ (operator) | ❌ | ✅ | ✅ |
-| Reads ShinyProxy YAML | ✅ | — (native) | ❌ | ❌ | ❌ |
-| License | open source | open source (Apache-2.0) | open source (free tier) | **commercial** | open source (BSD) |
+## Self-hosting a single framework
 
-"Footprint" is the idle resident memory of the orchestrator itself, not
-the apps it runs. Feature checkmarks are deliberately coarse — see the
-per-tool notes for the nuance.
+Streamlit, Dash, Voilà and Gradio ship their own dev server but **no
+multi-app portal, session isolation, auth, or scaling** — self-hosting
+means rolling your own reverse proxy, container lifecycle and landing
+page. That glue is exactly what Ruscker is. Point a spec at your image
+and you get the portal, sticky sessions, WebSocket forwarding, scaling
+and reaping for free. See [What Ruscker can serve](./use-cases.md).
 
-## ShinyProxy
+## Sub-path handling (the strip model)
 
-The closest comparison, and the one Ruscker is YAML-compatible with.
-ShinyProxy is mature and capable, but it's a **Spring Boot application
-on the JVM**: it idles at hundreds of megabytes, takes seconds to start,
-and is configured by hand-editing `application.yml` and restarting.
-Theming is Thymeleaf templates.
-
-**What Ruscker changes:** the same container-per-session model and the
-*same config file*, but as a single static binary that idles in the low
-tens of MB, plus a real admin panel (apps CRUD, image library, encrypted
-credentials, live dashboard, audit log, user roles) instead of "edit
-YAML and restart". See [Migrating from ShinyProxy](./migrating.md).
-
-**What ShinyProxy still does that Ruscker doesn't (yet):** a mature
-Kubernetes operator and pluggable enterprise auth (OIDC/SAML/LDAP for
-*app access*). Ruscker's multi-host is Docker-over-ssh/tcp today. Per-app
-visibility and access control (`access-groups` / `access-users`,
-ShinyProxy-compatible) are already supported; OIDC/SAML/LDAP gating at
-the proxy level is not (apps can handle their own auth internally).
-
-### Strip model vs. `SHINYPROXY_PUBLIC_PATH`
-
-One migration detail worth knowing: ShinyProxy uses a **no-strip** model —
-it passes the full public path to the container as the
-`SHINYPROXY_PUBLIC_PATH` environment variable, and well-behaved
-ShinyProxy demo images read that variable to self-prefix all their URLs.
-Ruscker uses a **strip** model — the proxy strips `/app/{id}` from the
+Ruscker uses a **strip** model: the proxy strips `/app/{id}` from the
 request path before forwarding, so the container always receives a
 root-relative path (e.g. `/lab/...` instead of `/app/jupyter/lab/...`).
-The container does **not** need to know its mount path; the proxy injects
+The container does **not** need to know its mount path — the proxy injects
 a `<base href>`, rewrites static URLs in HTML responses, and patches
 runtime fetches via a small JS shim.
 
-This means **do not set `SHINYPROXY_PUBLIC_PATH` in `container-env`** for
-Ruscker — the container would misconfigure itself and 404 on every request.
-Most apps need no mount-path configuration at all; just serve them at the
-root. Jupyter, for example, runs at `--ServerApp.base_url=/`:
+The practical consequence: serve apps at the root and don't hard-code a
+mount path. Jupyter, for example, runs at `--ServerApp.base_url=/`:
 
 ```yaml
 - id: jupyter
@@ -79,84 +54,40 @@ root. Jupyter, for example, runs at `--ServerApp.base_url=/`:
     - --ServerApp.base_url=/
 ```
 
-For the rare app that genuinely needs to know its external mount path — to
-build absolute URLs the proxy can't rewrite — Ruscker exposes an explicit
-opt-in token `#{publicPath}`, substituted at spawn with the spec's actual
-mount path (including any `--base-path` prefix), for use in `container-cmd`
-or `container-env`. Do **not** use it for Jupyter: under the strip model a
+If you're carrying over a config where the app reads a `*_PUBLIC_PATH`
+environment variable to self-prefix its URLs, **drop it** under Ruscker —
+the strip model already handles the mount path, and a self-prefixing app
+would misconfigure itself and 404 on every request.
+
+For the rare app that genuinely needs its external mount path — to build
+absolute URLs the proxy can't rewrite — Ruscker exposes an explicit opt-in
+token `#{publicPath}`, substituted at spawn with the spec's actual mount
+path (including any `--base-path` prefix), for use in `container-cmd` or
+`container-env`. Do **not** use it for Jupyter: under the strip model a
 non-root `base_url` makes it 404 every path (see
 [Troubleshooting](./troubleshooting.md)). Apps like Shiny, Streamlit, Dash
 and Voilà never need it.
 
-### Secrets via env-var interpolation
+## Secrets via env-var interpolation
 
-Both Ruscker and ShinyProxy support `${VAR}` references in the YAML. The
-difference is where resolution happens. In Ruscker, `${VAR}` references
-in `container-env` values are resolved **at spawn**, not at parse: the
-literal `${DB_PASSWORD}` is stored in the config and the database; only
-when a container is actually started does Ruscker look up the environment
-variable and inject the real value. This means **secrets never land in
-the database** — the DB only ever sees the placeholder. Set secrets in
-the process environment (or in `/etc/ruscker/ruscker.env` for the systemd
-service) and reference them by name in the YAML.
-
-## Shiny Server (open source / "Free")
-
-Shiny Server's free edition runs R/Shiny apps but **does not isolate
-sessions** — users share R processes per app — and it **doesn't scale or
-load-balance**. Authentication, per-user resources and monitoring are
-Pro (commercial) features. Administration is "edit the config file and
-restart".
-
-**What Ruscker changes:** real per-session isolation (one container per
-visitor), an auto-scaler with replica pools, a monitoring dashboard, and
-it isn't limited to R — Streamlit, Dash, Voilà, FastAPI and anything in
-a container are first-class.
-
-## Posit Connect (formerly RStudio Connect)
-
-The polished commercial option: a publishing platform for R, Python,
-Quarto and APIs with push-button deploys, scheduling, and fine-grained
-access control. It does far more than Ruscker — but it's **commercial,
-per-seat licensed, and heavy**.
-
-**Where Ruscker fits:** when you want a self-hosted, open-source,
-lightweight orchestrator and don't need Connect's publishing workflow or
-are unwilling to pay per-seat. Ruscker is a proxy/orchestrator, not a
-publishing platform — you bring your own container images.
-
-## JupyterHub
-
-JupyterHub spawns a **per-user** server (notebook/Lab), typically via a
-Docker or Kubernetes spawner. It's excellent for interactive Python/data
-science, but it's Python-centric, leans on Kubernetes for real scale, and
-is organized around *users with notebooks* rather than *apps with
-sessions*.
-
-**Where Ruscker fits:** a per-**app** portal (each app a card, each
-visitor a container) across mixed frameworks, lighter to run, configured
-by one YAML file. You can still run a Jupyter/Lab image as a Ruscker spec.
-
-## Streamlit, Dash, Voilà, Gradio (self-hosted)
-
-These frameworks ship their own dev server but **no multi-app portal,
-session isolation, auth, or scaling** — self-hosting means rolling your
-own reverse proxy, container lifecycle and landing page. That glue is
-exactly what Ruscker is. Point a spec at your Streamlit/Dash/Voilà/Gradio
-image and you get the portal, sticky sessions, WebSocket forwarding,
-scaling and reaping for free. See [What Ruscker can serve](./use-cases.md).
+Ruscker supports `${VAR}` references in the YAML, resolved **at spawn**,
+not at parse: the literal `${DB_PASSWORD}` is stored in the config and the
+database; only when a container is actually started does Ruscker look up
+the environment variable and inject the real value. This means **secrets
+never land in the database** — the DB only ever sees the placeholder. Set
+secrets in the process environment (or in `/etc/ruscker/ruscker.env` for
+the systemd service) and reference them by name in the YAML.
 
 ## When Ruscker is *not* the right tool
 
-- You need a **publishing/authoring workflow** (push from an IDE,
-  scheduled reports, content versioning) — that's Posit Connect.
+- You need a **publishing / authoring workflow** — pushing content from an
+  IDE, scheduled reports, content versioning. Ruscker is a
+  proxy/orchestrator; you bring your own container images.
 - You're **all-in on Kubernetes** and want a CRD-native operator today —
-  ShinyProxy's operator or a k8s-native platform is a better match
-  (Ruscker schedules onto Docker hosts, not k8s).
+  Ruscker schedules onto Docker hosts (over ssh/tcp), not Kubernetes.
 - You need **enterprise SSO gating app access per user** (OIDC/SAML/LDAP
   at the proxy level) — Ruscker's auth covers admin roles (Viewer /
-  Editor / Admin) and per-app visibility (`access-groups` / `access-users`),
-  but proxy-level SSO is not yet supported.
+  Editor / Admin) and per-app visibility (`access-groups` /
+  `access-users`), but proxy-level SSO is not yet supported.
 
-If none of those apply and you want ShinyProxy's model without the JVM,
-start with the [Quickstart](./quickstart.md).
+If none of those apply, start with the [Quickstart](./quickstart.md).

--- a/book/src/faq.md
+++ b/book/src/faq.md
@@ -32,8 +32,8 @@ No. Ruscker drives the **Docker** daemon. A single Docker host is the
 common case; for more capacity it can schedule across several Docker
 daemons over `ssh://` or `tcp://` (see
 [multi-host scheduling](./deploying.md)). There's no Kubernetes
-requirement — if you're all-in on k8s, see the
-[alternatives](./alternatives.md).
+requirement — if you're all-in on k8s, see
+[where Ruscker fits](./alternatives.md).
 
 ### How does scaling work?
 

--- a/book/src/introduction.md
+++ b/book/src/introduction.md
@@ -93,13 +93,12 @@ what's shipped and what's next.
 - [Quickstart](./quickstart.md) — from zero to a running app in minutes.
 - [What Ruscker can serve](./use-cases.md) — Shiny, Streamlit, Dash,
   FastAPI, JupyterLab, LLM UIs, BI tools, and more.
-- [Ruscker vs. alternatives](./alternatives.md) — how it compares to
-  ShinyProxy, Shiny Server, Posit Connect, and JupyterHub.
+- [Where Ruscker fits](./alternatives.md) — what Ruscker is for and when
+  to use it.
 - [Installation](./installation.md) — Docker, the `.deb`, or `brew`.
-- [Migrating from ShinyProxy](./migrating.md) — point Ruscker at your
+- [Migrate an existing config](./migrating.md) — point Ruscker at your
   existing `application.yml`.
 - [Configuration](./configuration.md) — the full YAML reference.
 - [The admin panel](./admin.md) — what each screen does.
-- [Deploying in production](./deploying.md) — systemd + nginx,
-  side-by-side with ShinyProxy.
+- [Deploying in production](./deploying.md) — systemd + nginx.
 - [Roadmap](./roadmap.md) — shipped phases and what's planned.

--- a/book/src/introduction.md
+++ b/book/src/introduction.md
@@ -5,17 +5,17 @@
 
 # Ruscker
 
-**Ruscker** is a **portal and orchestrator** for containerized web
-workloads behind one proxy. It handles two shapes:
+**Ruscker** is a high-performance **portal and orchestrator** for
+containerized web workloads. Behind a single proxy, it manages both:
 
 - **Container-per-session** interactive apps — R/Shiny, Streamlit,
   Dash, Voilà, Jupyter, RStudio.
 - **Container-per-API** stateless HTTP services — Plumber2, FastAPI.
 
-It keeps a ShinyProxy-compatible YAML schema for low-friction migration,
-ships as a **single static binary, no JVM**, and adds a real admin
-panel, a live monitoring dashboard, and load balancing. Idle footprint
-is megabytes, not hundreds of megabytes, and startup is instant.
+Deployed as a single, ultra-lightweight **static binary** with **instant
+startup**, Ruscker comes fully equipped with an **admin panel**,
+**real-time monitoring**, and **load balancing**. It uses a familiar
+YAML schema, so migration is smooth and configuration is effortless.
 
 <p align="center">
   <img src="images/landing.png" alt="The Ruscker landing page: a portal of app cards with a Featured carousel at the top, plus search and type/access filters — all served by a single binary." width="860">
@@ -34,25 +34,29 @@ containers are reaped automatically.
   <img src="images/architecture.svg" alt="How Ruscker works: browsers and API clients reach one Ruscker binary, which reverse-proxies to app containers it spawns on demand through the Docker daemon." width="640">
 </p>
 
-## Why
+## Why Ruscker
 
-ShinyProxy is mature but heavy: a JVM that idles at hundreds of MB,
-slow to start, configured by hand-editing YAML and restarting. Shiny
-Server Free doesn't isolate sessions or scale. Ruscker keeps
-ShinyProxy's YAML schema (so migration is friction-free) and adds a
-proper admin panel, a monitoring dashboard, and load balancing.
+Modern web workloads demand speed and minimal overhead. Ruscker is
+engineered to keep the runtime light while staying compatible:
+
+- **Zero-friction migration** — bring your apps over with a familiar
+  YAML schema, no rewrite.
+- **Single compiled binary** — one artifact to ship and run, with a tiny
+  idle footprint and instant startup.
+- **Batteries included** — a proper admin panel, a live monitoring
+  dashboard, and load balancing, out of the box.
 
 ## In production
 
-Ruscker is on **v0.1.57** and runs in production today. Where the
-JVM-based stack it replaced idled at hundreds of megabytes, Ruscker
-idles in the low tens:
+Ruscker is on **v0.1.57** and runs in production today. Built for extreme
+efficiency, its idle footprint sits in the low tens of megabytes:
 
-> **~540 MB → ~14 MB idle** — roughly a 38× cut.
+> **~540 MB → ~14 MB idle** — measured on a real production deployment.
 
-A real 31-spec config migrated with **no unsupported features**, and
-apps spawn on demand. Releases are multi-arch and **cosign-signed**;
-the [Roadmap](./roadmap.md) tracks what's shipped and what's next.
+It handles complex, multi-spec configurations with **no unsupported
+features** during migration, and apps spawn on demand reliably. Releases
+are multi-arch and **cosign-signed**; the [Roadmap](./roadmap.md) tracks
+what's shipped and what's next.
 
 ## What's in the box
 
@@ -74,8 +78,8 @@ the [Roadmap](./roadmap.md) tracks what's shipped and what's next.
   Viewer / Editor / Admin roles**, and a live monitoring dashboard
   (CPU/memory, live-follow logs, stop/restart).
 - **Sub-path mounting**: serve the whole portal under a prefix via
-  `server.context-path` (ShinyProxy-compatible) or `--base-path`. Health
-  probes (`/healthz`, `/readyz`) stay at the root for load balancers.
+  `server.context-path` or `--base-path`. Health probes (`/healthz`,
+  `/readyz`) stay at the root for load balancers.
 - **Operations**: graceful shutdown, structured (JSON) logging, per-API
   rate limiting + CORS, request body-size limits, gzip/br compression,
   immutable-versioned static assets, and an opt-in Prometheus `/metrics`


### PR DESCRIPTION
Applies the documentation review across the most public docs: **emphasize what Ruscker is and does**, and **don't frame it against other systems/competitors**.

## `book/src/introduction.md`
- Opening pitches Ruscker directly (high-performance portal + orchestrator, single ultra-light static binary, instant startup, admin panel, real-time monitoring, load balancing, familiar YAML). Dropped "ShinyProxy-compatible" framing and "no JVM".
- "Why" → "Why Ruscker": competitor-comparison paragraph replaced with Ruscker's own strengths.
- "In production": keeps the measured **~540 MB → ~14 MB** footprint, drops the "38× vs traditional stacks / JVM-based stack it replaced" framing.
- Nav link text softened ("Where Ruscker fits", "Migrate an existing config", "systemd + nginx").

## `README.md`
- Drop the "alternative to ShinyProxy / Shiny Server" lead, the **feature-comparison table**, the competitor-bullet "Why", and the "38×" framing.
- Keep the measured ~540 MB → ~14 MB footprint as **Ruscker's own result**.
- The two remaining mentions are **functional**, not marketing: the real `validate` output line and the `--strict-compat` flag's purpose (a genuine migration-compatibility feature) — left accurate.

## `book/src/alternatives.md` → "Where Ruscker fits"
- The page was repurposed from "Ruscker vs. the alternatives": the **at-a-glance comparison table** and the **per-competitor sections** (ShinyProxy / Shiny Server / Posit / JupyterHub) are gone.
- The genuinely useful **Ruscker-specific** sections are kept and reframed as Ruscker behavior: the strip-model sub-path handling, the `#{publicPath}` opt-in, and secrets via env-var interpolation.
- "When Ruscker is *not* the right tool" now describes scenarios **by capability**, not by product name.
- `SUMMARY.md` / intro / `faq.md` link text updated to "Where Ruscker fits".

`mdbook build` is clean.

> The `migrating.md` guide (a functional ShinyProxy-config migration page) and the CLI's `--strict-compat` / `ShinyProxy compatibility` output are left as-is — they document real interop features truthfully rather than positioning against a competitor.

🤖 Generated with [Claude Code](https://claude.com/claude-code)