### PR TITLE
feat(landing): sticky filter cluster on the public portal (#623, slice 2)

### DIFF
--- a/crates/ruscker-admin/assets/tailwind/input.css
+++ b/crates/ruscker-admin/assets/tailwind/input.css
@@ -185,6 +185,19 @@ body {
   .topbar-progress { transition: opacity 0.25s ease; }
 }
 
+/* ─── Sticky filter cluster (design handoff #623) ─────────────────
+ * Keeps search + filters reachable while scrolling a long catalog. The
+ * portal header isn't sticky, so this sticks to the viewport top (top:0)
+ * once the header scrolls away. The --bg backdrop hides the cards passing
+ * underneath; z-index sits above the grid but below any modal. */
+.portal-sticky {
+  position: sticky; top: 0; z-index: 30;
+  background: var(--bg);
+  padding-top: 12px; padding-bottom: 10px;
+  margin-bottom: 6px;
+  border-bottom: 0.5px solid var(--border);
+}
+
 /* ─── Filter row: search pill + sort button ───────────────────── */
 .search-pill {
   display: flex; align-items: center; gap: 8px;

--- a/crates/ruscker-admin/templates/landing.html
+++ b/crates/ruscker-admin/templates/landing.html
@@ -173,6 +173,9 @@
   </section>
   {% endif %}
 
+  {# ── Sticky filter cluster (#623): search + filters + meta stay
+     reachable while the catalog scrolls under them. ── #}
+  <div class="portal-sticky">
   {# ── Filter row 1: search + theme select + sort + status ───── #}
   <div class="flex flex-wrap gap-2.5 items-center mb-3.5">
     <label class="search-pill flex-1 min-w-[180px]">
@@ -260,6 +263,7 @@
       {{ self.t("filter-clear") }}
     </button>
   </div>
+  </div>{# /portal-sticky #}
 
   {# ── Card grid (fixed-width cards, columns auto-fill) ──────── #}
   <section class="cards-grid" x-ref="grid">


### PR DESCRIPTION
**Slice 2 of #623.**

The portal already shares the handoff's structure and class vocabulary (`.rcard` / `.rcover` / `.search-pill` / `.highlights` — the handoff CSS was *adapted from this codebase*), so the bulk of "Portal público" was already in place from earlier phases. This slice closes the one behavioural gap vs the design: **search + filters stay reachable while the catalog scrolls**.

Wraps the search/select row, the type + access chips, and the result-count row in a `.portal-sticky` container. The portal header isn't sticky, so it sticks to the viewport top (`top:0`) once the header scrolls away, with a `--bg` backdrop hiding the cards underneath. (The handoff's `top:53px` assumed a fixed-height sticky header — not our layout.)

## Verification
Admin suite (12 groups) + clippy + i18n green; serve smoke — landing `200`, the wrapper renders once and div-balances, `.portal-sticky` compiles into the served CSS.

> Note: deeper pixel-level portal polish (header chrome, carousel chevron styling) is best done with browser-based visual iteration against the prototype — flagged for a visual pairing pass rather than blind CSS edits to a production page.

Part of #623.

🤖 Generated with [Claude Code](https://claude.com/claude-code)