### PR TITLE
chore(release): bump workspace version 0.1.68 → 0.1.69

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2845,7 +2845,7 @@ dependencies = [
 
 [[package]]
 name = "ruscker-admin"
-version = "0.1.68"
+version = "0.1.69"
 dependencies = [
  "aes-gcm",
  "anyhow",
@@ -2894,7 +2894,7 @@ dependencies = [
 
 [[package]]
 name = "ruscker-cli"
-version = "0.1.68"
+version = "0.1.69"
 dependencies = [
  "anyhow",
  "clap",
@@ -2914,7 +2914,7 @@ dependencies = [
 
 [[package]]
 name = "ruscker-config"
-version = "0.1.68"
+version = "0.1.69"
 dependencies = [
  "chrono",
  "ordered-float",
@@ -2929,7 +2929,7 @@ dependencies = [
 
 [[package]]
 name = "ruscker-core"
-version = "0.1.68"
+version = "0.1.69"
 dependencies = [
  "async-trait",
  "chrono",
@@ -2942,7 +2942,7 @@ dependencies = [
 
 [[package]]
 name = "ruscker-docker"
-version = "0.1.68"
+version = "0.1.69"
 dependencies = [
  "anyhow",
  "async-stream",
@@ -2961,7 +2961,7 @@ dependencies = [
 
 [[package]]
 name = "ruscker-proxy"
-version = "0.1.68"
+version = "0.1.69"
 dependencies = [
  "anyhow",
  "axum",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -10,7 +10,7 @@ members = [
 ]
 
 [workspace.package]
-version = "0.1.68"
+version = "0.1.69"
 edition = "2021"
 rust-version = "1.85"
 license = "Apache-2.0"

--- a/book/src/faq.md
+++ b/book/src/faq.md
@@ -80,7 +80,7 @@ the **sign-in session** paths to a single upstream — see
 
 ### Is it production-ready?
 
-Yes. The current release is **v0.1.68** — Phases 0–7 are complete and
+Yes. The current release is **v0.1.69** — Phases 0–7 are complete and
 the proxy is production-ready and horizontally scalable.
 Releases are multi-arch and cosign-signed; see the
 [release notes](./news.md) and the [Roadmap](./roadmap.md).

--- a/book/src/introduction.md
+++ b/book/src/introduction.md
@@ -48,7 +48,7 @@ engineered to keep the runtime light while staying compatible:
 
 ## In production
 
-Ruscker is on **v0.1.68** and runs in production today. Built for extreme
+Ruscker is on **v0.1.69** and runs in production today. Built for extreme
 efficiency, its idle footprint sits in the low tens of megabytes:
 
 > **~540 MB → ~14 MB idle** — measured on a real production deployment.

--- a/book/src/news.md
+++ b/book/src/news.md
@@ -9,6 +9,18 @@ the [GitHub releases page](https://github.com/StrategicProjects/ruscker/releases
 
 ---
 
+## v0.1.69 — 2026-06-05
+
+Lighter image and asset serving.
+
+**Performance**
+- Card images: a warm thumbnail hit and an ETag revalidation no longer
+  re-read the full source blob from the database/disk — the content hash
+  is remembered per file (#592).
+- The bundled CSS/JS are brotli/gzip-compressed once at startup instead of
+  being re-encoded on every request; clients get the precompressed variant
+  they accept (#593).
+
 ## v0.1.68 — 2026-06-05
 
 Manage groups from the admin.

--- a/book/src/roadmap.md
+++ b/book/src/roadmap.md
@@ -1,6 +1,6 @@
 # Roadmap
 
-Ruscker is at **v0.1.68** — Phases 0 through 7 are done and the proxy is
+Ruscker is at **v0.1.69** — Phases 0 through 7 are done and the proxy is
 production-ready and horizontally scalable. Phase 8 (external auth) is
 the main optional, demand-driven work left. For what changed in each
 release, see the [release notes](./news.md).
@@ -71,7 +71,7 @@ can serve any session; one scaler leader via Postgres advisory locks,
 with failover. A runnable 2-instance compose harness lives in
 `examples/ha/`. See [Deployment shapes](./architecture.md#deployment-shapes).
 
-### Post-phase polish → **v0.1.4 – v0.1.68**
+### Post-phase polish → **v0.1.4 – v0.1.69**
 
 Incremental improvements shipped after Phase 7.
 

--- a/docs/SECURITY.md
+++ b/docs/SECURITY.md
@@ -5,7 +5,7 @@ Status: living document. Tracks the Phase 5 security audit
 **[accepted limitation]**, or **[deferred]**. File references use
 `crate/path:symbol` so they survive line-number drift.
 
-> **Scope.** This covers v0.1.68: single-operator install, Ruscker
+> **Scope.** This covers v0.1.69: single-operator install, Ruscker
 > behind a TLS-terminating reverse proxy, Docker on the same host.
 > Multi-tenant / shared-team auth (OIDC, RBAC) is out of scope until
 > Phase 8.


### PR DESCRIPTION
Cuts **v0.1.69** — perf: blob-free thumbnail hits & 304s (#619/#592) + precompressed bundled assets (#620/#593). Version bump + Cargo.lock + book/docs refs + news entry.

🤖 Generated with [Claude Code](https://claude.com/claude-code)