### PR TITLE
docs(faq) no-competitor pass + fix(media) toolbar spacing

### DIFF
--- a/book/src/faq.md
+++ b/book/src/faq.md
@@ -1,17 +1,17 @@
 # FAQ
 
-### Is Ruscker really compatible with my ShinyProxy `application.yml`?
+### Can I import my existing `application.yml`?
 
-Yes — Ruscker reads the ShinyProxy YAML schema. Point it at your existing
+Yes — Ruscker reads the familiar YAML schema. Point it at your existing
 file and run `ruscker validate application.yml --strict-compat` to get a
-report of any ShinyProxy feature Ruscker doesn't support yet (it refuses
-to silently ignore them). See [Migrating from ShinyProxy](./migrating.md).
+report of any feature Ruscker doesn't support yet (it refuses to silently
+ignore them). See [Migrate an existing config](./migrating.md).
 
-### Do I need Java or the JVM?
+### What does Ruscker need to run?
 
-No. Ruscker is a single static binary written in Rust. There's no JVM, no
-Java toolchain, and no application server to manage — the idle footprint
-is **~14 MB** instead of the hundreds of MB a JVM-based proxy idles at.
+Just the binary and a Docker host. Ruscker is a single static binary
+written in Rust — no language runtime, no toolchain, and no application
+server to manage alongside it. The idle footprint is **~14 MB**.
 
 ### Which app frameworks can it host?
 
@@ -20,7 +20,7 @@ the reference case, but Streamlit, Dash, Voilà, Gradio, Panel, Bokeh,
 Plumber, FastAPI, Flask, and plain web services all work. The full list
 is in [What Ruscker can serve](./use-cases.md).
 
-### Does it isolate sessions like ShinyProxy (and unlike Shiny Server Free)?
+### Does it isolate sessions?
 
 Yes. Stateful apps get **one container per session** with sticky routing
 and WebSocket forwarding by default. Stateless APIs are load-balanced

--- a/crates/ruscker-admin/templates/admin/images.html
+++ b/crates/ruscker-admin/templates/admin/images.html
@@ -70,7 +70,7 @@
      leaving `q`/`filtered` undefined and no tiles). The browser un-escapes
      `&quot;` back to `"` before Alpine parses it. #}
   <div x-data="ruscker.mediaGallery({{ self.images_json() }})" x-cloak>
-    <div class="mb-4 flex flex-wrap items-center gap-2">
+    <div class="mt-6 mb-4 flex flex-wrap items-center gap-2">
       <input type="search" x-model="q"
              placeholder="{{ self.t("admin-images-search") }}"
              class="admin-table-search">


### PR DESCRIPTION
Two small follow-ups.

## `book/src/faq.md` — finish the no-competitor pass
Extends #577 to the FAQ: the questions that compared Ruscker to other systems are reworded to describe Ruscker directly.
- "Is Ruscker really compatible with my **ShinyProxy** `application.yml`?" → "**Can I import my existing `application.yml`?**"
- "Do I need Java or the **JVM**? … hundreds of MB a **JVM-based proxy** idles at" → "**What does Ruscker need to run?**" (single static binary, no runtime/toolchain, ~14 MB).
- "Does it isolate sessions like **ShinyProxy** (and unlike **Shiny Server Free**)?" → "**Does it isolate sessions?**"

Functional bits kept (`--strict-compat` migration check, the migrate-config link).

## `images.html` — Media toolbar spacing
The search + type-filter toolbar only had a bottom margin, so it touched the dashed drag-drop upload zone above it (see report). Added `mt-6` to match the empty-state spacing.

`mdbook build` + `cargo build` green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)