### PR TITLE
perf(proxy): cache resolved specs on the hot path with a short TTL (#587)

### DIFF
--- a/crates/ruscker-admin/src/lib.rs
+++ b/crates/ruscker-admin/src/lib.rs
@@ -170,6 +170,17 @@ pub struct AppState {
     /// closes. Shared (Arc) so the signal handler and every request
     /// handler observe the same flag.
     pub draining: Arc<std::sync::atomic::AtomicBool>,
+
+    /// Hot-path spec cache (#587): `find_spec` runs on every proxied
+    /// request (incl. every subresource), and a DB-first lookup parses
+    /// `config_json` each time. This caches the resolved spec by id for a
+    /// short TTL ([`crate::routes::proxy::SPEC_CACHE_TTL`]) so a page
+    /// load's burst of requests hits memory, not the DB. Only positive
+    /// results are cached (so the map stays bounded by the real catalog);
+    /// the TTL bounds staleness so an admin edit takes effect without any
+    /// explicit invalidation wiring. Shared so every cloned `AppState`
+    /// sees the same cache.
+    pub spec_cache: Arc<dashmap::DashMap<String, (Arc<ruscker_config::Spec>, std::time::Instant)>>,
 }
 
 impl AppState {
@@ -225,6 +236,7 @@ impl AdminServer {
             leader: std::sync::Arc::new(leader::AlwaysLeader),
             metrics: metrics_cache::MetricsCache::new(),
             draining: Arc::new(std::sync::atomic::AtomicBool::new(false)),
+            spec_cache: Arc::new(dashmap::DashMap::new()),
         };
         Ok(Self {
             addr,

--- a/crates/ruscker-admin/src/routes/proxy.rs
+++ b/crates/ruscker-admin/src/routes/proxy.rs
@@ -791,10 +791,45 @@ pub(crate) fn apply_public_path(env: &mut [String], cmd: &mut Option<Vec<String>
     }
 }
 
+/// How long a resolved spec stays cached on the proxy hot path (#587).
+/// Short enough that an admin edit (including an access-control change)
+/// takes effect within this window without explicit invalidation, long
+/// enough that one page load's burst of subresource requests all hit the
+/// cache instead of the DB.
+pub(crate) const SPEC_CACHE_TTL: std::time::Duration = std::time::Duration::from_secs(1);
+
 pub(crate) async fn find_spec(state: &AppState, id: &str) -> Option<Spec> {
-    // DB-first — the operator-editable catalog (admin UI + showcase
-    // seed) shadows the YAML for matching ids. Cheap: single indexed
-    // SELECT by primary key.
+    // Hot path: `find_spec` runs on every proxied request. Serve a recent
+    // resolution from the in-memory cache to skip a DB SELECT +
+    // config_json parse; the TTL bounds staleness (#587).
+    if let Some(entry) = state.spec_cache.get(id) {
+        if entry.1.elapsed() < SPEC_CACHE_TTL {
+            return Some((*entry.0).clone());
+        }
+    }
+    let resolved = load_spec(state, id).await;
+    match &resolved {
+        // Cache only positives, so the map stays bounded by the real
+        // catalog; refresh the timestamp on every (re)load.
+        Some(spec) => {
+            state
+                .spec_cache
+                .insert(id.to_string(), (std::sync::Arc::new(spec.clone()), std::time::Instant::now()));
+        }
+        // A now-missing spec (deleted/renamed): drop any stale entry so
+        // the cache doesn't pin a removed spec.
+        None => {
+            state.spec_cache.remove(id);
+        }
+    }
+    resolved
+}
+
+/// Resolve a spec by id without the cache: DB-first — the operator-
+/// editable catalog (admin UI + showcase seed) shadows the YAML for
+/// matching ids — then the YAML `--config`. A single indexed SELECT by
+/// primary key.
+async fn load_spec(state: &AppState, id: &str) -> Option<Spec> {
     if let Some(db) = state.db.as_ref() {
         match crate::db::specs::fetch_one(db, id).await {
             Ok(Some(spec)) => return Some(spec),
@@ -1770,6 +1805,7 @@ mod tests {
             leader: StdArc::new(crate::leader::AlwaysLeader),
             metrics: crate::metrics_cache::MetricsCache::new(),
             draining: StdArc::new(std::sync::atomic::AtomicBool::new(false)),
+            spec_cache: StdArc::new(dashmap::DashMap::new()),
         }
     }
 
@@ -2157,5 +2193,53 @@ docker-registry-password: hunter2
             "two cold spawns should run in parallel, took {:?}",
             elapsed
         );
+    }
+
+    #[tokio::test]
+    async fn find_spec_serves_from_cache_within_ttl() {
+        // #587: a recent resolution is served from the in-memory cache
+        // instead of re-querying the DB; clearing the cache re-reads.
+        let backend = StdArc::new(CountingBackend {
+            spawns: AtomicU32::new(0),
+            delay: StdDuration::from_millis(0),
+        });
+        let mut state = coalescer_state(backend as StdArc<dyn ContainerBackend>);
+        let cdb = crate::db::ConfigDb::Sqlite(crate::db::open_memory().await.unwrap());
+        let v1: Spec =
+            serde_yaml_ng::from_str("id: alpha\ncontainer-image: nginx\ndisplay-name: Old").unwrap();
+        crate::db::specs::upsert_one(&cdb, &v1, None).await.unwrap();
+        state.db = Some(cdb);
+
+        // First lookup resolves from the DB and populates the cache.
+        let first = find_spec(&state, "alpha").await.expect("found");
+        assert_eq!(first.display_name.as_deref(), Some("Old"));
+
+        // Change it in the DB out from under the cache.
+        let v2: Spec =
+            serde_yaml_ng::from_str("id: alpha\ncontainer-image: nginx\ndisplay-name: New").unwrap();
+        crate::db::specs::upsert_one(state.db.as_ref().unwrap(), &v2, None)
+            .await
+            .unwrap();
+
+        // Within the TTL, the cache still serves the old value.
+        let cached = find_spec(&state, "alpha").await.expect("found");
+        assert_eq!(
+            cached.display_name.as_deref(),
+            Some("Old"),
+            "served from cache within TTL"
+        );
+
+        // Clearing the cache makes the next lookup re-read the DB.
+        state.spec_cache.clear();
+        let fresh = find_spec(&state, "alpha").await.expect("found");
+        assert_eq!(
+            fresh.display_name.as_deref(),
+            Some("New"),
+            "DB value after cache clear"
+        );
+
+        // A missing id is not cached (map stays bounded by the catalog).
+        assert!(find_spec(&state, "ghost").await.is_none());
+        assert!(state.spec_cache.get("ghost").is_none());
     }
 }

--- a/crates/ruscker-admin/src/scaler.rs
+++ b/crates/ruscker-admin/src/scaler.rs
@@ -968,6 +968,7 @@ mod tests {
             leader: Arc::new(crate::leader::AlwaysLeader),
             metrics: crate::metrics_cache::MetricsCache::new(),
             draining: Arc::new(std::sync::atomic::AtomicBool::new(false)),
+            spec_cache: Arc::new(dashmap::DashMap::new()),
         }
     }
 

--- a/crates/ruscker-admin/tests/admin_landing_picker.rs
+++ b/crates/ruscker-admin/tests/admin_landing_picker.rs
@@ -43,6 +43,7 @@ async fn state_with_db() -> AppState {
         leader: Arc::new(ruscker_admin::leader::AlwaysLeader),
         metrics: ruscker_admin::metrics_cache::MetricsCache::new(),
         draining: Arc::new(std::sync::atomic::AtomicBool::new(false)),
+        spec_cache: std::sync::Arc::new(dashmap::DashMap::new()),
     }
 }
 

