### PR TITLE
perf(db): index spec_access(day) for the trend query (#589)

### DIFF
--- a/crates/ruscker-admin/migrations-pg/0015_spec_access_day_idx.sql
+++ b/crates/ruscker-admin/migrations-pg/0015_spec_access_day_idx.sql
@@ -1,0 +1,3 @@
+-- Postgres twin of migrations/0015 (#589). Index spec_access(day) so the
+-- `WHERE day >= $1` trend query uses an index instead of a full scan.
+CREATE INDEX IF NOT EXISTS spec_access_day_idx ON spec_access (day);

--- a/crates/ruscker-admin/migrations/0015_spec_access_day_idx.sql
+++ b/crates/ruscker-admin/migrations/0015_spec_access_day_idx.sql
@@ -1,0 +1,6 @@
+-- Index spec_access by day (#589). `recent_series` filters `WHERE day >= ?`
+-- for the trend sparkline, but the PRIMARY KEY (spec_id, day) leads with
+-- spec_id and cannot serve that predicate, so the query was a full scan on
+-- every Apps-list render. No retention is applied: the all-time access
+-- total is a SUM over every row, so old rows must stay.
+CREATE INDEX IF NOT EXISTS spec_access_day_idx ON spec_access (day);


### PR DESCRIPTION
**Audit perf P3 (#589).** `recent_series` (db/spec_access.rs) filters `WHERE day >= ?` for the 14-day sparkline, but `spec_access`'s `PRIMARY KEY (spec_id, day)` leads with `spec_id` and can't serve that predicate → a **full table scan on every Apps-list render**.

## Fix
New migration `0015_spec_access_day_idx` (both `migrations/` and `migrations-pg/`):
```sql
CREATE INDEX IF NOT EXISTS spec_access_day_idx ON spec_access (day);
```
No retention sweep — the all-time access total is a SUM over every row, so old rows must stay.

## Verification
Fresh DB, `EXPLAIN QUERY PLAN` for the exact query:
- before: `SCAN spec_access`
- after: `SEARCH spec_access USING INDEX spec_access_day_idx (day>?)`

`cargo test -p ruscker-admin` green (migrations apply in tests).

Closes #589.

🤖 Generated with [Claude Code](https://claude.com/claude-code)