### PR TITLE
chore(release): bump workspace version 0.1.63 → 0.1.64

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2845,7 +2845,7 @@ dependencies = [
 
 [[package]]
 name = "ruscker-admin"
-version = "0.1.63"
+version = "0.1.64"
 dependencies = [
  "aes-gcm",
  "anyhow",
@@ -2892,7 +2892,7 @@ dependencies = [
 
 [[package]]
 name = "ruscker-cli"
-version = "0.1.63"
+version = "0.1.64"
 dependencies = [
  "anyhow",
  "clap",
@@ -2912,7 +2912,7 @@ dependencies = [
 
 [[package]]
 name = "ruscker-config"
-version = "0.1.63"
+version = "0.1.64"
 dependencies = [
  "chrono",
  "ordered-float",
@@ -2927,7 +2927,7 @@ dependencies = [
 
 [[package]]
 name = "ruscker-core"
-version = "0.1.63"
+version = "0.1.64"
 dependencies = [
  "async-trait",
  "chrono",
@@ -2940,7 +2940,7 @@ dependencies = [
 
 [[package]]
 name = "ruscker-docker"
-version = "0.1.63"
+version = "0.1.64"
 dependencies = [
  "anyhow",
  "async-stream",
@@ -2959,7 +2959,7 @@ dependencies = [
 
 [[package]]
 name = "ruscker-proxy"
-version = "0.1.63"
+version = "0.1.64"
 dependencies = [
  "anyhow",
  "axum",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -10,7 +10,7 @@ members = [
 ]
 
 [workspace.package]
-version = "0.1.63"
+version = "0.1.64"
 edition = "2021"
 rust-version = "1.85"
 license = "Apache-2.0"

--- a/book/src/faq.md
+++ b/book/src/faq.md
@@ -80,7 +80,7 @@ the **sign-in session** paths to a single upstream — see
 
 ### Is it production-ready?
 
-Yes. The current release is **v0.1.63** — Phases 0–7 are complete and
+Yes. The current release is **v0.1.64** — Phases 0–7 are complete and
 the proxy is production-ready and horizontally scalable.
 Releases are multi-arch and cosign-signed; see the
 [release notes](./news.md) and the [Roadmap](./roadmap.md).

--- a/book/src/introduction.md
+++ b/book/src/introduction.md
@@ -48,7 +48,7 @@ engineered to keep the runtime light while staying compatible:
 
 ## In production
 
-Ruscker is on **v0.1.63** and runs in production today. Built for extreme
+Ruscker is on **v0.1.64** and runs in production today. Built for extreme
 efficiency, its idle footprint sits in the low tens of megabytes:
 
 > **~540 MB → ~14 MB idle** — measured on a real production deployment.

--- a/book/src/news.md
+++ b/book/src/news.md
@@ -9,6 +9,19 @@ the [GitHub releases page](https://github.com/StrategicProjects/ruscker/releases
 
 ---
 
+## v0.1.64 — 2026-06-04
+
+Audit fixes, batch 5 (Docker backend).
+
+**Fixes (from the code audit)**
+- The Docker backend distinguishes a real image-not-found (404) from a
+  daemon error, rebuilds replica uptime from the container's real
+  creation time after a restart, and maps container state by matching
+  the API enum directly (#586).
+- The disk panel's "unused images" detection cross-references the real
+  running containers instead of an unreliable per-image count, so an
+  image in use is no longer flagged as reclaimable (#585).
+
 ## v0.1.63 — 2026-06-04
 
 Audit fixes, batch 4.

--- a/book/src/roadmap.md
+++ b/book/src/roadmap.md
@@ -1,6 +1,6 @@
 # Roadmap
 
-Ruscker is at **v0.1.63** — Phases 0 through 7 are done and the proxy is
+Ruscker is at **v0.1.64** — Phases 0 through 7 are done and the proxy is
 production-ready and horizontally scalable. Phase 8 (external auth) is
 the main optional, demand-driven work left. For what changed in each
 release, see the [release notes](./news.md).
@@ -71,7 +71,7 @@ can serve any session; one scaler leader via Postgres advisory locks,
 with failover. A runnable 2-instance compose harness lives in
 `examples/ha/`. See [Deployment shapes](./architecture.md#deployment-shapes).
 
-### Post-phase polish → **v0.1.4 – v0.1.63**
+### Post-phase polish → **v0.1.4 – v0.1.64**
 
 Incremental improvements shipped after Phase 7.
 

--- a/docs/SECURITY.md
+++ b/docs/SECURITY.md
@@ -5,7 +5,7 @@ Status: living document. Tracks the Phase 5 security audit
 **[accepted limitation]**, or **[deferred]**. File references use
 `crate/path:symbol` so they survive line-number drift.
 
-> **Scope.** This covers v0.1.63: single-operator install, Ruscker
+> **Scope.** This covers v0.1.64: single-operator install, Ruscker
 > behind a TLS-terminating reverse proxy, Docker on the same host.
 > Multi-tenant / shared-team auth (OIDC, RBAC) is out of scope until
 > Phase 8.


### PR DESCRIPTION
Cuts **v0.1.64** — audit batch 5 (Docker backend): #608/#586 (inspect 404, real uptime, enum state) + #609/#585 (reliable disk in-use detection). Version bump + Cargo.lock + book/docs refs + news entry.

🤖 Generated with [Claude Code](https://claude.com/claude-code)