### PR TITLE
docs: vendor the UX design handoff (#623, slice 0)

### DIFF
--- a/docs/design-handoff/NOTES.md
+++ b/docs/design-handoff/NOTES.md
@@ -1,0 +1,33 @@
+# Design handoff — vendored reference
+
+This directory is the **high-fidelity UX prototype** handed off for the
+Ruscker redesign, vendored verbatim so it's versioned and accessible to
+whoever implements it. Tracking issue: **#623**.
+
+**It is reference, not production code.** The prototype is React/JSX with
+Babel-in-browser (`Ruscker UX.html` + `src/*.jsx`); the real product is
+**Askama + HTMX + Alpine.js + Tailwind 4, zero Node, no SPA**. Recreate
+the screens — do not port the JSX.
+
+## What to trust
+
+- **`assets/ruscker.css`** — source of truth for design tokens and
+  component styles. Reconcile against the live
+  `crates/ruscker-admin/assets/tailwind/input.css`.
+- **`README.md`** — view-by-view spec, interactions, perceived-performance
+  primitives, and the shared-state model.
+
+## Known doc drift
+
+- The README prose mentions **Geist** for typography, but both
+  `ruscker.css` and the live `input.css` use **Jost** (self-hosted, latin
+  subset). Use **Jost** — ignore the Geist reference.
+- Tabler icons: the subset the app serves is **outline only** — there is
+  no `ti-*-filled`. "Filled" glyphs (e.g. the featured star) are inline
+  SVG with a toggled `fill`, as already done in the app.
+- The "simulated user" picker in the prototype is a prototype-only device
+  for previewing per-group access; it is **not** part of the product
+  (the real app uses login/session).
+
+To browse the prototype: open `Ruscker UX.html` directly in a browser
+(no build step — uses in-browser Babel).

--- a/docs/design-handoff/README.md
+++ b/docs/design-handoff/README.md
@@ -1,0 +1,503 @@
+# Handoff: Ruscker — Portal Público + Admin
+
+## Visão Geral
+
+O Ruscker é uma plataforma de hospedagem de aplicações científicas (Shiny, Jupyter, Streamlit, FastAPI, etc.) desenvolvida na UFPE. Este pacote contém o protótipo UX completo com **alta fidelidade**, cobrindo:
+
+- **Portal público** — catálogo de apps com busca, filtros, destaques e controle de acesso por grupo
+- **Admin** — dashboard de monitoramento, gerenciamento de apps, usuários, grupos, disco, credenciais, logs, auditoria e configuração de aparência
+
+## Sobre os arquivos de design
+
+Os arquivos neste bundle são **protótipos de referência criados em HTML + React (Babel inline)**. Eles **não** são código de produção — são mockups funcionais de alta fidelidade que mostram layout, comportamento, interações e estados.
+
+**Sua tarefa** é recriar estas telas no ambiente do projeto real (framework, design system e bibliotecas já existentes). Analise cada tela no HTML e implemente de acordo com os padrões do codebase alvo.
+
+## Fidelidade
+
+**Alta fidelidade (hifi)** — cores, tipografia, espaçamento, ícones e interações estão definidos com precisão. O desenvolvedor deve reproduzir as telas pixel-a-pixel usando as bibliotecas e padrões do projeto real.
+
+---
+
+## Design Tokens
+
+### Cores principais
+```
+--teal-600:    #0f6e56   (accent primário — verde Ruscker)
+--teal-400:    #06d6a0   (dot de status "ready")
+--warn:        #f59e0b   (warning)
+--lock:        #ef4444   (restrito/vermelho)
+--lock-open:   #10b981   (público/verde)
+--text:        #111827   (light) / #e6edf3 (dark)
+--text-muted:  #6b7280
+--text-faint:  #9ca3af
+--bg:          #f4f5f0   (light) / #0d1117 (dark)
+--surface:     #ffffff   (light) / #161b22 (dark)
+--surface-soft:#f8faf8   (light) / #1c2128 (dark)
+--border:      rgba(0,0,0,.1) (light) / rgba(255,255,255,.08) (dark)
+```
+
+### Cores de grupos de acesso
+```
+admin:  #ef476f  (rosa/vermelho)
+editor: #06b6d4  (ciano)
+viewer: #26547c  (azul escuro)
+```
+
+### Tipografia
+- **Interface:** `'Geist'` (Google Fonts) — fallback: `system-ui, -apple-system, sans-serif`
+- **Mono:** `'Geist Mono'` — fallback: `'JetBrains Mono', monospace`
+- Tamanhos base: 13–14px para body, 11–12px para labels/meta, 30–36px para métricas
+
+### Ícones
+Tabler Icons — `https://unpkg.com/@tabler/icons-webfont@latest/dist/tabler-icons.min.css`
+Classe padrão: `<i class="ti ti-{name}"></i>`
+
+### Bordas e sombras
+```
+border-radius base:  8–10px
+border-radius card:  14px
+border-radius pill:  999px
+shadow-sm: 0 1px 3px rgba(0,0,0,.06)
+shadow-lg: 0 8px 30px rgba(0,0,0,.12)
+```
+
+---
+
+## Telas / Views
+
+### 1. Portal Público
+
+**Propósito:** Catálogo de aplicações acessível ao público, com controle de visibilidade por grupo de acesso.
+
+**Layout:** single-column, max-width ~1200px centrado.
+
+#### Cabeçalho (`.lhead`)
+- Logo (SVG ~28px) + nome do portal + tagline abaixo
+- Fundo: gradiente configurável (suave/vibrante/nenhum) baseado no accent color
+- Direita: 3 ícones — tema (sol/lua), idioma (PT/EN), entrar (login icon)
+- Em mobile: collapse para hamburger
+
+#### Seletor de usuário simulado (protótipo)
+- Botão discreto no canto direito acima do catálogo
+- Dropdown com lista de usuários para simular acesso por grupo
+- Pontinhos coloridos de grupo ao lado do nome
+
+#### Carrossel de destaques (`.feat`)
+- Título "Em destaque / Featured" com `ti-star`
+- Navegação: chevrons esquerdo/direito, 3 cards por página
+- Cards idênticos aos do catálogo
+- Só aparece quando há apps favoritados E visíveis ao usuário atual
+- Controlado pelo toggle em Admin → Aparência
+
+#### Barra de busca + filtros (`.portal-sticky`)
+- Sticky abaixo do carrossel
+- Input de busca com ícone de lupa + atalho ⌘K
+- Botão de ordenação (Recente/Nome)
+- Chips de filtro: Todos · Apps · APIs · Pacotes · Relatórios | público · restrito
+- Linha de resultados com contagem e botão "Limpar"
+
+#### Grade de cards (`.cards-grid`)
+- CSS grid: `repeat(auto-fill, minmax(280px, 1fr))`
+- Cards com: cover area (logo + badges de tipo/subject + cadeado), nome, descrição, data de atualização, status dot
+- Estado de loading: skeleton cards animados
+
+#### Filtro de acesso por grupo
+- Apps com `accessGroups: []` → visíveis a todos (logados ou não)
+- Apps com `accessGroups: ["editor","viewer"]` → só visíveis para usuários desses grupos
+- A filtragem ocorre no `useMemo` do `filtered` array — deps incluem `portalUser` e `appAccess`
+
+**3 variações de layout:**
+- **A — Refinado:** carrossel horizontal + grid de cards
+- **B — Compacto:** nav rail lateral + lista de linhas densas + carrossel no topo
+- **C — Seções:** agrupado por tipo (Apps / APIs / Pacotes / Relatórios)
+
+---
+
+### 2. Dashboard de Monitoramento
+
+**Propósito:** Visão operacional do servidor — réplicas rodando, uso de recursos, estado de cada app.
+
+**Layout:** 2 colunas (métricas + lista de réplicas)
+
+#### Métricas globais
+- 4 KPI cards: CPU, RAM, Réplicas ativas, Uptime
+- Números com animação de "live" (contagem suave)
+- Mini sparkline (SVG path) em cada card
+
+#### Lista de réplicas (por app)
+- Apps agrupados com collapse/expand
+- Por réplica: ID curto, estado (dot colorido), CPU %, RAM, uptime
+- Estados: `ready` (verde), `boot` (âmbar), `warn` (laranja), `off` (cinza)
+- Botão de restart por réplica
+
+**3 variações:**
+- **A — Agrupado:** accordion por app, réplicas em tabela
+- **B — Cards:** um card por app com métricas e lista de réplicas colapsável
+- **C — Ops:** foco em ações — lista densa com checkboxes para operações em lote
+
+---
+
+### 3. Admin — Apps
+
+**Propósito:** Catálogo de specs de apps cadastrados no banco de dados.
+
+**Layout:** página full-width com tabela sticky-header
+
+#### Barra de ações
+- Busca instantânea, chips de filtro por tipo (Shiny/Interativo/API/Externo), ordenação
+- Botões: Importar YAML + Novo app
+
+#### Tabela
+Colunas: ID · Nome (logo+texto) · Tipo (pill colorida) · Acesso (público ou group-badges) · Estado (pill) · Atualizado · Ações
+
+- **Coluna Acesso:** `[]` → ícone globo + "público"; `[grupos]` → group-badge pills
+- **Ações:** estrela SVG (outline/preenchida âmbar), lápis (abre editor), duplicar
+- Clicar na linha abre o editor completo
+
+#### Estrela / Favoritar
+- SVG personalizado: `<path d="M12 17.27L18.18 21...">` 
+- `fill="currentColor"` quando favoritado (âmbar `#d97706` + fundo amarelo)
+- `fill="none"` quando não favoritado (stroke apenas)
+- Estado compartilhado globalmente — reflete no Portal (carrossel) e Aparência (preview)
+
+---
+
+### 4. Admin — Editor de App
+
+**Propósito:** Criar ou editar spec de um app com preview ao vivo do card.
+
+**Layout:** 2 colunas — formulário (esquerda) + preview fixo (direita)
+
+#### Seções do formulário
+1. **Identity** — ID, Nome
+2. **Kind** — tipo (App/API/Pacote/Relatório), cobertura do card
+3. **Description** — PT + EN
+4. **Appearance** — cor accent, ícone mono
+5. **Access & scale** — toggle Restrito, grupos de acesso (mutex: Público OU grupos), réplicas
+6. **Advanced** — env vars, recursos (CPU/RAM), autoscale, health check, URL externa
+7. **Live preview** — card ao vivo reagindo ao formulário
+
+#### Seleção de grupos de acesso (seção Access & scale)
+- Botão "Público" (verde teal) — quando ativo, desabilita os 3 botões de grupo (`disabled + opacity: 0.32`)
+- Botões de grupo: Administrador / Editor / Visualizador — multi-seleção
+- Regra: nunca Público + grupos ao mesmo tempo
+- Ao salvar, persiste em estado global `appAccess: Map<appId, string[]>`
+
+---
+
+### 5. Admin — Importar YAML
+
+**Propósito:** Importar specs de apps a partir de um arquivo YAML.
+
+**Layout:** modal/page com textarea + preview de apps detectados
+
+- Textarea para colar YAML
+- Lista de apps detectados com checkbox por app (selecionar subconjunto)
+- Botão "Importar selecionados"
+- Validação inline (ID duplicado, campos obrigatórios)
+
+---
+
+### 6. Admin — Aparência
+
+**Propósito:** Configurar a identidade visual do portal público com preview ao vivo.
+
+**Layout:** 2 colunas — formulário (esquerda) + mini-preview do portal (direita, sticky)
+
+#### Seções do formulário
+1. **Identidade** — título, tagline
+2. **Cor da marca** — swatches predefinidos + input hex
+3. **Logo** — Marca+nome / Só símbolo / URL customizada + sliders de tamanho/margem
+4. **Fundo & gradientes** — hero do cabeçalho (nenhum/suave/vibrante) + cover dos cards (tint/gradient)
+5. **Tema padrão** — Claro / Escuro / Auto
+6. **Layout do catálogo** — Grid / Lista / Seções + Confortável / Compacto
+7. **Seções visíveis** — toggles: carrossel destaques, busca, filtros de acesso
+8. **SEO** — meta title, meta description, og:image
+9. **Analytics** — Nenhum / Google Analytics / Plausible / Matomo + ID + respeitar DNT
+10. **CSS customizado** — code editor com syntax highlighting (CSS)
+11. **Blocos HTML** — 4 slots injetáveis: abaixo do cabeçalho / após destaques / antes do rodapé / dentro do rodapé
+
+#### Editor de código (CSS + HTML)
+- Fundo sempre escuro `#0d1117` (GitHub/VS Code Dark)
+- Overlay pattern: `<pre>` com highlight + `<textarea>` transparente por cima
+- Paleta de tokens (VS Code Dark+):
+  - Comentários: `#6A9955` itálico
+  - Strings: `#CE9178`
+  - At-rules: `#C586C0`
+  - Seletores: `#D7BA7D`
+  - Propriedades: `#9CDCFE`
+  - Números/unidades: `#B5CEA8`
+  - !important: `#F44747`
+  - Tags HTML: `#4EC9B0`
+
+#### Preview ao vivo (mini-portal)
+- Escala fixa ~350px de largura
+- Reflete em tempo real: hero gradient, cor accent, logo, tagline, carrossel de destaques, filtros
+- Cabeçalho com: logo + nome + 3 ícones (tema, idioma, login)
+- Estado global `portalCfg` compartilhado — mudanças na Aparência refletem instantaneamente no Portal
+
+---
+
+### 7. Admin — Mídia
+
+**Propósito:** Biblioteca de imagens/SVGs disponíveis no sistema.
+
+**Layout:** grid de tiles + zona de upload
+
+- Grid `repeat(auto-fill, minmax(180px, 1fr))`
+- Cada tile: preview da imagem + nome (mono) + tamanho + tipo MIME
+- Hover: botão de remover (trash, vermelho)
+- Zona de drag-and-drop no topo (suporta PNG/JPEG/WebP/SVG, até 10MB)
+- Busca instantânea
+
+---
+
+### 8. Admin — Disco
+
+**Propósito:** Uso de armazenamento do servidor com ações de limpeza.
+
+**Layout:** hero de uso + 2 painéis side-by-side
+
+#### Hero de uso
+- Número grande: "X.X GB / 50 GB" + percentual
+- Barra de progresso segmentada por categoria (imagens, containers, cache, logs, backups)
+- Legenda com ícone + label + tamanho por categoria
+
+#### Painel: Imagens de container
+- Tabela: Imagem:tag · In use (badge verde/vermelho) · Tamanho · Ação (trash)
+- Imagens com `usedBy === 0` ficam levemente opacas (`.is-unused`)
+- Badge "dangling" para imagens sem tag
+- Botão "Prune unused · X.X GB" — remove todas as não utilizadas
+
+#### Painel: Containers
+- Tabela: ID (8 chars hex) · App · Estado (running/stopped/exited + dot) · RAM · Criado · Ação
+- Botão "Prune stopped · X MB" — remove parados/exited
+
+---
+
+### 9. Admin — Usuários
+
+**Propósito:** Gerenciar usuários com acesso ao portal e ao admin.
+
+**Layout:** tabela com inline editor por linha
+
+#### Tabela
+Colunas: Usuário (avatar+nome+email) · Grupos · Estado · Visto · Ações
+
+- **Avatar:** círculo com iniciais colorido por hash do nome
+- **Grupos:** um ou mais group-badge pills por usuário (cor por tipo)
+- **Estado:** dot + label (ativo/convidado/suspenso)
+- Linha suspensa: `opacity: 0.55`
+
+#### Editor inline de grupos
+- Clique em ✎ expande uma linha extra com toggles de grupo
+- Cada toggle: checkbox-style (ativo = cor do grupo + check icon)
+- Mínimo 1 grupo por usuário (último não pode ser removido)
+
+#### Modelo de dados de usuário
+```typescript
+interface User {
+  id: number;
+  name: string;
+  email: string;
+  groups: ("admin" | "editor" | "viewer")[];  // array, multi-grupo
+  status: "active" | "invited" | "suspended";
+  seen: { pt: string; en: string };
+}
+```
+
+---
+
+### 10. Admin — Grupos
+
+**Propósito:** Visualizar papéis de acesso, seus membros e apps vinculados.
+
+**Layout:** 3 cards em grid + seção de apps públicos abaixo
+
+#### Card de grupo
+- Barra colorida na esquerda (4px)
+- Nome do grupo, descrição, permissões (pills: Gerenciar/Deploy/Visualizar)
+- Rodapé: contagem de membros + apps + botão editar
+- Expandível via chevron → mostra membros (avatar+nome+email) e apps vinculados
+
+#### Apps públicos
+- Seção separada listando apps com `accessGroups: []`
+- Ícone de globo ao lado do nome
+
+#### Modelo de dados
+```typescript
+interface Group {
+  id: "admin" | "editor" | "viewer";
+  name: Record<"pt"|"en", string>;
+  desc: Record<"pt"|"en", string>;
+  perms: ("manage" | "deploy" | "view")[];
+  color: string;
+}
+
+interface App {
+  accessGroups: string[];  // [] = público, [...] = restrito
+}
+```
+
+---
+
+### 11. Admin — Credenciais
+
+**Propósito:** Gerenciar tokens de API e usuários de serviço.
+
+**Layout:** tabela + botão de criação
+
+- Colunas: Nome · Token (mascarado `rk_live_****`) · Escopo · Criado · Ações (eye/copy/ban)
+- Criar novo token: abre form com nome + escopos
+- Revogar: confirmação antes de remover
+
+---
+
+### 12. Admin — Logs
+
+**Propósito:** Stream ao vivo de logs do servidor.
+
+**Layout:** painel de terminal com controles no topo
+
+- Stream simulado de linhas de log (auto-scroll)
+- Filtros: nível (INFO/WARN/ERROR/DEBUG), app, texto livre
+- Botão Pausar/Retomar
+- Cores por nível: ERROR=vermelho, WARN=âmbar, INFO=texto normal, DEBUG=faint
+
+---
+
+### 13. Admin — Auditoria
+
+**Propósito:** Registro de ações administrativas.
+
+**Layout:** tabela filtrável + export
+
+- Colunas: Quando · Ator (avatar+nome) · Ação (`code` mono) · Alvo · IP
+- Categorias: Apps / Usuários / Segurança / Config
+- Chips de filtro por categoria
+- Busca por ator/ação/alvo
+- Botão Export → CSV
+
+---
+
+## Interações & Comportamento
+
+### Velocidade percebida (foco do projeto)
+- **Barra de progresso top-of-page:** fina linha teal animada ao trocar de tela
+- **Skeletons:** cards/linhas de tabela skeleton aparecem imediatamente; conteúdo real aparece após ~600ms
+- **Filtros instantâneos:** busca e chips filtram sem debounce
+- **Animações de entrada:** `fade-in` + `stagger` (delay escalonado) nos cards
+- **Números animados:** métricas do dashboard "contam" até o valor final
+
+### Estados de loading
+- Skeleton: `background: linear-gradient(90deg, var(--surface-soft) 25%, var(--border) 50%, var(--surface-soft) 75%); background-size: 200% 100%; animation: shimmer 1.4s infinite`
+- Barra de progresso: opacity 0→1, width aumenta em etapas (10%→58%→86%→100%), depois some
+
+### Temas
+- Toggle claro/escuro via atributo `data-theme` no `<html>`
+- Persistido em `localStorage`
+
+### i18n (PT/EN)
+- Toggle no header
+- Todas as strings têm versão PT e EN
+- Persistido em `localStorage`
+
+---
+
+## Estado Global Compartilhado
+
+```typescript
+// Elevado no componente raiz (App)
+const [featured, setFeatured]       // Set<appId> — apps favoritados
+const [appAccess, setAppAccess]     // Map<appId, string[]> — grupos de acesso
+const [portalUser, setPortalUser]   // User | null — usuário simulado (protótipo)
+const [portalCfg, setPortalCfg]     // PortalConfig — configuração da aparência
+```
+
+`portalCfg` inclui:
+```typescript
+interface PortalConfig {
+  title: string;
+  tagline: string;
+  accent: string;         // hex color
+  theme: "light"|"dark"|"auto";
+  layout: "grid"|"list"|"sections";
+  featured: boolean;      // mostrar carrossel
+  showSearch: boolean;
+  showAccess: boolean;
+  density: "comfortable"|"compact";
+  logo: "wordmark"|"mark"|"custom";
+  logoUrl: string;
+  logoSize: number;
+  logoGap: number;
+  hero: "none"|"soft"|"bold";
+  cover: "tint"|"gradient";
+  seoTitle: string;
+  seoDesc: string;
+  ogImage: string;
+  analytics: "none"|"ga"|"plausible"|"matomo";
+  analyticsId: string;
+  customCss: string;
+  htmlTop: string;
+  htmlAfterFeatured: string;
+  htmlBeforeFooter: string;
+  htmlFooter: string;
+}
+```
+
+---
+
+## Assets
+
+| Asset | Origem | Uso |
+|---|---|---|
+| `ruscker-mark.svg` | Marca Ruscker | Logo em cabeçalhos e rodapé |
+| `ruscker-mark-knockout.svg` | Marca Ruscker (knockout) | Fundos escuros |
+| Tabler Icons | CDN unpkg | Todos os ícones da interface |
+| Geist / Geist Mono | Google Fonts | Tipografia |
+| Logos de frameworks | simpleicons.org CDN | Logos de Shiny, Jupyter, RStudio, etc. |
+
+---
+
+## Arquivos de Design
+
+| Arquivo | Conteúdo |
+|---|---|
+| `Ruscker UX.html` | Ponto de entrada — carrega todos os scripts Babel |
+| `src/data.jsx` | Dados mock: apps, réplicas, i18n, logos |
+| `src/components.jsx` | Componentes compartilhados: Logo, AppCard, AppRow, Skeletons, StarIcon |
+| `src/portal.jsx` | Portal público (3 variações + FeaturedCarousel + filtros) |
+| `src/dashboard.jsx` | Dashboard de monitoramento (3 variações) |
+| `src/admin.jsx` | Telas Apps + Mídia |
+| `src/admin2.jsx` | Telas Disco + Credenciais + Logs |
+| `src/admin3.jsx` | Telas Usuários + Grupos + Auditoria |
+| `src/appearance.jsx` | Tela Aparência + mini-portal preview + code editor |
+| `src/forms.jsx` | Editor de app + Import YAML |
+| `src/app.jsx` | Shell do protótipo: navegação, estado global, MockHeader |
+| `assets/ruscker.css` | Todos os tokens CSS e estilos de componentes |
+
+---
+
+## Como rodar o protótipo
+
+Abrir `Ruscker UX.html` diretamente no navegador (não requer build — usa Babel in-browser).
+
+**Controles do protótipo (barra cinza no topo):**
+- **Tela:** alterna Portal ↔ Admin
+- **Variação:** A/B/C para Portal e Dashboard
+- **Reload:** replay dos skeletons de loading
+- **Tema:** claro/escuro
+- **Idioma:** PT/EN
+
+**No Portal:** botão discreto no canto direito para simular usuário logado (controle de acesso por grupo).
+
+---
+
+## Notas de implementação
+
+1. O carrossel de destaques deve re-filtrar quando o usuário muda — inclua `portalUser` e `appAccess` nas deps do `useMemo`
+2. O editor CSS/HTML usa o padrão textarea+pre overlay — sincronize scroll entre os dois
+3. A estrela de favorito deve propagar para o portal E para o preview de Aparência via estado global
+4. O mutex Público/grupos no editor de app deve desabilitar os botões de grupo via `disabled` prop (não apenas opacity CSS)
+5. `FeaturedCarousel` deve receber `portalCfg` como prop — sem ele crasha quando `feat.length > 0`

--- a/docs/design-handoff/Ruscker UX.html
+++ b/docs/design-handoff/Ruscker UX.html
@@ -1,0 +1,43 @@
+<!doctype html>
+<html lang="pt-BR" data-theme="light">
+<head>
+<meta charset="utf-8">
+<meta name="viewport" content="width=device-width, initial-scale=1">
+<title>Ruscker · UX Prototype</title>
+<link rel="icon" href="assets/ruscker-mark.svg" type="image/svg+xml">
+<link rel="stylesheet" href="assets/tabler-icons.min.css">
+<link rel="stylesheet" href="assets/ruscker.css">
+<template id="__bundler_thumbnail">
+  <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 80 80" width="100%" height="100%">
+    <rect width="80" height="80" fill="#0F6E56"/>
+    <polygon points="20,50 40,41 60,50 40,59" fill="#ffffff"/>
+    <polygon points="20,41 40,32 60,41 40,50" fill="#5DCAA5"/>
+    <polygon points="20,32 40,23 60,32 40,41" fill="#cdeee4"/>
+  </svg>
+</template>
+<style>
+  #root { min-height: 100vh; }
+  .boot-splash { position:fixed; inset:0; display:flex; align-items:center; justify-content:center; background:var(--bg); z-index:9999; }
+  .boot-splash img { width:40px; height:40px; opacity:.5; animation:bootpulse 1.2s ease-in-out infinite; }
+  @keyframes bootpulse { 0%,100%{opacity:.3;transform:scale(.96)} 50%{opacity:.7;transform:scale(1)} }
+</style>
+</head>
+<body>
+<div id="root"><div class="boot-splash"><img src="assets/ruscker-mark.svg" alt="Ruscker"></div></div>
+
+<script src="https://unpkg.com/react@18.3.1/umd/react.development.js" integrity="sha384-hD6/rw4ppMLGNu3tX5cjIb+uRZ7UkRJ6BPkLpg4hAu/6onKUg4lLsHAs9EBPT82L" crossorigin="anonymous"></script>
+<script src="https://unpkg.com/react-dom@18.3.1/umd/react-dom.development.js" integrity="sha384-u6aeetuaXnQ38mYT8rp6sbXaQe3NL9t+IBXmnYxwkUI2Hw4bsp2Wvmx4yRQF1uAm" crossorigin="anonymous"></script>
+<script src="https://unpkg.com/@babel/standalone@7.29.0/babel.min.js" integrity="sha384-m08KidiNqLdpJqLq95G/LEi8Qvjl/xUYll3QILypMoQ65QorJ9Lvtp2RXYGBFj1y" crossorigin="anonymous"></script>
+
+<script type="text/babel" src="src/data.jsx"></script>
+<script type="text/babel" src="src/components.jsx"></script>
+<script type="text/babel" src="src/portal.jsx"></script>
+<script type="text/babel" src="src/dashboard.jsx"></script>
+<script type="text/babel" src="src/admin.jsx"></script>
+<script type="text/babel" src="src/admin2.jsx"></script>
+<script type="text/babel" src="src/admin3.jsx"></script>
+<script type="text/babel" src="src/appearance.jsx"></script>
+<script type="text/babel" src="src/forms.jsx"></script>
+<script type="text/babel" src="src/app.jsx"></script>
+</body>
+</html>

--- a/docs/design-handoff/assets/ruscker-mark-knockout.svg
+++ b/docs/design-handoff/assets/ruscker-mark-knockout.svg
@@ -1,0 +1,7 @@
+<?xml version="1.0"?>
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 80 80" width="512" height="512" role="img" aria-label="Ruscker">
+  <title>Ruscker — Knockout branco (uso sobre fundos escuros)</title>
+  <polygon points="14,52 40,40 66,52 40,64" fill="#FFFFFF" opacity="0.4"></polygon>
+  <polygon points="14,40 40,28 66,40 40,52" fill="#FFFFFF" opacity="0.7"></polygon>
+  <polygon points="14,28 40,16 66,28 40,40" fill="#FFFFFF"></polygon>
+</svg>

--- a/docs/design-handoff/assets/ruscker-mark.svg
+++ b/docs/design-handoff/assets/ruscker-mark.svg
@@ -1,0 +1,7 @@
+<?xml version="1.0"?>
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 80 80" width="512" height="512" role="img" aria-label="Ruscker">
+  <title>Ruscker — Pilha de containers</title>
+  <polygon points="14,52 40,40 66,52 40,64" fill="#0F6E56"></polygon>
+  <polygon points="14,40 40,28 66,40 40,52" fill="#1D9E75"></polygon>
+  <polygon points="14,28 40,16 66,28 40,40" fill="#5DCAA5"></polygon>
+</svg>

--- a/docs/design-handoff/assets/ruscker.css
+++ b/docs/design-handoff/assets/ruscker.css
@@ -1,0 +1,939 @@
+/* ===================================================================
+   Ruscker — UX prototype stylesheet
+   Tokens + components adapted from the real input.css, plus new
+   perceived-performance primitives (skeletons, progress, transitions).
+   =================================================================== */
+
+@font-face { font-family:"Jost"; font-style:normal; font-weight:400; font-display:swap; src:url("fonts/jost-latin-400-normal.woff2") format("woff2"); }
+@font-face { font-family:"Jost"; font-style:normal; font-weight:500; font-display:swap; src:url("fonts/jost-latin-500-normal.woff2") format("woff2"); }
+@font-face { font-family:"Jost"; font-style:normal; font-weight:600; font-display:swap; src:url("fonts/jost-latin-600-normal.woff2") format("woff2"); }
+
+:root {
+  --font-display: "Jost", ui-sans-serif, system-ui, sans-serif;
+  --font-mono: ui-monospace, SFMono-Regular, Menlo, monospace;
+
+  --teal-200:#5dcaa5; --teal-400:#1d9e75; --teal-600:#0f6e56; --teal-800:#085041;
+
+  --kind-app:#06d6a0;   --kind-app-ink:#04553f;
+  --kind-api:#06b6d4;   --kind-api-ink:#083344;
+  --kind-package:#26547c; --kind-package-ink:#ffffff;
+  --kind-report:#ef476f; --kind-report-ink:#ffffff;
+  --kind-talk:#ffd166;  --kind-talk-ink:#5a4400;
+
+  --lock:#ef4444; --lock-open:#10b981;
+  --status-new:#3b82f6; --status-updated:#10b981; --status-unknown:#9ca3af;
+  --warn:#f59e0b; --info:#3b82f6; --ok:#10b981;
+
+  /* light theme */
+  color-scheme: light;
+  --bg:#fafaf7; --surface:#ffffff; --surface-soft:#f4f4f0;
+  --text:#1a1a1a; --text-muted:#6b6b66; --text-faint:#888888;
+  --border:#e8e6df; --border-soft:#f0eee8; --border-strong:#c0c0bb;
+  --shadow-sm:0 1px 2px rgba(0,0,0,.04);
+  --shadow-md:0 4px 24px rgba(0,0,0,.06);
+  --shadow-lg:0 10px 40px rgba(0,0,0,.16);
+}
+
+[data-theme="dark"] {
+  color-scheme: dark;
+  --bg:#161616; --surface:#1f1f1f; --surface-soft:#1a1a1a;
+  --text:#f0f0f0; --text-muted:#b0b0b0; --text-faint:#707070;
+  --border:#2a2a2a; --border-soft:#232323; --border-strong:#404040;
+  --shadow-sm:0 1px 2px rgba(0,0,0,.4);
+  --shadow-md:0 4px 24px rgba(0,0,0,.5);
+  --shadow-lg:0 10px 40px rgba(0,0,0,.6);
+}
+
+* { box-sizing: border-box; }
+html, body { margin:0; background:var(--bg); color:var(--text); }
+body {
+  font-family: var(--font-display); font-weight:400;
+  font-feature-settings:"cv02","cv11";
+  -webkit-font-smoothing:antialiased;
+}
+button { font-family: inherit; }
+::selection { background: color-mix(in srgb, var(--teal-400) 30%, transparent); }
+
+/* scrollbars */
+*::-webkit-scrollbar { width:10px; height:10px; }
+*::-webkit-scrollbar-thumb { background:var(--border-strong); border-radius:8px; border:3px solid var(--bg); }
+*::-webkit-scrollbar-track { background:transparent; }
+
+/* ===================================================================
+   Prototype chrome (lives OUTSIDE the mock product)
+   =================================================================== */
+.proto-shell { min-height:100vh; display:flex; flex-direction:column; }
+.proto-bar {
+  position:sticky; top:0; z-index:200;
+  display:flex; align-items:center; gap:14px; flex-wrap:wrap;
+  padding:10px 18px;
+  background:color-mix(in srgb, var(--bg) 82%, transparent);
+  backdrop-filter:saturate(140%) blur(12px);
+  border-bottom:0.5px solid var(--border);
+}
+.proto-bar__brand { display:flex; align-items:center; gap:9px; margin-right:4px; }
+.proto-bar__brand img { width:20px; height:20px; display:block; }
+.proto-bar__brand .wm { font-weight:500; letter-spacing:-0.02em; font-size:15px; }
+.proto-bar__brand .tag {
+  font-size:10px; color:var(--text-muted); border:0.5px solid var(--border);
+  border-radius:999px; padding:2px 8px; letter-spacing:.04em; text-transform:uppercase;
+}
+.proto-bar__spacer { flex:1; }
+.proto-group { display:flex; align-items:center; gap:6px; }
+.proto-label { font-size:10px; text-transform:uppercase; letter-spacing:.07em; color:var(--text-faint); margin-right:2px; }
+
+/* segmented control */
+.seg { display:inline-flex; border:0.5px solid var(--border); border-radius:9px; background:var(--surface); overflow:hidden; }
+.seg button {
+  display:inline-flex; align-items:center; gap:6px;
+  padding:7px 12px; border:0; background:transparent; cursor:pointer;
+  color:var(--text-muted); font-size:12.5px; line-height:1; transition:color .12s, background .12s;
+}
+.seg button + button { border-left:0.5px solid var(--border); }
+.seg button:hover { color:var(--text); }
+.seg button.on { background:var(--text); color:var(--bg); }
+.seg button .ti { font-size:15px; }
+.seg.seg--teal button.on { background:var(--teal-600); color:#fff; }
+
+.icon-btn {
+  width:34px; height:34px; flex:none; display:inline-flex; align-items:center; justify-content:center;
+  border:0.5px solid var(--border); border-radius:9px; background:var(--surface);
+  color:var(--text-muted); cursor:pointer; transition:all .12s;
+}
+.icon-btn:hover { color:var(--text); border-color:var(--border-strong); }
+.icon-btn .ti { font-size:17px; }
+.icon-btn.lang { font-size:11px; font-weight:600; letter-spacing:.05em; }
+
+/* stage that holds the mock product */
+.proto-stage { flex:1; position:relative; }
+
+/* ===================================================================
+   Top progress bar — the #1 perceived-speed primitive
+   =================================================================== */
+.topbar-progress {
+  position:fixed; top:0; left:0; height:2.5px; z-index:500;
+  background:linear-gradient(90deg, var(--teal-400), var(--teal-200));
+  box-shadow:0 0 8px color-mix(in srgb, var(--teal-400) 70%, transparent);
+  width:0; opacity:0; transition:width .2s ease, opacity .25s ease;
+}
+.topbar-progress.is-active { opacity:1; }
+
+/* ===================================================================
+   Skeleton primitives — shimmer
+   =================================================================== */
+.sk { position:relative; overflow:hidden; background:color-mix(in srgb, var(--text) 9%, var(--surface)); border-radius:6px; }
+.sk::after {
+  content:""; position:absolute; inset:0; transform:translateX(-100%);
+  background:linear-gradient(90deg, transparent, color-mix(in srgb, var(--surface) 75%, transparent), transparent);
+  animation:sk-shimmer 1.3s ease-in-out infinite;
+}
+@keyframes sk-shimmer { 100% { transform:translateX(100%); } }
+.sk-line { height:10px; border-radius:5px; }
+.sk-pill { border-radius:999px; }
+@media (prefers-reduced-motion: reduce) {
+  .sk::after { animation:none; }
+}
+
+/* content fade-in once "loaded" — kept quick so it never works against
+   the perceived-speed goal; entrance is a short, near-uniform reveal. */
+.fade-in { animation:fade-in .32s ease both; }
+@keyframes fade-in { from { opacity:0; transform:translateY(5px); } to { opacity:1; transform:none; } }
+.stagger > * { animation:fade-in .3s ease both; }
+
+/* ===================================================================
+   Mock product chrome (header bar inside the mock)
+   =================================================================== */
+.mock { min-height:100%; }
+.mock-pad { max-width:1180px; margin:0 auto; padding:0 28px; }
+
+.lhead {
+  display:flex; align-items:center; justify-content:space-between; gap:16px;
+  padding:16px 28px; position:relative;
+}
+.lhead__brand { display:flex; align-items:center; gap:10px; }
+.lhead__brand img { width:26px; height:26px; display:block; }
+.lhead__brand .wm { font-size:19px; font-weight:500; letter-spacing:-0.02em; }
+.lhead__right { display:flex; align-items:center; gap:6px; }
+
+.chrome-icon {
+  width:32px; height:32px; display:inline-flex; align-items:center; justify-content:center;
+  background:transparent; border:0.5px solid var(--border); border-radius:10px;
+  color:var(--text); cursor:pointer; transition:all .12s;
+}
+.chrome-icon:hover { background:var(--surface-soft); border-color:var(--border-strong); }
+.chrome-icon .ti { font-size:16px; }
+.chrome-signin {
+  display:inline-flex; align-items:center; gap:6px; height:32px; padding:0 12px;
+  border:0.5px solid var(--border); border-radius:10px; background:transparent;
+  color:var(--text); font-size:12px; cursor:pointer; text-decoration:none;
+}
+.chrome-signin:hover { background:var(--surface-soft); border-color:var(--border-strong); }
+.chrome-signin .ti { font-size:14px; }
+
+/* ===================================================================
+   Search / filter row
+   =================================================================== */
+.search-pill {
+  display:flex; align-items:center; gap:8px; flex:1;
+  background:var(--surface); border:0.5px solid var(--border);
+  border-radius:999px; padding:10px 16px; transition:border-color .15s, box-shadow .15s;
+}
+.search-pill:focus-within { border-color:var(--text); box-shadow:0 0 0 3px color-mix(in srgb, var(--teal-400) 14%, transparent); }
+.search-pill input { border:0; outline:0; background:transparent; font-size:13px; flex:1; font-family:inherit; color:var(--text); }
+.search-pill input::placeholder { color:var(--text-faint); }
+.search-pill .ti { font-size:15px; color:var(--text-faint); }
+.kbd { font-size:10px; color:var(--text-faint); font-family:var(--font-mono); background:var(--surface-soft); padding:2px 7px; border-radius:5px; }
+
+.sort-btn {
+  display:flex; align-items:center; gap:6px;
+  background:var(--surface); border:0.5px solid var(--border); border-radius:999px;
+  padding:10px 14px; font-size:12px; color:var(--text-muted); cursor:pointer; transition:all .15s; white-space:nowrap;
+}
+.sort-btn:hover { border-color:var(--border-strong); color:var(--text); }
+.sort-btn .ti { font-size:13px; }
+
+.chip {
+  display:inline-flex; align-items:center; gap:6px; padding:7px 13px;
+  border-radius:999px; font-size:12px; border:0.5px solid var(--border);
+  background:var(--surface); color:var(--text-muted); cursor:pointer;
+  transition:all .12s; line-height:1; white-space:nowrap;
+}
+.chip:hover { border-color:var(--border-strong); color:var(--text); }
+.chip-count { font-size:10px; opacity:.55; font-variant-numeric:tabular-nums; }
+.chip.on-all { background:var(--text); color:var(--bg); border-color:var(--text); }
+.chip.on-app { background:#06d6a0; color:#04553f; border-color:#06d6a0; }
+.chip.on-api { background:#06b6d4; color:#083344; border-color:#06b6d4; }
+.chip.on-package { background:#26547c; color:#fff; border-color:#26547c; }
+.chip.on-report { background:#ef476f; color:#fff; border-color:#ef476f; }
+.chip-divider { width:0.5px; height:18px; background:var(--border); margin:0 4px; }
+.access-chip {
+  display:inline-flex; align-items:center; gap:5px; padding:7px 12px; border-radius:999px;
+  font-size:12px; border:0.5px solid var(--border); background:var(--surface); color:var(--text-muted); cursor:pointer; transition:all .12s;
+}
+.access-chip:hover { border-color:var(--border-strong); color:var(--text); }
+.access-chip.on { background:var(--text); color:var(--bg); border-color:var(--text); }
+
+/* ===================================================================
+   App cards
+   =================================================================== */
+.cards-grid { display:grid; grid-template-columns:repeat(auto-fill, 256px); gap:14px; justify-content:center; }
+
+/* Portal A: filter band pins under the chrome while the catalog scrolls. */
+.portal-sticky {
+  position:sticky; top:53px; z-index:30;
+  display:flex; flex-direction:column; gap:12px;
+  background:var(--bg);
+  padding:12px 0 12px; margin-bottom:6px;
+  border-bottom:0.5px solid var(--border);
+}
+
+.rcard {
+  position:relative; width:256px; background:var(--surface);
+  border:0.5px solid var(--border); border-radius:12px; overflow:hidden;
+  display:flex; flex-direction:column; cursor:pointer; text-decoration:none; color:inherit;
+  transition:transform .2s ease, border-color .2s ease, box-shadow .2s ease;
+}
+.rcard:hover { transform:translateY(-3px); border-color:var(--text); box-shadow:var(--shadow-md); }
+.rcard:hover .arrow-go { transform:translateX(3px); color:var(--text); }
+.rcover {
+  position:relative; height:150px; margin:10px 10px 0; border-radius:8px; overflow:hidden;
+  background:var(--surface-soft); border:0.5px solid var(--border); box-shadow:0 1px 1px rgba(0,0,0,.03);
+}
+.rcover-bg { position:absolute; inset:0; z-index:0; }
+.rcover-logo {
+  position:absolute; inset:0; z-index:1; display:flex; align-items:center; justify-content:center;
+  font-size:30px; font-weight:600; letter-spacing:-0.02em;
+}
+.rbadges { position:absolute; top:8px; left:8px; z-index:2; display:flex; align-items:center; gap:4px; flex-wrap:wrap; max-width:calc(100% - 44px); }
+.rbadge { font-size:9px; font-weight:500; padding:3px 9px; border-radius:999px; letter-spacing:.4px; }
+.rbadge--subject {
+  background:color-mix(in srgb, var(--surface) 86%, transparent); color:var(--text-muted);
+  border:0.5px solid var(--border); font-weight:400; letter-spacing:.1px; white-space:nowrap; backdrop-filter:blur(3px);
+}
+.b-app { background:#06d6a0; color:#04553f; }
+.b-api { background:#06b6d4; color:#083344; }
+.b-package { background:#26547c; color:#fff; }
+.b-report { background:#ef476f; color:#fff; }
+.tint-app { background:radial-gradient(120% 92% at 50% 36%, #fff 0%, #fff 16%, #cdeee4 100%); }
+.tint-api { background:radial-gradient(120% 92% at 50% 36%, #fff 0%, #fff 16%, #c7ebf3 100%); }
+.tint-package { background:radial-gradient(120% 92% at 50% 36%, #fff 0%, #fff 16%, #ccd9f0 100%); }
+.tint-report { background:radial-gradient(120% 92% at 50% 36%, #fff 0%, #fff 16%, #ffd0db 100%); }
+.rlock { position:absolute; top:8px; right:8px; z-index:2; width:22px; height:22px; background:rgba(255,255,255,.92); border-radius:50%; display:flex; align-items:center; justify-content:center; }
+.rlock .ti { font-size:12px; }
+.rbody { padding:12px 14px; flex:1; display:flex; flex-direction:column; min-height:0; }
+.rtitle {
+  font-size:14px; font-weight:500; letter-spacing:-0.15px; line-height:1.25; margin-bottom:6px;
+  display:-webkit-box; -webkit-line-clamp:2; -webkit-box-orient:vertical; overflow:hidden; min-height:calc(1.25em*2);
+}
+.rdesc {
+  font-size:11.5px; line-height:1.5; color:var(--text-muted);
+  display:-webkit-box; -webkit-line-clamp:2; -webkit-box-orient:vertical; overflow:hidden; min-height:calc(1.5em*2); margin-bottom:12px;
+}
+.rmeta { display:flex; align-items:center; justify-content:space-between; font-size:10.5px; color:var(--text-faint); margin-top:auto; }
+.rmeta-left { display:flex; align-items:center; gap:6px; }
+.status-dot { width:5px; height:5px; border-radius:50%; display:inline-block; flex-shrink:0; }
+.status-dot-new { background:var(--status-new); }
+.status-dot-updated { background:var(--status-updated); }
+.arrow-go { transition:transform .2s ease, color .2s ease; font-size:14px; color:var(--text-muted); }
+
+/* compact list-row card (variation B) */
+.rrow {
+  display:flex; align-items:center; gap:14px; padding:11px 14px;
+  background:var(--surface); border:0.5px solid var(--border); border-radius:10px;
+  cursor:pointer; text-decoration:none; color:inherit; transition:border-color .15s, background .15s, transform .12s;
+}
+.rrow:hover { border-color:var(--text); background:var(--surface); transform:translateX(2px); }
+.rrow:hover .arrow-go { transform:translateX(3px); color:var(--text); }
+.rrow__logo { width:42px; height:42px; flex:none; border-radius:9px; display:flex; align-items:center; justify-content:center; font-weight:600; font-size:16px; border:0.5px solid var(--border); }
+.rrow__main { flex:1; min-width:0; }
+.rrow__title { font-size:13.5px; font-weight:500; letter-spacing:-0.01em; display:flex; align-items:center; gap:8px; }
+.rrow__desc { font-size:11.5px; color:var(--text-muted); margin-top:2px; white-space:nowrap; overflow:hidden; text-overflow:ellipsis; }
+.rrow__meta { display:flex; align-items:center; gap:10px; font-size:10.5px; color:var(--text-faint); white-space:nowrap; }
+
+/* section rail (variation C) */
+.rail-section { margin-bottom:30px; }
+.rail-head { display:flex; align-items:baseline; gap:10px; margin-bottom:12px; }
+.rail-head__title { font-size:15px; font-weight:600; letter-spacing:-0.01em; display:flex; align-items:center; gap:8px; }
+.rail-head__count { font-size:11px; color:var(--text-faint); font-variant-numeric:tabular-nums; }
+.rail-head__line { flex:1; height:0.5px; background:var(--border); }
+.rail { display:flex; gap:14px; overflow-x:auto; padding:6px 2px 14px; scroll-snap-type:x proximity; }
+.rail > * { scroll-snap-align:start; flex:0 0 auto; }
+.rail::-webkit-scrollbar { height:8px; }
+
+/* ===================================================================
+   Left nav rail (variation B wayfinding)
+   =================================================================== */
+.split { display:grid; grid-template-columns:220px 1fr; gap:26px; align-items:start; }
+@media (max-width:880px){ .split { grid-template-columns:1fr; } }
+.navrail { position:sticky; top:76px; display:flex; flex-direction:column; gap:2px; }
+.navrail__group { font-size:10px; text-transform:uppercase; letter-spacing:.07em; color:var(--text-faint); margin:14px 8px 6px; }
+.navrail__item {
+  display:flex; align-items:center; gap:9px; padding:8px 10px; border-radius:8px;
+  font-size:13px; color:var(--text-muted); cursor:pointer; border:0; background:transparent; text-align:left; transition:background .12s, color .12s;
+}
+.navrail__item:hover { background:var(--surface-soft); color:var(--text); }
+.navrail__item.on { background:var(--text); color:var(--bg); }
+.navrail__item .ti { font-size:16px; }
+.navrail__item .count { margin-left:auto; font-size:11px; opacity:.6; font-variant-numeric:tabular-nums; }
+.navrail__item.on .count { opacity:.8; }
+
+/* ===================================================================
+   Featured carousel
+   =================================================================== */
+.feat { margin-bottom:26px; }
+.feat-head { display:flex; align-items:center; justify-content:center; gap:8px; margin-bottom:12px; font-size:13px; font-weight:600; }
+.feat-head .ti { color:var(--teal-600); font-size:15px; }
+.feat-stage { display:flex; align-items:center; justify-content:center; gap:12px; }
+.feat-arrow {
+  flex:0 0 auto; width:36px; height:36px; border-radius:999px; border:0.5px solid var(--border);
+  background:var(--surface); color:var(--text-muted); cursor:pointer; display:inline-flex; align-items:center; justify-content:center;
+  box-shadow:0 1px 3px rgba(0,0,0,.08); transition:all .12s;
+}
+.feat-arrow:hover:not(:disabled) { border-color:var(--teal-600); color:var(--teal-600); }
+.feat-arrow:disabled { opacity:.3; cursor:default; }
+.feat-viewport { overflow:hidden; max-width:calc(3 * 256px + 28px); padding:6px 0; }
+.feat-track { display:flex; gap:14px; transition:transform .34s cubic-bezier(.4,0,.2,1); }
+
+/* hero featured strip (variation B/C) */
+.hero-feat {
+  display:flex; gap:18px; align-items:stretch; padding:18px; border-radius:14px;
+  border:0.5px solid var(--border); background:var(--surface); margin-bottom:24px; overflow:hidden; position:relative;
+}
+.hero-feat__art { width:200px; flex:none; border-radius:10px; display:flex; align-items:center; justify-content:center; font-size:42px; font-weight:600; border:0.5px solid var(--border); }
+.hero-feat__body { flex:1; display:flex; flex-direction:column; justify-content:center; min-width:0; }
+.hero-feat__kicker { font-size:11px; font-weight:600; letter-spacing:.06em; text-transform:uppercase; color:var(--teal-600); display:flex; align-items:center; gap:6px; }
+.hero-feat__title { font-size:24px; font-weight:600; letter-spacing:-0.02em; margin:8px 0 6px; }
+.hero-feat__desc { font-size:13.5px; color:var(--text-muted); line-height:1.55; max-width:48ch; }
+.hero-feat__cta { margin-top:16px; display:inline-flex; align-items:center; gap:7px; align-self:flex-start; background:var(--teal-600); color:#fff; border:0; border-radius:999px; padding:9px 16px; font-size:13px; cursor:pointer; transition:background .15s; }
+.hero-feat__cta:hover { background:var(--teal-800); }
+.hero-feat__dots { display:flex; gap:6px; margin-top:14px; }
+.hero-feat__dots span { width:6px; height:6px; border-radius:999px; background:var(--border-strong); cursor:pointer; transition:all .15s; }
+.hero-feat__dots span.on { width:18px; background:var(--teal-600); }
+
+/* ===================================================================
+   Buttons & misc
+   =================================================================== */
+.btn {
+  display:inline-flex; align-items:center; gap:7px; padding:9px 15px; border-radius:8px;
+  font-size:13px; cursor:pointer; border:0.5px solid var(--border); background:var(--surface); color:var(--text); transition:all .15s;
+}
+.btn:hover { border-color:var(--border-strong); }
+.btn--primary { background:var(--teal-600); color:#fff; border-color:var(--teal-600); }
+.btn--primary:hover { background:var(--teal-800); border-color:var(--teal-800); }
+.btn .ti { font-size:15px; }
+
+.page-title { font-size:26px; font-weight:600; letter-spacing:-0.02em; }
+.page-sub { font-size:13px; color:var(--text-muted); margin-top:3px; }
+.crumbs { display:flex; align-items:center; gap:7px; font-size:11px; color:var(--text-faint); text-transform:uppercase; letter-spacing:.06em; margin-bottom:8px; }
+.crumbs .ti { font-size:12px; }
+.crumbs a { color:var(--text-faint); text-decoration:none; cursor:pointer; }
+.crumbs a:hover { color:var(--text); }
+
+.empty-hint { display:flex; align-items:center; gap:8px; font-size:12.5px; color:var(--text-muted); }
+.empty-hint .ti { font-size:15px; }
+
+/* live "tail" pulse dot */
+.live-dot { width:7px; height:7px; border-radius:50%; background:var(--ok); display:inline-block; position:relative; }
+.live-dot::after { content:""; position:absolute; inset:-4px; border-radius:50%; border:1.5px solid var(--ok); opacity:.6; animation:ring 1.8s ease-out infinite; }
+@keyframes ring { 0%{transform:scale(.6);opacity:.7;} 100%{transform:scale(1.6);opacity:0;} }
+@media (prefers-reduced-motion: reduce){ .live-dot::after { animation:none; } }
+
+/* ===================================================================
+   Dashboard
+   =================================================================== */
+.dash-metrics { display:grid; grid-template-columns:repeat(5, 1fr); gap:12px; margin-bottom:24px; }
+@media (max-width:880px){ .dash-metrics { grid-template-columns:repeat(2,1fr); } }
+.metric {
+  background:var(--surface); border:0.5px solid var(--border); border-radius:12px; padding:15px 16px;
+}
+.metric__label { font-size:11.5px; color:var(--text-muted); margin-bottom:8px; display:flex; align-items:center; gap:6px; }
+.metric__label .ti { font-size:14px; color:var(--text-faint); }
+.metric__value { font-size:28px; font-weight:600; line-height:1; letter-spacing:-0.02em; }
+.metric__value small { font-size:14px; font-weight:400; color:var(--text-faint); }
+.live-flash { animation:live-flash .65s ease; }
+@keyframes live-flash { 0% { color:var(--teal-400); } 60% { color:var(--teal-400); } 100% { color:inherit; } }
+@media (prefers-reduced-motion: reduce) { .live-flash { animation:none; } }
+.metric__sub { font-size:11px; color:var(--text-faint); margin-top:7px; }
+.bar-track { height:4px; background:var(--surface-soft); border-radius:2px; overflow:hidden; width:100%; }
+.bar-fill { height:100%; border-radius:2px; transition:width .5s ease; }
+
+.dot { width:7px; height:7px; border-radius:50%; display:inline-block; flex-shrink:0; }
+.dot-ready { background:var(--ok); }
+.dot-warn { background:var(--warn); }
+.dot-off { background:#9ca3af; }
+.dot-boot { background:var(--info); animation:pulse 1.4s ease-in-out infinite; }
+@keyframes pulse { 0%,100%{opacity:1;} 50%{opacity:.35;} }
+
+/* grouped app table */
+.grouped-sticky {
+  position: sticky; top: 53px; z-index: 30;
+  background: var(--bg);
+  padding-top: 8px; margin-bottom: 2px;
+  border-bottom: 0.5px solid var(--border);
+}
+.app-group { border:0.5px solid var(--border); border-radius:12px; background:var(--surface); margin-bottom:10px; overflow:hidden; }
+.app-group__head {
+  display:grid; grid-template-columns:24px 1.6fr 80px 90px 1fr 1fr 100px 40px; align-items:center; gap:10px;
+  padding:13px 16px; cursor:pointer; transition:background .12s; background:var(--surface);
+}
+.app-group__head:hover { background:var(--surface-soft); }
+.app-group.is-open .app-group__head { border-bottom:0.5px solid var(--border-soft); }
+.app-group__chev { color:var(--text-faint); transition:transform .2s ease; font-size:16px; display:inline-flex; }
+.app-group.is-open .app-group__chev { transform:rotate(90deg); }
+.app-group__name { font-weight:500; font-size:14px; display:flex; align-items:center; gap:9px; }
+.app-group__id { font-family:var(--font-mono); font-size:11px; color:var(--text-faint); }
+.app-group__logo { width:30px; height:30px; border-radius:8px; flex:none; display:flex; align-items:center; justify-content:center; font-weight:600; font-size:13px; border:0.5px solid var(--border); }
+.app-group__replicas { display:inline-flex; align-items:center; gap:6px; font-size:12px; color:var(--text-muted); }
+.app-group__b>span { }
+.metric-cell { font-size:12px; }
+.metric-cell .v { display:block; margin-bottom:3px; }
+.col-h { font-size:10px; text-transform:uppercase; letter-spacing:.05em; color:var(--text-muted); }
+
+.replica-list { background:var(--surface-soft); }
+.replica-row {
+  display:grid; grid-template-columns:24px 1.6fr 80px 90px 1fr 1fr 100px 40px; align-items:center; gap:10px;
+  padding:9px 16px 9px 16px; border-top:0.5px solid var(--border-soft); font-size:12px;
+}
+.replica-row .cid { font-family:var(--font-mono); font-size:11px; color:var(--text-muted); }
+.replica-actions { display:flex; gap:2px; justify-content:flex-end; color:var(--text-faint); }
+.replica-actions button { border:0; background:transparent; color:var(--text-faint); cursor:pointer; width:26px; height:26px; border-radius:6px; display:inline-flex; align-items:center; justify-content:center; }
+.replica-actions button:hover { background:var(--surface); color:var(--text); }
+
+/* app cards (dashboard variation B) */
+.dash-cards { display:grid; grid-template-columns:repeat(auto-fill, minmax(280px,1fr)); gap:14px; }
+.dcard { border:0.5px solid var(--border); border-radius:12px; background:var(--surface); padding:16px; cursor:pointer; transition:border-color .15s, transform .12s, box-shadow .15s; }
+.dcard:hover { border-color:var(--text); transform:translateY(-2px); box-shadow:var(--shadow-md); }
+.dcard__top { display:flex; align-items:center; gap:11px; margin-bottom:14px; }
+.dcard__logo { width:38px; height:38px; border-radius:9px; flex:none; display:flex; align-items:center; justify-content:center; font-weight:600; font-size:15px; border:0.5px solid var(--border); }
+.dcard__name { font-weight:500; font-size:15px; }
+.dcard__id { font-family:var(--font-mono); font-size:11px; color:var(--text-faint); }
+.dcard__health { margin-left:auto; }
+.health-pill { display:inline-flex; align-items:center; gap:5px; font-size:11px; padding:3px 9px; border-radius:999px; }
+.health-pill.ok { background:color-mix(in srgb, var(--ok) 14%, transparent); color:#047857; }
+.health-pill.warn { background:color-mix(in srgb, var(--warn) 16%, transparent); color:#92600a; }
+.health-pill.boot { background:color-mix(in srgb, var(--info) 14%, transparent); color:#1d4ed8; }
+.dcard__stats { display:grid; grid-template-columns:repeat(3,1fr); gap:10px; }
+.dcard__stat .k { font-size:10px; text-transform:uppercase; letter-spacing:.05em; color:var(--text-faint); }
+.dcard__stat .v { font-size:18px; font-weight:600; letter-spacing:-0.01em; margin-top:3px; }
+.dcard__spark { margin-top:14px; }
+
+/* sparkline */
+.spark { display:block; width:100%; height:30px; }
+
+/* dense ops table (variation C) */
+.ops-toolbar { display:flex; align-items:center; gap:10px; margin-bottom:14px; flex-wrap:wrap; }
+.ops-table { width:100%; border-collapse:collapse; background:var(--surface); border:0.5px solid var(--border); border-radius:12px; overflow:hidden; font-size:12px; }
+.ops-table thead th {
+  position:sticky; top:60px; z-index:5; text-align:left; font-weight:500; font-size:10px; text-transform:uppercase; letter-spacing:.05em;
+  color:var(--text-muted); padding:11px 14px; background:var(--surface-soft); border-bottom:0.5px solid var(--border);
+}
+.ops-table tbody td { padding:10px 14px; border-bottom:0.5px solid var(--border-soft); vertical-align:middle; }
+.ops-table tbody tr:last-child td { border-bottom:0; }
+.ops-table tbody tr:hover td { background:var(--surface-soft); }
+.ops-table .grp-row td { background:var(--surface-soft); font-weight:500; cursor:pointer; }
+.ops-table .grp-row td:hover { background:var(--surface-soft); }
+.ops-table .cid { font-family:var(--font-mono); font-size:11px; color:var(--text-muted); }
+
+.mono { font-family:var(--font-mono); }
+.muted { color:var(--text-muted); }
+.faint { color:var(--text-faint); }
+.tnum { font-variant-numeric:tabular-nums; }
+
+/* toast */
+.toast-wrap { position:fixed; bottom:22px; left:50%; transform:translateX(-50%); z-index:600; display:flex; flex-direction:column; gap:8px; align-items:center; }
+.toast {
+  display:flex; align-items:center; gap:9px; background:var(--text); color:var(--bg);
+  padding:10px 16px; border-radius:10px; font-size:13px; box-shadow:var(--shadow-lg); animation:fade-in .25s ease both;
+}
+.toast .ti { font-size:16px; }
+
+/* footer */
+.mock-foot { display:flex; align-items:center; justify-content:space-between; padding:18px 28px; border-top:0.5px solid var(--border); margin-top:30px; font-size:11px; color:var(--text-faint); }
+.mock-foot .v { display:flex; align-items:center; gap:7px; }
+.mock-foot .v img { width:14px; height:14px; }
+
+/* ===================================================================
+   Admin pages (Apps catalog + Media library)
+   =================================================================== */
+.admin-sticky {
+  position:sticky; top:53px; z-index:30;
+  background:var(--bg); padding:10px 0; border-bottom:0.5px solid var(--border);
+}
+.admin-table { width:100%; border-collapse:collapse; background:var(--surface); border:0.5px solid var(--border); border-radius:12px; overflow:hidden; font-size:12.5px; }
+.admin-table th {
+  text-align:left; font-weight:500; font-size:10px; text-transform:uppercase; letter-spacing:.05em;
+  color:var(--text-muted); padding:11px 14px; border-bottom:0.5px solid var(--border); background:var(--surface-soft);
+}
+.admin-table td { padding:11px 14px; border-bottom:0.5px solid var(--border-soft); vertical-align:middle; }
+.admin-table tbody tr:last-child td { border-bottom:none; }
+.admin-table tbody tr:hover td { background:var(--surface-soft); }
+
+.pill { display:inline-flex; align-items:center; padding:3px 9px; font-size:10px; border-radius:999px; letter-spacing:.04em; text-transform:uppercase; font-weight:500; }
+.pill-state-active { background:rgba(16,185,129,.14); color:#047857; }
+.pill-kind-shiny { background:rgba(6,214,160,.18); color:#04553f; }
+.pill-kind-interactive { background:rgba(6,214,160,.18); color:#04553f; }
+.pill-kind-api { background:rgba(6,182,212,.18); color:#0e6f86; }
+.pill-kind-external { background:rgba(38,84,124,.15); color:#3a6ea5; }
+[data-theme="dark"] .pill-kind-external { color:#7aa6d6; }
+[data-theme="dark"] .pill-state-active { color:#34d399; }
+
+.star-toggle { display:inline-flex; align-items:center; justify-content:center; width:30px; height:30px; border:0; background:none; border-radius:7px; color:var(--text-faint); cursor:pointer; transition:color .12s, background .12s; }
+.star-toggle:hover { background:var(--surface-soft); color:var(--text); }
+.star-toggle.is-on { color:#d97706; background:color-mix(in srgb, #eab308 14%, transparent); }
+.star-toggle.is-on:hover { color:#b45309; background:color-mix(in srgb, #eab308 22%, transparent); }
+.star-toggle .ti { font-size:16px; }
+.star-toggle.is-on .ti { font-size:17px; }
+.star-toggle svg { transition:transform .15s ease; }
+.star-toggle.is-on svg { transform:scale(1.1); }
+
+/* Media library */
+.media-grid { display:grid; grid-template-columns:repeat(auto-fill, minmax(180px, 1fr)); gap:12px; }
+.image-tile { position:relative; background:var(--surface); border:0.5px solid var(--border); border-radius:10px; overflow:hidden; display:flex; flex-direction:column; }
+.image-tile-frame { display:block; height:130px; border-bottom:0.5px solid var(--border); overflow:hidden; }
+.image-tile-frame img { width:100%; height:100%; object-fit:contain; padding:22px; display:block; }
+.image-tile-meta { padding:9px 11px; }
+.image-tile-name { font-family:var(--font-mono); font-size:11px; white-space:nowrap; overflow:hidden; text-overflow:ellipsis; margin-bottom:3px; }
+.image-tile-sub { display:flex; gap:5px; flex-wrap:wrap; font-size:10px; color:var(--text-faint); }
+.image-tile-delete {
+  position:absolute; top:7px; right:7px; background:rgba(0,0,0,.6); color:#fff; border:0; border-radius:6px;
+  width:24px; height:24px; cursor:pointer; display:flex; align-items:center; justify-content:center; opacity:0; transition:opacity .15s;
+}
+.image-tile-delete .ti { font-size:13px; }
+.image-tile:hover .image-tile-delete { opacity:1; }
+.image-tile-delete:hover { background:var(--lock); }
+.image-upload-zone {
+  display:flex; align-items:center; justify-content:center; gap:14px; flex-wrap:wrap;
+  padding:22px; border:1px dashed var(--border-strong); border-radius:12px; background:var(--surface-soft); transition:border-color .12s, background .12s;
+}
+.image-upload-hint { font-size:12px; color:var(--text-muted); }
+.image-upload-zone.is-dragover { border-color:var(--teal-600); background:color-mix(in srgb, var(--teal-600) 8%, var(--surface-soft)); }
+
+/* admin top-nav (functional) */
+.admin-nav {
+  display:inline-flex; align-items:center; gap:6px; padding:6px 11px; font-size:12.5px;
+  color:var(--text-muted); border:0; background:transparent; border-radius:7px; cursor:pointer;
+  font-family:inherit; transition:background .12s, color .12s;
+}
+.admin-nav:hover { background:var(--surface-soft); color:var(--text); }
+.admin-nav.on { background:var(--text); color:var(--bg); }
+.admin-nav .ti { font-size:15px; }
+
+/* ── Disk ── */
+.disk-hero { background:var(--surface); border:0.5px solid var(--border); border-radius:12px; padding:20px; }
+.disk-hero__head { display:flex; align-items:flex-end; justify-content:space-between; margin-bottom:16px; }
+.disk-stack { display:flex; height:14px; border-radius:7px; overflow:hidden; background:var(--surface-soft); gap:1.5px; }
+.disk-stack__seg { height:100%; transition:width .5s ease; }
+.disk-legend { display:flex; flex-wrap:wrap; gap:14px 22px; margin-top:16px; }
+.disk-legend__item { display:flex; align-items:center; gap:7px; font-size:12px; color:var(--text-muted); }
+.disk-legend__dot { width:9px; height:9px; border-radius:3px; flex:none; }
+.disk-legend__val { margin-left:4px; color:var(--text); font-weight:500; }
+
+/* disk: two-column panels for images vs containers */
+.disk-cols { display:grid; grid-template-columns:1fr 1fr; gap:16px; margin-top:24px; }
+@media (max-width:1000px){ .disk-cols { grid-template-columns:1fr; } }
+.disk-panel { border:0.5px solid var(--border); border-radius:12px; background:var(--surface); overflow:hidden; }
+.disk-panel__head { display:flex; align-items:flex-start; justify-content:space-between; gap:12px; padding:15px 16px; border-bottom:0.5px solid var(--border); }
+.disk-panel__title { font-size:14px; font-weight:600; display:flex; align-items:center; gap:8px; }
+.disk-panel__title .ti { font-size:17px; }
+.disk-panel__sub { font-size:11.5px; color:var(--text-faint); margin-top:3px; }
+.disk-panel .admin-table { border:0; border-radius:0; }
+.disk-panel .admin-table th { background:var(--surface); }
+.admin-table tr.is-unused td { background:color-mix(in srgb, var(--warn) 5%, transparent); }
+.admin-table tr.is-unused:hover td { background:color-mix(in srgb, var(--warn) 9%, transparent); }
+
+.btn--danger { color:var(--lock); border-color:color-mix(in srgb, var(--lock) 35%, var(--border)); white-space:nowrap; }
+.btn--danger:hover { background:color-mix(in srgb, var(--lock) 10%, transparent); border-color:var(--lock); }
+.btn--danger .ti { font-size:14px; }
+
+.use-badge { font-size:10px; padding:2px 8px; border-radius:999px; white-space:nowrap; }
+.use-badge--on { background:color-mix(in srgb, var(--ok) 14%, transparent); color:#047857; }
+.use-badge--off { background:color-mix(in srgb, var(--warn) 16%, transparent); color:#92600a; }
+[data-theme="dark"] .use-badge--on { color:#34d399; }
+[data-theme="dark"] .use-badge--off { color:#fbbf24; }
+.pill-unused { background:var(--surface-soft); color:var(--text-faint); font-family:var(--font-mono); text-transform:none; letter-spacing:0; }
+
+/* ── Credentials ── */
+.cred-ico { width:28px; height:28px; border-radius:7px; flex:none; display:flex; align-items:center; justify-content:center; background:color-mix(in srgb, var(--teal-400) 14%, var(--surface)); color:var(--teal-600); }
+.cred-ico .ti { font-size:15px; }
+.pill-scope-admin { background:rgba(239,71,111,.15); color:#c0294f; }
+.pill-scope-deploy { background:rgba(6,182,212,.18); color:#0e6f86; }
+.pill-scope-read { background:var(--surface-soft); color:var(--text-muted); }
+[data-theme="dark"] .pill-scope-admin { color:#ff7da0; }
+
+/* ── Logs ── */
+.log-select { font-family:inherit; font-size:12px; color:var(--text-muted); background:var(--surface); border:0.5px solid var(--border); border-radius:999px; padding:6px 10px; cursor:pointer; }
+.log-body {
+  height:460px; overflow-y:auto; background:var(--surface); border:0.5px solid var(--border); border-radius:0 0 12px 12px;
+  padding:10px 4px; font-family:var(--font-mono); font-size:12px; line-height:1.7;
+}
+[data-theme="dark"] .log-body { background:#121212; }
+.log-line { display:grid; grid-template-columns:96px 52px 130px 1fr; gap:10px; padding:1px 14px; white-space:nowrap; animation:log-in .25s ease; }
+.log-line:hover { background:var(--surface-soft); }
+@keyframes log-in { from { opacity:0; transform:translateY(2px); } to { opacity:1; transform:none; } }
+@media (prefers-reduced-motion: reduce){ .log-line { animation:none; } }
+.log-ts { color:var(--text-faint); }
+.log-lvl { font-weight:600; font-size:10px; letter-spacing:.04em; align-self:center; }
+.log-lvl-info { color:#3b82f6; }
+.log-lvl-warn { color:#d97706; }
+.log-lvl-error { color:#ef4444; }
+.log-app { color:var(--teal-600); overflow:hidden; text-overflow:ellipsis; }
+.log-msg { color:var(--text-muted); overflow:hidden; text-overflow:ellipsis; }
+
+/* ── Forms: editor + import ── */
+.editor-grid { display:grid; grid-template-columns:1fr 320px; gap:26px; align-items:start; }
+@media (max-width:920px){ .editor-grid { grid-template-columns:1fr; } }
+.editor-form { display:flex; flex-direction:column; gap:8px; }
+.form-section { background:var(--surface); border:0.5px solid var(--border); border-radius:12px; padding:16px 18px; margin-bottom:12px; }
+.form-section__title { font-size:11px; text-transform:uppercase; letter-spacing:.06em; color:var(--text-faint); font-weight:600; margin-bottom:14px; }
+.form-field { display:flex; flex-direction:column; gap:6px; margin-bottom:14px; }
+.form-field:last-child { margin-bottom:0; }
+.form-label { font-size:12px; color:var(--text); font-weight:500; }
+.form-hint { color:var(--text-faint); font-weight:400; }
+.form-row.two { display:grid; grid-template-columns:1fr 1fr; gap:14px; }
+.form-row.two .form-field { margin-bottom:14px; }
+.form-input {
+  font-family:inherit; font-size:13px; color:var(--text); background:var(--surface-soft);
+  border:0.5px solid var(--border); border-radius:8px; padding:9px 12px; outline:0; transition:border-color .12s, box-shadow .12s; resize:vertical;
+}
+.form-input:focus { border-color:var(--text); box-shadow:0 0 0 3px color-mix(in srgb, var(--teal-400) 14%, transparent); background:var(--surface); }
+.form-input.mono { font-family:var(--font-mono); font-size:12px; }
+
+.kind-picker { display:grid; grid-template-columns:1fr 1fr; gap:8px; }
+.kind-opt { display:flex; align-items:center; gap:8px; padding:11px 12px; font-size:13px; font-family:inherit; color:var(--text); background:var(--surface-soft); border:1px solid var(--border); border-radius:9px; cursor:pointer; transition:border-color .12s, background .12s; }
+.kind-opt:hover { background:var(--surface); }
+.kind-opt.on { background:var(--surface); border-width:1.5px; font-weight:500; }
+.kind-opt .ti { font-size:17px; }
+
+.swatches { display:flex; gap:8px; flex-wrap:wrap; }
+.swatch { width:28px; height:28px; border-radius:8px; border:2px solid transparent; cursor:pointer; box-shadow:inset 0 0 0 1px rgba(0,0,0,.08); transition:transform .1s; }
+.swatch:hover { transform:scale(1.08); }
+.swatch.on { border-color:var(--text); }
+
+.toggle-row { display:flex; align-items:center; justify-content:space-between; gap:14px; padding:11px 0; cursor:pointer; border-bottom:0.5px solid var(--border-soft); }
+.toggle-row:first-of-type { padding-top:0; }
+.toggle-row__label { font-size:13px; font-weight:500; }
+.toggle-row__hint { font-size:11.5px; color:var(--text-faint); margin-top:2px; }
+.switch { width:40px; height:23px; border-radius:999px; background:var(--border-strong); position:relative; flex:none; transition:background .15s; }
+.switch.on { background:var(--teal-600); }
+.switch__dot { position:absolute; top:2.5px; left:2.5px; width:18px; height:18px; border-radius:50%; background:#fff; transition:transform .15s; box-shadow:0 1px 2px rgba(0,0,0,.3); }
+.switch.on .switch__dot { transform:translateX(17px); }
+
+.stepper { display:inline-flex; align-items:center; gap:0; border:0.5px solid var(--border); border-radius:8px; overflow:hidden; align-self:flex-start; }
+.stepper button { width:34px; height:34px; border:0; background:var(--surface-soft); color:var(--text); cursor:pointer; display:flex; align-items:center; justify-content:center; }
+.stepper button:hover { background:var(--surface); }
+.stepper span { min-width:44px; text-align:center; font-size:14px; font-weight:500; }
+
+.editor-preview__sticky { position:sticky; top:64px; background:var(--surface); border:0.5px solid var(--border); border-radius:12px; padding:16px; }
+.preview-note { font-size:11.5px; color:var(--text-faint); margin-top:14px; text-align:center; line-height:1.5; }
+.btn.is-disabled { opacity:.45; pointer-events:none; }
+
+.yaml-head { display:flex; align-items:center; justify-content:space-between; font-size:12px; font-family:var(--font-mono); color:var(--text-muted); padding:10px 14px; background:var(--surface-soft); border:0.5px solid var(--border); border-bottom:0; border-radius:12px 12px 0 0; }
+.yaml-editor { width:100%; box-sizing:border-box; height:420px; resize:vertical; background:var(--surface); color:var(--text); border:0.5px solid var(--border); border-radius:0 0 12px 12px; padding:14px; font-size:12.5px; line-height:1.65; outline:0; tab-size:2; }
+[data-theme="dark"] .yaml-editor { background:#121212; }
+.yaml-editor:focus { border-color:var(--teal-600); }
+.parsed-row { display:flex; align-items:center; gap:10px; padding:9px 10px; border:0.5px solid var(--border); border-radius:9px; background:var(--surface-soft); }
+.parsed-row__ico { width:30px; height:30px; border-radius:7px; flex:none; display:flex; align-items:center; justify-content:center; }
+.parsed-row__ico .ti { font-size:15px; }
+
+/* advanced collapsible */
+.adv-section { padding:0; overflow:hidden; }
+.adv-head { width:100%; display:flex; align-items:center; gap:10px; padding:15px 18px; border:0; background:transparent; cursor:pointer; font-family:inherit; text-align:left; }
+.adv-head:hover { background:var(--surface-soft); }
+.adv-head__hint { font-size:11.5px; color:var(--text-faint); flex:1; }
+.adv-chev { color:var(--text-faint); transition:transform .2s ease; font-size:16px; }
+.adv-section.is-open .adv-chev { transform:rotate(180deg); }
+.adv-body { padding:4px 18px 18px; border-top:0.5px solid var(--border-soft); }
+
+/* range slider */
+.rk-range { -webkit-appearance:none; appearance:none; height:4px; border-radius:2px; background:var(--surface-soft); outline:0; cursor:pointer; }
+.rk-range::-webkit-slider-thumb { -webkit-appearance:none; width:16px; height:16px; border-radius:50%; background:var(--teal-600); border:2px solid var(--surface); box-shadow:0 1px 3px rgba(0,0,0,.3); cursor:pointer; }
+.rk-range::-moz-range-thumb { width:16px; height:16px; border-radius:50%; background:var(--teal-600); border:2px solid var(--surface); cursor:pointer; }
+.res-row { display:grid; grid-template-columns:120px 1fr 110px; align-items:center; gap:12px; margin-bottom:12px; }
+.res-row__k { font-size:12.5px; color:var(--text-muted); display:flex; align-items:center; gap:6px; }
+.res-row__k .ti { font-size:15px; color:var(--text-faint); }
+.res-row__v { font-size:12.5px; font-weight:500; text-align:right; }
+
+/* env vars */
+.mini-add { display:inline-flex; align-items:center; gap:4px; font-size:11.5px; color:var(--teal-600); background:transparent; border:0; cursor:pointer; font-family:inherit; }
+.mini-add:hover { text-decoration:underline; }
+.env-row { display:grid; grid-template-columns:1fr 14px 1.3fr 30px; align-items:center; gap:6px; }
+.env-row .form-input { padding:7px 10px; }
+.env-eq { text-align:center; color:var(--text-faint); }
+
+/* spec summary in preview */
+.spec-summary { display:flex; flex-direction:column; gap:7px; margin-top:14px; padding-top:14px; border-top:0.5px solid var(--border-soft); }
+.spec-summary__row { display:flex; align-items:center; gap:8px; font-size:11.5px; color:var(--text-muted); }
+.spec-summary__row .ti { font-size:14px; color:var(--text-faint); width:16px; }
+
+/* import: checkboxes + subset */
+.import-head { display:flex; align-items:center; justify-content:space-between; margin-bottom:12px; padding-bottom:12px; border-bottom:0.5px solid var(--border-soft); }
+.sel-all { display:inline-flex; align-items:center; gap:9px; cursor:pointer; }
+.rk-check { width:18px; height:18px; flex:none; border-radius:5px; border:1.5px solid var(--border-strong); display:inline-flex; align-items:center; justify-content:center; color:#fff; transition:background .12s, border-color .12s; }
+.rk-check .ti { font-size:13px; opacity:0; }
+.rk-check.on { background:var(--teal-600); border-color:var(--teal-600); }
+.rk-check.on .ti { opacity:1; }
+.rk-check.mixed { background:var(--teal-600); border-color:var(--teal-600); }
+.rk-check.mixed .ti { opacity:1; }
+.parsed-row.is-off { opacity:.5; }
+.import-tag { font-size:9px; font-weight:600; padding:2px 6px; border-radius:999px; text-transform:uppercase; letter-spacing:.03em; }
+.import-summary { display:flex; align-items:center; gap:7px; justify-content:center; margin-top:14px; padding-top:12px; border-top:0.5px solid var(--border-soft); font-size:11.5px; color:var(--text-muted); }
+.import-summary b { color:var(--text); }
+
+/* ── Appearance configurator ── */
+.appear-grid { display:grid; grid-template-columns:1fr 380px; gap:26px; align-items:start; }
+@media (max-width:980px){ .appear-grid { grid-template-columns:1fr; } }
+.prev-toolbar { display:flex; align-items:center; gap:5px; padding:8px 12px; background:var(--surface-soft); border-bottom:0.5px solid var(--border); }
+.prev-dot { width:8px; height:8px; border-radius:50%; background:var(--border-strong); }
+
+/* mini portal preview */
+.pv-root { --pv-accent:#0f6e56; background:#fafaf7; color:#1a1a1a; font-size:11px; max-height:560px; overflow-y:auto; }
+.pv-root.pv-dark { background:#161616; color:#f0f0f0; }
+.pv-head { display:flex; align-items:center; justify-content:space-between; padding:10px 14px; }
+.pv-brand { display:flex; align-items:center; gap:6px; font-size:13px; }
+.pv-brand img { width:15px; height:15px; }
+.pv-signin { font-size:10px; border:0.5px solid; border-radius:999px; padding:3px 10px; }
+.pv-hero { padding:6px 14px 14px; border-radius:0; transition:background .25s ease; }
+.pv-body { padding:4px 14px 14px; }
+.pv-title { font-size:18px; font-weight:600; letter-spacing:-0.02em; }
+.pv-tag { font-size:11px; opacity:.6; margin-bottom:12px; }
+.pv-featured { display:flex; align-items:center; gap:9px; padding:9px 11px; border-radius:9px; margin-bottom:12px; }
+.pv-star { font-size:14px; }
+.pv-feat-name { font-size:12px; font-weight:600; }
+.pv-feat-desc { font-size:10px; opacity:.6; white-space:nowrap; overflow:hidden; text-overflow:ellipsis; }
+.pv-search { display:flex; align-items:center; gap:6px; font-size:10.5px; opacity:.55; border:0.5px solid currentColor; border-radius:999px; padding:6px 12px; margin-bottom:10px; }
+.pv-search .ti { font-size:12px; }
+.pv-chips { display:flex; gap:5px; margin-bottom:12px; flex-wrap:wrap; }
+.pv-chip { font-size:9.5px; padding:3px 9px; border-radius:999px; border:0.5px solid color-mix(in srgb, currentColor 25%, transparent); }
+.pv-chip.on { color:#fff; border:0; }
+.pv-chip--ghost { display:inline-flex; align-items:center; }
+.pv-chip--ghost .ti { font-size:11px; }
+.pv-grid { display:grid; grid-template-columns:repeat(3, 1fr); }
+.pv-card { border:0.5px solid color-mix(in srgb, currentColor 12%, transparent); border-radius:8px; overflow:hidden; background:color-mix(in srgb, currentColor 3%, transparent); }
+.pv-card-cover { height:46px; display:flex; align-items:center; justify-content:center; }
+.pv-card-cover img { width:24px; height:24px; object-fit:contain; }
+.pv-card-cover span { font-size:14px; }
+.pv-card-name { font-size:10px; font-weight:500; padding:6px 8px; white-space:nowrap; overflow:hidden; text-overflow:ellipsis; }
+.pv-row { display:flex; align-items:center; gap:9px; padding:7px 9px; border:0.5px solid color-mix(in srgb, currentColor 12%, transparent); border-radius:8px; }
+.pv-logo { width:26px; height:26px; border-radius:6px; flex:none; display:flex; align-items:center; justify-content:center; font-size:11px; font-weight:600; }
+.pv-logo img { width:16px; height:16px; object-fit:contain; }
+.pv-row-name { font-size:11px; font-weight:500; }
+.pv-row-desc { font-size:9.5px; opacity:.6; white-space:nowrap; overflow:hidden; text-overflow:ellipsis; }
+.pv-sec-head { font-size:11px; font-weight:600; margin-bottom:6px; }
+.pv-rail { display:flex; gap:7px; }
+.pv-rail .pv-card { flex:1; }
+.pv-foot { padding:10px 14px; border-top:0.5px solid color-mix(in srgb, currentColor 12%, transparent); font-size:9.5px; opacity:.5; }
+
+/* gradient picker (appearance) */
+.grad-picker { display:grid; grid-template-columns:1fr 1fr 1fr; gap:8px; }
+.grad-opt { display:flex; flex-direction:column; align-items:center; gap:7px; padding:8px; font-size:11.5px; font-family:inherit; color:var(--text); background:var(--surface-soft); border:1px solid var(--border); border-radius:9px; cursor:pointer; transition:border-color .12s; }
+.grad-opt.on { border-width:1.5px; border-color:var(--text); font-weight:500; }
+.grad-swatch { width:100%; height:30px; border-radius:6px; border:0.5px solid var(--border); }
+
+/* media picker (appearance logo) */
+.media-picker { display:grid; grid-template-columns:repeat(5, 1fr); gap:7px; }
+.media-pick { position:relative; aspect-ratio:1; border:1px solid var(--border); border-radius:8px; cursor:pointer; padding:6px; display:flex; align-items:center; justify-content:center; transition:border-color .12s; }
+.media-pick:hover { border-color:var(--border-strong); }
+.media-pick.on { border-color:var(--teal-600); border-width:1.5px; }
+.media-pick img { max-width:100%; max-height:100%; object-fit:contain; }
+.media-pick__check { position:absolute; top:-6px; right:-6px; width:18px; height:18px; border-radius:50%; background:var(--teal-600); color:#fff; display:flex; align-items:center; justify-content:center; border:2px solid var(--surface); }
+.media-pick__check .ti { font-size:11px; }
+
+/* appearance preview extras */
+.pv-brand-col { min-width:0; }
+.pv-brand b { white-space:nowrap; }
+.pv-feat-wrap { margin-bottom:12px; }
+.pv-feat-label { display:flex; align-items:center; gap:5px; font-size:10.5px; font-weight:600; margin-bottom:6px; }
+.pv-feat-label .ti { font-size:12px; }
+.pv-featured { display:flex; align-items:center; gap:9px; padding:9px 11px; border-radius:9px; }
+.pv-foot-logo { object-fit:contain; vertical-align:middle; }
+.pv-foot { display:flex; align-items:center; }
+
+/* SEO SERP preview + analytics + custom css */
+.serp { background:var(--surface); border:0.5px solid var(--border); border-radius:9px; padding:12px 14px; margin-top:4px; }
+.serp__url { font-size:11px; color:#3b7a45; display:flex; align-items:center; gap:5px; }
+.serp__url .ti { font-size:12px; }
+.serp__title { font-size:15px; color:#1a0dab; margin:3px 0 2px; letter-spacing:-0.01em; }
+[data-theme="dark"] .serp__title { color:#8ab4f8; }
+[data-theme="dark"] .serp__url { color:#6cc18a; }
+.serp__desc { font-size:11.5px; color:var(--text-muted); line-height:1.5; }
+.char-count { font-size:10.5px; color:var(--text-faint); margin-top:4px; text-align:right; }
+.char-count.over { color:var(--warn); }
+.css-editor { width:100%; box-sizing:border-box; min-height:140px; resize:vertical; background:#121212; color:#e6e6e6; border:0.5px solid var(--border); border-radius:8px; padding:12px; font-family:var(--font-mono); font-size:12px; line-height:1.6; outline:0; tab-size:2; }
+[data-theme="light"] .css-editor { background:#1e1e1e; color:#e6e6e6; }
+.css-editor:focus { border-color:var(--teal-600); }
+.provider-grid { display:grid; grid-template-columns:1fr 1fr; gap:8px; }
+
+/* ── Users / Groups / Audit ── */
+.rk-avatar { flex:none; border-radius:50%; display:inline-flex; align-items:center; justify-content:center; font-weight:600; }
+.status-pill { display:inline-flex; align-items:center; gap:6px; font-size:11.5px; }
+.status-pill--invited { color:var(--info); }
+.status-pill--suspended { color:var(--text-faint); }
+
+.groups-grid { display:grid; grid-template-columns:repeat(auto-fill, minmax(280px, 1fr)); gap:14px; }
+.group-card { display:flex; background:var(--surface); border:0.5px solid var(--border); border-radius:12px; overflow:hidden; }
+.group-card__bar { width:5px; flex:none; }
+.group-card__body { padding:16px 18px; flex:1; min-width:0; }
+.group-card__name { font-size:15px; font-weight:600; letter-spacing:-0.01em; }
+.group-card__desc { font-size:12px; color:var(--text-muted); line-height:1.5; margin:5px 0 14px; }
+.group-card__perms { display:flex; flex-wrap:wrap; gap:6px; margin-bottom:14px; }
+.perm-tag { display:inline-flex; align-items:center; gap:4px; font-size:10.5px; padding:3px 9px; border-radius:999px; background:var(--surface-soft); color:var(--text-muted); }
+.perm-tag .ti { color:var(--ok); }
+.group-card__foot { display:flex; align-items:center; gap:14px; font-size:11px; color:var(--text-faint); padding-top:12px; border-top:0.5px solid var(--border-soft); }
+.group-card__foot span { display:inline-flex; align-items:center; gap:5px; }
+.group-card__foot .ti { font-size:13px; }
+
+.audit-action { display:inline-flex; align-items:center; gap:7px; font-size:11.5px; }
+.audit-action .ti { font-size:15px; }
+.audit-action code { font-size:11px; }
+
+
+/* ── Group / access UI ── */
+.group-badge { display:inline-flex; align-items:center; padding:2px 8px; font-size:10px; border-radius:999px; font-weight:500; letter-spacing:.02em; white-space:nowrap; }
+.group-editor-row { display:flex; align-items:center; gap:8px; flex-wrap:wrap; padding:10px 14px; background:var(--surface-soft); border-top:0.5px solid var(--border-soft); }
+.group-toggle { display:inline-flex; align-items:center; gap:5px; padding:5px 11px; font-size:12px; border:0.5px solid var(--border); border-radius:999px; background:var(--surface); color:var(--text-muted); cursor:pointer; font-family:inherit; transition:all .12s; }
+.group-toggle:hover { border-color:var(--border-strong); color:var(--text); }
+.group-toggle.on { font-weight:500; }
+.group-toggle .ti { font-size:13px; }
+
+/* group-card expanded */
+.group-detail { padding:14px 0 0; border-top:0.5px solid var(--border-soft); margin-top:14px; }
+.group-detail__section { margin-bottom:16px; }
+.group-detail__label { font-size:10.5px; text-transform:uppercase; letter-spacing:.06em; color:var(--text-faint); margin-bottom:9px; display:flex; align-items:center; gap:6px; }
+.group-detail__label .ti { font-size:13px; }
+.group-card.is-sel { border-color:var(--border-strong); }
+
+/* portal user banner */
+.user-banner { display:flex; align-items:center; gap:12px; flex-wrap:wrap; padding:8px 28px; background:color-mix(in srgb, var(--teal-400) 8%, var(--bg)); border-bottom:0.5px solid color-mix(in srgb, var(--teal-400) 20%, var(--border)); font-size:12px; }
+.user-banner__left { display:flex; align-items:center; gap:8px; }
+.user-banner__left .ti { color:var(--teal-600); }
+.user-banner__groups { display:flex; gap:5px; align-items:center; }
+.user-select { font-family:inherit; font-size:12px; color:var(--text); background:var(--surface); border:0.5px solid var(--border); border-radius:8px; padding:4px 8px; cursor:pointer; }
+.user-select:focus { outline:none; border-color:var(--teal-600); }
+
+/* ── Appearance: mini featured card row ── */
+.pv-feat-card { flex:0 0 90px; border-radius:8px; border:0.5px solid; padding:0 0 7px; overflow:hidden; display:flex; flex-direction:column; }
+.pv-feat-card__logo { height:44px; display:flex; align-items:center; justify-content:center; }
+.pv-feat-card__logo img { width:22px; height:22px; object-fit:contain; }
+.pv-feat-card__name { font-size:9.5px; font-weight:600; padding:5px 7px 2px; white-space:nowrap; overflow:hidden; text-overflow:ellipsis; }
+.pv-feat-card__desc { font-size:8.5px; opacity:.55; padding:0 7px; line-height:1.35; display:-webkit-box; -webkit-line-clamp:2; -webkit-box-orient:vertical; overflow:hidden; flex:1; }
+.pv-feat-card__cta { margin:6px 7px 0; width:16px; height:16px; border-radius:50%; display:flex; align-items:center; justify-content:center; color:#fff; align-self:flex-end; }
+
+/* ── pv-chev: chevron button for the mini featured carousel ── */
+.pv-chev { flex:none; width:20px; height:20px; border-radius:50%; border:0.5px solid color-mix(in srgb, currentColor 22%, transparent); background:color-mix(in srgb, currentColor 5%, transparent); color:inherit; cursor:pointer; display:flex; align-items:center; justify-content:center; transition:opacity .12s; }
+.pv-chev:disabled { opacity:.25; cursor:default; }
+.pv-chev:not(:disabled):hover { background:color-mix(in srgb, currentColor 12%, transparent); }
+
+/* ── HTML block editor (Appearance) ── */
+.html-block { border:0.5px solid var(--border); border-radius:9px; overflow:hidden; }
+.html-block__head { display:flex; align-items:center; gap:8px; width:100%; padding:9px 12px; background:var(--surface); border:0; cursor:pointer; font-family:inherit; transition:background .12s; text-align:left; }
+.html-block__head:hover { background:var(--surface-soft); }
+.html-block__dot { width:6px; height:6px; border-radius:50%; background:var(--teal-600); flex-shrink:0; }
+.html-block__body { padding:10px 12px; background:var(--surface-soft); border-top:0.5px solid var(--border-soft); display:flex; flex-direction:column; gap:8px; }
+.html-block__preview { margin-top:4px; }
+
+/* ── HTML slot (Portal) ── */
+.html-slot { width:100%; }
+
+/* ── Syntax-highlighted code editor (always dark, like a real IDE) ── */
+.code-editor-wrap {
+  position: relative;
+  border: 1px solid #30363d;
+  border-radius: 10px;
+  overflow: hidden;
+  background: #0d1117;
+  font-family: var(--font-mono);
+  font-size: 12.5px;
+  line-height: 1.65;
+  box-shadow: inset 0 1px 0 rgba(255,255,255,.04);
+}
+.code-editor-pre, .code-editor-ta {
+  margin: 0;
+  padding: 14px 16px;
+  width: 100%;
+  box-sizing: border-box;
+  font: inherit;
+  line-height: inherit;
+  tab-size: 2;
+  white-space: pre-wrap;
+  word-wrap: break-word;
+  overflow: auto;
+}
+.code-editor-pre {
+  position: absolute;
+  inset: 0;
+  pointer-events: none;
+  color: #e6edf3;
+  border: none;
+  background: transparent;
+  overflow: hidden;
+}
+.code-editor-ta {
+  position: relative;
+  z-index: 1;
+  background: transparent;
+  color: transparent;
+  caret-color: #e6edf3;
+  resize: vertical;
+  border: none;
+  outline: none;
+  min-height: 120px;
+  width: 100%;
+}
+.code-editor-ta::selection { background: rgba(56,139,253,.3); color: transparent; }
+.code-editor-ta::placeholder { color: #484f58; }
+
+/* Code token colors — VS Code Dark+ palette, all visually distinct */
+.tok-comment   { color: #6A9955; font-style: italic; }   /* green  */
+.tok-string    { color: #CE9178; }                        /* salmon */
+.tok-atrule    { color: #C586C0; }                        /* pink   */
+.tok-selector  { color: #D7BA7D; }                        /* gold   */
+.tok-prop      { color: #9CDCFE; }                        /* cyan   */
+.tok-number    { color: #B5CEA8; }                        /* mint   */
+.tok-hexcolor  { color: #CE9178; font-weight: 500; }      /* salmon bold */
+.tok-important { color: #F44747; font-weight: 700; }      /* red    */
+.tok-tag       { color: #4EC9B0; }                        /* teal   */
+.tok-attr      { color: #9CDCFE; }                        /* cyan   */
+.tok-value     { color: #dcdcdc; }                        /* off-white (default text) */
+
+/* ── pv-icon-btn: mini icon button in the Appearance preview header ── */
+.pv-icon-btn { display:inline-flex; align-items:center; justify-content:center; width:20px; height:20px; border-radius:5px; background:rgba(128,128,128,.12); color:inherit; font-family:var(--font-mono); cursor:default; }

--- a/docs/design-handoff/src/admin.jsx
+++ b/docs/design-handoff/src/admin.jsx
@@ -1,0 +1,211 @@
+/* global React, window */
+// ── Admin pages: Apps catalog + Media library (refined style) ──
+const { useState: amS, useMemo: amM } = React;
+const AM = window.RKC;
+
+const ADMIN_KIND = {
+  shiny: "shiny", rmarkdown: "shiny", "shiny-for-python": "shiny",
+  jupyter: "interactive", rstudio: "interactive", streamlit: "interactive",
+  dash: "interactive", quarto: "interactive", voila: "interactive",
+  fastapi: "api", plumber: "api",
+  bokeh: "external", "ruscker-docs": "external",
+};
+const KIND_LABEL = {
+  pt: { shiny: "SHINY", interactive: "INTERATIVO", api: "API", external: "EXTERNO" },
+  en: { shiny: "SHINY", interactive: "INTERACTIVE", api: "API", external: "EXTERNAL" },
+};
+
+/* ══════════════════════════════════════ APPS ═══════════════════ */
+function AdminApps({ t, loading, push, onEdit, onImport, featured, toggleFeatured, appAccess, setAccess }) {
+  const APPS = window.RK.APPS;
+  const [q, setQ] = amS("");
+  const [kind, setKind] = amS("all");
+  const [sort, setSort] = amS("recent");
+
+  const kinds = amM(() => {
+    const c = { all: APPS.length, shiny: 0, interactive: 0, api: 0, external: 0 };
+    APPS.forEach((a) => { c[ADMIN_KIND[a.id]]++; });
+    return c;
+  }, []);
+
+  const rows = amM(() => {
+    let list = APPS.filter((a) => {
+      if (kind !== "all" && ADMIN_KIND[a.id] !== kind) return false;
+      if (q.trim() && !(a.id + " " + a.name).toLowerCase().includes(q.trim().toLowerCase())) return false;
+      return true;
+    });
+    if (sort === "name") list = [...list].sort((a, b) => a.name.localeCompare(b.name));
+    if (sort === "id") list = [...list].sort((a, b) => a.id.localeCompare(b.id));
+    return list;
+  }, [q, kind, sort]);
+
+  const lang = t._lang;
+  const GROUP_COLOR = { admin: "#ef476f", editor: "#06b6d4", viewer: "#26547c" };
+  const G_LABEL = { admin: "Admin", editor: "Editor", viewer: "Viewer" };
+
+  const KindChip = ({ k, label }) => (
+    <button className={"chip" + (kind === k ? " on-all" : "")} onClick={() => setKind(k)}>{label} <span className="chip-count">{kinds[k]}</span></button>
+  );
+
+  return (
+    <div className="mock-pad" style={{ paddingTop: 16, paddingBottom: 40 }}>
+      <div style={{ display: "flex", alignItems: "flex-end", justifyContent: "space-between", gap: 16, marginBottom: 18 }}>
+        <div>
+          <div className="page-title">Apps</div>
+          <div className="page-sub">{lang === "pt" ? "Catálogo de specs no banco de dados" : "Spec catalog stored in the database"}</div>
+        </div>
+        <div style={{ display: "flex", alignItems: "center", gap: 10 }}>
+          <span className="faint tnum" style={{ fontSize: 12 }}>{APPS.length}</span>
+          <button className="btn" onClick={onImport}><i className="ti ti-file-import"></i>{lang === "pt" ? "Importar YAML" : "Import YAML"}</button>
+          <button className="btn btn--primary" onClick={() => onEdit(null, true)}><i className="ti ti-plus"></i>{lang === "pt" ? "Novo app" : "Add app"}</button>
+        </div>
+      </div>
+
+      <div className="admin-sticky">
+        <div style={{ display: "flex", alignItems: "center", gap: 10, flexWrap: "wrap" }}>
+          <div className="search-pill" style={{ maxWidth: 280, flex: "0 1 280px", padding: "8px 14px" }}>
+            <i className="ti ti-search"></i>
+            <input value={q} onChange={(e) => setQ(e.target.value)} placeholder={lang === "pt" ? "Buscar app…" : "Search app…"} />
+          </div>
+          <KindChip k="all" label={t.all} />
+          <KindChip k="shiny" label="Shiny" />
+          <KindChip k="interactive" label={lang === "pt" ? "Interativo" : "Interactive"} />
+          <KindChip k="api" label="API" />
+          <KindChip k="external" label={lang === "pt" ? "Externo" : "External"} />
+          <div style={{ flex: 1 }}></div>
+          <button className="sort-btn" onClick={() => setSort(sort === "recent" ? "name" : sort === "name" ? "id" : "recent")}>
+            <i className="ti ti-arrows-sort"></i>{sort === "recent" ? t.recent : sort === "name" ? t.name : "ID"}
+          </button>
+        </div>
+      </div>
+
+      <table className="admin-table" style={{ marginTop: 12 }}>
+        <thead>
+          <tr>
+            <th style={{ width: 130 }}>ID</th>
+            <th>{lang === "pt" ? "Nome" : "Name"}</th>
+            <th style={{ width: 130 }}>{lang === "pt" ? "Tipo" : "Kind"}</th>
+            <th style={{ width: 180 }}>{lang === "pt" ? "Acesso" : "Access"}</th>
+            <th style={{ width: 90 }}>{lang === "pt" ? "Estado" : "State"}</th>
+            <th style={{ width: 120 }}>{lang === "pt" ? "Atualizado" : "Updated"}</th>
+            <th style={{ width: 80 }}>{lang === "pt" ? "Versão" : "Version"}</th>
+            <th style={{ width: 130, textAlign: "right" }}>{lang === "pt" ? "Ações" : "Actions"}</th>
+          </tr>
+        </thead>
+        <tbody>
+          {loading
+            ? Array.from({ length: 8 }).map((_, i) => (
+                <tr key={i}><td colSpan={7} style={{ padding: 0 }}><div style={{ padding: "11px 12px" }}><AM.SkBlock w={"100%"} h={14} /></div></td></tr>
+              ))
+            : rows.map((a) => {
+                const ak = ADMIN_KIND[a.id];
+                const groups = appAccess ? (appAccess.get(a.id) ?? a.accessGroups ?? []) : (a.accessGroups || []);
+                const isPublic = groups.length === 0;
+                const toggleG = (g) => {
+                  if (!setAccess) return;
+                  const next = groups.includes(g) ? groups.filter((x) => x !== g) : [...groups, g];
+                  setAccess(a.id, next);
+                };
+                return (
+                  <React.Fragment key={a.id}>
+                    <tr style={{ cursor: "pointer" }} onClick={() => onEdit(a)}>
+                      <td className="mono muted">{a.id}</td>
+                      <td><span style={{ display: "inline-flex", alignItems: "center", gap: 10 }}><AM.Logo app={a} size={26} radius={6} /><span style={{ fontWeight: 500 }}>{a.name}</span></span></td>
+                      <td><span className={"pill pill-kind-" + ak}>{KIND_LABEL[lang][ak]}</span></td>
+                      <td style={{ cursor: "default" }} onClick={(e) => e.stopPropagation()}>
+                        <div style={{ display: "flex", gap: 4, flexWrap: "wrap" }}>
+                          {isPublic
+                            ? <span style={{ display: "inline-flex", alignItems: "center", gap: 4, fontSize: 11, color: "var(--teal-600)" }}><i className="ti ti-world" style={{ fontSize: 13 }}></i>{lang === "pt" ? "público" : "public"}</span>
+                            : groups.map((g) => <span key={g} className="group-badge" style={{ background: `color-mix(in srgb, ${GROUP_COLOR[g]} 16%, transparent)`, color: GROUP_COLOR[g] }}>{G_LABEL[g]}</span>)}
+                        </div>
+                      </td>
+                      <td><span className="pill pill-state-active">{lang === "pt" ? "ATIVO" : "ACTIVE"}</span></td>
+                      <td className="muted tnum" style={{ fontSize: 11.5 }}>{a.updated}/2026</td>
+                      <td onClick={(e) => e.stopPropagation()}>
+                        <div style={{ display: "flex", gap: 2, justifyContent: "flex-end", alignItems: "center" }}>
+                          <button className={"star-toggle" + (featured.has(a.id) ? " is-on" : "")} title={featured.has(a.id) ? (lang === "pt" ? "Remover destaque" : "Unfeature") : (lang === "pt" ? "Destacar" : "Feature")}
+                            onClick={() => { toggleFeatured(a.id); push((featured.has(a.id) ? (lang === "pt" ? "Removido dos destaques" : "Unfeatured") : (lang === "pt" ? "Adicionado aos destaques" : "Featured")) + " · " + a.name, featured.has(a.id) ? "ti-star-off" : "ti-star-filled"); }}>
+                            <AM.StarIcon on={featured.has(a.id)} size={17} />
+                          </button>
+                          <button className="star-toggle" title={lang === "pt" ? "Editar" : "Edit"} onClick={() => onEdit(a)}><i className="ti ti-pencil"></i></button>
+                          <button className="star-toggle" title={lang === "pt" ? "Duplicar" : "Duplicate"} onClick={() => push((lang === "pt" ? "Duplicado · " : "Duplicated · ") + a.name, "ti-copy")}><i className="ti ti-copy"></i></button>
+                        </div>
+                      </td>
+                    </tr>
+
+                  </React.Fragment>
+                );
+              })}
+        </tbody>
+      </table>
+      {!loading && rows.length === 0 && (
+        <div style={{ textAlign: "center", padding: "48px", color: "var(--text-muted)" }}>
+          <i className="ti ti-search-off" style={{ fontSize: 28, color: "var(--text-faint)" }}></i>
+          <div style={{ marginTop: 10, fontSize: 13 }}>{t.noResults}</div>
+        </div>
+      )}
+    </div>
+  );
+}
+
+/* ══════════════════════════════════════ MEDIA ═════════════════ */
+function AdminMedia({ t, loading, push }) {
+  const APPS = window.RK.APPS;
+  const lang = t._lang;
+  const [q, setQ] = amS("");
+  const [drag, setDrag] = amS(false);
+
+  const items = amM(() => {
+    const sizes = ["396 B", "5.0 KB", "10.6 KB", "6.1 KB", "3.6 KB", "5.1 KB", "820 B", "7.2 KB", "4.5 KB", "9.2 KB", "3.2 KB", "8.4 KB", "5.2 KB"];
+    return APPS.map((a, i) => ({ id: a.id, name: a.id + ".svg", src: a.logo, accent: a.accent, mono: a.mono, size: sizes[i % sizes.length] }));
+  }, []);
+  const filtered = items.filter((m) => !q.trim() || m.name.toLowerCase().includes(q.trim().toLowerCase()));
+
+  return (
+    <div className="mock-pad" style={{ paddingTop: 16, paddingBottom: 40 }}>
+      <div style={{ display: "flex", alignItems: "flex-end", justifyContent: "space-between", gap: 16, marginBottom: 18 }}>
+        <div>
+          <div className="page-title">{lang === "pt" ? "Biblioteca de mídia" : "Media library"}</div>
+          <div className="page-sub">{lang === "pt" ? "PNG, JPEG e WebP são convertidos para WebP. SVG passa direto." : "PNG, JPEG and WebP are converted to WebP. SVG passes through."}</div>
+        </div>
+        <span className="faint tnum" style={{ fontSize: 13 }}>{items.length}</span>
+      </div>
+
+      <div className={"image-upload-zone" + (drag ? " is-dragover" : "")}
+        onDragOver={(e) => { e.preventDefault(); setDrag(true); }}
+        onDragLeave={() => setDrag(false)}
+        onDrop={(e) => { e.preventDefault(); setDrag(false); push(lang === "pt" ? "Imagem enviada" : "Image uploaded", "ti-photo-up"); }}>
+        <button className="btn btn--primary" onClick={() => push(lang === "pt" ? "Selecionar arquivo…" : "Choose file…", "ti-photo")}><i className="ti ti-photo-plus"></i>{lang === "pt" ? "Escolher imagem" : "Choose image"}</button>
+        <span className="image-upload-hint">{lang === "pt" ? "Clique ou arraste · PNG · JPEG · WebP · SVG · até 10 MB" : "Click or drop · PNG · JPEG · WebP · SVG · up to 10 MB"}</span>
+      </div>
+
+      <div className="search-pill" style={{ maxWidth: 320, margin: "18px 0 0", padding: "8px 14px" }}>
+        <i className="ti ti-search"></i>
+        <input value={q} onChange={(e) => setQ(e.target.value)} placeholder={lang === "pt" ? "Buscar imagens…" : "Search images…"} />
+      </div>
+
+      {loading ? (
+        <div className="media-grid" style={{ marginTop: 16 }}>{Array.from({ length: 8 }).map((_, i) => (
+          <div className="image-tile" key={i}><div className="sk" style={{ height: 120, borderRadius: 0 }}></div><div style={{ padding: "8px 10px" }}><AM.SkBlock w={"70%"} h={9} /></div></div>
+        ))}</div>
+      ) : (
+        <div className="media-grid stagger" style={{ marginTop: 16 }}>
+          {filtered.map((m, i) => (
+            <div className="image-tile" key={m.id} style={{ animationDelay: Math.min(i, 10) * 12 + "ms" }}>
+              <button className="image-tile-delete" title={lang === "pt" ? "Remover" : "Delete"} onClick={() => push((lang === "pt" ? "Removida · " : "Deleted · ") + m.name, "ti-trash")}><i className="ti ti-trash"></i></button>
+              <div className="image-tile-frame" style={{ background: `color-mix(in srgb, ${m.accent} 9%, var(--surface-soft))` }}>
+                {m.src ? <img src={m.src} alt={m.name} onError={(e) => { e.target.style.display = "none"; }} /> : <div style={{ width: "100%", height: "100%", display: "flex", alignItems: "center", justifyContent: "center", color: m.accent, fontWeight: 600, fontSize: 22 }}>{m.mono}</div>}
+              </div>
+              <div className="image-tile-meta">
+                <div className="image-tile-name">{m.name}</div>
+                <div className="image-tile-sub"><span>{m.size}</span><span>·</span><span>image/svg+xml</span></div>
+              </div>
+            </div>
+          ))}
+        </div>
+      )}
+    </div>
+  );
+}
+
+window.RKAdmin = { AdminApps, AdminMedia };

--- a/docs/design-handoff/src/admin2.jsx
+++ b/docs/design-handoff/src/admin2.jsx
@@ -1,0 +1,350 @@
+/* global React, window */
+// ── Admin pages: Disk · Credentials · Logs (refined style) ──
+const { useState: a2S, useMemo: a2M, useEffect: a2E, useRef: a2R } = React;
+const A2 = window.RKC;
+
+const fmtGB = (mb) => (mb >= 1024 ? (mb / 1024).toFixed(1) + " GB" : Math.round(mb) + " MB");
+
+/* ══════════════════════════════════════ DISK ══════════════════ */
+const SEED_IMAGES = [
+  { ref: "ruscker/shiny", tag: "4.3", mb: 1240, usedBy: 3 },
+  { ref: "ruscker/shiny", tag: "4.2", mb: 1180, usedBy: 0 },
+  { ref: "ruscker/python", tag: "3.12", mb: 980, usedBy: 4 },
+  { ref: "ruscker/jupyter", tag: "7", mb: 1410, usedBy: 2 },
+  { ref: "ruscker/rstudio", tag: "2024.04", mb: 1620, usedBy: 1 },
+  { ref: "ruscker/quarto", tag: "1.3", mb: 720, usedBy: 0 },
+  { ref: "ruscker/streamlit", tag: "1.32", mb: 640, usedBy: 1 },
+  { ref: "<none>", tag: "<none>", mb: 410, usedBy: 0, dangling: true },
+];
+const SEED_CONTAINERS = [
+  { cid: "a1c4f29e", app: "Shiny", state: "running", mb: 84, created: "2 h" },
+  { cid: "9f2b7d10", app: "Jupyter", state: "running", mb: 132, created: "5 h" },
+  { cid: "77de03a2", app: "Streamlit", state: "running", mb: 96, created: "1 d" },
+  { cid: "3c0a55b1", app: "Shiny", state: "exited", mb: 78, created: "3 d" },
+  { cid: "b8e1f4c7", app: "RStudio", state: "stopped", mb: 210, created: "6 d" },
+  { cid: "5d92a0fe", app: "Voilà", state: "exited", mb: 64, created: "8 d" },
+];
+
+function AdminDisk({ t, loading, push }) {
+  const lang = t._lang;
+  const TOTAL = 51200; // 50 GB
+  const [images, setImages] = a2S(SEED_IMAGES);
+  const [containers, setContainers] = a2S(SEED_CONTAINERS);
+
+  const STATIC = [
+    { id: "cache", label: lang === "pt" ? "Cache de sessões" : "Session cache", mb: 6420, color: "#3b82f6", icon: "ti-bolt" },
+    { id: "logs", label: "Logs", mb: 1890, color: "#f59e0b", icon: "ti-terminal-2" },
+    { id: "backups", label: "Backups", mb: 2110, color: "#8b5cf6", icon: "ti-database-export" },
+  ];
+  const imagesMb = images.reduce((s, i) => s + i.mb, 0);
+  const containersMb = containers.reduce((s, c) => s + c.mb, 0);
+  const cats = [
+    { id: "images", label: lang === "pt" ? "Imagens de container" : "Container images", mb: imagesMb, color: "#06b6d4", icon: "ti-stack-2" },
+    { id: "containers", label: "Containers", mb: containersMb, color: "#06d6a0", icon: "ti-box" },
+    ...STATIC,
+  ];
+  const used = cats.reduce((s, c) => s + c.mb, 0);
+  const pct = (used / TOTAL) * 100;
+
+  const unusedImages = images.filter((i) => i.usedBy === 0);
+  const reclaimImg = unusedImages.reduce((s, i) => s + i.mb, 0);
+  const stoppedCt = containers.filter((c) => c.state !== "running");
+  const reclaimCt = stoppedCt.reduce((s, c) => s + c.mb, 0);
+
+  const pruneImages = () => {
+    if (!unusedImages.length) return;
+    setImages((l) => l.filter((i) => i.usedBy > 0));
+    push((lang === "pt" ? "Removidas " : "Removed ") + unusedImages.length + (lang === "pt" ? ` imagens · ${fmtGB(reclaimImg)} liberados` : ` images · ${fmtGB(reclaimImg)} freed`), "ti-trash");
+  };
+  const pruneContainers = () => {
+    if (!stoppedCt.length) return;
+    setContainers((l) => l.filter((c) => c.state === "running"));
+    push((lang === "pt" ? "Removidos " : "Removed ") + stoppedCt.length + (lang === "pt" ? ` containers · ${fmtGB(reclaimCt)} liberados` : ` containers · ${fmtGB(reclaimCt)} freed`), "ti-trash");
+  };
+
+  const stLabel = (s) => s === "running" ? (lang === "pt" ? "em execução" : "running") : s === "stopped" ? (lang === "pt" ? "parado" : "stopped") : (lang === "pt" ? "saiu" : "exited");
+
+  return (
+    <div className="mock-pad" style={{ paddingTop: 16, paddingBottom: 40 }}>
+      <div style={{ display: "flex", alignItems: "flex-end", justifyContent: "space-between", gap: 16, marginBottom: 20 }}>
+        <div>
+          <div className="page-title">{lang === "pt" ? "Disco" : "Disk"}</div>
+          <div className="page-sub">{lang === "pt" ? "Uso de armazenamento do servidor" : "Server storage usage"}</div>
+        </div>
+        <button className="btn" onClick={() => push(lang === "pt" ? "Cache de sessões limpo" : "Session cache cleared", "ti-eraser")}><i className="ti ti-eraser"></i>{lang === "pt" ? "Limpar cache" : "Clear cache"}</button>
+      </div>
+
+      {loading ? (
+        <div><A2.SkBlock w={"100%"} h={120} r={12} style={{ marginBottom: 14 }} /><A2.SkBlock w={"100%"} h={240} r={12} /></div>
+      ) : (
+        <React.Fragment>
+          {/* usage hero */}
+          <div className="disk-hero">
+            <div className="disk-hero__head">
+              <div>
+                <div style={{ fontSize: 13, color: "var(--text-muted)", marginBottom: 4 }}>{lang === "pt" ? "Usado" : "Used"}</div>
+                <div style={{ fontSize: 30, fontWeight: 600, letterSpacing: "-0.02em" }}><A2.LiveNum value={fmtGB(used)} /> <span style={{ fontSize: 15, color: "var(--text-faint)", fontWeight: 400 }}>/ {fmtGB(TOTAL)}</span></div>
+              </div>
+              <div style={{ textAlign: "right" }}>
+                <div style={{ fontSize: 30, fontWeight: 600, letterSpacing: "-0.02em", color: pct > 80 ? "var(--warn)" : "var(--teal-600)" }}><A2.LiveNum value={pct.toFixed(1) + "%"} /></div>
+                <div style={{ fontSize: 11.5, color: "var(--text-faint)" }}>{fmtGB(TOTAL - used)} {lang === "pt" ? "livres" : "free"}</div>
+              </div>
+            </div>
+            <div className="disk-stack">
+              {cats.map((c) => <div key={c.id} className="disk-stack__seg" title={c.label} style={{ width: (c.mb / TOTAL) * 100 + "%", background: c.color }}></div>)}
+            </div>
+            <div className="disk-legend">
+              {cats.map((c) => (
+                <div className="disk-legend__item" key={c.id}>
+                  <span className="disk-legend__dot" style={{ background: c.color }}></span>
+                  <i className={"ti " + c.icon} style={{ fontSize: 14, color: "var(--text-faint)" }}></i>
+                  <span>{c.label}</span>
+                  <span className="disk-legend__val tnum">{fmtGB(c.mb)}</span>
+                </div>
+              ))}
+            </div>
+          </div>
+
+          {/* two-column: container images + containers */}
+          <div className="disk-cols">
+            {/* ── Container images ── */}
+            <div className="disk-panel">
+              <div className="disk-panel__head">
+                <div>
+                  <div className="disk-panel__title"><i className="ti ti-stack-2" style={{ color: "#06b6d4" }}></i>{lang === "pt" ? "Imagens de container" : "Container images"}</div>
+                  <div className="disk-panel__sub">{images.length} {lang === "pt" ? "imagens" : "images"} · {fmtGB(imagesMb)}{unusedImages.length ? ` · ${unusedImages.length} ${lang === "pt" ? "não usadas" : "unused"}` : ""}</div>
+                </div>
+                <button className={"btn btn--danger" + (unusedImages.length ? "" : " is-disabled")} onClick={pruneImages}>
+                  <i className="ti ti-trash"></i>{lang === "pt" ? "Limpar não usadas" : "Prune unused"}{unusedImages.length ? ` · ${fmtGB(reclaimImg)}` : ""}
+                </button>
+              </div>
+              <table className="admin-table">
+                <thead><tr>
+                  <th>{lang === "pt" ? "Imagem" : "Image"}</th>
+                  <th style={{ width: 80 }}>{lang === "pt" ? "Uso" : "In use"}</th>
+                  <th style={{ width: 90, textAlign: "right" }}>{lang === "pt" ? "Tamanho" : "Size"}</th>
+                  <th style={{ width: 44 }}></th>
+                </tr></thead>
+                <tbody>
+                  {images.map((im) => (
+                    <tr key={im.ref + im.tag} className={im.usedBy === 0 ? "is-unused" : ""}>
+                      <td>
+                        <div style={{ display: "flex", alignItems: "center", gap: 8 }}>
+                          <code className="mono" style={{ fontSize: 11.5 }}>{im.ref}<span className="faint">:{im.tag}</span></code>
+                          {im.dangling && <span className="pill pill-unused">dangling</span>}
+                        </div>
+                      </td>
+                      <td>{im.usedBy > 0
+                        ? <span className="use-badge use-badge--on">{im.usedBy} {lang === "pt" ? "apps" : "apps"}</span>
+                        : <span className="use-badge use-badge--off">{lang === "pt" ? "não usada" : "unused"}</span>}</td>
+                      <td className="tnum" style={{ textAlign: "right", fontWeight: 500 }}>{fmtGB(im.mb)}</td>
+                      <td style={{ textAlign: "right" }}><button className="star-toggle" title={lang === "pt" ? "Remover" : "Remove"} onClick={() => setImages((l) => l.filter((x) => x !== im))}><i className="ti ti-trash"></i></button></td>
+                    </tr>
+                  ))}
+                  {images.length === 0 && <tr><td colSpan={4} style={{ textAlign: "center", color: "var(--text-faint)", padding: 24, fontSize: 12 }}>{lang === "pt" ? "Nenhuma imagem." : "No images."}</td></tr>}
+                </tbody>
+              </table>
+            </div>
+
+            {/* ── Containers ── */}
+            <div className="disk-panel">
+              <div className="disk-panel__head">
+                <div>
+                  <div className="disk-panel__title"><i className="ti ti-box" style={{ color: "#06d6a0" }}></i>Containers</div>
+                  <div className="disk-panel__sub">{containers.length} {lang === "pt" ? "containers" : "containers"} · {fmtGB(containersMb)}{stoppedCt.length ? ` · ${stoppedCt.length} ${lang === "pt" ? "parados" : "stopped"}` : ""}</div>
+                </div>
+                <button className={"btn btn--danger" + (stoppedCt.length ? "" : " is-disabled")} onClick={pruneContainers}>
+                  <i className="ti ti-trash"></i>{lang === "pt" ? "Limpar parados" : "Prune stopped"}{stoppedCt.length ? ` · ${fmtGB(reclaimCt)}` : ""}
+                </button>
+              </div>
+              <table className="admin-table">
+                <thead><tr>
+                  <th>{lang === "pt" ? "Container" : "Container"}</th>
+                  <th style={{ width: 120 }}>{lang === "pt" ? "Estado" : "State"}</th>
+                  <th style={{ width: 90, textAlign: "right" }}>{lang === "pt" ? "Camada" : "Layer"}</th>
+                  <th style={{ width: 44 }}></th>
+                </tr></thead>
+                <tbody>
+                  {containers.map((ct) => (
+                    <tr key={ct.cid} className={ct.state !== "running" ? "is-unused" : ""}>
+                      <td><code className="mono" style={{ fontSize: 11.5 }}>{ct.cid}</code> <span className="faint" style={{ fontSize: 11 }}>· {ct.app}</span></td>
+                      <td>
+                        <span style={{ display: "inline-flex", alignItems: "center", gap: 6, fontSize: 11.5 }}>
+                          <span className={"dot " + (ct.state === "running" ? "dot-ready" : "dot-off")}></span>{stLabel(ct.state)}
+                        </span>
+                      </td>
+                      <td className="tnum" style={{ textAlign: "right", fontWeight: 500 }}>{fmtGB(ct.mb)}</td>
+                      <td style={{ textAlign: "right" }}><button className="star-toggle" title={lang === "pt" ? "Remover" : "Remove"} onClick={() => setContainers((l) => l.filter((x) => x !== ct))} disabled={ct.state === "running"} style={ct.state === "running" ? { opacity: 0.3, pointerEvents: "none" } : null}><i className="ti ti-trash"></i></button></td>
+                    </tr>
+                  ))}
+                  {containers.length === 0 && <tr><td colSpan={4} style={{ textAlign: "center", color: "var(--text-faint)", padding: 24, fontSize: 12 }}>{lang === "pt" ? "Nenhum container." : "No containers."}</td></tr>}
+                </tbody>
+              </table>
+            </div>
+          </div>
+        </React.Fragment>
+      )}
+    </div>
+  );
+}
+
+/* ═══════════════════════════════════ CREDENTIALS ══════════════ */
+const SCOPES = {
+  pt: { admin: "Administrador", deploy: "Deploy", read: "Somente leitura" },
+  en: { admin: "Administrator", deploy: "Deploy", read: "Read-only" },
+};
+function AdminCredentials({ t, loading, push }) {
+  const lang = t._lang;
+  const [creds, setCreds] = a2S(() => ([
+    { id: 1, name: "CI / Deploy", scope: "deploy", token: "rk_live_a1c4", created: "12/03/2026", lastUsed: lang === "pt" ? "há 2 min" : "2 min ago", active: true },
+    { id: 2, name: "Grafana scraper", scope: "read", token: "rk_live_9f2b", created: "28/02/2026", lastUsed: lang === "pt" ? "há 1 h" : "1 h ago", active: true },
+    { id: 3, name: "Backup job", scope: "admin", token: "rk_live_77de", created: "04/01/2026", lastUsed: lang === "pt" ? "ontem" : "yesterday", active: true },
+    { id: 4, name: "Laptop — Ana", scope: "read", token: "rk_live_3c0a", created: "15/12/2025", lastUsed: lang === "pt" ? "há 18 dias" : "18 days ago", active: false },
+  ]));
+  const [reveal, setReveal] = a2S(() => new Set());
+  const toggleReveal = (id) => setReveal((s) => { const n = new Set(s); n.has(id) ? n.delete(id) : n.add(id); return n; });
+  const revoke = (id) => { setCreds((c) => c.map((x) => x.id === id ? { ...x, active: false } : x)); push(lang === "pt" ? "Credencial revogada" : "Credential revoked", "ti-ban"); };
+
+  return (
+    <div className="mock-pad" style={{ paddingTop: 16, paddingBottom: 40 }}>
+      <div style={{ display: "flex", alignItems: "flex-end", justifyContent: "space-between", gap: 16, marginBottom: 20 }}>
+        <div>
+          <div className="page-title">{lang === "pt" ? "Credenciais" : "Credentials"}</div>
+          <div className="page-sub">{lang === "pt" ? "Tokens de API para deploy e integrações" : "API tokens for deploy and integrations"}</div>
+        </div>
+        <button className="btn btn--primary" onClick={() => push(lang === "pt" ? "Nova credencial — token gerado e copiado" : "New credential — token generated & copied", "ti-key")}><i className="ti ti-plus"></i>{lang === "pt" ? "Nova credencial" : "New credential"}</button>
+      </div>
+
+      {loading ? (
+        <A2.SkBlock w={"100%"} h={240} r={12} />
+      ) : (
+        <table className="admin-table">
+          <thead><tr>
+            <th>{lang === "pt" ? "Nome" : "Name"}</th>
+            <th style={{ width: 150 }}>{lang === "pt" ? "Escopo" : "Scope"}</th>
+            <th style={{ width: 220 }}>Token</th>
+            <th style={{ width: 120 }}>{lang === "pt" ? "Criado" : "Created"}</th>
+            <th style={{ width: 120 }}>{lang === "pt" ? "Último uso" : "Last used"}</th>
+            <th style={{ width: 110, textAlign: "right" }}>{lang === "pt" ? "Ações" : "Actions"}</th>
+          </tr></thead>
+          <tbody>
+            {creds.map((c) => (
+              <tr key={c.id} style={{ opacity: c.active ? 1 : 0.5 }}>
+                <td><span style={{ display: "inline-flex", alignItems: "center", gap: 9, fontWeight: 500 }}>
+                  <span className="cred-ico"><i className="ti ti-key"></i></span>{c.name}
+                  {!c.active && <span className="pill" style={{ background: "var(--surface-soft)", color: "var(--text-faint)" }}>{lang === "pt" ? "REVOGADA" : "REVOKED"}</span>}
+                </span></td>
+                <td><span className={"pill pill-scope-" + c.scope}>{SCOPES[lang][c.scope]}</span></td>
+                <td>
+                  <span style={{ display: "inline-flex", alignItems: "center", gap: 7 }}>
+                    <code className="mono" style={{ fontSize: 12 }}>{reveal.has(c.id) ? c.token + "8e1d2f" : c.token.slice(0, 7) + "••••••"}</code>
+                    <button className="star-toggle" style={{ width: 26, height: 26 }} title={reveal.has(c.id) ? (lang === "pt" ? "Ocultar" : "Hide") : (lang === "pt" ? "Mostrar" : "Show")} onClick={() => toggleReveal(c.id)}><i className={"ti " + (reveal.has(c.id) ? "ti-eye-off" : "ti-eye")} style={{ fontSize: 14 }}></i></button>
+                    <button className="star-toggle" style={{ width: 26, height: 26 }} title={lang === "pt" ? "Copiar" : "Copy"} onClick={() => push(lang === "pt" ? "Token copiado" : "Token copied", "ti-copy")}><i className="ti ti-copy" style={{ fontSize: 14 }}></i></button>
+                  </span>
+                </td>
+                <td className="muted tnum" style={{ fontSize: 11.5 }}>{c.created}</td>
+                <td className="muted" style={{ fontSize: 11.5 }}>{c.lastUsed}</td>
+                <td style={{ textAlign: "right" }}>
+                  {c.active && <button className="star-toggle" title={lang === "pt" ? "Revogar" : "Revoke"} onClick={() => revoke(c.id)}><i className="ti ti-ban"></i></button>}
+                </td>
+              </tr>
+            ))}
+          </tbody>
+        </table>
+      )}
+    </div>
+  );
+}
+
+/* ══════════════════════════════════════ LOGS ══════════════════ */
+const LOG_TPL = [
+  { lvl: "info", msg: (a) => `request served · 200 · ${(8 + Math.random() * 40).toFixed(0)}ms`, app: true },
+  { lvl: "info", msg: (a) => `session started · ${Math.random().toString(16).slice(2, 8)}`, app: true },
+  { lvl: "info", msg: () => `load balancer · routing to replica node-${["a", "b"][Math.floor(Math.random() * 2)]}`, app: true },
+  { lvl: "warn", msg: (a) => `replica memory at ${(70 + Math.random() * 20).toFixed(0)}% · ${a}`, app: true },
+  { lvl: "info", msg: () => `health check ok`, app: true },
+  { lvl: "error", msg: (a) => `upstream timeout after 30s · ${a} · retrying`, app: true },
+  { lvl: "warn", msg: () => `session pool near capacity (9/10)`, app: true },
+  { lvl: "info", msg: (a) => `container ready · ${a}`, app: true },
+];
+function AdminLogs({ t, loading, push }) {
+  const lang = t._lang;
+  const APPS = window.RK.APPS;
+  const [lines, setLines] = a2S([]);
+  const [paused, setPaused] = a2S(false);
+  const [lvl, setLvl] = a2S("all");
+  const [appF, setAppF] = a2S("all");
+  const bodyRef = a2R(null);
+  const seq = a2R(0);
+
+  const mkLine = () => {
+    const tpl = LOG_TPL[Math.floor(Math.random() * LOG_TPL.length)];
+    const app = APPS[Math.floor(Math.random() * 8)];
+    const now = new Date();
+    const ts = now.toTimeString().slice(0, 8) + "." + String(now.getMilliseconds()).padStart(3, "0");
+    return { id: ++seq.current, ts, lvl: tpl.lvl, app: app.name, msg: tpl.msg(app.name) };
+  };
+
+  // seed + live stream
+  a2E(() => {
+    if (loading) return undefined;
+    if (lines.length === 0) setLines(Array.from({ length: 14 }, mkLine));
+    if (paused) return undefined;
+    const iv = setInterval(() => setLines((l) => [...l.slice(-140), mkLine()]), 1100);
+    return () => clearInterval(iv);
+  }, [loading, paused]);
+
+  // autoscroll
+  a2E(() => { if (!paused && bodyRef.current) bodyRef.current.scrollTop = bodyRef.current.scrollHeight; }, [lines, paused]);
+
+  const shown = lines.filter((l) => (lvl === "all" || l.lvl === lvl) && (appF === "all" || l.app === appF));
+  const LvlChip = ({ k, label }) => <button className={"chip" + (lvl === k ? " on-all" : "")} onClick={() => setLvl(lvl === k ? "all" : k)}>{label}</button>;
+
+  return (
+    <div className="mock-pad" style={{ paddingTop: 16, paddingBottom: 40 }}>
+      <div style={{ display: "flex", alignItems: "flex-end", justifyContent: "space-between", gap: 16, marginBottom: 16 }}>
+        <div>
+          <div className="page-title">Logs</div>
+          <div className="page-sub">{lang === "pt" ? "Stream de eventos do balanceador e das réplicas" : "Event stream from the balancer and replicas"}</div>
+        </div>
+        <span style={{ display: "inline-flex", alignItems: "center", gap: 7, fontSize: 11.5, color: "var(--text-muted)" }}>
+          {!paused && <span className="live-dot"></span>}{paused ? (lang === "pt" ? "pausado" : "paused") : t.live}
+        </span>
+      </div>
+
+      <div className="ops-toolbar" style={{ marginBottom: 0, borderRadius: "12px 12px 0 0", border: "0.5px solid var(--border)", borderBottom: 0, background: "var(--surface-soft)", padding: "10px 12px" }}>
+        <button className="sort-btn" onClick={() => setPaused((p) => !p)}><i className={"ti " + (paused ? "ti-player-play" : "ti-player-pause")}></i>{paused ? (lang === "pt" ? "Retomar" : "Resume") : (lang === "pt" ? "Pausar" : "Pause")}</button>
+        <span className="chip-divider"></span>
+        <LvlChip k="info" label="Info" />
+        <LvlChip k="warn" label={lang === "pt" ? "Alerta" : "Warn"} />
+        <LvlChip k="error" label={lang === "pt" ? "Erro" : "Error"} />
+        <select className="log-select" value={appF} onChange={(e) => setAppF(e.target.value)}>
+          <option value="all">{lang === "pt" ? "Todos os apps" : "All apps"}</option>
+          {APPS.slice(0, 8).map((a) => <option key={a.id} value={a.name}>{a.name}</option>)}
+        </select>
+        <div style={{ flex: 1 }}></div>
+        <span className="faint tnum" style={{ fontSize: 11 }}>{shown.length} {lang === "pt" ? "linhas" : "lines"}</span>
+        <button className="star-toggle" title={lang === "pt" ? "Limpar" : "Clear"} onClick={() => setLines([])}><i className="ti ti-eraser"></i></button>
+        <button className="star-toggle" title={lang === "pt" ? "Baixar" : "Download"} onClick={() => push(lang === "pt" ? "Baixando logs…" : "Downloading logs…", "ti-download")}><i className="ti ti-download"></i></button>
+      </div>
+
+      {loading ? (
+        <div className="log-body" style={{ padding: 14 }}>{Array.from({ length: 10 }).map((_, i) => <A2.SkBlock key={i} w={(50 + Math.random() * 45) + "%"} h={9} style={{ marginBottom: 11 }} />)}</div>
+      ) : (
+        <div className="log-body" ref={bodyRef}>
+          {shown.map((l) => (
+            <div className="log-line" key={l.id}>
+              <span className="log-ts">{l.ts}</span>
+              <span className={"log-lvl log-lvl-" + l.lvl}>{l.lvl.toUpperCase()}</span>
+              <span className="log-app">{l.app}</span>
+              <span className="log-msg">{l.msg}</span>
+            </div>
+          ))}
+          {shown.length === 0 && <div style={{ color: "var(--text-faint)", fontSize: 12, padding: 20, textAlign: "center" }}>{lang === "pt" ? "Sem linhas para este filtro." : "No lines for this filter."}</div>}
+        </div>
+      )}
+    </div>
+  );
+}
+
+window.RKAdmin2 = { AdminDisk, AdminCredentials, AdminLogs };

--- a/docs/design-handoff/src/admin3.jsx
+++ b/docs/design-handoff/src/admin3.jsx
@@ -1,0 +1,366 @@
+/* global React, window */
+// ── Admin: Users · Groups · Audit (multi-group model) ──
+const { useState: a3S, useMemo: a3M } = React;
+const A3 = window.RKC;
+
+const initials = (n) => n.split(" ").map((w) => w[0]).slice(0, 2).join("").toUpperCase();
+const AV_COLORS = ["#447099", "#059487", "#ef476f", "#7c3aed", "#f37726", "#0d76bf"];
+const avColor = (s) => AV_COLORS[[...s].reduce((a, c) => a + c.charCodeAt(0), 0) % AV_COLORS.length];
+
+function Avatar({ name, size = 30 }) {
+  return <span className="rk-avatar" style={{ width: size, height: size, fontSize: size * 0.38, background: `color-mix(in srgb, ${avColor(name)} 18%, var(--surface))`, color: avColor(name) }}>{initials(name)}</span>;
+}
+
+const ALL_GROUPS = ["admin", "editor", "viewer"];
+const GROUP_COLOR = { admin: "#ef476f", editor: "#06b6d4", viewer: "#26547c" };
+const GROUP_LABEL = {
+  pt: { admin: "Administrador", editor: "Editor", viewer: "Visualizador" },
+  en: { admin: "Administrator", editor: "Editor", viewer: "Viewer" },
+};
+const ST_LABEL = {
+  pt: { active: "ativo", invited: "convidado", suspended: "suspenso" },
+  en: { active: "active", invited: "invited", suspended: "suspended" },
+};
+
+// Users: each belongs to one or more groups
+const SEED_USERS = [
+  { id: 1, name: "Ana Ribeiro",   email: "ana@ufpe.br",    groups: ["admin","editor"],   status: "active",    seen: { pt: "há 2 min",  en: "2 min ago" } },
+  { id: 2, name: "Carlos Mendes", email: "carlos@ufpe.br", groups: ["editor"],           status: "active",    seen: { pt: "há 1 h",    en: "1 h ago" } },
+  { id: 3, name: "Beatriz Lima",  email: "bia@ufpe.br",    groups: ["editor","viewer"],  status: "active",    seen: { pt: "ontem",     en: "yesterday" } },
+  { id: 4, name: "Diego Souza",   email: "diego@ufpe.br",  groups: ["viewer"],           status: "invited",   seen: { pt: "—",         en: "—" } },
+  { id: 5, name: "Elena Castro",  email: "elena@ext.com",  groups: ["viewer"],           status: "active",    seen: { pt: "há 3 dias", en: "3 days ago" } },
+  { id: 6, name: "Felipe Araújo", email: "felipe@ufpe.br", groups: ["editor"],           status: "suspended", seen: { pt: "há 21 dias",en: "21 days ago" } },
+];
+// Export for portal simulation
+window.RUSCKER_USERS = SEED_USERS;
+
+function GroupBadge({ g, lang }) {
+  return (
+    <span className="group-badge" style={{
+      background: `color-mix(in srgb, ${GROUP_COLOR[g]} 16%, transparent)`,
+      color: GROUP_COLOR[g],
+    }}>{GROUP_LABEL[lang][g]}</span>
+  );
+}
+
+/* ══════════════════════════════════════ USERS ═══════════════════ */
+function AdminUsers({ t, loading, push }) {
+  const lang = t._lang;
+  const [users, setUsers] = a3S(SEED_USERS);
+  const [q, setQ] = a3S("");
+  const [stF, setStF] = a3S("all");
+  const [editId, setEditId] = a3S(null);
+
+  const shown = users.filter((u) => {
+    if (stF !== "all" && u.status !== stF) return false;
+    if (q.trim() && !(u.name + " " + u.email).toLowerCase().includes(q.trim().toLowerCase())) return false;
+    return true;
+  });
+  const counts = {
+    all: users.length,
+    active: users.filter((u) => u.status === "active").length,
+    invited: users.filter((u) => u.status === "invited").length,
+    suspended: users.filter((u) => u.status === "suspended").length,
+  };
+  const suspend = (id) => setUsers((l) => l.map((u) => u.id === id ? { ...u, status: u.status === "suspended" ? "active" : "suspended" } : u));
+  const toggleGroup = (uid, g) => setUsers((l) => l.map((u) => {
+    if (u.id !== uid) return u;
+    const gs = u.groups.includes(g) ? u.groups.filter((x) => x !== g) : [...u.groups, g];
+    return { ...u, groups: gs.length ? gs : u.groups }; // min 1 group
+  }));
+
+  const Chip = ({ k, label }) => <button className={"chip" + (stF === k ? " on-all" : "")} onClick={() => setStF(stF === k ? "all" : k)}>{label} <span className="chip-count">{counts[k]}</span></button>;
+
+  return (
+    <div className="mock-pad" style={{ paddingTop: 16, paddingBottom: 40 }}>
+      <div style={{ display: "flex", alignItems: "flex-end", justifyContent: "space-between", gap: 16, marginBottom: 18 }}>
+        <div>
+          <div className="page-title">{lang === "pt" ? "Usuários" : "Users"}</div>
+          <div className="page-sub">{lang === "pt" ? "Um usuário pode pertencer a vários grupos" : "A user can belong to multiple groups"}</div>
+        </div>
+        <button className="btn btn--primary" onClick={() => push(lang === "pt" ? "Convite enviado por e-mail" : "Invite sent by email", "ti-mail")}><i className="ti ti-user-plus"></i>{lang === "pt" ? "Convidar usuário" : "Invite user"}</button>
+      </div>
+
+      <div className="admin-sticky">
+        <div style={{ display: "flex", alignItems: "center", gap: 10, flexWrap: "wrap" }}>
+          <div className="search-pill" style={{ maxWidth: 280, flex: "0 1 280px", padding: "8px 14px" }}>
+            <i className="ti ti-search"></i>
+            <input value={q} onChange={(e) => setQ(e.target.value)} placeholder={lang === "pt" ? "Buscar nome ou e-mail…" : "Search name or email…"} />
+          </div>
+          <Chip k="active" label={ST_LABEL[lang].active} />
+          <Chip k="invited" label={ST_LABEL[lang].invited} />
+          <Chip k="suspended" label={ST_LABEL[lang].suspended} />
+        </div>
+      </div>
+
+      {loading ? <div style={{ marginTop: 12 }}><A3.SkBlock w={"100%"} h={300} r={12} /></div> : (
+        <table className="admin-table" style={{ marginTop: 12 }}>
+          <thead><tr>
+            <th>{lang === "pt" ? "Usuário" : "User"}</th>
+            <th style={{ width: 280 }}>{lang === "pt" ? "Grupos (clique ✎ para editar)" : "Groups (click ✎ to edit)"}</th>
+            <th style={{ width: 110 }}>{lang === "pt" ? "Estado" : "Status"}</th>
+            <th style={{ width: 120 }}>{lang === "pt" ? "Visto" : "Last seen"}</th>
+            <th style={{ width: 70, textAlign: "right" }}></th>
+          </tr></thead>
+          <tbody>
+            {shown.map((u) => (
+              <React.Fragment key={u.id}>
+                <tr style={{ opacity: u.status === "suspended" ? 0.55 : 1 }}>
+                  <td><span style={{ display: "inline-flex", alignItems: "center", gap: 10 }}>
+                    <Avatar name={u.name} />
+                    <span><span style={{ fontWeight: 500, display: "block" }}>{u.name}</span><span className="faint mono" style={{ fontSize: 11 }}>{u.email}</span></span>
+                  </span></td>
+                  <td>
+                    <div style={{ display: "flex", gap: 5, flexWrap: "wrap", alignItems: "center" }}>
+                      {u.groups.map((g) => <GroupBadge key={g} g={g} lang={lang} />)}
+                      <button className="star-toggle" style={{ width: 22, height: 22 }} title={lang === "pt" ? "Editar grupos" : "Edit groups"} onClick={() => setEditId(editId === u.id ? null : u.id)}>
+                        <i className={"ti " + (editId === u.id ? "ti-x" : "ti-pencil")} style={{ fontSize: 12 }}></i>
+                      </button>
+                    </div>
+                  </td>
+                  <td><span className={"status-pill status-pill--" + u.status}><span className={"dot " + (u.status === "active" ? "dot-ready" : u.status === "invited" ? "dot-boot" : "dot-off")}></span>{ST_LABEL[lang][u.status]}</span></td>
+                  <td className="muted" style={{ fontSize: 11.5 }}>{u.seen[lang]}</td>
+                  <td style={{ textAlign: "right" }}>
+                    <button className="star-toggle" title={u.status === "suspended" ? (lang === "pt" ? "Reativar" : "Reactivate") : (lang === "pt" ? "Suspender" : "Suspend")} onClick={() => suspend(u.id)}>
+                      <i className={"ti " + (u.status === "suspended" ? "ti-user-check" : "ti-user-x")}></i>
+                    </button>
+                  </td>
+                </tr>
+                {editId === u.id && (
+                  <tr className="fade-in">
+                    <td></td>
+                    <td colSpan={4}>
+                      <div className="group-editor-row">
+                        <span className="faint" style={{ fontSize: 12 }}>{lang === "pt" ? "Grupos de" : "Groups for"} <b>{u.name}</b>:</span>
+                        {ALL_GROUPS.map((g) => (
+                          <button key={g} className={"group-toggle" + (u.groups.includes(g) ? " on" : "")}
+                            style={u.groups.includes(g) ? { "--gc": GROUP_COLOR[g], borderColor: GROUP_COLOR[g], background: `color-mix(in srgb, ${GROUP_COLOR[g]} 14%, transparent)`, color: GROUP_COLOR[g] } : null}
+                            onClick={() => toggleGroup(u.id, g)}>
+                            <i className={"ti " + (u.groups.includes(g) ? "ti-check" : "ti-plus")} style={{ fontSize: 12 }}></i>
+                            {GROUP_LABEL[lang][g]}
+                          </button>
+                        ))}
+                        <span className="faint" style={{ fontSize: 11 }}>{lang === "pt" ? "mín. 1" : "min 1"}</span>
+                      </div>
+                    </td>
+                  </tr>
+                )}
+              </React.Fragment>
+            ))}
+            {shown.length === 0 && <tr><td colSpan={5} style={{ textAlign: "center", color: "var(--text-faint)", padding: 30, fontSize: 12 }}>{lang === "pt" ? "Nenhum usuário." : "No users."}</td></tr>}
+          </tbody>
+        </table>
+      )}
+    </div>
+  );
+}
+
+/* ══════════════════════════════════════ GROUPS ════════════════════ */
+const SEED_GROUPS = [
+  { id: "admin",  name: { pt: "Administradores", en: "Administrators" }, desc: { pt: "Acesso total ao admin e a todos os apps.",        en: "Full access to admin and all apps." },            perms: ["manage","deploy","view"], color: "#ef476f" },
+  { id: "editor", name: { pt: "Editores",        en: "Editors" },        desc: { pt: "Gerenciam apps e mídia, sem acesso a credenciais.", en: "Manage apps and media, no credential access." }, perms: ["deploy","view"],          color: "#06b6d4" },
+  { id: "viewer", name: { pt: "Visualizadores",  en: "Viewers" },        desc: { pt: "Acessam apps restritos do portal.",                 en: "Access restricted portal apps." },               perms: ["view"],                   color: "#26547c" },
+];
+const PERM_LABEL = {
+  pt: { manage: "Gerenciar", deploy: "Deploy", view: "Visualizar" },
+  en: { manage: "Manage",    deploy: "Deploy", view: "View" },
+};
+
+function AdminGroups({ t, loading, push, appAccess }) {
+  const lang = t._lang;
+  const [sel, setSel] = a3S(null); // selected group id for detail
+  const APPS = window.RK.APPS;
+
+  const groupMembers = (gid) => SEED_USERS.filter((u) => u.groups.includes(gid));
+  const groupApps = (gid) => APPS.filter((a) => {
+    const ag = appAccess ? (appAccess.get(a.id) || a.accessGroups || []) : (a.accessGroups || []);
+    return ag.includes(gid);
+  });
+  const publicApps = APPS.filter((a) => {
+    const ag = appAccess ? (appAccess.get(a.id) || a.accessGroups || []) : (a.accessGroups || []);
+    return ag.length === 0;
+  });
+
+  return (
+    <div className="mock-pad" style={{ paddingTop: 16, paddingBottom: 40 }}>
+      <div style={{ display: "flex", alignItems: "flex-end", justifyContent: "space-between", gap: 16, marginBottom: 18 }}>
+        <div>
+          <div className="page-title">{lang === "pt" ? "Grupos" : "Groups"}</div>
+          <div className="page-sub">{lang === "pt" ? "Papéis de acesso — apps podem pertencer a vários grupos" : "Access roles — apps can belong to multiple groups"}</div>
+        </div>
+        <button className="btn btn--primary" onClick={() => push(lang === "pt" ? "Novo grupo (em breve)" : "New group (soon)", "ti-plus")}><i className="ti ti-plus"></i>{lang === "pt" ? "Novo grupo" : "New group"}</button>
+      </div>
+
+      {loading ? <div className="groups-grid">{Array.from({ length: 3 }).map((_, i) => <A3.SkBlock key={i} w={"100%"} h={220} r={12} />)}</div> : (
+        <div className="groups-grid stagger">
+          {SEED_GROUPS.map((g, i) => {
+            const members = groupMembers(g.id);
+            const apps = groupApps(g.id);
+            const isOpen = sel === g.id;
+            return (
+              <div className={"group-card" + (isOpen ? " is-sel" : "")} key={g.id} style={{ animationDelay: Math.min(i, 10) * 30 + "ms" }}>
+                <div className="group-card__bar" style={{ background: g.color }}></div>
+                <div className="group-card__body">
+                  <div style={{ display: "flex", alignItems: "flex-start", justifyContent: "space-between" }}>
+                    <div className="group-card__name">{g.name[lang]}</div>
+                    <button className="star-toggle" style={{ marginTop: -2 }} onClick={() => setSel(isOpen ? null : g.id)}><i className={"ti " + (isOpen ? "ti-chevron-up" : "ti-chevron-down")} style={{ fontSize: 14 }}></i></button>
+                  </div>
+                  <div className="group-card__desc">{g.desc[lang]}</div>
+                  <div className="group-card__perms">{g.perms.map((p) => <span className="perm-tag" key={p}><i className="ti ti-check" style={{ fontSize: 11 }}></i>{PERM_LABEL[lang][p]}</span>)}</div>
+                  <div className="group-card__foot">
+                    <span><i className="ti ti-users"></i> {members.length} {lang === "pt" ? "membros" : "members"}</span>
+                    <span><i className="ti ti-apps"></i> {apps.length} apps</span>
+                    <button className="star-toggle" style={{ marginLeft: "auto" }} onClick={() => push((lang === "pt" ? "Editar grupo · " : "Edit group · ") + g.name[lang], "ti-pencil")}><i className="ti ti-pencil"></i></button>
+                  </div>
+
+                  {isOpen && (
+                    <div className="group-detail fade-in">
+                      <div className="group-detail__section">
+                        <div className="group-detail__label"><i className="ti ti-users"></i>{lang === "pt" ? "Membros" : "Members"}</div>
+                        <div style={{ display: "flex", flexDirection: "column", gap: 6 }}>
+                          {members.map((u) => (
+                            <div key={u.id} style={{ display: "flex", alignItems: "center", gap: 8, fontSize: 12 }}>
+                              <Avatar name={u.name} size={22} />
+                              <span style={{ fontWeight: 500 }}>{u.name}</span>
+                              <span className="faint mono" style={{ fontSize: 10.5 }}>{u.email}</span>
+                            </div>
+                          ))}
+                          {members.length === 0 && <span className="faint" style={{ fontSize: 12 }}>{lang === "pt" ? "Nenhum membro" : "No members"}</span>}
+                        </div>
+                      </div>
+                      <div className="group-detail__section">
+                        <div className="group-detail__label"><i className="ti ti-apps"></i>{lang === "pt" ? "Apps restritos a este grupo" : "Apps restricted to this group"}</div>
+                        <div style={{ display: "flex", flexWrap: "wrap", gap: 6 }}>
+                          {apps.map((a) => (
+                            <div key={a.id} style={{ display: "inline-flex", alignItems: "center", gap: 6, fontSize: 11.5, padding: "3px 8px", borderRadius: 8, background: "var(--surface-soft)", border: "0.5px solid var(--border)" }}>
+                              <A3.Logo app={a} size={16} radius={4} />{a.name}
+                            </div>
+                          ))}
+                          {apps.length === 0 && <span className="faint" style={{ fontSize: 12 }}>{lang === "pt" ? "Nenhum app exclusivo" : "No exclusive apps"}</span>}
+                        </div>
+                      </div>
+                    </div>
+                  )}
+                </div>
+              </div>
+            );
+          })}
+        </div>
+      )}
+
+      {/* Public apps section */}
+      <div style={{ marginTop: 26 }}>
+        <div className="rail-head" style={{ marginBottom: 12 }}>
+          <span className="rail-head__title"><i className="ti ti-world" style={{ fontSize: 17, color: "var(--teal-600)" }}></i>{lang === "pt" ? "Apps públicos" : "Public apps"}
+            <span style={{ fontSize: 11, fontWeight: 400, color: "var(--text-faint)", marginLeft: 6 }}>· {lang === "pt" ? "sem grupo = visíveis a todos" : "no group = visible to everyone"}</span>
+          </span>
+          <span className="rail-head__count">{publicApps.length}</span>
+          <span className="rail-head__line"></span>
+        </div>
+        <div style={{ display: "flex", flexWrap: "wrap", gap: 8 }}>
+          {publicApps.map((a) => (
+            <div key={a.id} style={{ display: "inline-flex", alignItems: "center", gap: 7, padding: "5px 10px 5px 7px", borderRadius: 9, background: "var(--surface)", border: "0.5px solid var(--border)", fontSize: 12 }}>
+              <A3.Logo app={a} size={20} radius={5} />{a.name}
+              <i className="ti ti-world" style={{ fontSize: 12, color: "var(--teal-600)", marginLeft: 2 }}></i>
+            </div>
+          ))}
+          {publicApps.length === 0 && <span className="faint" style={{ fontSize: 12 }}>{lang === "pt" ? "Nenhum app público." : "No public apps."}</span>}
+        </div>
+      </div>
+    </div>
+  );
+}
+
+/* ══════════════════════════════════════ AUDIT ══════════════════════ */
+const AUDIT_ACTIONS = {
+  "app.created":         { cat: "app",      icon: "ti-plus",     color: "#10b981" },
+  "app.updated":         { cat: "app",      icon: "ti-pencil",   color: "#3b82f6" },
+  "app.deleted":         { cat: "app",      icon: "ti-trash",    color: "#ef4444" },
+  "user.invited":        { cat: "user",     icon: "ti-user-plus",color: "#10b981" },
+  "user.suspended":      { cat: "user",     icon: "ti-user-x",   color: "#f59e0b" },
+  "credential.created":  { cat: "security", icon: "ti-key",      color: "#10b981" },
+  "credential.revoked":  { cat: "security", icon: "ti-ban",      color: "#ef4444" },
+  "auth.login":          { cat: "security", icon: "ti-login-2",  color: "#3b82f6" },
+  "appearance.published":{ cat: "config",   icon: "ti-palette",  color: "#7c3aed" },
+  "disk.pruned":         { cat: "config",   icon: "ti-eraser",   color: "#3b82f6" },
+};
+const SEED_AUDIT = [
+  { ts: "05/06 19:42:10", actor: "Ana Ribeiro",   action: "appearance.published", target: "portal",         ip: "200.17.12.4" },
+  { ts: "05/06 19:38:55", actor: "Carlos Mendes", action: "app.updated",          target: "streamlit",      ip: "200.17.12.9" },
+  { ts: "05/06 18:20:03", actor: "Ana Ribeiro",   action: "user.invited",         target: "diego@ufpe.br",  ip: "200.17.12.4" },
+  { ts: "05/06 17:05:41", actor: "sistema",       action: "disk.pruned",          target: "3 imgs · 2.3 GB",ip: "—" },
+  { ts: "05/06 16:11:22", actor: "Beatriz Lima",  action: "app.created",          target: "sales-dashboard",ip: "200.17.12.31" },
+  { ts: "05/06 15:48:09", actor: "Carlos Mendes", action: "credential.revoked",   target: "rk_live_3c0a",   ip: "200.17.12.9" },
+  { ts: "05/06 14:30:17", actor: "Ana Ribeiro",   action: "auth.login",           target: "admin",          ip: "200.17.12.4" },
+  { ts: "05/06 11:02:50", actor: "Felipe Araújo", action: "app.deleted",          target: "old-demo",       ip: "187.4.55.2" },
+  { ts: "04/06 22:14:33", actor: "Ana Ribeiro",   action: "credential.created",   target: "CI / Deploy",    ip: "200.17.12.4" },
+  { ts: "04/06 20:55:08", actor: "sistema",       action: "user.suspended",       target: "felipe@ufpe.br", ip: "—" },
+];
+const CAT_LABEL = {
+  pt: { app: "Apps", user: "Usuários", security: "Segurança", config: "Configuração" },
+  en: { app: "Apps", user: "Users",    security: "Security",   config: "Config" },
+};
+
+function AdminAudit({ t, loading, push }) {
+  const lang = t._lang;
+  const [q, setQ] = a3S("");
+  const [cat, setCat] = a3S("all");
+  const shown = SEED_AUDIT.filter((e) => {
+    if (cat !== "all" && AUDIT_ACTIONS[e.action].cat !== cat) return false;
+    if (q.trim() && !(e.actor + " " + e.action + " " + e.target).toLowerCase().includes(q.trim().toLowerCase())) return false;
+    return true;
+  });
+  const Chip = ({ k, label }) => <button className={"chip" + (cat === k ? " on-all" : "")} onClick={() => setCat(cat === k ? "all" : k)}>{label}</button>;
+  return (
+    <div className="mock-pad" style={{ paddingTop: 16, paddingBottom: 40 }}>
+      <div style={{ display: "flex", alignItems: "flex-end", justifyContent: "space-between", gap: 16, marginBottom: 18 }}>
+        <div><div className="page-title">{lang === "pt" ? "Auditoria" : "Audit log"}</div><div className="page-sub">{lang === "pt" ? "Registro de ações administrativas" : "Record of administrative actions"}</div></div>
+        <button className="btn" onClick={() => push(lang === "pt" ? "Exportando CSV…" : "Exporting CSV…", "ti-download")}><i className="ti ti-download"></i>{lang === "pt" ? "Exportar" : "Export"}</button>
+      </div>
+      <div className="admin-sticky">
+        <div style={{ display: "flex", alignItems: "center", gap: 10, flexWrap: "wrap" }}>
+          <div className="search-pill" style={{ maxWidth: 280, flex: "0 1 280px", padding: "8px 14px" }}>
+            <i className="ti ti-search"></i>
+            <input value={q} onChange={(e) => setQ(e.target.value)} placeholder={lang === "pt" ? "Buscar evento, ator, alvo…" : "Search event, actor, target…"} />
+          </div>
+          <Chip k="app" label={CAT_LABEL[lang].app} />
+          <Chip k="user" label={CAT_LABEL[lang].user} />
+          <Chip k="security" label={CAT_LABEL[lang].security} />
+          <Chip k="config" label={CAT_LABEL[lang].config} />
+          <div style={{ flex: 1 }}></div>
+          <span className="faint tnum" style={{ fontSize: 11 }}>{shown.length} {lang === "pt" ? "eventos" : "events"}</span>
+        </div>
+      </div>
+      {loading ? <div style={{ marginTop: 12 }}><A3.SkBlock w={"100%"} h={340} r={12} /></div> : (
+        <table className="admin-table" style={{ marginTop: 12 }}>
+          <thead><tr>
+            <th style={{ width: 140 }}>{lang === "pt" ? "Quando" : "When"}</th>
+            <th style={{ width: 170 }}>{lang === "pt" ? "Ator" : "Actor"}</th>
+            <th style={{ width: 200 }}>{lang === "pt" ? "Ação" : "Action"}</th>
+            <th>{lang === "pt" ? "Alvo" : "Target"}</th>
+            <th style={{ width: 120 }}>IP</th>
+          </tr></thead>
+          <tbody>
+            {shown.map((e, i) => {
+              const a = AUDIT_ACTIONS[e.action];
+              return (
+                <tr key={i}>
+                  <td className="mono faint" style={{ fontSize: 11 }}>{e.ts}</td>
+                  <td>{e.actor === "sistema" || e.actor === "system"
+                    ? <span style={{ display: "inline-flex", alignItems: "center", gap: 8, color: "var(--text-muted)" }}><span className="rk-avatar" style={{ width: 26, height: 26, background: "var(--surface-soft)", color: "var(--text-faint)" }}><i className="ti ti-robot" style={{ fontSize: 13 }}></i></span>{lang === "pt" ? "sistema" : "system"}</span>
+                    : <span style={{ display: "inline-flex", alignItems: "center", gap: 8 }}><Avatar name={e.actor} size={26} />{e.actor}</span>}</td>
+                  <td><span className="audit-action" style={{ color: a.color }}><i className={"ti " + a.icon}></i><code className="mono">{e.action}</code></span></td>
+                  <td className="mono muted" style={{ fontSize: 11.5 }}>{e.target}</td>
+                  <td className="mono faint" style={{ fontSize: 11 }}>{e.ip}</td>
+                </tr>
+              );
+            })}
+            {shown.length === 0 && <tr><td colSpan={5} style={{ textAlign: "center", color: "var(--text-faint)", padding: 30, fontSize: 12 }}>{lang === "pt" ? "Nenhum evento." : "No events."}</td></tr>}
+          </tbody>
+        </table>
+      )}
+    </div>
+  );
+}
+
+window.RKAdmin3 = { AdminUsers, AdminGroups, AdminAudit };

--- a/docs/design-handoff/src/app.jsx
+++ b/docs/design-handoff/src/app.jsx
@@ -1,0 +1,276 @@
+/* global React, ReactDOM, window */
+const { useState: aS, useEffect: aE, useRef: aR } = React;
+const AC = window.RKC;
+
+const VARIATIONS = {
+  portal: [
+    { k: "a", label: { pt: "Refinado", en: "Refined" } },
+    { k: "b", label: { pt: "Compacto", en: "Compact" } },
+    { k: "c", label: { pt: "Seções", en: "Sections" } },
+  ],
+  dashboard: [
+    { k: "a", label: { pt: "Agrupado", en: "Grouped" } },
+    { k: "b", label: { pt: "Cards", en: "Cards" } },
+    { k: "c", label: { pt: "Operações", en: "Ops" } },
+  ],
+};
+
+function load(key, def) { try { return localStorage.getItem("rk_" + key) || def; } catch (e) { return def; } }
+function save(key, v) { try { localStorage.setItem("rk_" + key, v); } catch (e) {} }
+
+function App() {
+  // migrate legacy "dashboard" screen value → admin + dashboard sub-page
+  const legacy = load("screen", "portal");
+  const [screen, setScreen] = aS(() => (legacy === "dashboard" ? "admin" : legacy));
+  const [adminPage, setAdminPage] = aS(() => load("apage", "dashboard"));
+  const [editApp, setEditApp] = aS(null); // {app, isNew} | null
+  const [variation, setVariation] = aS(() => load("var", "a"));
+  const [theme, setTheme] = aS(() => load("theme", "light"));
+  const [lang, setLang] = aS(() => load("lang", "pt"));
+  const [loading, setLoading] = aS(true);
+  const [prog, setProg] = aS(0);
+  const [barOn, setBarOn] = aS(false);
+  const [push, toastNode] = AC.useToasts();
+  // Shared favorite/featured state — starred apps surface in the portal's
+  // Featured carousel and in the Appearance preview.
+  const [featured, setFeatured] = aS(() => new Set(window.RK.APPS.filter((a) => a.featured).map((a) => a.id)));
+  const toggleFeatured = (id) => setFeatured((s) => { const n = new Set(s); n.has(id) ? n.delete(id) : n.add(id); return n; });
+
+  // Shared app-access state: Map<appId, string[]>  [] = public, else restricted to group ids
+  const [appAccess, setAppAccess] = aS(() => {
+    const m = new Map();
+    window.RK.APPS.forEach((a) => m.set(a.id, a.accessGroups || []));
+    return m;
+  });
+  const setAccess = (id, groups) => setAppAccess((m) => { const n = new Map(m); n.set(id, groups); return n; });
+
+  // Simulated portal user (null = anonymous)
+  const [portalUser, setPortalUser] = aS(null);
+
+  // Portal appearance config — shared between Appearance (editor) and Portal (renderer)
+  const [portalCfg, setPortalCfg] = aS({
+    title: "Ruscker",
+    tagline: "Catálogo de aplicações e APIs",
+    accent: "#0f6e56",
+    theme: "light",
+    layout: "grid",
+    featured: true,
+    showAccess: true,
+    showSearch: true,
+    density: "comfortable",
+    footer: "v0.1.45 · Ruscker",
+    logo: "wordmark",
+    logoUrl: "assets/ruscker-mark.svg",
+    logoSize: 28,
+    logoGap: 8,
+    footerLogo: null,
+    footerLogoSize: 14,
+    footerLogoGap: 7,
+    hero: "soft",
+    cover: "tint",
+    seoTitle: "Ruscker — Portal de aplicações",
+    seoDesc: "Acesse aplicações e APIs interativas hospedadas com Ruscker.",
+    ogImage: "assets/ruscker-mark.svg",
+    analytics: "none",
+    analyticsId: "",
+    respectDnt: true,
+    customCss: "/* CSS aplicado ao portal público */\n.rcard { border-radius: 14px; }",
+    htmlTop: "",
+    htmlAfterFeatured: "",
+    htmlBeforeFooter: "",
+    htmlFooter: "",
+  });
+
+  const timers = aR([]);
+
+  aE(() => { document.documentElement.setAttribute("data-theme", theme); save("theme", theme); }, [theme]);
+  aE(() => save("lang", lang), [lang]);
+  aE(() => save("screen", screen), [screen]);
+  aE(() => save("apage", adminPage), [adminPage]);
+  aE(() => save("var", variation), [variation]);
+
+  const runLoad = (p0) => {
+    timers.current.forEach(clearTimeout);
+    setLoading(true); setBarOn(true); setProg(p0);
+    const T = [];
+    T.push(setTimeout(() => setProg(58), 110));
+    T.push(setTimeout(() => setProg(86), 300));
+    T.push(setTimeout(() => setProg(100), 560));
+    T.push(setTimeout(() => setLoading(false), 600));
+    T.push(setTimeout(() => { setBarOn(false); setProg(0); }, 880));
+    timers.current = T;
+  };
+
+  // Loading sequence — the core "perceived speed" demo
+  aE(() => { runLoad(10); return () => timers.current.forEach(clearTimeout); }, [screen, variation, adminPage]);
+  const reload = () => runLoad(12);
+
+  // navigating the admin nav clears any open form
+  const goAdmin = (p) => { setEditApp(null); setAdminPage(p); };
+
+  const t = { ...window.RK.I18N[lang], _lang: lang };
+
+  // variation only applies to portal & the admin dashboard
+  const inForm = screen === "admin" && (adminPage === "editor" || adminPage === "import");
+  const hasVars = screen === "portal" || (screen === "admin" && adminPage === "dashboard");
+  const vars = screen === "portal" ? VARIATIONS.portal : VARIATIONS.dashboard;
+  const curVar = vars.map((v) => v.k).includes(variation) ? variation : "a";
+
+  const openApp = (app) => push((lang === "pt" ? "Abrindo " : "Opening ") + app.name + "…", "ti-external-link");
+  const onEdit = (app, isNew) => { setEditApp({ app, isNew: !!isNew }); setAdminPage("editor"); };
+  const onImport = () => { setEditApp(null); setAdminPage("import"); };
+  const closeForm = () => setAdminPage("apps");
+
+  return (
+    <div className="proto-shell">
+      <div className={"topbar-progress" + (barOn ? " is-active" : "")} style={{ width: prog + "%" }}></div>
+
+      {/* ── Prototype chrome ── */}
+      <div className="proto-bar">
+        <div className="proto-bar__brand">
+          <img src="assets/ruscker-mark.svg" alt="" />
+          <span className="wm">ruscker</span>
+          <span className="tag">UX proto</span>
+        </div>
+
+        <div className="proto-group">
+          <span className="proto-label">{lang === "pt" ? "Tela" : "Screen"}</span>
+          <div className="seg">
+            <button className={screen === "portal" ? "on" : ""} onClick={() => setScreen("portal")}><i className="ti ti-layout-grid"></i>{t.portal}</button>
+            <button className={screen === "admin" ? "on" : ""} onClick={() => setScreen("admin")}><i className="ti ti-server-cog"></i>Admin</button>
+          </div>
+        </div>
+
+        {hasVars && (
+          <div className="proto-group">
+            <span className="proto-label">{lang === "pt" ? "Variação" : "Variation"}</span>
+            <div className="seg seg--teal">
+              {vars.map((v) => (
+                <button key={v.k} className={curVar === v.k ? "on" : ""} onClick={() => setVariation(v.k)}>
+                  {v.k.toUpperCase()} · {v.label[lang]}
+                </button>
+              ))}
+            </div>
+          </div>
+        )}
+
+        <div className="proto-bar__spacer"></div>
+
+        <button className="icon-btn" title={lang === "pt" ? "Recarregar (ver skeletons)" : "Reload (replay skeletons)"} onClick={reload}><i className="ti ti-refresh"></i></button>
+        <button className="icon-btn" title={lang === "pt" ? "Tema" : "Theme"} onClick={() => setTheme(theme === "dark" ? "light" : "dark")}>
+          <i className={"ti " + (theme === "dark" ? "ti-moon" : "ti-sun")}></i>
+        </button>
+        <button className="icon-btn lang" title="Idioma / Language" onClick={() => setLang(lang === "pt" ? "en" : "pt")}>{lang.toUpperCase()}</button>
+      </div>
+
+      {/* ── Mock product ── */}
+      <div className="proto-stage" style={screen === "portal" && portalCfg ? { "--teal-600": portalCfg.accent, "--teal-400": portalCfg.accent } : null}>
+        <MockHeader screen={screen} adminPage={adminPage} setAdminPage={goAdmin} setScreen={setScreen}
+          t={t} lang={lang} theme={theme} setTheme={setTheme} setLang={setLang} push={push} inForm={inForm} portalCfg={portalCfg} />
+        <div className="mock">
+          {screen === "portal" && <window.RKPortal variation={curVar} t={t} loading={loading} onOpen={openApp} featured={featured} appAccess={appAccess} portalUser={portalUser} setPortalUser={setPortalUser} portalCfg={portalCfg} />}
+          {screen === "admin" && adminPage === "dashboard" && <window.RKDashboard variation={curVar} t={t} loading={loading} push={push} />}
+          {screen === "admin" && adminPage === "apps" && <window.RKAdmin.AdminApps t={t} loading={loading} push={push} onEdit={onEdit} onImport={onImport} featured={featured} toggleFeatured={toggleFeatured} appAccess={appAccess} setAccess={setAccess} />}
+          {screen === "admin" && adminPage === "media" && <window.RKAdmin.AdminMedia t={t} loading={loading} push={push} />}
+          {screen === "admin" && adminPage === "appearance" && <window.RKAppearance t={t} loading={loading} push={push} featured={featured} portalCfg={portalCfg} setPortalCfg={setPortalCfg} />}
+          {screen === "admin" && adminPage === "disk" && <window.RKAdmin2.AdminDisk t={t} loading={loading} push={push} />}
+          {screen === "admin" && adminPage === "users" && <window.RKAdmin3.AdminUsers t={t} loading={loading} push={push} appAccess={appAccess} />}
+          {screen === "admin" && adminPage === "groups" && <window.RKAdmin3.AdminGroups t={t} loading={loading} push={push} appAccess={appAccess} />}
+          {screen === "admin" && adminPage === "audit" && <window.RKAdmin3.AdminAudit t={t} loading={loading} push={push} />}
+          {screen === "admin" && adminPage === "credentials" && <window.RKAdmin2.AdminCredentials t={t} loading={loading} push={push} />}
+          {screen === "admin" && adminPage === "logs" && <window.RKAdmin2.AdminLogs t={t} loading={loading} push={push} />}
+          {screen === "admin" && adminPage === "editor" && <window.RKForms.AppEditor t={t} app={(editApp && editApp.app) || window.RK.APPS[0]} isNew={editApp ? editApp.isNew : true} onClose={closeForm} push={push} appAccess={appAccess} setAccess={setAccess} />}
+          {screen === "admin" && adminPage === "import" && <window.RKForms.ImportYaml t={t} onClose={closeForm} push={push} />}
+        </div>
+        <Footer screen={screen} />
+      </div>
+
+      {toastNode}
+    </div>
+  );
+}
+
+function MockHeader({ screen, adminPage, setAdminPage, setScreen, t, lang, theme, setTheme, setLang, push, inForm, portalCfg }) {
+  const ThemeLang = (
+    <React.Fragment>
+      <button className="chrome-icon" onClick={() => setTheme(theme === "dark" ? "light" : "dark")}><i className={"ti " + (theme === "dark" ? "ti-moon" : "ti-sun")}></i></button>
+      <button className="chrome-icon lang" style={{ fontSize: 11, fontWeight: 600 }} onClick={() => setLang(lang === "pt" ? "en" : "pt")}>{lang.toUpperCase()}</button>
+    </React.Fragment>
+  );
+
+  if (screen === "portal") {
+    const cfg = portalCfg || {};
+    const heroBg = cfg.hero === "bold"
+      ? `linear-gradient(150deg, ${cfg.accent||"var(--teal-600)"}, color-mix(in srgb, ${cfg.accent||"var(--teal-600)"} 45%, #000))`
+      : cfg.hero === "soft"
+      ? `linear-gradient(160deg, color-mix(in srgb, ${cfg.accent||"var(--teal-600)"} 20%, transparent), transparent 80%)`
+      : "transparent";
+    const heroInk = cfg.hero === "bold" ? "#fff" : "inherit";
+    const showLogo = cfg.logo !== "mark";
+    const logoSrc = cfg.logo === "custom" && cfg.logoUrl ? cfg.logoUrl : "assets/ruscker-mark.svg";
+    return (
+      <div className="lhead" style={{ background: heroBg, color: heroInk }}>
+        <div className="lhead__brand" style={{ gap: cfg.logoGap || 8, alignItems: "center" }}>
+          <img src={logoSrc} alt="" style={{ width: cfg.logoSize || 28, height: cfg.logoSize || 28, display: "block", flexShrink: 0 }} />
+          {showLogo && (
+            <div>
+              <span className="wm" style={{ color: heroInk, fontSize: 17, fontWeight: 700, letterSpacing: "-0.02em" }}>{cfg.title || "Ruscker"}</span>
+              {cfg.tagline && <div style={{ fontSize: 11, opacity: 0.6, lineHeight: 1.2, marginTop: 1 }}>{cfg.tagline}</div>}
+            </div>
+          )}
+        </div>
+        <div className="lhead__right">
+          {ThemeLang}
+          <button className="chrome-signin" style={cfg.hero === "bold" ? { borderColor: "rgba(255,255,255,.5)", color: "#fff" } : null} onClick={() => push(t.signin + "…", "ti-login-2")}><i className="ti ti-login-2"></i>{t.signin}</button>
+        </div>
+      </div>
+    );
+  }
+
+  // admin top nav — all pages functional
+  const items = [
+    { id: "dashboard", icon: "ti-activity", label: lang === "pt" ? "Painel" : "Dashboard" },
+    { id: "apps", icon: "ti-apps", label: "Apps" },
+    { id: "appearance", icon: "ti-palette", label: lang === "pt" ? "Aparência" : "Appearance" },
+    { id: "media", icon: "ti-photo", label: lang === "pt" ? "Mídia" : "Media" },
+    { id: "disk", icon: "ti-database", label: lang === "pt" ? "Disco" : "Disk" },
+    { id: "users", icon: "ti-users", label: lang === "pt" ? "Usuários" : "Users" },
+    { id: "groups", icon: "ti-users-group", label: lang === "pt" ? "Grupos" : "Groups" },
+    { id: "credentials", icon: "ti-key", label: lang === "pt" ? "Credenciais" : "Credentials" },
+    { id: "audit", icon: "ti-history", label: lang === "pt" ? "Auditoria" : "Audit" },
+    { id: "logs", icon: "ti-terminal-2", label: "Logs" },
+  ];
+  // editor/import are sub-pages of Apps — keep Apps highlighted there
+  const activeId = inForm ? "apps" : adminPage;
+  return (
+    <div className="lhead" style={{ borderBottom: "0.5px solid var(--border)", paddingTop: 11, paddingBottom: 11 }}>
+      <div style={{ display: "flex", alignItems: "center", gap: 16, minWidth: 0 }}>
+        <button className="lhead__brand" style={{ border: 0, background: "transparent", cursor: "pointer", padding: 0 }} onClick={() => setScreen("portal")} title={lang === "pt" ? "Voltar ao portal" : "Back to portal"}>
+          <img src="assets/ruscker-mark.svg" alt="" style={{ width: 22, height: 22 }} /><span className="wm" style={{ fontSize: 15 }}>ruscker · admin</span>
+        </button>
+        <nav style={{ display: "flex", gap: 2, flexWrap: "wrap" }}>
+          {items.map((it) => (
+            <button key={it.id}
+              className={"admin-nav" + (activeId === it.id ? " on" : "")}
+              onClick={() => setAdminPage(it.id)}>
+              <i className={"ti " + it.icon}></i>{it.label}
+            </button>
+          ))}
+          <button className="admin-nav" onClick={() => setScreen("portal")}><i className="ti ti-external-link"></i>Portal</button>
+        </nav>
+      </div>
+      <div className="lhead__right">{ThemeLang}<button className="chrome-icon"><i className="ti ti-user"></i></button></div>
+    </div>
+  );
+}
+
+function Footer({ screen }) {
+  return (
+    <div className="mock-foot mock-pad" style={{ maxWidth: 1180 }}>
+      <span>v0.1.45</span>
+      <span className="v"><img src="assets/ruscker-mark.svg" alt="" />{screen === "portal" ? "Ruscker" : "ruscker · admin"}</span>
+    </div>
+  );
+}
+
+ReactDOM.createRoot(document.getElementById("root")).render(<App />);

--- a/docs/design-handoff/src/appearance.jsx
+++ b/docs/design-handoff/src/appearance.jsx
@@ -1,0 +1,557 @@
+/* global React, window */
+// ── Admin: Landing/Portal appearance configurator (live preview) ──
+const { useState: apS, useRef: apR } = React;
+const AP = window.RKC;
+
+const BRAND_COLORS = ["#0f6e56", "#447099", "#26547c", "#059487", "#ef476f", "#7c3aed"];
+
+// Media assets available to pick from (mirrors the Media library):
+// the Ruscker mark + every unique app logo.
+function mediaAssets() {
+  const seen = new Set();
+  const list = [{ id: "ruscker-mark", name: "ruscker-mark.svg", src: "assets/ruscker-mark.svg", accent: "#0f6e56", mono: "Ru" }];
+  seen.add("assets/ruscker-mark.svg");
+  window.RK.APPS.forEach((a) => {
+    if (a.logo && !seen.has(a.logo)) { seen.add(a.logo); list.push({ id: a.id, name: a.id + ".svg", src: a.logo, accent: a.accent, mono: a.mono }); }
+  });
+  return list;
+}
+
+function MediaPicker({ value, onPick, lang }) {
+  const items = mediaAssets();
+  return (
+    <div className="media-picker">
+      {items.map((m) => (
+        <button key={m.id} className={"media-pick" + (value === m.src ? " on" : "")} title={m.name} onClick={() => onPick(m.src)}
+          style={{ background: `color-mix(in srgb, ${m.accent} 9%, var(--surface-soft))` }}>
+          <img src={m.src} alt={m.name} onError={(e) => { e.target.style.display = "none"; }} />
+          {value === m.src && <span className="media-pick__check"><i className="ti ti-check"></i></span>}
+        </button>
+      ))}
+    </div>
+  );
+}
+
+function Appearance({ t, loading, push, featured, portalCfg, setPortalCfg }) {
+  const lang = t._lang;
+  const cfg = portalCfg;
+  const set = (k, v) => setPortalCfg((c) => ({ ...c, [k]: v }));
+
+  const layouts = [
+    { k: "grid", icon: "ti-layout-grid", label: lang === "pt" ? "Grade" : "Grid" },
+    { k: "list", icon: "ti-list", label: lang === "pt" ? "Lista" : "List" },
+    { k: "sections", icon: "ti-layout-rows", label: lang === "pt" ? "Seções" : "Sections" },
+  ];
+
+  if (loading) {
+    return <div className="mock-pad" style={{ paddingTop: 16 }}><AP.SkBlock w={"100%"} h={420} r={12} /></div>;
+  }
+
+  return (
+    <div className="mock-pad" style={{ paddingTop: 16, paddingBottom: 40 }}>
+      <div style={{ display: "flex", alignItems: "flex-end", justifyContent: "space-between", gap: 16, marginBottom: 22 }}>
+        <div>
+          <div className="page-title">{lang === "pt" ? "Aparência do portal" : "Portal appearance"}</div>
+          <div className="page-sub">{lang === "pt" ? "Configure como o portal público é exibido aos visitantes" : "Configure how the public portal looks to visitors"}</div>
+        </div>
+        <div style={{ display: "flex", gap: 8 }}>
+          <button className="btn btn--primary" onClick={() => push(lang === "pt" ? "Aparência publicada" : "Appearance published", "ti-check")}><i className="ti ti-device-floppy"></i>{lang === "pt" ? "Publicar" : "Publish"}</button>
+        </div>
+      </div>
+
+      <div className="appear-grid">
+        {/* ── controls ── */}
+        <div className="editor-form">
+          <div className="form-section">
+            <div className="form-section__title">{lang === "pt" ? "Identidade" : "Identity"}</div>
+            <label className="form-field"><span className="form-label">{lang === "pt" ? "Título do portal" : "Portal title"}</span>
+              <input className="form-input" value={cfg.title} onChange={(e) => set("title", e.target.value)} /></label>
+            <label className="form-field"><span className="form-label">{lang === "pt" ? "Subtítulo" : "Tagline"}</span>
+              <input className="form-input" value={cfg.tagline} onChange={(e) => set("tagline", e.target.value)} /></label>
+            <label className="form-field"><span className="form-label">{lang === "pt" ? "Rodapé" : "Footer"}</span>
+              <input className="form-input mono" value={cfg.footer} onChange={(e) => set("footer", e.target.value)} /></label>
+            <div className="toggle-row" style={{ borderBottom: 0, paddingBottom: 0 }} onClick={() => set("footerLogo", cfg.footerLogo ? null : "assets/ruscker-mark.svg")}>
+              <div><div className="toggle-row__label">{lang === "pt" ? "Logo no rodapé" : "Footer logo"}</div><div className="toggle-row__hint">{lang === "pt" ? "Exibe um logo da mídia ao lado do texto" : "Shows a media logo beside the text"}</div></div>
+              <span className={"switch" + (cfg.footerLogo ? " on" : "")}><span className="switch__dot"></span></span>
+            </div>
+            {cfg.footerLogo && (
+              <div className="fade-in" style={{ marginTop: 12 }}>
+                <MediaPicker value={cfg.footerLogo} onPick={(src) => set("footerLogo", src)} lang={lang} />
+                <div style={{ marginTop: 14, display: "flex", flexDirection: "column", gap: 10 }}>
+                  <SizeSlider label={lang === "pt" ? "Tamanho" : "Size"} value={cfg.footerLogoSize} min={10} max={28} step={1} unit="px" onChange={(v) => set("footerLogoSize", v)} />
+                  <SizeSlider label={lang === "pt" ? "Margem" : "Margin"} value={cfg.footerLogoGap} min={0} max={20} step={1} unit="px" onChange={(v) => set("footerLogoGap", v)} />
+                </div>
+              </div>
+            )}
+          </div>
+
+          <div className="form-section">
+            <div className="form-section__title">{lang === "pt" ? "Cor da marca" : "Brand color"}</div>
+            <div className="swatches">
+              {BRAND_COLORS.map((c) => <button key={c} className={"swatch" + (cfg.accent === c ? " on" : "")} style={{ background: c }} onClick={() => set("accent", c)}></button>)}
+            </div>
+          </div>
+
+          <div className="form-section">
+            <div className="form-section__title">{lang === "pt" ? "Logo" : "Logo"}</div>
+            <div className="kind-picker" style={{ gridTemplateColumns: "1fr 1fr 1fr" }}>
+              {[["wordmark", lang === "pt" ? "Marca + nome" : "Mark + name", "ti-text-size"], ["mark", lang === "pt" ? "Só símbolo" : "Symbol only", "ti-square-rounded"], ["custom", lang === "pt" ? "Personalizado" : "Custom", "ti-photo"]].map(([k, lbl, ic]) => (
+                <button key={k} className={"kind-opt" + (cfg.logo === k ? " on" : "")} style={{ flexDirection: "column", gap: 6, padding: "12px 6px", fontSize: 11.5, ...(cfg.logo === k ? { borderColor: cfg.accent } : null) }} onClick={() => set("logo", k)}>
+                  <i className={"ti " + ic} style={{ fontSize: 18, color: cfg.logo === k ? cfg.accent : "var(--text-muted)" }}></i>{lbl}
+                </button>
+              ))}
+            </div>
+            {cfg.logo === "custom" && (
+              <div className="fade-in" style={{ marginTop: 12 }}>
+                <div className="form-label" style={{ marginBottom: 8, display: "flex", alignItems: "center", gap: 6 }}><i className="ti ti-photo" style={{ fontSize: 14, color: "var(--text-faint)" }}></i>{lang === "pt" ? "Escolher da biblioteca de mídia" : "Choose from media library"}</div>
+                <MediaPicker value={cfg.logoUrl} onPick={(src) => set("logoUrl", src)} lang={lang} />
+                <label className="form-field" style={{ marginTop: 12, marginBottom: 0 }}><span className="form-label" style={{ fontSize: 11, color: "var(--text-faint)" }}>{lang === "pt" ? "ou cole uma URL" : "or paste a URL"}</span>
+                  <input className="form-input mono" value={cfg.logoUrl} onChange={(e) => set("logoUrl", e.target.value)} placeholder="assets/logos/portal.svg" /></label>
+              </div>
+            )}
+            <div style={{ marginTop: 14, display: "flex", flexDirection: "column", gap: 10 }}>
+              <SizeSlider label={lang === "pt" ? "Tamanho do logo" : "Logo size"} value={cfg.logoSize} min={12} max={32} step={1} unit="px" onChange={(v) => set("logoSize", v)} />
+              <SizeSlider label={lang === "pt" ? "Margem do logo" : "Logo margin"} value={cfg.logoGap} min={0} max={20} step={1} unit="px" onChange={(v) => set("logoGap", v)} />
+            </div>
+          </div>
+
+          <div className="form-section">
+            <div className="form-section__title">{lang === "pt" ? "Fundo & gradientes" : "Background & gradients"}</div>
+            <Field label={lang === "pt" ? "Cabeçalho do portal" : "Portal header"}>
+              <div className="grad-picker">
+                {[["none", lang === "pt" ? "Liso" : "Flat"], ["soft", lang === "pt" ? "Suave" : "Soft"], ["bold", lang === "pt" ? "Vibrante" : "Bold"]].map(([k, lbl]) => (
+                  <button key={k} className={"grad-opt" + (cfg.hero === k ? " on" : "")} onClick={() => set("hero", k)}>
+                    <span className="grad-swatch" style={{ background: k === "none" ? "var(--surface-soft)" : k === "soft" ? `linear-gradient(135deg, color-mix(in srgb, ${cfg.accent} 22%, transparent), transparent)` : `linear-gradient(135deg, ${cfg.accent}, color-mix(in srgb, ${cfg.accent} 50%, #000))` }}></span>
+                    {lbl}
+                  </button>
+                ))}
+              </div>
+            </Field>
+            <Field label={lang === "pt" ? "Capa dos cards" : "Card covers"}>
+              <div className="seg" style={{ width: "100%" }}>
+                {[["tint", lang === "pt" ? "Tonalizado" : "Tinted"], ["gradient", lang === "pt" ? "Gradiente" : "Gradient"]].map(([k, lbl]) => (
+                  <button key={k} className={cfg.cover === k ? "on" : ""} style={{ flex: 1, justifyContent: "center" }} onClick={() => set("cover", k)}>{lbl}</button>
+                ))}
+              </div>
+            </Field>
+          </div>
+
+          <div className="form-section">
+            <div className="form-section__title">{lang === "pt" ? "Tema padrão" : "Default theme"}</div>
+            <div className="seg seg--teal" style={{ width: "100%" }}>
+              {[["light", lang === "pt" ? "Claro" : "Light", "ti-sun"], ["dark", lang === "pt" ? "Escuro" : "Dark", "ti-moon"], ["auto", "Auto", "ti-device-desktop"]].map(([k, lbl, ic]) => (
+                <button key={k} className={cfg.theme === k ? "on" : ""} style={{ flex: 1, justifyContent: "center" }} onClick={() => set("theme", k)}><i className={"ti " + ic}></i>{lbl}</button>
+              ))}
+            </div>
+          </div>
+
+          <div className="form-section">
+            <div className="form-section__title">{lang === "pt" ? "Layout do catálogo" : "Catalog layout"}</div>
+            <div className="kind-picker" style={{ gridTemplateColumns: "1fr 1fr 1fr" }}>
+              {layouts.map((l) => (
+                <button key={l.k} className={"kind-opt" + (cfg.layout === l.k ? " on" : "")} style={{ flexDirection: "column", gap: 6, padding: "12px 8px", ...(cfg.layout === l.k ? { borderColor: cfg.accent } : null) }} onClick={() => set("layout", l.k)}>
+                  <i className={"ti " + l.icon} style={{ fontSize: 20, color: cfg.layout === l.k ? cfg.accent : "var(--text-muted)" }}></i>{l.label}
+                </button>
+              ))}
+            </div>
+            <div className="seg" style={{ marginTop: 12, width: "100%" }}>
+              {[["comfortable", lang === "pt" ? "Confortável" : "Comfortable"], ["compact", lang === "pt" ? "Compacto" : "Compact"]].map(([k, lbl]) => (
+                <button key={k} className={cfg.density === k ? "on" : ""} style={{ flex: 1, justifyContent: "center" }} onClick={() => set("density", k)}>{lbl}</button>
+              ))}
+            </div>
+          </div>
+
+          <div className="form-section">
+            <div className="form-section__title">{lang === "pt" ? "Seções visíveis" : "Visible sections"}</div>
+            <Toggle label={lang === "pt" ? "Carrossel de destaques" : "Featured carousel"} on={cfg.featured} onClick={() => set("featured", !cfg.featured)} />
+            <Toggle label={lang === "pt" ? "Barra de busca" : "Search bar"} on={cfg.showSearch} onClick={() => set("showSearch", !cfg.showSearch)} />
+            <Toggle label={lang === "pt" ? "Filtros de acesso (livre/restrito)" : "Access filters (public/restricted)"} on={cfg.showAccess} onClick={() => set("showAccess", !cfg.showAccess)} last />
+          </div>
+
+          {/* SEO */}
+          <div className="form-section">
+            <div className="form-section__title"><i className="ti ti-search" style={{ fontSize: 13, marginRight: 6, verticalAlign: "-2px" }}></i>SEO</div>
+            <label className="form-field"><span className="form-label">{lang === "pt" ? "Título (meta)" : "Meta title"}</span>
+              <input className="form-input" value={cfg.seoTitle} onChange={(e) => set("seoTitle", e.target.value)} maxLength={70} />
+              <div className={"char-count" + (cfg.seoTitle.length > 60 ? " over" : "")}>{cfg.seoTitle.length}/60</div>
+            </label>
+            <label className="form-field"><span className="form-label">{lang === "pt" ? "Descrição (meta)" : "Meta description"}</span>
+              <textarea className="form-input" rows={3} value={cfg.seoDesc} onChange={(e) => set("seoDesc", e.target.value)} maxLength={200}></textarea>
+              <div className={"char-count" + (cfg.seoDesc.length > 160 ? " over" : "")}>{cfg.seoDesc.length}/160</div>
+            </label>
+            <div className="form-label" style={{ marginBottom: 8 }}>{lang === "pt" ? "Imagem de compartilhamento (OG)" : "Share image (OG)"}</div>
+            <MediaPicker value={cfg.ogImage} onPick={(src) => set("ogImage", src)} lang={lang} />
+            <div className="form-label" style={{ margin: "16px 0 6px", fontSize: 11, color: "var(--text-faint)" }}>{lang === "pt" ? "Prévia no Google" : "Google preview"}</div>
+            <div className="serp">
+              <div className="serp__url"><i className="ti ti-world"></i>ruscker.app › portal</div>
+              <div className="serp__title">{cfg.seoTitle || cfg.title}</div>
+              <div className="serp__desc">{cfg.seoDesc}</div>
+            </div>
+          </div>
+
+          {/* Analytics */}
+          <div className="form-section">
+            <div className="form-section__title"><i className="ti ti-chart-bar" style={{ fontSize: 13, marginRight: 6, verticalAlign: "-2px" }}></i>Analytics</div>
+            <div className="provider-grid">
+              {[["none", lang === "pt" ? "Nenhum" : "None", "ti-circle-off"], ["ga", "Google Analytics", "ti-brand-google"], ["plausible", "Plausible", "ti-chart-dots"], ["matomo", "Matomo", "ti-chart-area"]].map(([k, lbl, ic]) => (
+                <button key={k} className={"kind-opt" + (cfg.analytics === k ? " on" : "")} style={{ padding: "10px 12px", fontSize: 12, ...(cfg.analytics === k ? { borderColor: cfg.accent } : null) }} onClick={() => set("analytics", k)}>
+                  <i className={"ti " + ic} style={{ fontSize: 16, color: cfg.analytics === k ? cfg.accent : "var(--text-muted)" }}></i>{lbl}
+                </button>
+              ))}
+            </div>
+            {cfg.analytics !== "none" && (
+              <div className="fade-in" style={{ marginTop: 14 }}>
+                <label className="form-field"><span className="form-label">{cfg.analytics === "ga" ? "Measurement ID" : cfg.analytics === "plausible" ? (lang === "pt" ? "Domínio" : "Domain") : "Site ID"}</span>
+                  <input className="form-input mono" value={cfg.analyticsId} onChange={(e) => set("analyticsId", e.target.value)} placeholder={cfg.analytics === "ga" ? "G-XXXXXXX" : cfg.analytics === "plausible" ? "ruscker.app" : "1"} /></label>
+                <Toggle label={lang === "pt" ? "Respeitar Do Not Track" : "Respect Do Not Track"} on={cfg.respectDnt} onClick={() => set("respectDnt", !cfg.respectDnt)} last />
+              </div>
+            )}
+          </div>
+
+          {/* Custom CSS */}
+          <div className="form-section">
+            <div className="form-section__title"><i className="ti ti-brand-css3" style={{ fontSize: 13, marginRight: 6, verticalAlign: "-2px" }}></i>{lang === "pt" ? "CSS customizado" : "Custom CSS"}</div>
+            <div className="toggle-row__hint" style={{ marginBottom: 10 }}>{lang === "pt" ? "Injetado no final do portal público. Use com cuidado." : "Injected at the end of the public portal. Use with care."}</div>
+            <CodeEditor mode="css" minHeight={140}
+              placeholder={lang === "pt" ? "/* CSS aplicado ao portal público */" : "/* CSS applied to the public portal */"}
+              value={cfg.customCss} onChange={(v) => set("customCss", v)} />
+          </div>
+
+          {/* ── HTML Blocks ── */}
+          <div className="form-section">
+            <div className="form-section__title">
+              <i className="ti ti-code" style={{ fontSize: 13, marginRight: 6, verticalAlign: "-2px" }}></i>
+              {lang === "pt" ? "Blocos HTML" : "HTML blocks"}
+            </div>
+            <div className="toggle-row__hint" style={{ marginBottom: 14 }}>
+              {lang === "pt"
+                ? "Injete HTML em posições-chave do portal. Útil para banners, avisos, integrações e widgets."
+                : "Inject HTML at key positions in the portal. Useful for banners, notices, integrations and widgets."}
+            </div>
+            {[
+              { key: "htmlTop",           icon: "ti-layout-navbar",                  label: lang === "pt" ? "Abaixo do cabeçalho (antes dos destaques)" : "Below header (before featured)" },
+              { key: "htmlAfterFeatured",  icon: "ti-layout-distribute-horizontal",   label: lang === "pt" ? "Após destaques (antes da busca)" : "After featured (before search)" },
+              { key: "htmlBeforeFooter",   icon: "ti-layout-bottombar",               label: lang === "pt" ? "Antes do rodapé (após o catálogo)" : "Before footer (after catalog)" },
+              { key: "htmlFooter",         icon: "ti-layout-bottombar-filled",        label: lang === "pt" ? "Dentro do rodapé" : "Inside footer" },
+            ].map(({ key, icon, label }) => (
+              <HtmlBlock key={key} label={label} icon={icon} val={cfg[key] || ""} lang={lang}
+                onChange={(v) => set(key, v)} />
+            ))}
+          </div>
+        </div>
+
+        {/* ── live portal preview ── */}
+        <div className="editor-preview">
+          <div className="editor-preview__sticky" style={{ padding: 0, overflow: "hidden" }}>
+            <div className="prev-toolbar"><span className="prev-dot"></span><span className="prev-dot"></span><span className="prev-dot"></span><span style={{ marginLeft: 8, fontSize: 11, color: "var(--text-faint)" }} className="mono">portal · {lang === "pt" ? "pré-visualização" : "preview"}</span></div>
+            <PortalPreview cfg={cfg} t={t} featured={featured} />
+          </div>
+          <div className="preview-note">{lang === "pt" ? "Mudanças aparecem aqui na hora. Publique para aplicar." : "Changes appear here instantly. Publish to apply."}</div>
+        </div>
+      </div>
+    </div>
+  );
+}
+
+function Toggle({ label, on, onClick, last }) {
+  return (
+    <div className="toggle-row" style={last ? { borderBottom: 0 } : null} onClick={onClick}>
+      <div className="toggle-row__label">{label}</div>
+      <span className={"switch" + (on ? " on" : "")}><span className="switch__dot"></span></span>
+    </div>
+  );
+}
+
+function SizeSlider({ label, value, min, max, step, unit, onChange }) {
+  return (
+    <div className="res-row" style={{ gridTemplateColumns: "110px 1fr 56px", margin: 0 }}>
+      <span className="res-row__k" style={{ fontSize: 12 }}>{label}</span>
+      <input type="range" min={min} max={max} step={step} value={value} className="rk-range" onChange={(e) => onChange(parseInt(e.target.value, 10))} />
+      <span className="res-row__v tnum">{value}{unit}</span>
+    </div>
+  );
+}
+
+/* ── Mini featured carousel — chevron navigation, no scroll,
+   mirrors the real Portal FeaturedCarousel ── */
+function PvFeatCarousel({ apps, cfg, lang }) {
+  const [page, setPage] = apS(0);
+  const per = 3; // cards visible at once in the preview width
+  const pages = Math.ceil(apps.length / per);
+  const slice = apps.slice(page * per, page * per + per);
+  return (
+    <div style={{ marginBottom: 10 }}>
+      <div style={{ display: "flex", alignItems: "center", gap: 6 }}>
+        <button className="pv-chev" disabled={page === 0} onClick={() => setPage(Math.max(0, page - 1))}><i className="ti ti-chevron-left" style={{ fontSize: 11 }}></i></button>
+        <div style={{ flex: 1, display: "flex", gap: 6, overflow: "hidden" }}>
+          {slice.map((a) => (
+            <div key={a.id} className="pv-feat-card" style={{
+              flex: "0 0 88px",
+              background: `color-mix(in srgb, ${a.accent} 10%, var(--surface, #fff))`,
+              borderColor: `color-mix(in srgb, ${a.accent} 22%, transparent)`,
+            }}>
+              <div className="pv-feat-card__logo" style={{ background: `color-mix(in srgb, ${a.accent} 18%, transparent)` }}>
+                {a.logo ? <img src={a.logo} alt="" /> : <span style={{ color: a.accent, fontWeight: 600, fontSize: 11 }}>{a.mono}</span>}
+              </div>
+              <div className="pv-feat-card__name">{a.name}</div>
+              <div className="pv-feat-card__desc">{a.desc[lang]}</div>
+              <div className="pv-feat-card__cta" style={{ background: cfg.accent }}><i className="ti ti-arrow-right" style={{ fontSize: 10 }}></i></div>
+            </div>
+          ))}
+        </div>
+        <button className="pv-chev" disabled={page >= pages - 1} onClick={() => setPage(Math.min(pages - 1, page + 1))}><i className="ti ti-chevron-right" style={{ fontSize: 11 }}></i></button>
+      </div>
+      {pages > 1 && (
+        <div style={{ display: "flex", gap: 4, justifyContent: "center", marginTop: 6 }}>
+          {Array.from({ length: pages }).map((_, i) => (
+            <span key={i} onClick={() => setPage(i)} style={{ cursor: "pointer", width: i === page ? 14 : 5, height: 5, borderRadius: 999, background: i === page ? cfg.accent : "color-mix(in srgb, currentColor 22%, transparent)", transition: "all .2s" }}></span>
+          ))}
+        </div>
+      )}
+    </div>
+  );
+}
+
+/* ── Syntax-highlighted code editor (textarea + pre overlay) ──
+   Supports CSS and HTML token coloring.                       */
+/* ── Proper single-pass tokenizer + syntax highlighter ── */
+function escHtml(s) { return s.replace(/&/g,"&amp;").replace(/</g,"&lt;").replace(/>/g,"&gt;"); }
+
+function highlightCSS(raw) {
+  let out = "", i = 0, n = raw.length;
+  while (i < n) {
+    // Comment /* ... */
+    if (raw[i] === "/" && raw[i+1] === "*") {
+      const e = raw.indexOf("*/", i+2); const end = e < 0 ? n : e+2;
+      out += `<span class="tok-comment">${escHtml(raw.slice(i,end))}</span>`; i = end; continue;
+    }
+    // String
+    if (raw[i] === '"' || raw[i] === "'") {
+      const q = raw[i]; let j = i+1;
+      while (j < n && raw[j] !== q) { if (raw[j] === "\\") j++; j++; }
+      out += `<span class="tok-string">${escHtml(raw.slice(i,j+1))}</span>`; i = j+1; continue;
+    }
+    // At-rule
+    if (raw[i] === "@") {
+      const m = raw.slice(i).match(/^@[\w-]+/);
+      if (m) { out += `<span class="tok-atrule">${escHtml(m[0])}</span>`; i += m[0].length; continue; }
+    }
+    // !important
+    if (raw.slice(i,i+10) === "!important") {
+      out += `<span class="tok-important">!important</span>`; i += 10; continue;
+    }
+    // Hex color
+    if (raw[i] === "#") {
+      const m = raw.slice(i).match(/^#[0-9a-fA-F]{3,8}\b/);
+      if (m) { out += `<span class="tok-hexcolor">${escHtml(m[0])}</span>`; i += m[0].length; continue; }
+    }
+    // Property name (word before lone :)
+    if (/[\w-]/.test(raw[i]) && i > 0) {
+      // Peek: is this a property or selector?
+      const m = raw.slice(i).match(/^([\w-]+)(\s*:(?!:))/);
+      if (m) {
+        const ctx = raw.slice(0, i).replace(/\/\*[\s\S]*?\*\//g,"");
+        const inBlock = (ctx.match(/{/g)||[]).length > (ctx.match(/}/g)||[]).length;
+        if (inBlock) {
+          out += `<span class="tok-prop">${escHtml(m[1])}</span>`; i += m[1].length; continue;
+        }
+      }
+    }
+    // Number + optional unit
+    if (/[\d.]/.test(raw[i]) && (i === 0 || !/[\w#]/.test(raw[i-1]))) {
+      const m = raw.slice(i).match(/^-?\d*\.?\d+(px|em|rem|%|vh|vw|s|ms|deg|fr|ch|ex|vmin|vmax|svh)?\b/);
+      if (m) { out += `<span class="tok-number">${escHtml(m[0])}</span>`; i += m[0].length; continue; }
+    }
+    // Selector hint: . or # at start of line
+    if ((raw[i] === "." || raw[i] === "#") && (i === 0 || /[\n\r,{ ]/.test(raw[i-1]))) {
+      const m = raw.slice(i).match(/^[.#][\w-]+/);
+      if (m) { out += `<span class="tok-selector">${escHtml(m[0])}</span>`; i += m[0].length; continue; }
+    }
+    out += escHtml(raw[i++]);
+  }
+  return out + "\n";
+}
+
+function highlightHTML(raw) {
+  let out = "", i = 0, n = raw.length;
+  while (i < n) {
+    if (raw.slice(i,i+4) === "<!--") {
+      const e = raw.indexOf("-->", i+4); const end = e < 0 ? n : e+3;
+      out += `<span class="tok-comment">${escHtml(raw.slice(i,end))}</span>`; i = end; continue;
+    }
+    if (raw[i] === "<") {
+      const m = raw.slice(i).match(/^<\/?([\w:-]+)/);
+      if (m) {
+        out += `<span class="tok-tag">&lt;${m[1].startsWith("/")?"<span class=\"tok-tag\">":""}${escHtml(m[1])}${m[1].startsWith("/")?"</span>":""}</span>`;
+        i += m[0].length; continue;
+      }
+    }
+    if (raw[i] === ">" || (raw[i] === "/" && raw[i+1] === ">")) {
+      const s = raw[i] === "/" ? "/>" : ">";
+      out += `<span class="tok-tag">${escHtml(s)}</span>`; i += s.length; continue;
+    }
+    if (raw[i] === '"' || raw[i] === "'") {
+      const q = raw[i]; let j = i+1;
+      while (j < n && raw[j] !== q) j++;
+      out += `<span class="tok-string">${escHtml(raw.slice(i,j+1))}</span>`; i = j+1; continue;
+    }
+    const am = raw.slice(i).match(/^[\w:-]+(?=\s*=)/);
+    if (am) { out += `<span class="tok-attr">${escHtml(am[0])}</span>`; i += am[0].length; continue; }
+    out += escHtml(raw[i++]);
+  }
+  return out + "\n";
+}
+
+function highlight(code, mode) {
+  return mode === "html" ? highlightHTML(code) : highlightCSS(code);
+}
+
+function CodeEditor({ value, onChange, mode = "css", placeholder, minHeight = 120 }) {
+  const ref = apR(null);
+  const preRef = apR(null);
+  const sync = () => {
+    if (preRef.current && ref.current) {
+      preRef.current.scrollTop = ref.current.scrollTop;
+      preRef.current.scrollLeft = ref.current.scrollLeft;
+    }
+  };
+  return (
+    <div className="code-editor-wrap" style={{ minHeight }}>
+      <pre ref={preRef} className="code-editor-pre" aria-hidden="true"
+        dangerouslySetInnerHTML={{ __html: highlight(value || "", mode) }} />
+      <textarea ref={ref} className="code-editor-ta" value={value || ""} placeholder={placeholder}
+        onChange={(e) => onChange(e.target.value)} onScroll={sync}
+        spellCheck={false} autoCapitalize="off" autoCorrect="off" />
+    </div>
+  );
+}
+function HtmlBlock({ label, icon, val, lang, onChange }) {
+  const [open, setOpen] = apS(false);
+  const hasContent = val && val.trim().length > 0;
+  return (
+    <div className="html-block" style={{ marginBottom: 8 }}>
+      <button className="html-block__head" onClick={() => setOpen((o) => !o)}>
+        <span style={{ display: "flex", alignItems: "center", gap: 7, flex: 1, minWidth: 0 }}>
+          <i className={"ti " + icon} style={{ fontSize: 13, color: "var(--text-faint)", flexShrink: 0 }}></i>
+          <span style={{ fontSize: 12.5, fontWeight: 500, overflow: "hidden", textOverflow: "ellipsis", whiteSpace: "nowrap" }}>{label}</span>
+          {hasContent && <span className="html-block__dot"></span>}
+        </span>
+        <i className={"ti " + (open ? "ti-chevron-up" : "ti-chevron-down")} style={{ fontSize: 12, color: "var(--text-faint)", flexShrink: 0 }}></i>
+      </button>
+      {open && (
+        <div className="html-block__body fade-in">
+          <CodeEditor mode="html" minHeight={90}
+            placeholder={lang === "pt" ? "<!-- HTML injetado aqui -->" : "<!-- HTML injected here -->"}
+            value={val} onChange={onChange} />
+          {hasContent && (
+            <div className="html-block__preview">
+              <span style={{ fontSize: 10, color: "var(--text-faint)", display: "block", marginBottom: 4 }}>{lang === "pt" ? "Pré-visualização:" : "Preview:"}</span>
+              <div dangerouslySetInnerHTML={{ __html: val }} style={{ fontSize: 12, lineHeight: 1.5, border: "0.5px solid var(--border)", borderRadius: 6, padding: "8px 10px", background: "var(--surface-soft)", overflowX: "auto" }} />
+            </div>
+          )}
+          <div style={{ display: "flex", gap: 6, marginTop: 8 }}>
+            <button className="btn" style={{ fontSize: 11 }} onClick={() => onChange("")}>{lang === "pt" ? "Limpar" : "Clear"}</button>
+            <button className="btn btn--primary" style={{ fontSize: 11 }} onClick={() => {}}>{lang === "pt" ? "Aplicar" : "Apply"}</button>
+          </div>
+        </div>
+      )}
+    </div>
+  );
+}
+function PortalPreview({ cfg, t, featured }) {
+  const lang = t._lang;
+  const apps = window.RK.APPS.slice(0, 6);
+  const featApps = window.RK.APPS.filter((a) => featured && featured.has(a.id));
+  const featApp = featApps[0] || apps[0];
+  const dark = cfg.theme === "dark";
+  const gap = cfg.density === "compact" ? 6 : 9;
+  const heroBg = cfg.hero === "none" ? "transparent"
+    : cfg.hero === "soft" ? `linear-gradient(160deg, color-mix(in srgb, ${cfg.accent} 20%, transparent), transparent 80%)`
+    : `linear-gradient(150deg, ${cfg.accent}, color-mix(in srgb, ${cfg.accent} 45%, #000))`;
+  const headInk = cfg.hero === "bold" ? "#fff" : "inherit";
+  const signinStyle = cfg.hero === "bold" ? { borderColor: "rgba(255,255,255,.6)", color: "#fff" } : { borderColor: cfg.accent, color: cfg.accent };
+  return (
+    <div className={"pv-root" + (dark ? " pv-dark" : "")} style={{ "--pv-accent": cfg.accent }}>
+      <div className="pv-head" style={{ background: heroBg, color: headInk }}>
+        <div className="pv-brand-col">
+          <div className="pv-brand" style={{ gap: cfg.logoGap, alignItems: "center" }}>
+            {cfg.logo === "custom" && cfg.logoUrl
+              ? <img src={cfg.logoUrl} alt="" style={{ width: cfg.logoSize, height: cfg.logoSize, display: "block", flexShrink: 0 }} onError={(e) => { e.target.style.display = "none"; }} />
+              : <img src="assets/ruscker-mark.svg" alt="" style={{ width: cfg.logoSize, height: cfg.logoSize, display: "block", flexShrink: 0 }} />}
+            {cfg.logo !== "mark" && (
+              <div>
+                <b style={{ fontSize: 13, fontWeight: 700, letterSpacing: "-0.02em" }}>{cfg.title || "Portal"}</b>
+                {cfg.tagline && <div className="pv-tag" style={{ marginTop: 1, fontSize: 8.5, opacity: cfg.hero === "bold" ? 0.85 : 0.6 }}>{cfg.tagline}</div>}
+              </div>
+            )}
+          </div>
+        </div>
+        <div style={{ display: "flex", alignItems: "center", gap: 4 }}>
+          <span className="pv-icon-btn"><i className="ti ti-sun" style={{ fontSize: 11 }}></i></span>
+          <span className="pv-icon-btn" style={{ fontSize: 9, fontWeight: 600 }}>{lang.toUpperCase()}</span>
+          <span className="pv-icon-btn" style={signinStyle}><i className="ti ti-login-2" style={{ fontSize: 11 }}></i></span>
+        </div>
+      </div>
+      <div className="pv-body">
+        {cfg.featured && featApps.length > 0 && (
+          <div className="pv-feat-wrap">
+            <div className="pv-feat-label"><i className="ti ti-star-filled" style={{ color: cfg.accent }}></i>{lang === "pt" ? "Em destaque" : "Featured"} <span style={{ opacity: .55, fontWeight: 400 }}>· {featApps.length}</span></div>
+            <PvFeatCarousel apps={featApps} cfg={cfg} lang={lang} />
+          </div>
+        )}
+
+        {cfg.showSearch && (
+          <div className="pv-search"><i className="ti ti-search"></i><span>{lang === "pt" ? "Buscar…" : "Search…"}</span></div>
+        )}
+
+        <div className="pv-chips">
+          <span className="pv-chip on" style={{ background: cfg.accent }}>{lang === "pt" ? "Todos" : "All"}</span>
+          <span className="pv-chip">Apps</span>
+          <span className="pv-chip">API</span>
+          {cfg.showAccess && <><span className="pv-chip pv-chip--ghost"><i className="ti ti-lock-open"></i></span><span className="pv-chip pv-chip--ghost"><i className="ti ti-lock"></i></span></>}
+        </div>
+
+        {cfg.layout === "list" ? (
+          <div style={{ display: "flex", flexDirection: "column", gap }}>
+            {apps.map((a) => (
+              <div className="pv-row" key={a.id}>
+                <span className="pv-logo" style={{ background: `color-mix(in srgb, ${a.accent} 15%, transparent)` }}>{a.logo ? <img src={a.logo} alt="" /> : a.mono}</span>
+                <div style={{ flex: 1, minWidth: 0 }}><div className="pv-row-name">{a.name}</div><div className="pv-row-desc">{a.desc[lang]}</div></div>
+              </div>
+            ))}
+          </div>
+        ) : cfg.layout === "sections" ? (
+          ["Apps", "API"].map((sec, si) => (
+            <div key={sec} style={{ marginBottom: 10 }}>
+              <div className="pv-sec-head">{sec}</div>
+              <div className="pv-rail">{apps.slice(si * 3, si * 3 + 3).map((a) => <MiniCard key={a.id} a={a} cfg={cfg} />)}</div>
+            </div>
+          ))
+        ) : (
+          <div className="pv-grid" style={{ gap }}>{apps.map((a) => <MiniCard key={a.id} a={a} cfg={cfg} />)}</div>
+        )}
+      </div>
+      <div className="pv-foot">
+        {cfg.footerLogo && <img className="pv-foot-logo" src={cfg.footerLogo} alt="" style={{ width: cfg.footerLogoSize, height: cfg.footerLogoSize, marginRight: cfg.footerLogoGap }} onError={(e) => { e.target.style.display = "none"; }} />}
+        <span>{cfg.footer}</span>
+      </div>
+    </div>
+  );
+}
+
+function MiniCard({ a, cfg }) {
+  const cover = cfg.cover === "gradient"
+    ? `linear-gradient(140deg, color-mix(in srgb, ${a.accent} 30%, transparent), color-mix(in srgb, ${a.accent} 6%, transparent))`
+    : `color-mix(in srgb, ${a.accent} 12%, transparent)`;
+  return (
+    <div className="pv-card">
+      <div className="pv-card-cover" style={{ background: cover }}>
+        {a.logo ? <img src={a.logo} alt="" /> : <span style={{ color: a.accent, fontWeight: 600 }}>{a.mono}</span>}
+      </div>
+      <div className="pv-card-name">{a.name}</div>
+    </div>
+  );
+}
+
+window.RKAppearance = Appearance;
+window.RKMedia = { mediaAssets, MediaPicker };

--- a/docs/design-handoff/src/components.jsx
+++ b/docs/design-handoff/src/components.jsx
@@ -1,0 +1,223 @@
+/* global React */
+// ── Shared visual atoms + skeletons for the Ruscker prototype ──
+const { useState, useEffect, useRef } = React;
+
+// Monogram logo on a soft accent plate — renders the real brand mark when
+// available (app.logo), falling back to the monogram if it errors/missing.
+function Logo({ app, size = 40, radius = 9 }) {
+  const [err, setErr] = useState(false);
+  const bg = `color-mix(in srgb, ${app.accent} 16%, var(--surface))`;
+  const base = {
+    width: size, height: size, borderRadius: radius, flex: "none",
+    display: "flex", alignItems: "center", justifyContent: "center",
+    background: bg, border: "0.5px solid var(--border)", overflow: "hidden",
+  };
+  if (app.logo && !err) {
+    return (
+      <div style={base}>
+        <img src={app.logo} alt="" onError={() => setErr(true)}
+             style={{ width: size * 0.62, height: size * 0.62, objectFit: "contain", display: "block" }} />
+      </div>
+    );
+  }
+  return <div style={{ ...base, color: app.accent, fontWeight: 600, fontSize: size * 0.4 }}>{app.mono}</div>;
+}
+
+// Big cover logo for the card — real brand mark on a tinted radial, with the
+// name wordmark as fallback when no logo is set / it fails to load.
+function CoverLogo({ app, coverStyle }) {
+  const k = window.RK.KIND[app.kind];
+  const [err, setErr] = useState(false);
+  const showImg = app.logo && !err;
+  return (
+    <div className="rcover">
+      <div className={"rcover-bg " + (coverStyle === "gradient" ? "" : k.tint)} style={coverStyle === "gradient" ? { background: `linear-gradient(140deg, color-mix(in srgb, ${app.accent} 30%, transparent), color-mix(in srgb, ${app.accent} 6%, transparent))` } : null}></div>
+      <div className="rcover-logo" style={{ color: app.accent }}>
+        {showImg ? (
+          <img src={app.logo} alt={app.name} onError={() => setErr(true)}
+               style={{ maxWidth: "54%", maxHeight: "56%", objectFit: "contain", display: "block" }} />
+        ) : (
+          <span style={{
+            fontSize: 26, fontWeight: 600, letterSpacing: "-0.02em",
+            fontFamily: app.kind === "api" ? "var(--font-mono)" : "inherit",
+          }}>{app.name}</span>
+        )}
+      </div>
+      <div className="rbadges">
+        <span className={"rbadge " + k.b}>{k.badge}</span>
+        <span className="rbadge rbadge--subject">{app.subject}</span>
+      </div>
+      <span className="rlock">
+        <i className={"ti " + (app.locked ? "ti-lock" : "ti-lock-open")}
+           style={{ color: app.locked ? "var(--lock)" : "var(--lock-open)" }}></i>
+      </span>
+    </div>
+  );
+}
+
+function StatusMeta({ app, t }) {
+  if (app.status === "new") return <span className="rmeta-left"><span className="status-dot status-dot-new"></span>{t.newBadge} {app.updated}</span>;
+  if (app.status === "updated") return <span className="rmeta-left"><span className="status-dot status-dot-updated"></span>{t.updatedBadge} {app.updated}</span>;
+  return <span className="rmeta-left"><span className="status-dot" style={{ background: "var(--text-faint)" }}></span>{t.updated} {app.updated}</span>;
+}
+
+// Full app card
+function AppCard({ app, t, onOpen, coverStyle }) {
+  return (
+    <a className="rcard" onClick={(e) => { e.preventDefault(); onOpen && onOpen(app); }}>
+      <CoverLogo app={app} coverStyle={coverStyle} />
+      <div className="rbody">
+        <div className="rtitle">{app.name}</div>
+        <div className="rdesc">{app.desc[t._lang]}</div>
+        <div className="rmeta">
+          <StatusMeta app={app} t={t} />
+          <i className="ti ti-arrow-right arrow-go"></i>
+        </div>
+      </div>
+    </a>
+  );
+}
+
+// Compact list row card
+function AppRow({ app, t, onOpen }) {
+  const k = window.RK.KIND[app.kind];
+  return (
+    <a className="rrow" onClick={(e) => { e.preventDefault(); onOpen && onOpen(app); }}>
+      <Logo app={app} size={42} />
+      <div className="rrow__main">
+        <div className="rrow__title">
+          {app.name}
+          <span className={"rbadge " + k.b} style={{ fontSize: 8 }}>{k.badge}</span>
+        </div>
+        <div className="rrow__desc">{app.desc[t._lang]}</div>
+      </div>
+      <div className="rrow__meta">
+        <i className={"ti " + (app.locked ? "ti-lock" : "ti-lock-open")}
+           style={{ color: app.locked ? "var(--lock)" : "var(--lock-open)", fontSize: 13 }}></i>
+        <span>{t.updated} {app.updated}</span>
+        <i className="ti ti-arrow-right arrow-go"></i>
+      </div>
+    </a>
+  );
+}
+
+/* ── Skeletons ────────────────────────────────────────────────── */
+function SkCard() {
+  return (
+    <div className="rcard" style={{ cursor: "default" }}>
+      <div className="sk" style={{ height: 150, margin: "10px 10px 0", borderRadius: 8 }}></div>
+      <div className="rbody">
+        <div className="sk sk-line" style={{ width: "60%", marginBottom: 10 }}></div>
+        <div className="sk sk-line" style={{ width: "92%", marginBottom: 6, height: 8 }}></div>
+        <div className="sk sk-line" style={{ width: "78%", marginBottom: 16, height: 8 }}></div>
+        <div className="sk sk-line" style={{ width: "40%", height: 8 }}></div>
+      </div>
+    </div>
+  );
+}
+function SkRow() {
+  return (
+    <div className="rrow" style={{ cursor: "default" }}>
+      <div className="sk" style={{ width: 42, height: 42, borderRadius: 9, flex: "none" }}></div>
+      <div style={{ flex: 1 }}>
+        <div className="sk sk-line" style={{ width: "35%", marginBottom: 8 }}></div>
+        <div className="sk sk-line" style={{ width: "70%", height: 8 }}></div>
+      </div>
+      <div className="sk sk-line" style={{ width: 70, height: 8 }}></div>
+    </div>
+  );
+}
+function SkBlock({ h = 12, w = "100%", r = 6, style }) {
+  return <div className="sk" style={{ height: h, width: w, borderRadius: r, ...style }}></div>;
+}
+
+/* ── Sparkline ────────────────────────────────────────────────── */
+function makeSpark(n = 24, base = 40, jitter = 30, seed = 1) {
+  const arr = [];
+  let v = base;
+  for (let i = 0; i < n; i++) {
+    v += (Math.sin(i * 0.6 + seed) * jitter * 0.4) + (Math.random() - 0.5) * jitter;
+    v = Math.max(4, Math.min(96, v));
+    arr.push(v);
+  }
+  return arr;
+}
+function Sparkline({ data, color = "var(--teal-600)", fill = true, h = 30 }) {
+  const w = 120;
+  const max = Math.max(...data), min = Math.min(...data);
+  const span = Math.max(1, max - min);
+  const pts = data.map((d, i) => {
+    const x = (i / (data.length - 1)) * w;
+    const y = h - 3 - ((d - min) / span) * (h - 6);
+    return [x, y];
+  });
+  const line = pts.map((p, i) => (i === 0 ? "M" : "L") + p[0].toFixed(1) + " " + p[1].toFixed(1)).join(" ");
+  const area = line + ` L ${w} ${h} L 0 ${h} Z`;
+  return (
+    <svg className="spark" viewBox={`0 0 ${w} ${h}`} preserveAspectRatio="none" style={{ height: h }}>
+      {fill && <path d={area} fill={color} opacity="0.12" />}
+      <path d={line} fill="none" stroke={color} strokeWidth="1.6" strokeLinejoin="round" strokeLinecap="round" />
+    </svg>
+  );
+}
+
+/* ── Bar (cpu/mem mini meter) ─────────────────────────────────── */
+function Meter({ pct, color }) {
+  return <div className="bar-track" style={{ marginTop: 4 }}><div className="bar-fill" style={{ width: pct + "%", background: color }}></div></div>;
+}
+function meterColor(pct) {
+  if (pct >= 80) return "var(--warn)";
+  if (pct >= 50) return "var(--info)";
+  return "var(--ok)";
+}
+
+/* ── Toast ────────────────────────────────────────────────────── */
+function useToasts() {
+  const [items, setItems] = useState([]);
+  const push = (msg, icon = "ti-check") => {
+    const id = Math.random();
+    setItems((x) => [...x, { id, msg, icon }]);
+    setTimeout(() => setItems((x) => x.filter((i) => i.id !== id)), 2200);
+  };
+  const node = (
+    <div className="toast-wrap">
+      {items.map((i) => (
+        <div className="toast" key={i.id}><i className={"ti " + i.icon}></i>{i.msg}</div>
+      ))}
+    </div>
+  );
+  return [push, node];
+}
+
+/* ── LiveNum: briefly flashes when its value changes (sells "ao vivo") ─ */
+function LiveNum({ value, className }) {
+  const [flash, setFlash] = useState(false);
+  const prev = useRef(value);
+  useEffect(() => {
+    if (prev.current !== value) {
+      prev.current = value;
+      setFlash(true);
+      const id = setTimeout(() => setFlash(false), 650);
+      return () => clearTimeout(id);
+    }
+    return undefined;
+  }, [value]);
+  return <span className={(className || "") + (flash ? " live-flash" : "")}>{value}</span>;
+}
+
+window.RKC = {
+  Logo, CoverLogo, AppCard, AppRow, StatusMeta,
+  SkCard, SkRow, SkBlock, Sparkline, makeSpark, Meter, meterColor, useToasts, LiveNum, StarIcon,
+};
+
+/* ── StarIcon: filled when on=true, outline when on=false ── */
+function StarIcon({ on, size = 16 }) {
+  return (
+    <svg viewBox="0 0 24 24" width={size} height={size} aria-hidden="true"
+      fill={on ? "currentColor" : "none"}
+      stroke="currentColor" strokeWidth="1.5" strokeLinejoin="round"
+      style={{ display: "block", flexShrink: 0 }}>
+      <path d="M12 17.27L18.18 21l-1.64-7.03L22 9.24l-7.19-.61L12 2 9.19 8.63 2 9.24l5.46 4.73L5.82 21z" />
+    </svg>
+  );
+}

--- a/docs/design-handoff/src/dashboard.jsx
+++ b/docs/design-handoff/src/dashboard.jsx
@@ -1,0 +1,418 @@
+/* global React, window */
+// ── Dashboard (monitoring) — 3 variations ──
+const { useState: dS, useMemo: dM, useEffect: dE, useRef: dR } = React;
+const DC = window.RKC;
+
+const clampN = (v, lo, hi) => Math.max(lo, Math.min(hi, v));
+const randN = (a, b) => a + Math.random() * (b - a);
+
+function aggregate(g) {
+  const reps = g.reps;
+  const sessions = reps.reduce((s, r) => s + r.sessions, 0);
+  const sessionsMax = reps.reduce((s, r) => s + r.sessionsMax, 0);
+  const mem = reps.reduce((s, r) => s + r.mem, 0);
+  const cpu = Math.round(reps.reduce((s, r) => s + r.cpu, 0) / reps.length);
+  const boot = reps.some((r) => r.state === "boot");
+  const warn = reps.some((r) => r.state === "warn");
+  const state = boot ? "boot" : warn ? "warn" : "ready";
+  return { sessions, sessionsMax, mem, cpu, state, n: reps.length };
+}
+
+function StateDot({ s }) {
+  const cls = s === "boot" ? "dot-boot" : s === "warn" ? "dot-warn" : s === "stopped" ? "dot-off" : "dot-ready";
+  return <span className={"dot " + cls}></span>;
+}
+function stateLabel(s, t) { return s === "boot" ? t.booting : s === "warn" ? t.warn : s === "stopped" ? t.stopped : t.ready; }
+
+function Dashboard({ variation, t, loading, push }) {
+  const init = dM(() => window.RK.buildReplicas(), []);
+  const [groups, setGroups] = dS(init.groups);
+  const total = init.total;
+
+  // ── Live data: random-walk metrics every 2.5s; the booting replica
+  //    progresses to ready (visible real progress). Sells responsiveness.
+  dE(() => {
+    if (loading) return undefined;
+    const iv = setInterval(() => {
+      setGroups((gs) => gs.map((g) => ({
+        ...g,
+        reps: g.reps.map((r) => {
+          if (r.state === "boot") {
+            const prog = (r.bootProg || 0) + 1;
+            if (prog >= 3) return { ...r, state: "ready", bootProg: prog, uptime: "0h 1m", cpu: Math.round(randN(4, 10)), mem: 140 + Math.round(randN(0, 70)), sessions: 0 };
+            return { ...r, bootProg: prog };
+          }
+          const cap = r.state === "warn" ? 42 : 30;
+          const cpu = Math.round(clampN(r.cpu + randN(-5, 5), 1, cap));
+          const ds = Math.random() < 0.28 ? (Math.random() < 0.5 ? -1 : 1) : 0;
+          const sessions = clampN(r.sessions + ds, 0, r.sessionsMax);
+          const mem = Math.round(clampN(r.mem + randN(-14, 14), 80, 900));
+          return { ...r, cpu, sessions, mem };
+        }),
+      })));
+    }, 2500);
+    return () => clearInterval(iv);
+  }, [loading]);
+
+  const totals = (() => {
+    const sessions = groups.reduce((s, g) => s + aggregate(g).sessions, 0);
+    const mem = groups.reduce((s, g) => s + aggregate(g).mem, 0);
+    return { containers: total, appsWith: groups.length, sessions, tracked: sessions, mem };
+  })();
+
+  if (variation === "b") return <DashCards t={t} groups={groups} totals={totals} loading={loading} push={push} />;
+  if (variation === "c") return <DashOps t={t} groups={groups} totals={totals} loading={loading} push={push} />;
+  return <DashGrouped t={t} groups={groups} totals={totals} loading={loading} push={push} />;
+}
+
+/* ── metrics strip (shared) ────────────────────────────────────── */
+function Metrics({ t, totals, loading }) {
+  const memStr = totals.mem > 1024 ? (totals.mem / 1024).toFixed(1) + " GB" : totals.mem + " MB";
+  const items = [
+    { icon: "ti-box", label: t.containers, value: totals.containers, sub: t.lastRefresh },
+    { icon: "ti-stack-2", label: t.appsReplicas, value: totals.appsWith },
+    { icon: "ti-users", label: t.activeSessions, value: totals.sessions, sub: t.peakToday + ": 134" },
+    { icon: "ti-activity", label: t.tracked, value: totals.tracked },
+    { icon: "ti-database", label: t.memUsed, value: memStr },
+  ];
+  return (
+    <div className="dash-metrics">
+      {items.map((m, i) => (
+        <div className="metric" key={i}>
+          <div className="metric__label"><i className={"ti " + m.icon}></i>{m.label}</div>
+          {loading ? <DC.SkBlock w={70} h={26} /> : <div className="metric__value"><DC.LiveNum value={m.value} /></div>}
+          {m.sub && !loading && <div className="metric__sub">{m.sub}</div>}
+        </div>
+      ))}
+    </div>
+  );
+}
+
+function DashHeader({ t, right }) {
+  return (
+    <div style={{ display: "flex", alignItems: "flex-end", justifyContent: "space-between", gap: 16, marginBottom: 20 }}>
+      <div>
+        <div className="page-title">{t.dashboard === "Painel" ? "Painel de monitoramento" : "Monitoring dashboard"}</div>
+        <div className="page-sub">{t.dashSub}</div>
+      </div>
+      <div style={{ display: "flex", alignItems: "center", gap: 12 }}>{right}</div>
+    </div>
+  );
+}
+
+function LiveBadge({ t }) {
+  return <span style={{ display: "inline-flex", alignItems: "center", gap: 7, fontSize: 11.5, color: "var(--text-muted)" }}><span className="live-dot"></span>{t.live} · 2.5s</span>;
+}
+
+/* ══════════════════════════════════════════════════════════════
+   VARIATION A — Grouped by app (collapse / expand)
+   ══════════════════════════════════════════════════════════════ */
+function DashGrouped({ t, groups, totals, loading, push }) {
+  const [open, setOpen] = dS(() => new Set());
+  const [q, setQ] = dS("");
+  const [stateF, setStateF] = dS("all");
+  const allOpen = open.size === groups.length;
+  const toggle = (id) => setOpen((s) => { const n = new Set(s); n.has(id) ? n.delete(id) : n.add(id); return n; });
+
+  const shown = groups.filter((g) => {
+    if (q.trim() && !(g.name + " " + g.id).toLowerCase().includes(q.trim().toLowerCase())) return false;
+    if (stateF !== "all" && aggregate(g).state !== stateF) return false;
+    return true;
+  });
+  const toggleAll = () => setOpen(allOpen ? new Set() : new Set(shown.map((g) => g.id)));
+
+  const StateChip = ({ k, label }) => (
+    <button className={"chip" + (stateF === k ? " on-all" : "")} onClick={() => setStateF(stateF === k ? "all" : k)}>
+      {k !== "all" && <StateDot s={k} />}{label}
+    </button>
+  );
+
+  return (
+    <div className="mock-pad" style={{ paddingTop: 16, paddingBottom: 40 }}>
+      <DashHeader t={t} right={<LiveBadge t={t} />} />
+      <Metrics t={t} totals={totals} loading={loading} />
+
+      {/* Sticky control + column-header band: stays pinned while the long
+          grouped list scrolls — filters & headers always reachable. */}
+      <div className="grouped-sticky">
+        <div style={{ display: "flex", alignItems: "center", gap: 10, flexWrap: "wrap", marginBottom: 10 }}>
+          <div style={{ fontSize: 14, fontWeight: 600, display: "flex", alignItems: "center", gap: 9, marginRight: 4 }}>
+            {t.activeReplicas}
+            <span style={{ fontSize: 11, fontWeight: 400, color: "var(--text-faint)" }}>· {t.groupedByApp}</span>
+          </div>
+          <div className="search-pill" style={{ maxWidth: 230, flex: "0 1 230px", padding: "8px 14px" }}>
+            <i className="ti ti-search"></i>
+            <input value={q} onChange={(e) => setQ(e.target.value)} placeholder={t.filterApp} />
+          </div>
+          <StateChip k="ready" label={t.ready} />
+          <StateChip k="warn" label={t.warn} />
+          <StateChip k="boot" label={t.booting} />
+          <div style={{ flex: 1 }}></div>
+          <span className="faint tnum" style={{ fontSize: 11 }}>{shown.length}/{groups.length}</span>
+          {!loading && (
+            <button className="sort-btn" onClick={toggleAll}>
+              <i className={"ti " + (allOpen ? "ti-fold" : "ti-fold-down")}></i>{allOpen ? t.collapseAll : t.expandAll}
+            </button>
+          )}
+        </div>
+        {/* column header */}
+        <div className="app-group__head" style={{ padding: "6px 16px 8px", cursor: "default", background: "transparent" }}>
+          <span></span>
+          <span className="col-h">App</span>
+          <span className="col-h">{t.replicas}</span>
+          <span className="col-h">{t.state}</span>
+          <span className="col-h">{t.sessions}</span>
+          <span className="col-h">{t.cpu}</span>
+          <span className="col-h">{t.mem}</span>
+          <span></span>
+        </div>
+      </div>
+
+      {loading
+        ? Array.from({ length: 6 }).map((_, i) => (
+            <div className="app-group" key={i} style={{ padding: "14px 16px" }}>
+              <div style={{ display: "flex", alignItems: "center", gap: 12 }}>
+                <DC.SkBlock w={16} h={16} /><DC.SkBlock w={30} h={30} r={8} />
+                <DC.SkBlock w={120} h={12} /><div style={{ flex: 1 }}></div><DC.SkBlock w={200} h={10} />
+              </div>
+            </div>
+          ))
+        : shown.length === 0
+        ? <div style={{ textAlign: "center", padding: "48px 20px", color: "var(--text-muted)" }}><i className="ti ti-server-off" style={{ fontSize: 30, color: "var(--text-faint)" }}></i><div style={{ marginTop: 10, fontSize: 13 }}>{t.noResults}</div></div>
+        : <div className="stagger" style={{ marginTop: 12 }}>{shown.map((g, i) => {
+            const a = aggregate(g);
+            const isOpen = open.has(g.id);
+            return (
+              <div className={"app-group" + (isOpen ? " is-open" : "")} key={g.id} style={{ animationDelay: Math.min(i, 10) * 10 + "ms" }}>
+                <div className="app-group__head" onClick={() => toggle(g.id)}>
+                  <span className="app-group__chev"><i className="ti ti-chevron-right"></i></span>
+                  <span className="app-group__name">
+                    <DC.Logo app={g} size={30} radius={8} />
+                    <span>{g.name}<span className="app-group__id" style={{ display: "block" }}>{g.id}</span></span>
+                  </span>
+                  <span className="app-group__replicas"><i className="ti ti-stack-2" style={{ fontSize: 14 }}></i>{a.n}</span>
+                  <span style={{ display: "inline-flex", alignItems: "center", gap: 7, fontSize: 12 }}><StateDot s={a.state} />{stateLabel(a.state, t)}</span>
+                  <span className="metric-cell"><span className="v tnum">{a.sessions}<span className="faint">/{a.sessionsMax}</span></span><DC.Meter pct={(a.sessions / a.sessionsMax) * 100} color="var(--info)" /></span>
+                  <span className="metric-cell"><span className="v tnum">{a.cpu}%</span><DC.Meter pct={a.cpu} color={DC.meterColor(a.cpu)} /></span>
+                  <span className="metric-cell tnum">{a.mem} MB</span>
+                  <span style={{ textAlign: "right", color: "var(--text-faint)" }}><i className="ti ti-dots-vertical"></i></span>
+                </div>
+                {isOpen && (
+                  <div className="replica-list fade-in">
+                    {g.reps.map((r) => (
+                      <div className="replica-row" key={r.cid}>
+                        <span><StateDot s={r.state} /></span>
+                        <span><span className="cid">{r.cid}</span> <span className="faint" style={{ fontSize: 11 }}>· {r.host}</span></span>
+                        <span className="mono faint" style={{ fontSize: 11 }}>{r.uptime}</span>
+                        <span style={{ fontSize: 11.5 }} className="muted">{stateLabel(r.state, t)}</span>
+                        <span className="metric-cell"><span className="tnum">{r.sessions}<span className="faint">/{r.sessionsMax}</span></span></span>
+                        <span className="metric-cell"><span className="tnum">{r.cpu}%</span><DC.Meter pct={r.cpu} color={DC.meterColor(r.cpu)} /></span>
+                        <span className="metric-cell tnum">{r.mem} MB</span>
+                        <span className="replica-actions">
+                          <button title={t.logs} onClick={() => push(t.logs + " · " + r.cid.slice(0, 6), "ti-file-text")}><i className="ti ti-file-text"></i></button>
+                          <button title={t.restart} onClick={() => push(t.restart + " · " + r.cid.slice(0, 6), "ti-refresh")}><i className="ti ti-refresh"></i></button>
+                          <button title={t.stop} onClick={() => push(t.stop + " · " + r.cid.slice(0, 6), "ti-square")}><i className="ti ti-square"></i></button>
+                        </span>
+                      </div>
+                    ))}
+                  </div>
+                )}
+              </div>
+            );
+          })}</div>}
+    </div>
+  );
+}
+
+/* ══════════════════════════════════════════════════════════════
+   VARIATION B — App cards + drill-in detail (wayfinding)
+   ══════════════════════════════════════════════════════════════ */
+function DashCards({ t, groups, totals, loading, push }) {
+  const [detail, setDetail] = dS(null);
+  const sel = detail ? groups.find((g) => g.id === detail) : null;
+
+  if (sel) {
+    const a = aggregate(sel);
+    return (
+      <div className="mock-pad" style={{ paddingTop: 16, paddingBottom: 40 }}>
+        <div className="crumbs">
+          <a onClick={() => setDetail(null)}>{t.dashboard}</a><i className="ti ti-chevron-right"></i>
+          <span style={{ color: "var(--text)" }}>{sel.name}</span>
+        </div>
+        <div style={{ display: "flex", alignItems: "center", gap: 13, marginBottom: 20 }}>
+          <DC.Logo app={sel} size={44} radius={11} />
+          <div style={{ flex: 1 }}>
+            <div className="page-title" style={{ fontSize: 22 }}>{sel.name}</div>
+            <div className="page-sub mono">{sel.id} · {a.n} {t.replicas}</div>
+          </div>
+          <button className="btn" onClick={() => setDetail(null)}><i className="ti ti-arrow-left"></i>{t.backToList}</button>
+        </div>
+        <div className="dash-metrics" style={{ gridTemplateColumns: "repeat(3,1fr)", maxWidth: 560 }}>
+          <div className="metric"><div className="metric__label"><i className="ti ti-users"></i>{t.totalSessions}</div><div className="metric__value tnum">{a.sessions}<small>/{a.sessionsMax}</small></div></div>
+          <div className="metric"><div className="metric__label"><i className="ti ti-cpu"></i>{t.avgCpu}</div><div className="metric__value tnum">{a.cpu}<small>%</small></div></div>
+          <div className="metric"><div className="metric__label"><i className="ti ti-database"></i>{t.totalMem}</div><div className="metric__value tnum">{a.mem}<small> MB</small></div></div>
+        </div>
+        <div style={{ height: 18 }}></div>
+        <div className="app-group is-open">
+          {sel.reps.map((r) => (
+            <div className="replica-row" key={r.cid} style={{ gridTemplateColumns: "24px 1.6fr 80px 90px 1fr 1fr 100px 40px" }}>
+              <span><StateDot s={r.state} /></span>
+              <span><span className="cid">{r.cid}</span> <span className="faint">· {r.host}</span></span>
+              <span className="mono faint" style={{ fontSize: 11 }}>{r.uptime}</span>
+              <span className="muted" style={{ fontSize: 11.5 }}>{stateLabel(r.state, t)}</span>
+              <span className="tnum">{r.sessions}<span className="faint">/{r.sessionsMax}</span></span>
+              <span className="metric-cell"><span className="tnum">{r.cpu}%</span><DC.Meter pct={r.cpu} color={DC.meterColor(r.cpu)} /></span>
+              <span className="tnum">{r.mem} MB</span>
+              <span className="replica-actions">
+                <button onClick={() => push(t.restart + " · " + r.cid.slice(0, 6), "ti-refresh")}><i className="ti ti-refresh"></i></button>
+              </span>
+            </div>
+          ))}
+        </div>
+      </div>
+    );
+  }
+
+  return (
+    <div className="mock-pad" style={{ paddingTop: 16, paddingBottom: 40 }}>
+      <DashHeader t={t} right={<LiveBadge t={t} />} />
+      <Metrics t={t} totals={totals} loading={loading} />
+      <div style={{ fontSize: 14, fontWeight: 600, marginBottom: 12 }}>{t.activeReplicas}</div>
+      {loading ? (
+        <div className="dash-cards">{Array.from({ length: 6 }).map((_, i) => (
+          <div className="dcard" key={i} style={{ cursor: "default" }}>
+            <div style={{ display: "flex", gap: 11, marginBottom: 14 }}><DC.SkBlock w={38} h={38} r={9} /><div style={{ flex: 1 }}><DC.SkBlock w={"50%"} h={12} style={{ marginBottom: 7 }} /><DC.SkBlock w={"30%"} h={9} /></div></div>
+            <DC.SkBlock w={"100%"} h={40} /><DC.SkBlock w={"100%"} h={30} style={{ marginTop: 14 }} />
+          </div>
+        ))}</div>
+      ) : (
+        <div className="dash-cards stagger">
+          {groups.map((g, i) => {
+            const a = aggregate(g);
+            const hp = a.state === "boot" ? "boot" : a.state === "warn" ? "warn" : "ok";
+            const spark = DC.makeSpark(24, 40 + i * 3, 26, i + 1);
+            return (
+              <div className="dcard" key={g.id} style={{ animationDelay: Math.min(i, 10) * 11 + "ms" }} onClick={() => setDetail(g.id)}>
+                <div className="dcard__top">
+                  <DC.Logo app={g} size={38} radius={9} />
+                  <div style={{ minWidth: 0 }}><div className="dcard__name">{g.name}</div><div className="dcard__id">{g.id}</div></div>
+                  <span className={"health-pill " + hp}>
+                    <StateDot s={a.state} />{a.state === "ok" || a.state === "ready" ? t.healthy : stateLabel(a.state, t)}
+                  </span>
+                </div>
+                <div className="dcard__stats">
+                  <div className="dcard__stat"><div className="k"><i className="ti ti-stack-2"></i> {t.replicas}</div><div className="v tnum">{a.n}</div></div>
+                  <div className="dcard__stat"><div className="k">{t.sessions}</div><div className="v tnum">{a.sessions}</div></div>
+                  <div className="dcard__stat"><div className="k">{t.cpu}</div><div className="v tnum">{a.cpu}%</div></div>
+                </div>
+                <div className="dcard__spark"><DC.Sparkline data={spark} color={g.accent} /></div>
+              </div>
+            );
+          })}
+        </div>
+      )}
+    </div>
+  );
+}
+
+/* ══════════════════════════════════════════════════════════════
+   VARIATION C — Dense ops table (grouped, sticky, filterable)
+   ══════════════════════════════════════════════════════════════ */
+function DashOps({ t, groups, totals, loading, push }) {
+  const [open, setOpen] = dS(() => new Set(groups.slice(0, 2).map((g) => g.id)));
+  const [filter, setFilter] = dS("");
+  const [stateF, setStateF] = dS("all");
+  const toggle = (id) => setOpen((s) => { const n = new Set(s); n.has(id) ? n.delete(id) : n.add(id); return n; });
+
+  const shown = groups.filter((g) => {
+    if (filter.trim() && !(g.name + " " + g.id).toLowerCase().includes(filter.trim().toLowerCase())) return false;
+    if (stateF !== "all" && aggregate(g).state !== stateF) return false;
+    return true;
+  });
+
+  const StateChip = ({ k, label }) => (
+    <button className={"chip" + (stateF === k ? " on-all" : "")} onClick={() => setStateF(stateF === k ? "all" : k)}>{label}</button>
+  );
+
+  return (
+    <div className="mock-pad" style={{ paddingTop: 16, paddingBottom: 40 }}>
+      <DashHeader t={t} right={<LiveBadge t={t} />} />
+      <Metrics t={t} totals={totals} loading={loading} />
+
+      <div className="ops-toolbar">
+        <div className="search-pill" style={{ maxWidth: 300, flex: "0 1 300px" }}>
+          <i className="ti ti-search"></i>
+          <input value={filter} onChange={(e) => setFilter(e.target.value)} placeholder={t.filterApp} />
+        </div>
+        <span className="chip-divider"></span>
+        <StateChip k="ready" label={t.ready} />
+        <StateChip k="warn" label={t.warn} />
+        <StateChip k="boot" label={t.booting} />
+        <div style={{ flex: 1 }}></div>
+        <span className="faint" style={{ fontSize: 11 }}>{t.lastRefresh}</span>
+      </div>
+
+      {loading ? (
+        <div className="ops-table" style={{ padding: 14 }}>{Array.from({ length: 8 }).map((_, i) => <DC.SkBlock key={i} w={"100%"} h={14} style={{ marginBottom: 12 }} />)}</div>
+      ) : (
+        <table className="ops-table">
+          <thead>
+            <tr>
+              <th style={{ width: 26 }}></th>
+              <th>App / {t.container}</th>
+              <th style={{ width: 70 }}>{t.replicas}</th>
+              <th style={{ width: 90 }}>{t.state}</th>
+              <th style={{ width: 80 }}>{t.uptime}</th>
+              <th style={{ width: 70 }}>{t.sessions}</th>
+              <th style={{ width: 90 }}>{t.cpu}</th>
+              <th style={{ width: 80 }}>{t.mem}</th>
+              <th style={{ width: 110 }}>24h</th>
+              <th style={{ width: 40 }}></th>
+            </tr>
+          </thead>
+          <tbody>
+            {shown.map((g, gi) => {
+              const a = aggregate(g);
+              const isOpen = open.has(g.id);
+              const spark = DC.makeSpark(20, 40 + gi * 2, 22, gi + 2);
+              return (
+                <React.Fragment key={g.id}>
+                  <tr className="grp-row" onClick={() => toggle(g.id)}>
+                    <td><i className="ti ti-chevron-right" style={{ transition: "transform .2s", transform: isOpen ? "rotate(90deg)" : "none", color: "var(--text-faint)" }}></i></td>
+                    <td><span style={{ display: "inline-flex", alignItems: "center", gap: 9 }}><DC.Logo app={g} size={24} radius={6} />{g.name} <span className="mono faint" style={{ fontSize: 10.5 }}>{g.id}</span></span></td>
+                    <td className="tnum">{a.n}</td>
+                    <td><span style={{ display: "inline-flex", alignItems: "center", gap: 6 }}><StateDot s={a.state} />{stateLabel(a.state, t)}</span></td>
+                    <td className="faint">—</td>
+                    <td className="tnum">{a.sessions}/{a.sessionsMax}</td>
+                    <td className="tnum">{a.cpu}%</td>
+                    <td className="tnum">{a.mem} MB</td>
+                    <td><DC.Sparkline data={spark} color={g.accent} h={22} /></td>
+                    <td></td>
+                  </tr>
+                  {isOpen && g.reps.map((r) => (
+                    <tr key={r.cid} className="fade-in">
+                      <td></td>
+                      <td style={{ paddingLeft: 46 }}><span className="cid">{r.cid}</span> <span className="faint">· {r.host}</span></td>
+                      <td></td>
+                      <td><span style={{ display: "inline-flex", alignItems: "center", gap: 6 }}><StateDot s={r.state} /><span className="muted">{stateLabel(r.state, t)}</span></span></td>
+                      <td className="mono faint">{r.uptime}</td>
+                      <td className="tnum">{r.sessions}/{r.sessionsMax}</td>
+                      <td className="tnum">{r.cpu}%</td>
+                      <td className="tnum">{r.mem} MB</td>
+                      <td></td>
+                      <td className="replica-actions">
+                        <button onClick={(e) => { e.stopPropagation(); push(t.restart + " · " + r.cid.slice(0, 6), "ti-refresh"); }}><i className="ti ti-refresh"></i></button>
+                      </td>
+                    </tr>
+                  ))}
+                </React.Fragment>
+              );
+            })}
+          </tbody>
+        </table>
+      )}
+    </div>
+  );
+}
+
+window.RKDashboard = Dashboard;

--- a/docs/design-handoff/src/data.jsx
+++ b/docs/design-handoff/src/data.jsx
@@ -1,0 +1,175 @@
+/* global window */
+// ── Ruscker prototype data: app catalog + dashboard replicas + i18n ──
+
+const KIND = {
+  app:     { badge: "APP", b: "b-app", tint: "tint-app", color: "#06d6a0", ink: "#04553f" },
+  api:     { badge: "API", b: "b-api", tint: "tint-api", color: "#06b6d4", ink: "#083344" },
+  package: { badge: "PKG", b: "b-package", tint: "tint-package", color: "#26547c", ink: "#ffffff" },
+  report:  { badge: "REL", b: "b-report", tint: "tint-report", color: "#ef476f", ink: "#ffffff" },
+};
+
+// Brand-ish accent + monogram used for the tinted cover placeholder
+// (real product would drop the framework logo here).
+const APPS = [
+  { id:"shiny", name:"Shiny", kind:"app", mono:"R", accent:"#447099",
+    subject:"Documentação", locked:true, status:"updated", updated:"02/06", featured:true,
+    desc:{pt:"Apps web reativos em R.", en:"Reactive web apps in R."}, replicas:6, state:"ready",
+    accessGroups:["admin","editor"] },
+  { id:"jupyter", name:"Jupyter", kind:"app", mono:"Jy", accent:"#f37726",
+    subject:"Documentação", locked:true, status:"updated", updated:"02/06", featured:true,
+    desc:{pt:"Notebooks interativos servidos como app web.", en:"Interactive notebooks served as a web app."}, replicas:4, state:"ready",
+    accessGroups:["admin","editor","viewer"] },
+  { id:"rstudio", name:"RStudio Server", kind:"app", mono:"R", accent:"#75aadb",
+    subject:"Documentação", locked:true, status:"updated", updated:"02/06", featured:true,
+    desc:{pt:"O IDE RStudio no navegador, servido por sessão.", en:"The RStudio IDE in your browser, served per session."}, replicas:3, state:"ready",
+    accessGroups:["admin"] },
+  { id:"streamlit", name:"Streamlit", kind:"app", mono:"St", accent:"#ff4b4b",
+    subject:"Documentação", locked:true, status:"updated", updated:"02/06", featured:true,
+    desc:{pt:"Dashboards de dados em Python, sem front-end.", en:"Python data dashboards, no front-end needed."}, replicas:5, state:"ready",
+    accessGroups:["admin","editor","viewer"] },
+  { id:"dash", name:"Dash", kind:"app", mono:"Da", accent:"#0d76bf",
+    subject:"Documentação", locked:true, status:"none", updated:"02/06", featured:false,
+    desc:{pt:"Apps analíticos em Python por Plotly.", en:"Analytical Python apps by Plotly."}, replicas:2, state:"ready",
+    accessGroups:["editor","viewer"] },
+  { id:"voila", name:"Voilà", kind:"app", mono:"Vo", accent:"#5a9e6f",
+    subject:"Documentação", locked:true, status:"none", updated:"02/06", featured:false,
+    desc:{pt:"Transforma notebooks Jupyter em apps standalone.", en:"Turns Jupyter notebooks into standalone apps."}, replicas:2, state:"warn",
+    accessGroups:["viewer","editor","admin"] },
+  { id:"shiny-for-python", name:"Shiny for Python", kind:"app", mono:"Sh", accent:"#1a6ea8",
+    subject:"Documentação", locked:true, status:"new", updated:"02/06", featured:false,
+    desc:{pt:"Apps web reativos em Python — o modelo do Shiny, ecossistema do Python.", en:"Reactive web apps in Python — Shiny's model, Python's ecosystem."}, replicas:3, state:"boot",
+    accessGroups:["admin","editor"] },
+  { id:"quarto", name:"Quarto", kind:"app", mono:"Qo", accent:"#39729e",
+    subject:"Documentação", locked:true, status:"none", updated:"02/06", featured:false,
+    desc:{pt:"Sistema de publicação científica e técnica.", en:"Scientific and technical publishing system."}, replicas:1, state:"ready",
+    accessGroups:[] },
+  { id:"fastapi", name:"FastAPI", kind:"api", mono:"Fa", accent:"#059487",
+    subject:"Documentação", locked:false, status:"none", updated:"02/06", featured:false,
+    desc:{pt:"Framework web de alta performance para APIs em Python.", en:"High-performance web framework for Python APIs."}, replicas:3, state:"ready",
+    accessGroups:[] },
+  { id:"plumber", name:"Plumber", kind:"api", mono:"Pl", accent:"#1f9e89",
+    subject:"Documentação", locked:false, status:"none", updated:"02/06", featured:false,
+    desc:{pt:"Transforma código R em uma API REST documentada.", en:"Turn R code into a documented REST API."}, replicas:2, state:"ready",
+    accessGroups:[] },
+  { id:"bokeh", name:"Bokeh", kind:"package", mono:"Bo", accent:"#22272e",
+    subject:"Documentação", locked:false, status:"none", updated:"02/06", featured:false,
+    desc:{pt:"Biblioteca de visualização interativa para navegadores.", en:"Interactive visualization library for browsers."}, replicas:1, state:"ready",
+    accessGroups:[] },
+  { id:"rmarkdown", name:"R Markdown", kind:"report", mono:"Rm", accent:"#75aadb",
+    subject:"Documentação", locked:true, status:"none", updated:"02/06", featured:false,
+    desc:{pt:"Documentos dinâmicos, relatórios e dashboards em R.", en:"Dynamic documents, reports and dashboards in R."}, replicas:1, state:"ready",
+    accessGroups:["editor","viewer"] },
+  { id:"ruscker-docs", name:"Ruscker", kind:"package", mono:"Ru", accent:"#0f6e56",
+    subject:"Documentação", locked:false, status:"none", updated:"02/06", featured:false,
+    desc:{pt:"Portal de containers e balanceador de carga para apps e APIs interativos.", en:"Container portal and load balancer for interactive web apps and APIs."}, replicas:1, state:"ready",
+    accessGroups:[] },
+];
+
+// host pool for replicas
+const HOSTS = ["local", "node-a", "node-b"];
+function rid() { return Math.random().toString(16).slice(2, 14); }
+
+// Build dashboard replicas grouped under each app.
+function buildReplicas() {
+  const groups = [];
+  let total = 0;
+  for (const a of APPS) {
+    const n = a.replicas;
+    const reps = [];
+    for (let i = 0; i < n; i++) {
+      const booting = a.state === "boot" && i === 0;
+      const warm = a.state === "warn" && i === 0;
+      reps.push({
+        cid: rid(),
+        host: HOSTS[i % HOSTS.length],
+        state: booting ? "boot" : warm ? "warn" : "ready",
+        uptime: booting ? "—" : `${(2 + i)}h ${10 + i * 7}m`,
+        sessions: booting ? 0 : Math.floor(Math.random() * 6),
+        sessionsMax: 10,
+        cpu: booting ? 0 : warm ? 34 : Math.floor(Math.random() * 18),
+        mem: booting ? 0 : warm ? 612 : 120 + Math.floor(Math.random() * 200),
+      });
+    }
+    total += n;
+    groups.push({ ...a, reps });
+  }
+  return { groups, total };
+}
+
+const I18N = {
+  pt: {
+    portal: "Portal", dashboard: "Painel",
+    portalSub: "Catálogo de aplicações e APIs",
+    dashSub: "Estado dos containers e sessões em tempo real",
+    search: "Buscar aplicação…", searchLong: "Buscar por nome, descrição, autor…",
+    all: "Todos", apps: "Aplicações", apis: "APIs", packages: "Pacotes", reports: "Relatórios",
+    free: "livres", restricted: "restritos",
+    recent: "Recentes", name: "Nome", sort: "Ordenar",
+    featured: "Em destaque", signin: "Entrar", openDocs: "Abrir",
+    results: "resultados", clear: "limpar filtros", noResults: "Nenhuma aplicação encontrada",
+    noResultsSub: "Tente outro termo ou limpe os filtros.",
+    loading: "Carregando catálogo…",
+    categories: "Categorias", access: "Acesso", quick: "Atalhos",
+    containers: "Containers", appsReplicas: "Apps com réplicas", activeSessions: "Sessões ativas",
+    tracked: "Sessões rastreadas", memUsed: "Memória usada",
+    activeReplicas: "Réplicas ativas", groupedByApp: "Agrupadas por aplicação",
+    expandAll: "Expandir tudo", collapseAll: "Recolher tudo",
+    replicas: "réplicas", replica: "réplica", state: "Estado", uptime: "Tempo no ar",
+    sessions: "Sessões", cpu: "CPU", mem: "Memória", host: "Host", container: "Container", actions: "Ações",
+    ready: "pronto", booting: "iniciando", warn: "alerta", stopped: "parado",
+    health: "Saúde", healthy: "saudável", logs: "Logs", restart: "Reiniciar", stop: "Parar",
+    refreshing: "Atualizando…", updated: "atualizado", live: "ao vivo",
+    backToList: "Réplicas", filterApp: "Filtrar app…",
+    avgCpu: "CPU média", totalMem: "Memória total", totalSessions: "Sessões",
+    newBadge: "novo", updatedBadge: "atualizado",
+    restarted: "reiniciado", peakToday: "pico hoje", lastRefresh: "atualizado agora",
+  },
+  en: {
+    portal: "Portal", dashboard: "Dashboard",
+    portalSub: "Application and API catalog",
+    dashSub: "Live container and session state",
+    search: "Search application…", searchLong: "Search by name, description, author…",
+    all: "All", apps: "Applications", apis: "APIs", packages: "Packages", reports: "Reports",
+    free: "public", restricted: "restricted",
+    recent: "Recent", name: "Name", sort: "Sort",
+    featured: "Featured", signin: "Sign in", openDocs: "Open",
+    results: "results", clear: "clear filters", noResults: "No application found",
+    noResultsSub: "Try another term or clear the filters.",
+    loading: "Loading catalog…",
+    categories: "Categories", access: "Access", quick: "Shortcuts",
+    containers: "Containers", appsReplicas: "Apps with replicas", activeSessions: "Active sessions",
+    tracked: "Tracked sessions", memUsed: "Memory used",
+    activeReplicas: "Active replicas", groupedByApp: "Grouped by application",
+    expandAll: "Expand all", collapseAll: "Collapse all",
+    replicas: "replicas", replica: "replica", state: "State", uptime: "Uptime",
+    sessions: "Sessions", cpu: "CPU", mem: "Memory", host: "Host", container: "Container", actions: "Actions",
+    ready: "ready", booting: "booting", warn: "warning", stopped: "stopped",
+    health: "Health", healthy: "healthy", logs: "Logs", restart: "Restart", stop: "Stop",
+    refreshing: "Refreshing…", updated: "updated", live: "live",
+    backToList: "Replicas", filterApp: "Filter app…",
+    avgCpu: "Avg CPU", totalMem: "Total memory", totalSessions: "Sessions",
+    newBadge: "new", updatedBadge: "updated",
+    restarted: "restarted", peakToday: "peak today", lastRefresh: "updated just now",
+  },
+};
+
+window.RK = { KIND, APPS, buildReplicas, I18N, rid };
+
+// ── Real brand logos (official simple marks; graceful monogram fallback
+//    via LogoImg). Drop exact files into assets/logos/<id>.svg to override. ──
+const LOGOS = {
+  jupyter: "https://cdn.simpleicons.org/jupyter",
+  rstudio: "https://cdn.simpleicons.org/rstudioide",
+  streamlit: "https://cdn.simpleicons.org/streamlit",
+  dash: "https://cdn.simpleicons.org/plotly",
+  "shiny-for-python": "https://cdn.simpleicons.org/python",
+  quarto: "https://cdn.simpleicons.org/quarto",
+  fastapi: "https://cdn.simpleicons.org/fastapi",
+  shiny: "https://cdn.simpleicons.org/r",
+  rmarkdown: "https://cdn.simpleicons.org/r",
+  plumber: "https://cdn.simpleicons.org/r",
+  bokeh: "https://cdn.simpleicons.org/python",
+  voila: "https://cdn.simpleicons.org/jupyter",
+  "ruscker-docs": "assets/ruscker-mark.svg",
+};
+APPS.forEach((a) => { a.logo = LOGOS[a.id] || null; });

--- a/docs/design-handoff/src/forms.jsx
+++ b/docs/design-handoff/src/forms.jsx
@@ -1,0 +1,486 @@
+/* global React, window */
+// ── Admin forms: App editor (live preview) + Import YAML ──
+const { useState: fS, useMemo: fM } = React;
+const AF = window.RKC;
+
+const ACCENTS = ["#447099", "#f37726", "#ff4b4b", "#0d76bf", "#059487", "#26547c", "#0f6e56", "#ef476f"];
+const RUNTIMES = {
+  pt: { "r": "R", "python": "Python", "quarto": "Quarto", "static": "Estático" },
+  en: { "r": "R", "python": "Python", "quarto": "Quarto", "static": "Static" },
+};
+
+/* ═══════════════════════════════ APP EDITOR ════════════════════ */
+function AppEditor({ t, app, isNew, onClose, push, appAccess, setAccess }) {
+  const lang = t._lang;
+  const [form, setForm] = fS(() => ({
+    id: isNew ? "" : app.id,
+    name: isNew ? "" : app.name,
+    kind: isNew ? "app" : app.kind,
+    descPt: isNew ? "" : (app.desc.pt || ""),
+    descEn: isNew ? "" : (app.desc.en || ""),
+    subject: isNew ? "Documentação" : app.subject,
+    locked: isNew ? true : app.locked,
+    replicas: isNew ? 1 : app.replicas,
+    accessGroups: isNew ? [] : (appAccess ? (appAccess.get(app.id) ?? app.accessGroups ?? []) : (app.accessGroups || [])),
+    accent: isNew ? ACCENTS[6] : app.accent,
+    mono: isNew ? "" : app.mono,
+    logo: isNew ? null : app.logo,
+    featured: isNew ? false : !!app.featured,
+    // advanced
+    runtime: isNew ? "r" : (app.kind === "api" ? "python" : "r"),
+    cmd: "",
+    workdir: "/srv/app",
+    port: 3838,
+    healthPath: "/",
+    timeout: 15,
+    maxSessions: 10,
+    cpu: 1,
+    mem: 512,
+    autoscale: false,
+    minR: 1,
+    maxR: 4,
+    env: [{ key: "", value: "" }],
+  }));
+  const [showAdv, setShowAdv] = fS(!isNew);
+  const set = (k, v) => setForm((f) => ({ ...f, [k]: v }));
+
+  // live preview app object
+  const preview = {
+    ...form,
+    name: form.name || (lang === "pt" ? "Nome do app" : "App name"),
+    mono: form.mono || (form.name ? form.name.slice(0, 2) : "Ap"),
+    desc: { pt: form.descPt || (lang === "pt" ? "Descrição curta do aplicativo." : ""), en: form.descEn || "Short app description." },
+    status: "none", updated: "05/06",
+  };
+
+  const KINDS = [
+    { k: "app", label: lang === "pt" ? "Aplicação" : "Application", icon: "ti-browser" },
+    { k: "api", label: "API", icon: "ti-api" },
+    { k: "package", label: lang === "pt" ? "Pacote" : "Package", icon: "ti-package" },
+    { k: "report", label: lang === "pt" ? "Relatório" : "Report", icon: "ti-file-text" },
+  ];
+
+  const valid = form.id.trim() && form.name.trim();
+  const setEnv = (i, k, v) => setForm((f) => { const env = f.env.map((e, j) => j === i ? { ...e, [k]: v } : e); return { ...f, env }; });
+  const addEnv = () => setForm((f) => ({ ...f, env: [...f.env, { key: "", value: "" }] }));
+  const rmEnv = (i) => setForm((f) => ({ ...f, env: f.env.filter((_, j) => j !== i).length ? f.env.filter((_, j) => j !== i) : [{ key: "", value: "" }] }));
+  const toggleGroup = (g) => set("accessGroups", form.accessGroups.includes(g) ? form.accessGroups.filter((x) => x !== g) : [...form.accessGroups, g]);
+  const GROUP_COLOR = { admin: "#ef476f", editor: "#06b6d4", viewer: "#26547c" };
+  const ALL_GROUPS = ["admin","editor","viewer"];
+  const save = () => { if (!valid) return; if (setAccess && !isNew) setAccess(form.id, form.accessGroups); push((isNew ? (lang === "pt" ? "App criado · " : "App created · ") : (lang === "pt" ? "Alterações salvas · " : "Saved · ")) + (form.name || form.id), "ti-check"); onClose(); };
+
+  return (
+    <div className="mock-pad" style={{ paddingTop: 16, paddingBottom: 40 }}>
+      <div className="crumbs">
+        <a onClick={onClose}>Apps</a><i className="ti ti-chevron-right"></i>
+        <span style={{ color: "var(--text)" }}>{isNew ? (lang === "pt" ? "Novo app" : "New app") : form.name}</span>
+      </div>
+      <div style={{ display: "flex", alignItems: "flex-end", justifyContent: "space-between", gap: 16, marginBottom: 22 }}>
+        <div className="page-title">{isNew ? (lang === "pt" ? "Novo aplicativo" : "New application") : (lang === "pt" ? "Editar aplicativo" : "Edit application")}</div>
+        <div style={{ display: "flex", gap: 8 }}>
+          <button className="btn" onClick={onClose}>{lang === "pt" ? "Cancelar" : "Cancel"}</button>
+          <button className={"btn btn--primary" + (valid ? "" : " is-disabled")} onClick={save}><i className="ti ti-device-floppy"></i>{lang === "pt" ? "Salvar" : "Save"}</button>
+        </div>
+      </div>
+
+      <div className="editor-grid">
+        {/* form */}
+        <div className="editor-form">
+          <div className="form-section">
+            <div className="form-section__title">{lang === "pt" ? "Identidade" : "Identity"}</div>
+            <div className="form-row two">
+              <Field label="ID" hint={lang === "pt" ? "slug único na URL" : "unique URL slug"}>
+                <input className="form-input mono" value={form.id} onChange={(e) => set("id", e.target.value.toLowerCase().replace(/[^a-z0-9-]/g, "-"))} placeholder="meu-app" />
+              </Field>
+              <Field label={lang === "pt" ? "Nome" : "Name"}>
+                <input className="form-input" value={form.name} onChange={(e) => set("name", e.target.value)} placeholder={lang === "pt" ? "Meu App" : "My App"} />
+              </Field>
+            </div>
+            <Field label={lang === "pt" ? "Assunto / categoria" : "Subject / category"}>
+              <input className="form-input" value={form.subject} onChange={(e) => set("subject", e.target.value)} />
+            </Field>
+          </div>
+
+          <div className="form-section">
+            <div className="form-section__title">{lang === "pt" ? "Tipo" : "Kind"}</div>
+            <div className="kind-picker">
+              {KINDS.map((kk) => (
+                <button key={kk.k} className={"kind-opt" + (form.kind === kk.k ? " on" : "")} onClick={() => set("kind", kk.k)} style={form.kind === kk.k ? { borderColor: window.RK.KIND[kk.k].color } : null}>
+                  <i className={"ti " + kk.icon} style={{ color: window.RK.KIND[kk.k].color }}></i>{kk.label}
+                </button>
+              ))}
+            </div>
+          </div>
+
+          <div className="form-section">
+            <div className="form-section__title">{lang === "pt" ? "Descrição" : "Description"}</div>
+            <Field label="Português">
+              <textarea className="form-input" rows={2} value={form.descPt} onChange={(e) => set("descPt", e.target.value)} placeholder={lang === "pt" ? "Descrição curta…" : "Short description…"}></textarea>
+            </Field>
+            <Field label="English">
+              <textarea className="form-input" rows={2} value={form.descEn} onChange={(e) => set("descEn", e.target.value)} placeholder="Short description…"></textarea>
+            </Field>
+          </div>
+
+          <div className="form-section">
+            <div className="form-section__title">{lang === "pt" ? "Aparência" : "Appearance"}</div>
+            <Field label={lang === "pt" ? "Cor de destaque" : "Accent color"}>
+              <div className="swatches">
+                {ACCENTS.map((c) => <button key={c} className={"swatch" + (form.accent === c ? " on" : "")} style={{ background: c }} onClick={() => set("accent", c)}></button>)}
+              </div>
+            </Field>
+            <div className="form-label" style={{ marginBottom: 8, display: "flex", alignItems: "center", gap: 6 }}><i className="ti ti-photo" style={{ fontSize: 14, color: "var(--text-faint)" }}></i>{lang === "pt" ? "Logo do app (da mídia)" : "App logo (from media)"}</div>
+            <window.RKMedia.MediaPicker value={form.logo} onPick={(src) => set("logo", form.logo === src ? null : src)} lang={lang} />
+            <div className="form-row two" style={{ marginTop: 14 }}>
+              <Field label={lang === "pt" ? "Monograma (fallback)" : "Monogram (fallback)"}>
+                <input className="form-input" maxLength={2} value={form.mono} onChange={(e) => set("mono", e.target.value)} placeholder="Ap" />
+              </Field>
+              <Field label={lang === "pt" ? "ou URL do logo" : "or Logo URL"}>
+                <input className="form-input mono" value={form.logo || ""} onChange={(e) => set("logo", e.target.value || null)} placeholder="assets/logos/…" />
+              </Field>
+            </div>
+          </div>
+
+          <div className="form-section">
+            <div className="form-section__title">{lang === "pt" ? "Acesso & escala" : "Access & scale"}</div>
+            <div className="toggle-row" onClick={() => set("locked", !form.locked)}>
+              <div><div className="toggle-row__label">{lang === "pt" ? "Acesso restrito" : "Restricted access"}</div><div className="toggle-row__hint">{lang === "pt" ? "Exige login para abrir" : "Requires sign-in to open"}</div></div>
+              <span className={"switch" + (form.locked ? " on" : "")}><span className="switch__dot"></span></span>
+            </div>
+
+            {/* Group access picker */}
+            <div style={{ paddingTop: 14 }}>
+              <div className="form-label" style={{ marginBottom: 9 }}>
+                <i className="ti ti-shield-lock" style={{ fontSize: 14, marginRight: 6, verticalAlign: "-2px", color: "var(--text-faint)" }}></i>
+                {lang === "pt" ? "Grupos com acesso" : "Groups with access"}
+                <span style={{ marginLeft: 8, fontSize: 11, color: "var(--text-faint)", fontWeight: 400 }}>{lang === "pt" ? "— vazio = público (todos)" : "— empty = public (everyone)"}</span>
+              </div>
+              <div style={{ display: "flex", gap: 8, flexWrap: "wrap", alignItems: "center" }}>
+                <button className={"group-toggle" + (form.accessGroups.length === 0 ? " on" : "")}
+                  style={form.accessGroups.length === 0 ? { borderColor: "var(--teal-600)", background: "color-mix(in srgb, var(--teal-600) 14%, transparent)", color: "var(--teal-600)" } : null}
+                  onClick={() => set("accessGroups", [])}>
+                  <i className={"ti " + (form.accessGroups.length === 0 ? "ti-check" : "ti-world")} style={{ fontSize: 13 }}></i>
+                  {lang === "pt" ? "Público" : "Public"}
+                </button>
+                {ALL_GROUPS.map((g) => (
+                  <button key={g}
+                    className={"group-toggle" + (form.accessGroups.includes(g) ? " on" : "")}
+                    disabled={form.accessGroups.length === 0}
+                    style={{
+                      ...(form.accessGroups.includes(g) ? { borderColor: GROUP_COLOR[g], background: `color-mix(in srgb, ${GROUP_COLOR[g]} 14%, transparent)`, color: GROUP_COLOR[g] } : null),
+                      ...(form.accessGroups.length === 0 ? { opacity: 0.32, cursor: "not-allowed" } : null),
+                    }}
+                    onClick={() => { if (form.accessGroups.length > 0) toggleGroup(g); }}>
+                    <i className={"ti " + (form.accessGroups.includes(g) ? "ti-check" : "ti-plus")} style={{ fontSize: 12 }}></i>
+                    {g === "admin" ? (lang === "pt" ? "Administrador" : "Administrator") : g === "editor" ? "Editor" : lang === "pt" ? "Visualizador" : "Viewer"}
+                  </button>
+                ))}
+              </div>
+              {form.accessGroups.length > 0 && (
+                <div style={{ fontSize: 11, color: "var(--text-faint)", marginTop: 8 }}>
+                  <i className="ti ti-info-circle" style={{ fontSize: 12, marginRight: 4 }}></i>
+                  {lang === "pt"
+                    ? `Visível apenas para usuários dos grupos: ${form.accessGroups.join(", ")}`
+                    : `Visible only to users in groups: ${form.accessGroups.join(", ")}`}
+                </div>
+              )}
+            </div>
+
+            <div className="toggle-row" onClick={() => set("featured", !form.featured)}>
+              <div><div className="toggle-row__label">{lang === "pt" ? "Em destaque" : "Featured"}</div><div className="toggle-row__hint">{lang === "pt" ? "Aparece no carrossel do portal" : "Shows in the portal carousel"}</div></div>
+              <span className={"switch" + (form.featured ? " on" : "")}><span className="switch__dot"></span></span>
+            </div>
+            <Field label={lang === "pt" ? "Réplicas iniciais" : "Initial replicas"}>
+              <div className="stepper">
+                <button onClick={() => set("replicas", Math.max(1, form.replicas - 1))}><i className="ti ti-minus"></i></button>
+                <span className="tnum">{form.replicas}</span>
+                <button onClick={() => set("replicas", Math.min(10, form.replicas + 1))}><i className="ti ti-plus"></i></button>
+              </div>
+            </Field>
+          </div>
+
+          {/* ── Advanced ── */}
+          <div className={"form-section adv-section" + (showAdv ? " is-open" : "")}>
+            <button className="adv-head" onClick={() => setShowAdv((s) => !s)}>
+              <span className="form-section__title" style={{ margin: 0 }}><i className="ti ti-adjustments" style={{ fontSize: 14, marginRight: 6, verticalAlign: "-2px" }}></i>{lang === "pt" ? "Avançado" : "Advanced"}</span>
+              <span className="adv-head__hint">{lang === "pt" ? "Runtime, recursos, ambiente, autoscaling" : "Runtime, resources, env, autoscaling"}</span>
+              <i className="ti ti-chevron-down adv-chev"></i>
+            </button>
+
+            {showAdv && (
+              <div className="adv-body fade-in">
+                <div className="form-row two">
+                  <Field label="Runtime">
+                    <div className="kind-picker" style={{ gridTemplateColumns: "1fr 1fr" }}>
+                      {Object.keys(RUNTIMES[lang]).map((rk) => (
+                        <button key={rk} className={"kind-opt" + (form.runtime === rk ? " on" : "")} style={{ padding: "8px 10px" }} onClick={() => set("runtime", rk)}>{RUNTIMES[lang][rk]}</button>
+                      ))}
+                    </div>
+                  </Field>
+                  <Field label={lang === "pt" ? "Porta interna" : "Internal port"}>
+                    <input className="form-input mono" value={form.port} onChange={(e) => set("port", e.target.value.replace(/\D/g, "").slice(0, 5))} />
+                  </Field>
+                </div>
+
+                <Field label={lang === "pt" ? "Comando de inicialização" : "Start command"} hint={lang === "pt" ? "opcional" : "optional"}>
+                  <input className="form-input mono" value={form.cmd} onChange={(e) => set("cmd", e.target.value)} placeholder={form.runtime === "python" ? "uvicorn app:app --port 3838" : "R -e 'shiny::runApp()'"} />
+                </Field>
+                <div className="form-row two">
+                  <Field label={lang === "pt" ? "Diretório de trabalho" : "Working directory"}>
+                    <input className="form-input mono" value={form.workdir} onChange={(e) => set("workdir", e.target.value)} />
+                  </Field>
+                  <Field label="Health check">
+                    <input className="form-input mono" value={form.healthPath} onChange={(e) => set("healthPath", e.target.value)} placeholder="/health" />
+                  </Field>
+                </div>
+
+                {/* resources */}
+                <div className="form-label" style={{ marginBottom: 10 }}>{lang === "pt" ? "Recursos por réplica" : "Resources per replica"}</div>
+                <div className="res-row">
+                  <span className="res-row__k"><i className="ti ti-cpu"></i> CPU</span>
+                  <input type="range" min="0.5" max="8" step="0.5" value={form.cpu} onChange={(e) => set("cpu", parseFloat(e.target.value))} className="rk-range" />
+                  <span className="res-row__v tnum">{form.cpu} {lang === "pt" ? "núcleos" : "cores"}</span>
+                </div>
+                <div className="res-row">
+                  <span className="res-row__k"><i className="ti ti-database"></i> {lang === "pt" ? "Memória" : "Memory"}</span>
+                  <input type="range" min="256" max="8192" step="256" value={form.mem} onChange={(e) => set("mem", parseInt(e.target.value, 10))} className="rk-range" />
+                  <span className="res-row__v tnum">{form.mem >= 1024 ? (form.mem / 1024).toFixed(form.mem % 1024 ? 1 : 0) + " GB" : form.mem + " MB"}</span>
+                </div>
+                <div className="form-row two" style={{ marginTop: 4 }}>
+                  <Field label={lang === "pt" ? "Timeout de sessão (min)" : "Session timeout (min)"}>
+                    <input className="form-input mono" value={form.timeout} onChange={(e) => set("timeout", e.target.value.replace(/\D/g, "").slice(0, 4))} />
+                  </Field>
+                  <Field label={lang === "pt" ? "Máx. sessões / réplica" : "Max sessions / replica"}>
+                    <input className="form-input mono" value={form.maxSessions} onChange={(e) => set("maxSessions", e.target.value.replace(/\D/g, "").slice(0, 4))} />
+                  </Field>
+                </div>
+
+                {/* env vars */}
+                <div style={{ display: "flex", alignItems: "center", justifyContent: "space-between", margin: "6px 0 8px" }}>
+                  <span className="form-label">{lang === "pt" ? "Variáveis de ambiente" : "Environment variables"}</span>
+                  <button className="mini-add" onClick={addEnv}><i className="ti ti-plus"></i>{lang === "pt" ? "Adicionar" : "Add"}</button>
+                </div>
+                <div style={{ display: "flex", flexDirection: "column", gap: 7 }}>
+                  {form.env.map((e, i) => (
+                    <div className="env-row" key={i}>
+                      <input className="form-input mono" value={e.key} onChange={(ev) => setEnv(i, "key", ev.target.value.toUpperCase().replace(/[^A-Z0-9_]/g, "_"))} placeholder="CHAVE" />
+                      <span className="env-eq">=</span>
+                      <input className="form-input mono" value={e.value} onChange={(ev) => setEnv(i, "value", ev.target.value)} placeholder="valor" />
+                      <button className="star-toggle" style={{ width: 30, height: 30 }} onClick={() => rmEnv(i)}><i className="ti ti-x" style={{ fontSize: 14 }}></i></button>
+                    </div>
+                  ))}
+                </div>
+
+                {/* autoscaling */}
+                <div className="toggle-row" style={{ marginTop: 14 }} onClick={() => set("autoscale", !form.autoscale)}>
+                  <div><div className="toggle-row__label">{lang === "pt" ? "Autoescala" : "Autoscaling"}</div><div className="toggle-row__hint">{lang === "pt" ? "Ajusta réplicas conforme a demanda" : "Scales replicas with demand"}</div></div>
+                  <span className={"switch" + (form.autoscale ? " on" : "")}><span className="switch__dot"></span></span>
+                </div>
+                {form.autoscale && (
+                  <div className="form-row two fade-in" style={{ marginTop: 12 }}>
+                    <Field label={lang === "pt" ? "Mín. réplicas" : "Min replicas"}>
+                      <div className="stepper">
+                        <button onClick={() => set("minR", Math.max(1, form.minR - 1))}><i className="ti ti-minus"></i></button>
+                        <span className="tnum">{form.minR}</span>
+                        <button onClick={() => set("minR", Math.min(form.maxR, form.minR + 1))}><i className="ti ti-plus"></i></button>
+                      </div>
+                    </Field>
+                    <Field label={lang === "pt" ? "Máx. réplicas" : "Max replicas"}>
+                      <div className="stepper">
+                        <button onClick={() => set("maxR", Math.max(form.minR, form.maxR - 1))}><i className="ti ti-minus"></i></button>
+                        <span className="tnum">{form.maxR}</span>
+                        <button onClick={() => set("maxR", Math.min(20, form.maxR + 1))}><i className="ti ti-plus"></i></button>
+                      </div>
+                    </Field>
+                  </div>
+                )}
+              </div>
+            )}
+          </div>
+        </div>
+
+        {/* live preview */}
+        <div className="editor-preview">
+          <div className="editor-preview__sticky">
+            <div className="form-section__title" style={{ marginBottom: 12 }}><i className="ti ti-eye" style={{ fontSize: 14, marginRight: 6, verticalAlign: "-2px" }}></i>{lang === "pt" ? "Pré-visualização" : "Live preview"}</div>
+            <div style={{ display: "flex", justifyContent: "center" }}>
+              <AF.AppCard app={preview} t={t} onOpen={() => {}} />
+            </div>
+            <div className="spec-summary">
+              <div className="spec-summary__row"><i className="ti ti-cpu"></i><span>{form.cpu} {lang === "pt" ? "núcleos" : "cores"} · {form.mem >= 1024 ? (form.mem / 1024).toFixed(form.mem % 1024 ? 1 : 0) + " GB" : form.mem + " MB"}</span></div>
+              <div className="spec-summary__row"><i className="ti ti-stack-2"></i><span>{form.autoscale ? `${form.minR}–${form.maxR} ${lang === "pt" ? "réplicas (auto)" : "replicas (auto)"}` : `${form.replicas} ${lang === "pt" ? "réplicas" : "replicas"}`}</span></div>
+              <div className="spec-summary__row"><i className="ti ti-clock"></i><span>{lang === "pt" ? "timeout" : "timeout"} {form.timeout} min · {form.maxSessions} {lang === "pt" ? "sessões" : "sessions"}</span></div>
+            </div>
+            <div className="preview-note">{lang === "pt" ? "É exatamente assim que o card aparece no portal." : "This is exactly how the card appears on the portal."}</div>
+          </div>
+        </div>
+      </div>
+    </div>
+  );
+}
+
+function Field({ label, hint, children }) {
+  return (
+    <label className="form-field">
+      <span className="form-label">{label}{hint && <span className="form-hint"> · {hint}</span>}</span>
+      {children}
+    </label>
+  );
+}
+
+/* ═══════════════════════════════ IMPORT YAML ══════════════════ */
+const SAMPLE_YAML = `apps:
+  - id: penguins-eda
+    name: Penguins EDA
+    kind: app
+    subject: Ciência de dados
+    locked: true
+    replicas: 3
+    description:
+      pt: Análise exploratória do dataset de pinguins.
+      en: Exploratory analysis of the penguins dataset.
+
+  - id: forecast-api
+    name: Forecast API
+    kind: api
+    locked: false
+    replicas: 2
+    description:
+      pt: Previsão de séries temporais via REST.
+      en: Time-series forecasting over REST.
+
+  - id: sales-dashboard
+    name: Sales Dashboard
+    kind: app
+    locked: true
+    replicas: 4
+    description:
+      pt: Painel de vendas em tempo real.
+      en: Real-time sales dashboard.
+
+  - id: docs-quarto
+    name: Docs (Quarto)
+    kind: report
+    locked: false
+    replicas: 1
+    description:
+      pt: Documentação técnica publicada com Quarto.
+      en: Technical docs published with Quarto.
+
+  - id: geo-utils
+    name: geo-utils
+    kind: package
+    locked: false
+    replicas: 1
+    description:
+      pt: Pacote utilitário de geoprocessamento.
+      en: Geoprocessing utility package.`;
+
+function ImportYaml({ t, onClose, push }) {
+  const lang = t._lang;
+  const [text, setText] = fS(SAMPLE_YAML);
+  const [sel, setSel] = fS(null); // Set of selected ids; null = all
+  const APPS = window.RK.APPS;
+  const existingIds = fM(() => new Set(APPS.map((a) => a.id)), []);
+
+  // ultra-light parse: split on "- id:" and pull a few fields for preview
+  const parsed = fM(() => {
+    const blocks = text.split(/\n\s*-\s+id:/).slice(1);
+    return blocks.map((b) => {
+      const id = b.trim().split(/\s|\n/)[0] || "?";
+      const name = (b.match(/name:\s*(.+)/) || [])[1] || id;
+      const kind = (b.match(/kind:\s*(.+)/) || [])[1] || "app";
+      const locked = /locked:\s*true/.test(b);
+      const replicas = ((b.match(/replicas:\s*(\d+)/) || [])[1]) || "1";
+      return { id: id.trim(), name: name.trim(), kind: kind.trim(), locked, replicas };
+    });
+  }, [text]);
+
+  const ids = parsed.map((p) => p.id);
+  const selected = sel === null ? new Set(ids) : new Set([...sel].filter((id) => ids.includes(id)));
+  const allOn = ids.length > 0 && ids.every((id) => selected.has(id));
+  const someOn = ids.some((id) => selected.has(id)) && !allOn;
+  const toggle = (id) => { const n = new Set(selected); n.has(id) ? n.delete(id) : n.add(id); setSel(n); };
+  const toggleAll = () => setSel(allOn ? new Set() : new Set(ids));
+  const count = selected.size;
+  const valid = count > 0 && parsed.every((p) => p.id && p.id !== "?");
+  const nNew = parsed.filter((p) => selected.has(p.id) && !existingIds.has(p.id)).length;
+  const nUpd = parsed.filter((p) => selected.has(p.id) && existingIds.has(p.id)).length;
+
+  return (
+    <div className="mock-pad" style={{ paddingTop: 16, paddingBottom: 40 }}>
+      <div className="crumbs">
+        <a onClick={onClose}>Apps</a><i className="ti ti-chevron-right"></i>
+        <span style={{ color: "var(--text)" }}>{lang === "pt" ? "Importar YAML" : "Import YAML"}</span>
+      </div>
+      <div style={{ display: "flex", alignItems: "flex-end", justifyContent: "space-between", gap: 16, marginBottom: 22 }}>
+        <div>
+          <div className="page-title">{lang === "pt" ? "Importar apps de YAML" : "Import apps from YAML"}</div>
+          <div className="page-sub">{lang === "pt" ? "Cole a definição ou arraste um arquivo .yml" : "Paste the definition or drop a .yml file"}</div>
+        </div>
+        <div style={{ display: "flex", gap: 8 }}>
+          <button className="btn" onClick={onClose}>{lang === "pt" ? "Cancelar" : "Cancel"}</button>
+          <button className={"btn btn--primary" + (valid ? "" : " is-disabled")} onClick={() => { if (valid) { push((lang === "pt" ? "Importados " : "Imported ") + count + (lang === "pt" ? " apps" : " apps"), "ti-check"); onClose(); } }}>
+            <i className="ti ti-file-import"></i>{lang === "pt" ? `Importar ${count}` : `Import ${count}`}{count !== parsed.length && parsed.length > 0 ? `/${parsed.length}` : ""}
+          </button>
+        </div>
+      </div>
+
+      <div className="editor-grid">
+        <div>
+          <div className="yaml-head">
+            <span><i className="ti ti-file-code" style={{ fontSize: 14, marginRight: 6, verticalAlign: "-2px" }}></i>apps.yml</span>
+            <button className="star-toggle" title={lang === "pt" ? "Restaurar exemplo" : "Reset sample"} onClick={() => { setText(SAMPLE_YAML); setSel(null); }} style={{ width: 26, height: 26 }}><i className="ti ti-rotate" style={{ fontSize: 14 }}></i></button>
+          </div>
+          <textarea className="yaml-editor mono" value={text} onChange={(e) => setText(e.target.value)} spellCheck={false}></textarea>
+        </div>
+
+        <div className="editor-preview">
+          <div className="editor-preview__sticky">
+            <div className="import-head">
+              <label className="sel-all" onClick={(e) => { e.preventDefault(); toggleAll(); }}>
+                <span className={"rk-check" + (allOn ? " on" : someOn ? " mixed" : "")}><i className={"ti " + (allOn ? "ti-check" : someOn ? "ti-minus" : "")}></i></span>
+                <span style={{ fontSize: 12, fontWeight: 500 }}>{lang === "pt" ? "Selecionar todos" : "Select all"}</span>
+              </label>
+              <span className="tnum faint" style={{ fontSize: 11 }}>{count}/{parsed.length}</span>
+            </div>
+            {parsed.length === 0 ? (
+              <div className="preview-note">{lang === "pt" ? "Nenhum app reconhecido ainda." : "No app recognized yet."}</div>
+            ) : (
+              <div style={{ display: "flex", flexDirection: "column", gap: 8 }}>
+                {parsed.map((p) => {
+                  const on = selected.has(p.id);
+                  const exists = existingIds.has(p.id);
+                  return (
+                    <div className={"parsed-row" + (on ? "" : " is-off")} key={p.id} onClick={() => toggle(p.id)} style={{ cursor: "pointer" }}>
+                      <span className={"rk-check" + (on ? " on" : "")}><i className="ti ti-check"></i></span>
+                      <span className="parsed-row__ico" style={{ background: "color-mix(in srgb, " + (window.RK.KIND[p.kind] ? window.RK.KIND[p.kind].color : "#888") + " 16%, var(--surface))" }}>
+                        <i className={"ti " + (p.kind === "api" ? "ti-api" : p.kind === "package" ? "ti-package" : p.kind === "report" ? "ti-file-text" : "ti-browser")}></i>
+                      </span>
+                      <div style={{ minWidth: 0, flex: 1 }}>
+                        <div style={{ fontSize: 13, fontWeight: 500, display: "flex", alignItems: "center", gap: 6 }}>{p.name}
+                          <span className="import-tag" style={exists ? { background: "rgba(245,158,11,.16)", color: "#92600a" } : { background: "rgba(16,185,129,.16)", color: "#047857" }}>{exists ? (lang === "pt" ? "atualiza" : "update") : (lang === "pt" ? "novo" : "new")}</span>
+                        </div>
+                        <div className="mono faint" style={{ fontSize: 10.5 }}>{p.id} · {p.replicas} {lang === "pt" ? "réplicas" : "replicas"}</div>
+                      </div>
+                      <i className={"ti " + (p.locked ? "ti-lock" : "ti-lock-open")} style={{ fontSize: 14, color: p.locked ? "var(--lock)" : "var(--lock-open)" }}></i>
+                    </div>
+                  );
+                })}
+              </div>
+            )}
+            {count > 0 && (
+              <div className="import-summary">
+                {nNew > 0 && <span><b className="tnum">{nNew}</b> {lang === "pt" ? "novos" : "new"}</span>}
+                {nNew > 0 && nUpd > 0 && <span>·</span>}
+                {nUpd > 0 && <span><b className="tnum">{nUpd}</b> {lang === "pt" ? "atualizados" : "updated"}</span>}
+              </div>
+            )}
+          </div>
+        </div>
+      </div>
+    </div>
+  );
+}
+
+window.RKForms = { AppEditor, ImportYaml };

--- a/docs/design-handoff/src/portal.jsx
+++ b/docs/design-handoff/src/portal.jsx
@@ -1,0 +1,403 @@
+/* global React, window */
+// ── Portal (public landing) — 3 variations ──
+const { useState: uS, useMemo: uM, useRef: uR, useEffect: uE } = React;
+const C = window.RKC;
+
+/* ── UserBanner: simulated "logged in as" bar at the top of the portal ──
+   Shows access context: anonymous vs. specific user (+ their groups).
+   This is a prototype control — in production, this is real auth. */
+function UserBanner({ t, portalUser, setPortalUser }) {
+  const lang = t._lang;
+  const [open, setOpen] = uS(false);
+  const users = (window.RUSCKER_USERS || []).filter((u) => u.status !== "suspended");
+  const GROUP_COLOR = { admin: "#ef476f", editor: "#06b6d4", viewer: "#26547c" };
+  return (
+    <div style={{ display: "flex", justifyContent: "flex-end", padding: "6px 0 2px", position: "relative" }}>
+      <button
+        onClick={() => setOpen((o) => !o)}
+        style={{
+          display: "inline-flex", alignItems: "center", gap: 6,
+          padding: "4px 10px 4px 8px", borderRadius: 999,
+          border: "0.5px solid var(--border)",
+          background: portalUser ? "color-mix(in srgb, var(--teal-600) 8%, var(--surface))" : "var(--surface)",
+          color: "var(--text-muted)", fontSize: 11.5, cursor: "pointer", fontFamily: "inherit",
+          transition: "all .12s",
+        }}
+      >
+        <i className={"ti " + (portalUser ? "ti-user-circle" : "ti-user-off")} style={{ fontSize: 14, color: portalUser ? "var(--teal-600)" : "var(--text-faint)" }}></i>
+        <span style={{ fontWeight: portalUser ? 500 : 400, color: portalUser ? "var(--text)" : "var(--text-faint)" }}>
+          {portalUser ? portalUser.name : (lang === "pt" ? "Anônimo" : "Anonymous")}
+        </span>
+        {portalUser && (portalUser.groups || []).map((g) => (
+          <span key={g} style={{ width: 6, height: 6, borderRadius: "50%", background: GROUP_COLOR[g], flexShrink: 0 }}></span>
+        ))}
+        <i className="ti ti-chevron-down" style={{ fontSize: 11, opacity: 0.5 }}></i>
+      </button>
+
+      {open && (
+        <div className="fade-in" style={{
+          position: "absolute", top: "calc(100% + 4px)", right: 0, zIndex: 50,
+          background: "var(--surface)", border: "0.5px solid var(--border)",
+          borderRadius: 10, boxShadow: "var(--shadow-lg)", minWidth: 200, overflow: "hidden",
+        }}>
+          <div style={{ padding: "8px 12px 6px", fontSize: 10, textTransform: "uppercase", letterSpacing: ".06em", color: "var(--text-faint)" }}>
+            {lang === "pt" ? "Simular usuário" : "Simulate user"}
+          </div>
+          {[null, ...users].map((u) => (
+            <button key={u ? u.id : "anon"}
+              onClick={() => { setPortalUser(u); setOpen(false); }}
+              style={{
+                display: "flex", alignItems: "center", gap: 8, width: "100%",
+                padding: "7px 12px", border: 0, background: (portalUser?.id === u?.id || (!portalUser && !u)) ? "var(--surface-soft)" : "transparent",
+                cursor: "pointer", fontSize: 12.5, fontFamily: "inherit", color: "var(--text)",
+                textAlign: "left",
+              }}
+            >
+              <i className={"ti " + (u ? "ti-user-circle" : "ti-world")} style={{ fontSize: 15, color: u ? "var(--teal-600)" : "var(--text-faint)", flexShrink: 0 }}></i>
+              <span style={{ flex: 1, fontWeight: (!portalUser && !u) || portalUser?.id === u?.id ? 600 : 400 }}>
+                {u ? u.name : (lang === "pt" ? "Anônimo (não logado)" : "Anonymous")}
+              </span>
+              {u && (u.groups || []).map((g) => (
+                <span key={g} style={{ width: 6, height: 6, borderRadius: "50%", background: GROUP_COLOR[g], flexShrink: 0 }}></span>
+              ))}
+            </button>
+          ))}
+        </div>
+      )}
+    </div>
+  );
+}
+
+function Portal({ variation, t, loading, onOpen, featured, appAccess, portalUser, setPortalUser, portalCfg }) {
+  const APPS = window.RK.APPS;
+  const [q, setQ] = uS("");
+  const [kind, setKind] = uS("all");
+  const [access, setAccess] = uS("all"); // all | free | restricted
+  const [sort, setSort] = uS("recent");
+
+  // ⌘K / Ctrl-K / "/" focuses search — keyboard-fast catalog navigation
+  uE(() => {
+    const onKey = (e) => {
+      const tag = (e.target.tagName || "").toLowerCase();
+      if (((e.metaKey || e.ctrlKey) && e.key.toLowerCase() === "k") || (e.key === "/" && tag !== "input" && tag !== "textarea")) {
+        e.preventDefault();
+        const el = document.getElementById("rk-portal-search");
+        if (el) el.focus();
+      }
+    };
+    window.addEventListener("keydown", onKey);
+    return () => window.removeEventListener("keydown", onKey);
+  }, []);
+
+  const counts = uM(() => {
+    const visible = APPS.filter((a) => {
+      const groups = appAccess ? (appAccess.get(a.id) ?? a.accessGroups ?? []) : (a.accessGroups || []);
+      if (groups.length === 0) return true;
+      if (!portalUser) return false;
+      return groups.some((g) => (portalUser.groups || []).includes(g));
+    });
+    const c = { all: visible.length, app: 0, api: 0, package: 0, report: 0, free: 0, restricted: 0 };
+    visible.forEach((a) => { c[a.kind]++; a.locked ? c.restricted++ : c.free++; });
+    return c;
+  }, [userKey, accessKey]);
+
+  // Convert appAccess Map to a stable key for memo deps
+  const accessKey = appAccess ? JSON.stringify([...appAccess.entries()].map(([k,v])=>k+':'+v.join(',')).sort()) : '';
+  const userKey = portalUser ? portalUser.id : 'anon';
+  const featKey = featured ? [...featured].sort().join(',') : '';
+
+  const filtered = uM(() => {
+    let list = APPS.filter((a) => {
+      // Access-group check: [] = public; non-empty = restricted to those groups
+      const groups = appAccess ? (appAccess.get(a.id) ?? a.accessGroups ?? []) : (a.accessGroups || []);
+      const isPublic = groups.length === 0;
+      if (!isPublic) {
+        if (!portalUser) return false; // anonymous: can't see restricted
+        const userGroups = portalUser.groups || [];
+        if (!groups.some((g) => userGroups.includes(g))) return false;
+      }
+      if (kind !== "all" && a.kind !== kind) return false;
+      if (access === "free" && a.locked) return false;
+      if (access === "restricted" && !a.locked) return false;
+      if (q.trim()) {
+        const s = (a.name + " " + a.desc[t._lang] + " " + a.subject).toLowerCase();
+        if (!s.includes(q.trim().toLowerCase())) return false;
+      }
+      return true;
+    });
+    if (sort === "name") list = [...list].sort((a, b) => a.name.localeCompare(b.name));
+    return list;
+  }, [q, kind, access, sort, t._lang, userKey, accessKey, featKey]);
+
+  const hasFilters = q.trim() || kind !== "all" || access !== "all";
+  const clear = () => { setQ(""); setKind("all"); setAccess("all"); };
+
+  const filterProps = { t, q, setQ, kind, setKind, access, setAccess, counts, sort, setSort, featured, appAccess, portalUser, setPortalUser, portalCfg };
+
+  if (variation === "b") return <PortalCompact {...filterProps} filtered={filtered} loading={loading} onOpen={onOpen} hasFilters={hasFilters} clear={clear} />;
+  if (variation === "c") return <PortalSections {...filterProps} loading={loading} onOpen={onOpen} hasFilters={hasFilters} clear={clear} filtered={filtered} />;
+  return <PortalRefined {...filterProps} filtered={filtered} loading={loading} onOpen={onOpen} hasFilters={hasFilters} clear={clear} />;
+}
+
+/* ── shared filter bar (chips) ─────────────────────────────────── */
+function FilterChips({ t, kind, setKind, access, setAccess, counts }) {
+  const Chip = ({ k, label }) => (
+    <button className={"chip" + (kind === k ? (k === "all" ? " on-all" : " on-" + k) : "")} onClick={() => setKind(k)}>
+      {label} <span className="chip-count">{counts[k] ?? 0}</span>
+    </button>
+  );
+  return (
+    <div style={{ display: "flex", flexWrap: "wrap", alignItems: "center", gap: 6 }}>
+      <Chip k="all" label={t.all} />
+      <Chip k="app" label={t.apps} />
+      <Chip k="api" label={t.apis} />
+      <Chip k="package" label={t.packages} />
+      <Chip k="report" label={t.reports} />
+      <span className="chip-divider"></span>
+      <button className={"access-chip" + (access === "free" ? " on" : "")} onClick={() => setAccess(access === "free" ? "all" : "free")}>
+        <i className="ti ti-lock-open" style={{ fontSize: 12, color: access === "free" ? "inherit" : "var(--lock-open)" }}></i>{t.free}
+      </button>
+      <button className={"access-chip" + (access === "restricted" ? " on" : "")} onClick={() => setAccess(access === "restricted" ? "all" : "restricted")}>
+        <i className="ti ti-lock" style={{ fontSize: 12, color: access === "restricted" ? "inherit" : "var(--lock)" }}></i>{t.restricted}
+      </button>
+    </div>
+  );
+}
+
+function SearchBar({ t, q, setQ, sort, setSort, long, inputId }) {
+  return (
+    <div style={{ display: "flex", gap: 10, alignItems: "center" }}>
+      <div className="search-pill">
+        <i className="ti ti-search"></i>
+        <input id={inputId} value={q} onChange={(e) => setQ(e.target.value)} placeholder={long ? t.searchLong : t.search} />
+        <span className="kbd">⌘ K</span>
+      </div>
+      <button className="sort-btn" onClick={() => setSort(sort === "recent" ? "name" : "recent")}>
+        <i className="ti ti-arrows-sort"></i>{sort === "recent" ? t.recent : t.name}
+        <i className="ti ti-chevron-down"></i>
+      </button>
+    </div>
+  );
+}
+
+function ResultsLine({ t, n, hasFilters, clear }) {
+  return (
+    <div style={{ fontSize: 11.5, color: "var(--text-faint)", display: "flex", alignItems: "center", gap: 8 }}>
+      <span className="tnum">{n} {t.results}</span>
+      {hasFilters && (
+        <button onClick={clear} style={{ fontSize: 11, padding: "2px 8px", color: "var(--teal-600)", background: "transparent", border: 0, cursor: "pointer", display: "inline-flex", alignItems: "center", gap: 4 }}>
+          <i className="ti ti-x" style={{ fontSize: 12 }}></i>{t.clear}
+        </button>
+      )}
+    </div>
+  );
+}
+
+function NoResults({ t }) {
+  return (
+    <div style={{ textAlign: "center", padding: "60px 20px", color: "var(--text-muted)" }}>
+      <i className="ti ti-mood-empty" style={{ fontSize: 34, color: "var(--text-faint)" }}></i>
+      <div style={{ fontSize: 15, fontWeight: 500, marginTop: 12, color: "var(--text)" }}>{t.noResults}</div>
+      <div style={{ fontSize: 12.5, marginTop: 4 }}>{t.noResultsSub}</div>
+    </div>
+  );
+}
+
+/* ── HtmlSlot: renders a named HTML injection point ── */
+function HtmlSlot({ html }) {
+  if (!html || !html.trim()) return null;
+  return <div className="html-slot fade-in" dangerouslySetInnerHTML={{ __html: html }} />;
+}
+
+/* ══════════════════════════════════════════════════════════════
+   VARIATION A — Refined (faithful + skeletons + instant filter)
+   ══════════════════════════════════════════════════════════════ */
+function FeaturedCarousel({ t, loading, onOpen, featured, appAccess, portalUser, portalCfg }) {
+  const userKey2 = portalUser ? portalUser.id : 'anon';
+  const feat = uM(() => window.RK.APPS.filter((a) => {
+    if (!featured || !featured.has(a.id)) return false;
+    const groups = appAccess ? (appAccess.get(a.id) ?? a.accessGroups ?? []) : (a.accessGroups || []);
+    if (groups.length === 0) return true;
+    if (!portalUser) return false;
+    return groups.some((g) => (portalUser.groups || []).includes(g));
+  }), [userKey2, featured, appAccess]);
+  const [page, setPage] = uS(0);
+  const per = 3, pages = Math.ceil((feat || []).length / per);
+  if (!loading && (!feat || feat.length === 0)) return null;
+  const card = 256 + 14;
+  return (
+    <div className="feat">
+      <div className="feat-head"><i className="ti ti-star"></i>{t.featured}</div>
+      <div className="feat-stage">
+        <button className="feat-arrow" disabled={page === 0} onClick={() => setPage(Math.max(0, page - 1))}><i className="ti ti-chevron-left"></i></button>
+        <div className="feat-viewport">
+          <div className="feat-track" style={{ transform: `translateX(-${page * per * card}px)` }}>
+            {loading
+              ? Array.from({ length: 3 }).map((_, i) => <div key={i} style={{ flex: "0 0 auto" }}><C.SkCard /></div>)
+              : feat.map((a) => <div key={a.id} style={{ flex: "0 0 auto" }}><C.AppCard app={a} t={t} onOpen={onOpen} coverStyle={portalCfg && portalCfg.cover} /></div>)}
+          </div>
+        </div>
+        <button className="feat-arrow" disabled={page >= pages - 1} onClick={() => setPage(Math.min(pages - 1, page + 1))}><i className="ti ti-chevron-right"></i></button>
+      </div>
+    </div>
+  );
+}
+
+function PortalRefined({ t, q, setQ, kind, setKind, access, setAccess, counts, sort, setSort, filtered, loading, onOpen, hasFilters, clear, featured, appAccess, portalUser, setPortalUser, portalCfg }) {
+  return (
+    <div className="mock-pad" style={{ paddingTop: 8, paddingBottom: 40, "--rk-accent": portalCfg ? portalCfg.accent : undefined }}>
+      {portalCfg && portalCfg.htmlTop && <HtmlSlot html={portalCfg.htmlTop} />}
+      <UserBanner t={t} portalUser={portalUser} setPortalUser={setPortalUser} />
+      {(portalCfg ? portalCfg.featured : true) && <FeaturedCarousel t={t} loading={loading} onOpen={onOpen} featured={featured} appAccess={appAccess} portalUser={portalUser} portalCfg={portalCfg} />}
+      <div className="portal-sticky">
+        {(!portalCfg || portalCfg.showSearch) && <SearchBar t={t} q={q} setQ={setQ} sort={sort} setSort={setSort} long inputId="rk-portal-search" />}
+        {(!portalCfg || portalCfg.showAccess) && <FilterChips t={t} kind={kind} setKind={setKind} access={access} setAccess={setAccess} counts={counts} />}
+        <ResultsLine t={t} n={loading ? "…" : filtered.length} hasFilters={hasFilters} clear={clear} />
+      </div>
+      {loading ? (
+        <div className="cards-grid">{Array.from({ length: 8 }).map((_, i) => <C.SkCard key={i} />)}</div>
+      ) : filtered.length === 0 ? <NoResults t={t} /> : (
+        <div className="cards-grid stagger" key={kind + access + sort + q}>
+          {filtered.map((a, i) => <div key={a.id} style={{ animationDelay: Math.min(i, 10) * 10 + "ms" }}><C.AppCard app={a} t={t} onOpen={onOpen} /></div>)}
+        </div>
+      )}
+      {portalCfg && portalCfg.htmlBeforeFooter && <HtmlSlot html={portalCfg.htmlBeforeFooter} />}
+    </div>
+  );
+}
+
+/* ══════════════════════════════════════════════════════════════
+   VARIATION B — Compact: left nav rail + dense rows
+   ══════════════════════════════════════════════════════════════ */
+function HeroFeatured({ t, loading, onOpen, featured }) {
+  const feat = window.RK.APPS.filter((a) => featured && featured.has(a.id));
+  const [i, setI] = uS(0);
+  const a = feat[i] || feat[0];
+  if (!loading && feat.length === 0) return null;
+  if (loading) {
+    return (
+      <div className="hero-feat">
+        <C.SkBlock w={200} h={160} r={10} />
+        <div style={{ flex: 1, display: "flex", flexDirection: "column", justifyContent: "center", gap: 12 }}>
+          <C.SkBlock w={120} h={10} /><C.SkBlock w={"50%"} h={22} /><C.SkBlock w={"80%"} h={10} /><C.SkBlock w={140} h={34} r={999} />
+        </div>
+      </div>
+    );
+  }
+  return (
+    <div className="hero-feat fade-in">
+      <div className="hero-feat__art" style={{ width: 200, background: `color-mix(in srgb, ${a.accent} 14%, var(--surface))`, color: a.accent }}>{a.mono}</div>
+      <div className="hero-feat__body">
+        <div className="hero-feat__kicker"><i className="ti ti-star"></i>{t.featured}</div>
+        <div className="hero-feat__title">{a.name}</div>
+        <div className="hero-feat__desc">{a.desc[t._lang]}</div>
+        <button className="hero-feat__cta" onClick={() => onOpen(a)}>{t.openDocs}<i className="ti ti-arrow-right"></i></button>
+        <div className="hero-feat__dots">{feat.map((_, k) => <span key={k} className={k === i ? "on" : ""} onClick={() => setI(k)}></span>)}</div>
+      </div>
+    </div>
+  );
+}
+
+function PortalCompact({ t, q, setQ, kind, setKind, access, setAccess, counts, sort, setSort, filtered, loading, onOpen, hasFilters, clear, featured, appAccess, portalUser, portalCfg }) {
+  const NavItem = ({ k, icon, label, count }) => (
+    <button className={"navrail__item" + (kind === k ? " on" : "")} onClick={() => setKind(k)}>
+      <i className={"ti " + icon}></i>{label}<span className="count">{count}</span>
+    </button>
+  );
+  return (
+    <div className="mock-pad" style={{ paddingTop: 8, paddingBottom: 40 }}>
+      <div className="split">
+        <aside className="navrail">
+          <div className="navrail__group">{t.categories}</div>
+          <NavItem k="all" icon="ti-stack-2" label={t.all} count={counts.all} />
+          <NavItem k="app" icon="ti-browser" label={t.apps} count={counts.app} />
+          <NavItem k="api" icon="ti-api" label={t.apis} count={counts.api} />
+          <NavItem k="package" icon="ti-package" label={t.packages} count={counts.package} />
+          <NavItem k="report" icon="ti-file-text" label={t.reports} count={counts.report} />
+          <div className="navrail__group">{t.access}</div>
+          <button className={"navrail__item" + (access === "free" ? " on" : "")} onClick={() => setAccess(access === "free" ? "all" : "free")}>
+            <i className="ti ti-lock-open"></i>{t.free}<span className="count">{counts.free}</span>
+          </button>
+          <button className={"navrail__item" + (access === "restricted" ? " on" : "")} onClick={() => setAccess(access === "restricted" ? "all" : "restricted")}>
+            <i className="ti ti-lock"></i>{t.restricted}<span className="count">{counts.restricted}</span>
+          </button>
+        </aside>
+        <main style={{ minWidth: 0 }}>
+          <FeaturedCarousel t={t} loading={loading} onOpen={onOpen} featured={featured} appAccess={appAccess} portalUser={portalUser} portalCfg={portalCfg} />
+          <div style={{ display: "flex", flexDirection: "column", gap: 12, marginBottom: 14 }}>
+            <SearchBar t={t} q={q} setQ={setQ} sort={sort} setSort={setSort} long />
+            <ResultsLine t={t} n={loading ? "…" : filtered.length} hasFilters={hasFilters} clear={clear} />
+          </div>
+          {loading ? (
+            <div style={{ display: "flex", flexDirection: "column", gap: 8 }}>{Array.from({ length: 7 }).map((_, i) => <C.SkRow key={i} />)}</div>
+          ) : filtered.length === 0 ? <NoResults t={t} /> : (
+            <div className="stagger" key={kind + access + sort + q} style={{ display: "flex", flexDirection: "column", gap: 8 }}>
+              {filtered.map((a, i) => <div key={a.id} style={{ animationDelay: Math.min(i, 10) * 9 + "ms" }}><C.AppRow app={a} t={t} onOpen={onOpen} /></div>)}
+            </div>
+          )}
+        </main>
+      </div>
+    </div>
+  );
+}
+
+/* ══════════════════════════════════════════════════════════════
+   VARIATION C — Sectioned rails (app-store feel)
+   ══════════════════════════════════════════════════════════════ */
+function PortalSections({ t, q, setQ, kind, setKind, access, setAccess, counts, sort, setSort, filtered, loading, onOpen, hasFilters, clear, featured, appAccess, portalUser, portalCfg }) {
+  const groupsDef = [
+    { k: "app", icon: "ti-browser", label: t.apps },
+    { k: "api", icon: "ti-api", label: t.apis },
+    { k: "package", icon: "ti-package", label: t.packages },
+    { k: "report", icon: "ti-file-text", label: t.reports },
+  ];
+  const searching = q.trim() || access !== "all";
+  return (
+    <div className="mock-pad" style={{ paddingTop: 8, paddingBottom: 40 }}>
+      <FeaturedCarousel t={t} loading={loading} onOpen={onOpen} featured={featured} appAccess={appAccess} portalUser={portalUser} portalCfg={portalCfg} />
+      <div style={{ display: "flex", flexDirection: "column", gap: 12, marginBottom: 22 }}>
+        <SearchBar t={t} q={q} setQ={setQ} sort={sort} setSort={setSort} long />
+        <FilterChips t={t} kind={kind} setKind={setKind} access={access} setAccess={setAccess} counts={counts} />
+      </div>
+
+      {loading ? (
+        [0, 1].map((s) => (
+          <div className="rail-section" key={s}>
+            <div className="rail-head"><C.SkBlock w={140} h={16} /></div>
+            <div className="rail">{Array.from({ length: 4 }).map((_, i) => <C.SkCard key={i} />)}</div>
+          </div>
+        ))
+      ) : searching || kind !== "all" ? (
+        <div>
+          <div className="rail-head" style={{ marginBottom: 14 }}>
+            <span className="rail-head__title"><i className="ti ti-search" style={{ fontSize: 16 }}></i>{filtered.length} {t.results}</span>
+            <span className="rail-head__line"></span>
+            {hasFilters && <button onClick={clear} style={{ fontSize: 11, color: "var(--teal-600)", background: "transparent", border: 0, cursor: "pointer" }}>{t.clear}</button>}
+          </div>
+          {filtered.length === 0 ? <NoResults t={t} /> :
+            <div className="cards-grid stagger" key={kind + access + q}>{filtered.map((a, i) => <div key={a.id} style={{ animationDelay: Math.min(i, 10) * 10 + "ms" }}><C.AppCard app={a} t={t} onOpen={onOpen} /></div>)}</div>}
+        </div>
+      ) : (
+        groupsDef.map((g) => {
+          const items = filtered.filter((a) => a.kind === g.k);
+          if (!items.length) return null;
+          return (
+            <div className="rail-section fade-in" key={g.k}>
+              <div className="rail-head">
+                <span className="rail-head__title"><i className={"ti " + g.icon} style={{ fontSize: 17, color: window.RK.KIND[g.k].color }}></i>{g.label}</span>
+                <span className="rail-head__count">{items.length}</span>
+                <span className="rail-head__line"></span>
+                <button onClick={() => setKind(g.k)} style={{ fontSize: 11.5, color: "var(--text-muted)", background: "transparent", border: 0, cursor: "pointer", display: "inline-flex", gap: 4, alignItems: "center" }}>
+                  {t.all}<i className="ti ti-chevron-right" style={{ fontSize: 13 }}></i>
+                </button>
+              </div>
+              <div className="rail">{items.map((a) => <C.AppCard key={a.id} app={a} t={t} onOpen={onOpen} />)}</div>
+            </div>
+          );
+        })
+      )}
+    </div>
+  );
+}
+
+window.RKPortal = Portal;


### PR DESCRIPTION
**Slice 0 of #623.** Vendors the high-fidelity UX prototype bundle into `docs/design-handoff/` so the redesign is versioned and accessible — it only existed on a local machine, blocking anyone else from implementing.

Adds `NOTES.md` flagging that:
- it's **reference** (React/JSX + in-browser Babel) to be **recreated** in Askama/HTMX/Alpine, not ported;
- `assets/ruscker.css` is the **token source of truth** (reconcile vs the live `input.css`);
- known doc drift — **Jost not Geist**, **no `ti-*-filled`** (inline SVG for filled glyphs), and the simulated-user picker is prototype-only.

No product code touched. Unblocks the remaining slices of #623.

🤖 Generated with [Claude Code](https://claude.com/claude-code)