--- a/crates/ruscker-admin/tests/api_policies.rs
+++ b/crates/ruscker-admin/tests/api_policies.rs
@@ -60,6 +60,7 @@ fn state() -> AppState {
         leader: Arc::new(ruscker_admin::leader::AlwaysLeader),
         metrics: ruscker_admin::metrics_cache::MetricsCache::new(),
         draining: Arc::new(std::sync::atomic::AtomicBool::new(false)),
+        spec_cache: std::sync::Arc::new(dashmap::DashMap::new()),
     }
 }
 

--- a/crates/ruscker-admin/tests/health_probes.rs
+++ b/crates/ruscker-admin/tests/health_probes.rs
@@ -44,6 +44,7 @@ fn base_state() -> AppState {
         leader: Arc::new(ruscker_admin::leader::AlwaysLeader),
         metrics: ruscker_admin::metrics_cache::MetricsCache::new(),
         draining: Arc::new(std::sync::atomic::AtomicBool::new(false)),
+        spec_cache: std::sync::Arc::new(dashmap::DashMap::new()),
     }
 }
 

--- a/crates/ruscker-admin/tests/landing_access.rs
+++ b/crates/ruscker-admin/tests/landing_access.rs
@@ -82,6 +82,7 @@ async fn app_state(db: ConfigDb) -> AppState {
         leader: Arc::new(ruscker_admin::leader::AlwaysLeader),
         metrics: ruscker_admin::metrics_cache::MetricsCache::new(),
         draining: Arc::new(std::sync::atomic::AtomicBool::new(false)),
+        spec_cache: std::sync::Arc::new(dashmap::DashMap::new()),
     }
 }
 

