### PR TITLE
perf(db): persist `featured` as a spec column (#588)

### DIFF
--- a/crates/ruscker-admin/migrations-pg/0015_spec_access_day_idx.sql
+++ b/crates/ruscker-admin/migrations-pg/0015_spec_access_day_idx.sql
@@ -1,0 +1,3 @@
+-- Postgres twin of migrations/0015 (#589). Index spec_access(day) so the
+-- `WHERE day >= $1` trend query uses an index instead of a full scan.
+CREATE INDEX IF NOT EXISTS spec_access_day_idx ON spec_access (day);

--- a/crates/ruscker-admin/migrations-pg/0016_specs_featured.sql
+++ b/crates/ruscker-admin/migrations-pg/0016_specs_featured.sql
@@ -1,0 +1,4 @@
+-- Postgres twin of migrations/0016 (#588). Derived cache of config_json's
+-- `featured` flag; backfilled from the existing JSON.
+ALTER TABLE specs ADD COLUMN IF NOT EXISTS featured BOOLEAN NOT NULL DEFAULT FALSE;
+UPDATE specs SET featured = COALESCE((config_json::jsonb ->> 'featured')::boolean, FALSE);

--- a/crates/ruscker-admin/migrations/0015_spec_access_day_idx.sql
+++ b/crates/ruscker-admin/migrations/0015_spec_access_day_idx.sql
@@ -1,0 +1,6 @@
+-- Index spec_access by day (#589). `recent_series` filters `WHERE day >= ?`
+-- for the trend sparkline, but the PRIMARY KEY (spec_id, day) leads with
+-- spec_id and cannot serve that predicate, so the query was a full scan on
+-- every Apps-list render. No retention is applied: the all-time access
+-- total is a SUM over every row, so old rows must stay.
+CREATE INDEX IF NOT EXISTS spec_access_day_idx ON spec_access (day);

--- a/crates/ruscker-admin/migrations/0016_specs_featured.sql
+++ b/crates/ruscker-admin/migrations/0016_specs_featured.sql
@@ -1,0 +1,7 @@
+-- Persist `featured` as a column (#588). It mirrors config_json's
+-- `featured` flag — a derived cache refreshed on every upsert (every write
+-- path goes through upsert_in_tx) — so the Apps list no longer
+-- deserializes every spec's config_json just to know which cards are
+-- featured. Backfill from the existing JSON.
+ALTER TABLE specs ADD COLUMN featured INTEGER NOT NULL DEFAULT 0;
+UPDATE specs SET featured = COALESCE(json_extract(config_json, '$.featured'), 0);

--- a/crates/ruscker-admin/src/db/specs.rs
+++ b/crates/ruscker-admin/src/db/specs.rs
@@ -428,8 +428,8 @@ async fn upsert_in_tx(
             sqlx::query(
                 "INSERT INTO specs (id, display_name, description, kind,
                                     container_image, config_json, state,
-                                    created_at, updated_at, version)
-                 VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, 1)",
+                                    created_at, updated_at, version, featured)
+                 VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, 1, ?)",
             )
             .bind(&spec.id)
             .bind(spec.display_name.as_deref())
@@ -440,6 +440,7 @@ async fn upsert_in_tx(
             .bind(state)
             .bind(now)
             .bind(now)
+            .bind(spec.is_featured())
             .execute(&mut **tx)
             .await
             .with_context(|| format!("insert spec {}", spec.id))?;
@@ -466,7 +467,7 @@ async fn upsert_in_tx(
                 "UPDATE specs
                     SET display_name = ?, description = ?, kind = ?,
                         container_image = ?, config_json = ?, state = ?,
-                        updated_at = ?, version = ?
+                        updated_at = ?, version = ?, featured = ?
                   WHERE id = ?",
             )
             .bind(spec.display_name.as_deref())
@@ -477,6 +478,7 @@ async fn upsert_in_tx(
             .bind(state)
             .bind(now)
             .bind(next_version)
+            .bind(spec.is_featured())
             .bind(&spec.id)
             .execute(&mut **tx)
             .await
@@ -528,8 +530,8 @@ async fn upsert_in_tx_pg(
             sqlx::query(
                 "INSERT INTO specs (id, display_name, description, kind,
                                     container_image, config_json, state,
-                                    created_at, updated_at, version)
-                 VALUES ($1, $2, $3, $4, $5, $6, $7, $8, $9, 1)",
+                                    created_at, updated_at, version, featured)
+                 VALUES ($1, $2, $3, $4, $5, $6, $7, $8, $9, 1, $10)",
             )
             .bind(&spec.id)
             .bind(spec.display_name.as_deref())
@@ -540,6 +542,7 @@ async fn upsert_in_tx_pg(
             .bind(state)
             .bind(now)
             .bind(now)
+            .bind(spec.is_featured())
             .execute(&mut **tx)
             .await
             .with_context(|| format!("insert spec {}", spec.id))?;
@@ -566,8 +569,8 @@ async fn upsert_in_tx_pg(
                 "UPDATE specs
                     SET display_name = $1, description = $2, kind = $3,
                         container_image = $4, config_json = $5, state = $6,
-                        updated_at = $7, version = $8
-                  WHERE id = $9",
+                        updated_at = $7, version = $8, featured = $9
+                  WHERE id = $10",
             )
             .bind(spec.display_name.as_deref())
             .bind(spec.description.as_deref())
@@ -577,6 +580,7 @@ async fn upsert_in_tx_pg(
             .bind(state)
             .bind(now)
             .bind(next_version)
+            .bind(spec.is_featured())
             .bind(&spec.id)
             .execute(&mut **tx)
             .await

--- a/crates/ruscker-admin/src/routes/admin/specs.rs
+++ b/crates/ruscker-admin/src/routes/admin/specs.rs
@@ -260,7 +260,9 @@ async fn index(
     };
 
     // Placeholder-free SELECT, so one query string serves both backends.
-    let sql = "SELECT id, display_name, kind, state, updated_at, version
+    // `featured` is now a column (#588) — read it here instead of
+    // deserializing every spec's config_json in a second pass.
+    let sql = "SELECT id, display_name, kind, state, updated_at, version, featured
            FROM specs
            ORDER BY updated_at DESC, id ASC";
     let loaded = match database {
@@ -290,22 +292,11 @@ async fn index(
             .unwrap_or_default()
     };
 
-    // Featured flag lives in `config_json`, not a column — fill it from a
-    // single `list_all` pass so the table's star toggle (#521) shows state.
-    {
-        use std::collections::HashSet;
-        let featured: HashSet<String> = crate::db::specs::list_all(database)
-            .await
-            .unwrap_or_default()
-            .iter()
-            .filter(|s| s.is_featured())
-            .map(|s| s.id.clone())
-            .collect();
-        for row in &mut specs {
-            row.featured = featured.contains(&row.id);
-            row.access_count = access.get(&row.id).copied().unwrap_or(0);
-            row.trend_svg = spark(&row.id);
-        }
+    // Per-row access total + sparkline (#549). `featured` already came from
+    // the lean SELECT (#588), so there's no second config_json deserialize.
+    for row in &mut specs {
+        row.access_count = access.get(&row.id).copied().unwrap_or(0);
+        row.trend_svg = spark(&row.id);
     }
 
     // Append specs that exist only in the YAML `--config` (not the DB) as


### PR DESCRIPTION
**Audit perf P2 (#588).** The Apps list ran a **second full `list_all`** — deserializing every spec's `config_json` — solely to build the set of featured ids for the star toggle. `config_json` is the largest column.

## Fix
Persist `featured` as a column: a **derived cache** of config_json's `featured` flag, written from `spec.is_featured()` on every upsert. Since every write path goes through `upsert_in_tx`/`upsert_in_tx_pg`, there's a single source of truth — no drift (an unchanged-config upsert early-returns, leaving the column correct). The lean Apps SELECT reads the column, so the per-render config_json parse is gone.

- migrations `0016` (sqlite + pg): add the column + backfill from existing JSON (`json_extract` / `jsonb ->>`).
- `upsert_in_tx` + `upsert_in_tx_pg`: write `featured` on INSERT and UPDATE.
- index handler: read `featured` in the lean query (`SpecRow.featured` is `#[sqlx(default)]`), drop the `list_all`-for-featured pass.

## Verification
Live smoke: toggling writes the column `1`/`0` consistently with config_json; the Apps list renders the star `on: false` → `on: true` from the column. `cargo test -p ruscker-admin` (273) + clippy green.

Closes #588.

🤖 Generated with [Claude Code](https://claude.com/claude-code)