### PR TITLE
docs(ha): require a direct Postgres connection for the leader lock (#596)

### DIFF
--- a/book/src/deploying.md
+++ b/book/src/deploying.md
@@ -252,6 +252,15 @@ rest serve traffic. If the leader dies its lock releases and another
 takes over within one scaler tick — nothing to configure. Each instance
 logs its role at startup (`acquired leadership` / `standing by`).
 
+> **Use a direct Postgres connection for the leader lock.** The advisory
+> lock is **session-scoped** — it lives on one specific backend
+> connection and is held for the process's lifetime. Point
+> `--config-db-url` (or `--session-store-url`) at Postgres **directly**, or
+> through a pooler in **session** mode only. A transaction-pooling proxy
+> (e.g. PgBouncer in transaction mode) hands the lock-holding connection
+> to other clients between statements, which can break the single-leader
+> guarantee and let two instances scale at once.
+
 **App traffic** doesn't need sticky upstreams — proxy sessions are
 shared (the sticky cookie is a shared-key HMAC and the `proxy_sessions`
 table is shared), so round-robin is fine for `/app` and `/api`. Keep

--- a/crates/ruscker-admin/src/leader.rs
+++ b/crates/ruscker-admin/src/leader.rs
@@ -36,6 +36,13 @@
 //! Single-node (SQLite, or no config DB) installs use [`AlwaysLeader`]:
 //! there's only one process, so it's always the leader and the scaler
 //! runs unconditionally — zero added dependencies.
+//!
+//! **Operational requirement:** because the lock is session-scoped, the
+//! Postgres URL (`--config-db-url` / `--session-store-url`) must reach the
+//! server **directly** or through a pooler in *session* mode only. A
+//! transaction-pooling proxy (PgBouncer transaction mode) reassigns the
+//! lock-holding backend connection between statements, which can break the
+//! single-leader guarantee. See the HA section of the deploy guide.
 
 use std::time::Duration;
 use sqlx::postgres::PgConnection;


### PR DESCRIPTION
**Audit operational note (#596).** The scaler leader lock is a **session-scoped** `pg_try_advisory_lock`, held for the process's lifetime. Behind a transaction-pooling proxy (PgBouncer transaction mode) the lock-holding backend connection is reassigned between statements, which can break the single-leader guarantee and let two instances scale at once.

Documents the requirement (direct connection, or a pooler in *session* mode only) in:
- the deploy guide's HA section (operator-facing), and
- the `leader.rs` module doc (discoverable from code).

`mdbook build` clean. Closes #596.

🤖 Generated with [Claude Code](https://claude.com/claude-code)