### PR TITLE
fix(proxy): reserve the seat atomically at pick — closes #582 (part 1)

### DIFF
--- a/crates/ruscker-admin/src/routes/proxy.rs
+++ b/crates/ruscker-admin/src/routes/proxy.rs
@@ -428,9 +428,9 @@ async fn forward(
     //    pick/spawn. Also pin down the session_id we'll track
     //    this visitor under so the cookie and the tracker share
     //    the same identity.
-    let (replica, session_id, cookie_used) =
+    let (replica, session_id, cookie_used, seat_reserved) =
         match resolve_replica(&state, &spec, &cookies).await {
-            Ok(triple) => triple,
+            Ok(quad) => quad,
             Err(err) => {
                 tracing::error!(spec = %spec.id, error = ?err, "resolve replica failed");
                 return with_cors(
@@ -448,7 +448,7 @@ async fn forward(
     if spec_kind_needs_sticky(spec.kind()) {
         let outcome = state
             .sessions
-            .touch_or_register(&state.replicas, session_id, &spec.id, &replica.id)
+            .touch_or_register(&state.replicas, session_id, &spec.id, &replica.id, seat_reserved)
             .await;
         // stop-on-logout (#337): when a *known* user first registers a
         // session on a spec that opts in, index it so their logout can
@@ -856,7 +856,7 @@ async fn resolve_replica(
     state: &AppState,
     spec: &Spec,
     cookies: &Cookies,
-) -> anyhow::Result<(Replica, uuid::Uuid, bool)> {
+) -> anyhow::Result<(Replica, uuid::Uuid, bool, bool)> {
     if let Some(raw) = cookies.get(COOKIE_NAME) {
         if let Ok(session) = sticky::decode(&state.cookie_key, raw.value()) {
             // Defense in depth: a cookie for spec A must not
@@ -875,14 +875,18 @@ async fn resolve_replica(
                 // pick + new session rather than 502-ing the visitor.
                 if let Some(r) = alive {
                     if matches!(r.state, ReplicaState::Ready | ReplicaState::Draining) {
-                        return Ok((r, session.session_id, true));
+                        // Existing session — its seat is already counted, so
+                        // nothing is reserved here (4th = false).
+                        return Ok((r, session.session_id, true, false));
                     }
                 }
             }
         }
     }
-    let r = pick_or_spawn(state, spec).await?;
-    Ok((r, uuid::Uuid::new_v4(), false))
+    // New session: `pick_or_spawn` already reserved its seat (when it
+    // returns `reserved = true`), so the session tracker must not re-count.
+    let (r, reserved) = pick_or_spawn(state, spec).await?;
+    Ok((r, uuid::Uuid::new_v4(), false, reserved))
 }
 
 /// Build + set the sticky cookie from an explicit `StickySession`
@@ -1029,19 +1033,28 @@ fn cold_start_splash(spec: &Spec, base: &str) -> Response {
 /// keyed by spec id. Entries stay around forever; that's a few
 /// dozen bytes per spec and `Mutex<()>` has no payload to
 /// matter. Phase 4 GC sweeps them when a spec is deleted.
-async fn pick_or_spawn(state: &AppState, spec: &Spec) -> anyhow::Result<Replica> {
+async fn pick_or_spawn(state: &AppState, spec: &Spec) -> anyhow::Result<(Replica, bool)> {
     let routing = spec.effective_routing();
     // APIs balance by in-flight requests, not seats (#424).
     let api = matches!(spec.kind(), SpecKind::Api);
+    // Seat-based specs (Shiny / interactive apps) reserve the chosen
+    // replica's seat ATOMICALLY with the pick — under the same write lock —
+    // so two concurrent first-requests can't both grab the last free seat
+    // (#582 part 1). APIs don't use seats. The returned `bool` tells the
+    // caller a seat was already counted here, so the session tracker must
+    // not increment it again. This path runs only for a *new* session (a
+    // live sticky cookie short-circuits in `resolve_replica`), so the
+    // write lock here is per-new-session, not per-request.
+    let reserve = !api;
 
-    // Fast path: read lock, no spawn coordination needed. Route to a
-    // replica that's actually `Ready` (preferably with a free seat) per
-    // the spec's strategy; only fall through to spawn when none is
-    // usable — never hand traffic to a Starting/Draining/Failed one.
+    // Fast path: pick + reserve under one write lock.
     {
-        let reg = state.replicas.read().await;
+        let mut reg = state.replicas.write().await;
         if let Some(r) = pick_accepting(reg.replicas_of(&spec.id), routing, api) {
-            return Ok(r);
+            if reserve {
+                reg.inc_sessions(&r.id);
+            }
+            return Ok((r, reserve));
         }
     }
 
@@ -1060,32 +1073,47 @@ async fn pick_or_spawn(state: &AppState, spec: &Spec) -> anyhow::Result<Replica>
     // that ran ahead of us already populated the registry; we
     // skip the spawn and reuse what they made.
     {
-        let reg = state.replicas.read().await;
-        let replicas = reg.replicas_of(&spec.id);
-        // An accepting replica (Ready + free seat) → use it.
-        if let Some(r) = pick_accepting(replicas, routing, api) {
-            return Ok(r);
+        let mut reg = state.replicas.write().await;
+        // An accepting replica (Ready + free seat) → use it (and reserve).
+        if let Some(r) = pick_accepting(reg.replicas_of(&spec.id), routing, api) {
+            if reserve {
+                reg.inc_sessions(&r.id);
+            }
+            return Ok((r, reserve));
         }
         // Coalescing: a sibling that holds the spawn mutex before us may
-        // have spawned a replica that's still `Starting` — it'll have
-        // seats once Ready, so reuse it instead of spawning a duplicate.
-        if let Some(r) = replicas.iter().find(|r| r.state == ReplicaState::Starting) {
-            return Ok(r.clone());
+        // have spawned a replica that's still `Starting` — reuse it instead
+        // of spawning a duplicate, BUT only if it still has a free seat
+        // (its spawner already reserved one): otherwise we'd oversubscribe
+        // it, so fall through to spawn our own (#582 part 1).
+        if let Some(r) = reg
+            .replicas_of(&spec.id)
+            .iter()
+            .find(|r| r.state == ReplicaState::Starting && r.available_seats() > 0)
+            .cloned()
+        {
+            if reserve {
+                reg.inc_sessions(&r.id);
+            }
+            return Ok((r, reserve));
         }
-        // Every existing replica is full (no free seat) and none is coming
-        // up. Seat-based specs honour `seats-per-container` by scaling out:
-        // spawn another replica when under `max-replicas` (#582) rather than
-        // oversubscribing a full one. APIs don't use seats (the auto-scaler
-        // sizes them), so they overload immediately. Only at the replica
-        // cap (or when a spawn would have nothing to fall back to) do seat
-        // specs overload via `pick_replica`'s Ready fallback — never
-        // exceeding `max`. The spec mutex serializes us with the splash
-        // gate's background spawn, so the cap holds.
-        let count = replicas.len();
+        // Every existing replica is full (no free seat) and none coming up
+        // with room. Seat-based specs honour `seats-per-container` by
+        // scaling out: spawn another when under `max-replicas` (#582) rather
+        // than oversubscribing. APIs don't use seats (the auto-scaler sizes
+        // them), so they overload immediately. Only at the replica cap (or
+        // when a spawn would have nothing to fall back to) do seat specs
+        // overload via `pick_replica`'s Ready fallback — never exceeding
+        // `max`. The spec mutex serializes us with the splash gate's
+        // background spawn, so the cap holds.
+        let count = reg.replicas_of(&spec.id).len();
         let max = spec.effective_max_replicas() as usize;
         if api || count >= max {
-            if let Some(r) = pick_replica(replicas, routing, api) {
-                return Ok(r);
+            if let Some(r) = pick_replica(reg.replicas_of(&spec.id), routing, api) {
+                if reserve {
+                    reg.inc_sessions(&r.id);
+                }
+                return Ok((r, reserve));
             }
             // Nothing usable (all Failed/Stopped) — fall through to spawn.
         }
@@ -1146,10 +1174,18 @@ async fn pick_or_spawn(state: &AppState, spec: &Spec) -> anyhow::Result<Replica>
     // right capacity from the first request.
     replica.sessions_max = spec.effective_seats();
 
-    // Take the write lock only for the insert — a few microseconds
-    // — and release before the spec mutex unwinds.
-    state.replicas.write().await.add(replica.clone());
-    Ok(replica)
+    // Take the write lock only for the insert — a few microseconds — and
+    // release before the spec mutex unwinds. Reserve the new replica's
+    // first seat for the request that triggered the spawn (#582 part 1),
+    // so the session tracker doesn't double-count it.
+    {
+        let mut reg = state.replicas.write().await;
+        reg.add(replica.clone());
+        if reserve {
+            reg.inc_sessions(&replica.id);
+        }
+    }
+    Ok((replica, reserve))
 }
 
 /// Build optional registry credentials from a spec. Returns
@@ -2186,8 +2222,8 @@ docker-registry-password: hunter2
         }
         let mut replica_ids = std::collections::HashSet::new();
         for t in tasks {
-            let r = t.await.expect("join");
-            replica_ids.insert(r.id);
+            let (replica, _reserved) = t.await.expect("join");
+            replica_ids.insert(replica.id);
         }
 
         assert_eq!(
@@ -2290,6 +2326,54 @@ docker-registry-password: hunter2
             sessions_active: 1,
             sessions_max: 1,
             host: None,
+        }
+    }
+
+    /// A Ready replica with one FREE seat (seats=1, 0 sessions).
+    fn accepting_replica(spec_id: &str) -> Replica {
+        Replica {
+            sessions_active: 0,
+            ..full_replica(spec_id)
+        }
+    }
+
+    #[tokio::test]
+    async fn pick_or_spawn_reserves_seat_atomically_under_race() {
+        // #582 part 1: two concurrent first-requests for the same spec,
+        // one free seat. With the atomic pick+reserve they must NOT both
+        // grab it — one reserves the seat, the other sees it full and
+        // scales out (max-replicas: 2), so they get distinct replicas.
+        let backend = StdArc::new(CountingBackend {
+            spawns: AtomicU32::new(0),
+            delay: StdDuration::from_millis(40),
+        });
+        let state = coalescer_state(backend.clone() as StdArc<dyn ContainerBackend>);
+        let spec: Spec = serde_yaml_ng::from_str(
+            "id: race\ncontainer-image: test:latest\nseats-per-container: 1\nmax-replicas: 2",
+        )
+        .unwrap();
+        state.replicas.write().await.add(accepting_replica("race"));
+
+        let (s1, s2) = (state.clone(), state.clone());
+        let (p1, p2) = (spec.clone(), spec.clone());
+        let (a, b) = tokio::join!(
+            tokio::spawn(async move { pick_or_spawn(&s1, &p1).await.expect("a").0 }),
+            tokio::spawn(async move { pick_or_spawn(&s2, &p2).await.expect("b").0 }),
+        );
+        let ra = a.unwrap();
+        let rb = b.unwrap();
+        assert_ne!(
+            ra.id, rb.id,
+            "concurrent picks must not share the last seat (atomic reserve)"
+        );
+        assert_eq!(
+            state.replicas.read().await.replicas_of("race").len(),
+            2,
+            "scaled out to a second replica instead of oversubscribing"
+        );
+        // No replica holds more than its 1 seat.
+        for r in state.replicas.read().await.replicas_of("race") {
+            assert!(r.sessions_active <= r.sessions_max, "no over-admission");
         }
     }
 

--- a/crates/ruscker-admin/src/sessions.rs
+++ b/crates/ruscker-admin/src/sessions.rs
@@ -73,12 +73,19 @@ pub trait SessionStore: Send + Sync {
     /// Record activity for `session_id`, registering it against
     /// `(spec_id, replica_id)` (and incrementing the replica counter)
     /// on first sight, else refreshing `last_seen`.
+    ///
+    /// `seat_reserved` is `true` when the caller already reserved the
+    /// replica's seat at pick time (the atomic pick+reserve that closes
+    /// the seat over-admission race, #582 part 1). When set, the store
+    /// registers the session but must **not** increment the replica
+    /// counter again.
     async fn touch_or_register(
         &self,
         registry: &RwLock<ReplicaRegistry>,
         session_id: Uuid,
         spec_id: &str,
         replica_id: &ReplicaId,
+        seat_reserved: bool,
     ) -> TouchOutcome;
 
     /// One idle-expiry pass: evict sessions past their (per-spec)
@@ -179,6 +186,7 @@ impl SessionStore for InMemorySessionStore {
         session_id: Uuid,
         spec_id: &str,
         replica_id: &ReplicaId,
+        seat_reserved: bool,
     ) -> TouchOutcome {
         // Fast path: the session already exists. Update
         // last_seen without touching the registry lock at all.
@@ -204,7 +212,11 @@ impl SessionStore for InMemorySessionStore {
             }
         };
         if was_new {
-            registry.write().await.inc_sessions(replica_id);
+            // Skip the increment when the caller already reserved the seat
+            // atomically at pick time (#582 part 1) — else we'd double-count.
+            if !seat_reserved {
+                registry.write().await.inc_sessions(replica_id);
+            }
             TouchOutcome::Registered
         } else {
             TouchOutcome::Touched
@@ -394,7 +406,7 @@ mod tests {
 
         let sid = Uuid::new_v4();
         assert_eq!(
-            store.touch_or_register(&reg, sid, "alpha", &rid).await,
+            store.touch_or_register(&reg, sid, "alpha", &rid, false).await,
             TouchOutcome::Registered
         );
         assert_eq!(store.len(), 1);
@@ -424,7 +436,7 @@ mod tests {
         // Two sessions on A, one on B.
         for spec_rid in [("alpha", &rid_a), ("alpha", &rid_a), ("beta", &rid_b)] {
             store
-                .touch_or_register(&reg, Uuid::new_v4(), spec_rid.0, spec_rid.1)
+                .touch_or_register(&reg, Uuid::new_v4(), spec_rid.0, spec_rid.1, false)
                 .await;
         }
         assert_eq!(store.len(), 3);
@@ -451,8 +463,8 @@ mod tests {
 
         let s1 = Uuid::new_v4();
         let s2 = Uuid::new_v4();
-        store.touch_or_register(&reg, s1, "alpha", &rid).await;
-        store.touch_or_register(&reg, s2, "alpha", &rid).await;
+        store.touch_or_register(&reg, s1, "alpha", &rid, false).await;
+        store.touch_or_register(&reg, s2, "alpha", &rid, false).await;
         assert_eq!(reg.read().await.replicas_of("alpha")[0].sessions_active, 2);
 
         // End s1: removed, counter drops to 1.
@@ -476,7 +488,7 @@ mod tests {
 
         let sid = Uuid::new_v4();
         let outcome = tracker
-            .touch_or_register(&reg, sid, "alpha", &rid)
+            .touch_or_register(&reg, sid, "alpha", &rid, false)
             .await;
         assert_eq!(outcome, TouchOutcome::Registered);
         assert_eq!(reg.read().await.replicas_of("alpha")[0].sessions_active, 1);
@@ -491,8 +503,8 @@ mod tests {
         let tracker = InMemorySessionStore::new();
 
         let sid = Uuid::new_v4();
-        let _ = tracker.touch_or_register(&reg, sid, "alpha", &rid).await;
-        let outcome = tracker.touch_or_register(&reg, sid, "alpha", &rid).await;
+        let _ = tracker.touch_or_register(&reg, sid, "alpha", &rid, false).await;
+        let outcome = tracker.touch_or_register(&reg, sid, "alpha", &rid, false).await;
         assert_eq!(outcome, TouchOutcome::Touched);
         assert_eq!(reg.read().await.replicas_of("alpha")[0].sessions_active, 1);
         assert_eq!(tracker.len(), 1);
@@ -507,7 +519,7 @@ mod tests {
         let tracker = InMemorySessionStore::new();
 
         let sid = Uuid::new_v4();
-        tracker.touch_or_register(&reg, sid, "alpha", &rid).await;
+        tracker.touch_or_register(&reg, sid, "alpha", &rid, false).await;
         assert_eq!(reg.read().await.replicas_of("alpha")[0].sessions_active, 1);
 
         // Force the entry's last_seen back in time so it expires
@@ -532,7 +544,7 @@ mod tests {
         let tracker = InMemorySessionStore::new();
 
         let sid = Uuid::new_v4();
-        tracker.touch_or_register(&reg, sid, "alpha", &rid).await;
+        tracker.touch_or_register(&reg, sid, "alpha", &rid, false).await;
         // last_seen is now, sweep with 10s timeout — nothing
         // should evict.
         let no_overrides = std::collections::HashMap::new();
@@ -560,8 +572,8 @@ mod tests {
         let tracker = InMemorySessionStore::new();
         let s_pinned = Uuid::new_v4();
         let s_normal = Uuid::new_v4();
-        tracker.touch_or_register(&reg, s_pinned, "pinned", &pid).await;
-        tracker.touch_or_register(&reg, s_normal, "normal", &nid).await;
+        tracker.touch_or_register(&reg, s_pinned, "pinned", &pid, false).await;
+        tracker.touch_or_register(&reg, s_normal, "normal", &nid, false).await;
         // Age both sessions well past the global timeout.
         for sid in [s_pinned, s_normal] {
             if let Some(mut e) = tracker.sessions.get_mut(&sid) {
@@ -590,7 +602,7 @@ mod tests {
         reg.write().await.add(r);
         let tracker = InMemorySessionStore::new();
         let sid = Uuid::new_v4();
-        tracker.touch_or_register(&reg, sid, "snappy", &rid).await;
+        tracker.touch_or_register(&reg, sid, "snappy", &rid, false).await;
         // 30s old.
         if let Some(mut e) = tracker.sessions.get_mut(&sid) {
             e.last_seen = Instant::now() - Duration::from_secs(30);

--- a/crates/ruscker-admin/src/sessions_pg.rs
+++ b/crates/ruscker-admin/src/sessions_pg.rs
@@ -308,6 +308,7 @@ impl SessionStore for PostgresSessionStore {
         session_id: Uuid,
         spec_id: &str,
         replica_id: &ReplicaId,
+        seat_reserved: bool,
     ) -> TouchOutcome {
         match self.try_touch(session_id, spec_id, replica_id).await {
             Ok(TouchRow { inserted: true, .. }) => {
@@ -316,12 +317,17 @@ impl SessionStore for PostgresSessionStore {
                 // truth read back from the shared table — an absolute
                 // value, so a concurrent reconcile can't lose a blind
                 // `+1` (B2). On a count read error, fall back to the
-                // old blind bump rather than skip the admission.
+                // old blind bump rather than skip the admission. The
+                // absolute `set_session_count` already accounts for any
+                // seat reserved at pick (#582 part 1); only the blind-bump
+                // fallback must skip when the seat was pre-reserved.
                 match self.count_for_replica(replica_id).await {
                     Ok(n) => registry.write().await.set_session_count(replica_id, n),
                     Err(e) => {
                         warn!(error = %e, "replica count read failed; using blind bump");
-                        registry.write().await.inc_sessions(replica_id);
+                        if !seat_reserved {
+                            registry.write().await.inc_sessions(replica_id);
+                        }
                     }
                 }
                 self.local_len.fetch_add(1, Ordering::Relaxed);
@@ -502,7 +508,7 @@ mod tests {
         // First touch registers + increments immediately.
         let sid = Uuid::new_v4();
         assert_eq!(
-            store.touch_or_register(&reg, sid, "alpha", &rid).await,
+            store.touch_or_register(&reg, sid, "alpha", &rid, false).await,
             TouchOutcome::Registered
         );
         assert_eq!(store.len(), 1);
@@ -510,7 +516,7 @@ mod tests {
 
         // Second touch only refreshes.
         assert_eq!(
-            store.touch_or_register(&reg, sid, "alpha", &rid).await,
+            store.touch_or_register(&reg, sid, "alpha", &rid, false).await,
             TouchOutcome::Touched
         );
 
@@ -578,7 +584,7 @@ mod tests {
         // A registers a session.
         let sid = Uuid::new_v4();
         assert_eq!(
-            a.touch_or_register(&reg_a, sid, "alpha", &rid).await,
+            a.touch_or_register(&reg_a, sid, "alpha", &rid, false).await,
             TouchOutcome::Registered
         );
         // B hasn't reconciled yet — its registry shows nothing.
@@ -637,7 +643,7 @@ mod tests {
         // A registers; A owns it, A.len() == 1, B.len() == 0.
         let sid = Uuid::new_v4();
         assert_eq!(
-            a.touch_or_register(&reg_a, sid, "alpha", &rid).await,
+            a.touch_or_register(&reg_a, sid, "alpha", &rid, false).await,
             TouchOutcome::Registered
         );
         assert_eq!(a.len(), 1);
@@ -647,7 +653,7 @@ mod tests {
         // exists, so this is a Touched (not Registered) — but B now
         // owns it and must count it in len() right away (B1 fix).
         assert_eq!(
-            b.touch_or_register(&reg_b, sid, "alpha", &rid).await,
+            b.touch_or_register(&reg_b, sid, "alpha", &rid, false).await,
             TouchOutcome::Touched
         );
         assert_eq!(b.len(), 1, "B counts the failed-over session immediately");
@@ -665,7 +671,7 @@ mod tests {
         // A repeat touch by the new owner is neither insert nor takeover
         // — len() stays 1, no double count.
         assert_eq!(
-            b.touch_or_register(&reg_b, sid, "alpha", &rid).await,
+            b.touch_or_register(&reg_b, sid, "alpha", &rid, false).await,
             TouchOutcome::Touched
         );
         assert_eq!(b.len(), 1);
@@ -706,7 +712,7 @@ mod tests {
 
         let sid = Uuid::new_v4();
         store
-            .touch_or_register(&reg, sid, "alpha", &rid)
+            .touch_or_register(&reg, sid, "alpha", &rid, false)
             .await;
         // Age the row well past any tiny timeout.
         sqlx::query("UPDATE proxy_sessions SET last_seen = now() - interval '1 hour'")


### PR DESCRIPTION
**Audit B2 (#582), part 1 — closes the over-admission race.** Part 2 (#613, merged in v0.1.66) made a full seats spec scale out; this closes the remaining race: two concurrent first-requests could both read the same last free seat (under a read lock) and both register, over-packing a `seats-per-container: 1` replica.

## Fix
`pick_or_spawn` now **picks AND reserves under one write lock** (`inc_sessions` on the chosen replica), returning whether it reserved so the session tracker skips the duplicate increment:
- fast path + double-check + the at-max overload all reserve;
- **coalescing** only reuses a `Starting` replica that still has a **free seat** (its spawner already reserved one), else it scales out — so a cold-start burst spawns **per seat up to max** instead of herding onto one replica;
- the spawn path reserves the new replica's first seat.

`SessionStore::touch_or_register` gains a `seat_reserved` flag: the in-memory store skips `inc_sessions` when set; the Postgres store's absolute `set_session_count` already accounts for it (only the blind-bump fallback guards on the flag). `pick_or_spawn` runs only for a **new** session (sticky cookies short-circuit earlier), so the write lock is per-new-session, not per-request, and `reserve == needs_sticky` so `touch_or_register` always runs (no leaked reservation).

## Verification
- Unit: `pick_or_spawn_reserves_seat_atomically_under_race` — two concurrent picks on one free seat get **distinct** replicas, none over its seat. Existing scale-out/overload/coalescer tests still pass. `cargo test -p ruscker-admin` (278) + clippy green.
- **Real Docker concurrency smoke** (`seats: 1`, `max-replicas: 3`): **5 simultaneous cold sessions spawned exactly 3 replicas** — no herd onto one.

**Draft** per the agreed plan (the `SessionStore` signature change is the riskiest surface): validated locally with real Docker; a confirmatory concurrency run on the prod-like box before merge is welcome.

Closes #582.

🤖 Generated with [Claude Code](https://claude.com/claude-code)