--- a/crates/ruscker-admin/tests/landing_render.rs
+++ b/crates/ruscker-admin/tests/landing_render.rs
@@ -42,6 +42,7 @@ fn app_state() -> AppState {
         leader: std::sync::Arc::new(ruscker_admin::leader::AlwaysLeader),
         metrics: ruscker_admin::metrics_cache::MetricsCache::new(),
         draining: std::sync::Arc::new(std::sync::atomic::AtomicBool::new(false)),
+        spec_cache: std::sync::Arc::new(dashmap::DashMap::new()),
     }
 }
 

--- a/crates/ruscker-admin/tests/max_body_size.rs
+++ b/crates/ruscker-admin/tests/max_body_size.rs
@@ -59,6 +59,7 @@ fn state() -> AppState {
         leader: Arc::new(ruscker_admin::leader::AlwaysLeader),
         metrics: ruscker_admin::metrics_cache::MetricsCache::new(),
         draining: Arc::new(std::sync::atomic::AtomicBool::new(false)),
+        spec_cache: std::sync::Arc::new(dashmap::DashMap::new()),
     }
 }
 

--- a/crates/ruscker-admin/tests/metrics.rs
+++ b/crates/ruscker-admin/tests/metrics.rs
@@ -32,6 +32,7 @@ fn state(yaml: &str) -> AppState {
         leader: Arc::new(ruscker_admin::leader::AlwaysLeader),
         metrics: ruscker_admin::metrics_cache::MetricsCache::new(),
         draining: Arc::new(std::sync::atomic::AtomicBool::new(false)),
+        spec_cache: std::sync::Arc::new(dashmap::DashMap::new()),
     }
 }
 

--- a/crates/ruscker-admin/tests/proxy_access.rs
+++ b/crates/ruscker-admin/tests/proxy_access.rs
@@ -79,6 +79,7 @@ async fn app_state(db: ConfigDb) -> AppState {
         leader: Arc::new(ruscker_admin::leader::AlwaysLeader),
         metrics: ruscker_admin::metrics_cache::MetricsCache::new(),
         draining: Arc::new(std::sync::atomic::AtomicBool::new(false)),
+        spec_cache: std::sync::Arc::new(dashmap::DashMap::new()),
     }
 }
 

--- a/crates/ruscker-admin/tests/rbac.rs
+++ b/crates/ruscker-admin/tests/rbac.rs
@@ -56,6 +56,7 @@ fn state() -> AppState {
         leader: Arc::new(ruscker_admin::leader::AlwaysLeader),
         metrics: ruscker_admin::metrics_cache::MetricsCache::new(),
         draining: Arc::new(std::sync::atomic::AtomicBool::new(false)),
+        spec_cache: std::sync::Arc::new(dashmap::DashMap::new()),
     }
 }
 

--- a/crates/ruscker-admin/tests/user_accounts.rs
+++ b/crates/ruscker-admin/tests/user_accounts.rs
@@ -43,6 +43,7 @@ async fn state_with_db() -> (AppState, sqlx::SqlitePool) {
         leader: Arc::new(ruscker_admin::leader::AlwaysLeader),
         metrics: ruscker_admin::metrics_cache::MetricsCache::new(),
         draining: Arc::new(std::sync::atomic::AtomicBool::new(false)),
+        spec_cache: std::sync::Arc::new(dashmap::DashMap::new()),
     };
     (state, pool)
 }


### PR DESCRIPTION
**Audit perf P1 (#587).** `find_spec` runs on **every** proxied request (including every subresource/XHR), and did a DB-first `fetch_one` + `config_json` parse each time — dozens of DB round-trips per page load.

## Fix
A small in-memory cache (`AppState.spec_cache`, a `DashMap<id, (Arc<Spec>, Instant)>`): a lookup within `SPEC_CACHE_TTL` (**1s**) returns the resolved spec without touching the DB, so a page load's burst of requests hits memory.

- **Bounded**: only positive results are cached (map size = real catalog); a now-missing spec drops its entry.
- **No invalidation wiring**: the 1s TTL bounds staleness — an admin edit (incl. an access-control change) takes effect within 1s — instead of threading invalidation through every spec-write path (which could be forgotten). 1s is short enough for correctness, long enough to capture a page's sub-second request burst.

The `load_spec` helper keeps the original DB-first → YAML resolution.

## Verification
New unit test `find_spec_serves_from_cache_within_ttl`: first lookup caches; a DB change is **not** seen within the TTL (served from cache); a `spec_cache.clear()` re-reads the new value; a missing id isn't cached. `cargo test -p ruscker-admin` (275) + clippy green; the existing proxy integration tests (mock-backend forward path) still pass.

> Follow-up (noted in #587): the per-restricted-spec **user-groups** lookup (`users::fetch`) could get a similar session-scoped cache; left out here to keep this change to the dominant per-request cost.

Closes #587.

🤖 Generated with [Claude Code](https://claude.com/claude-code)