### PR TITLE
feat(admin): syntax-highlighted code editors for CSS/HTML (#623, slice 6)

### DIFF
--- a/crates/ruscker-admin/assets/tailwind/input.css
+++ b/crates/ruscker-admin/assets/tailwind/input.css
@@ -289,6 +289,46 @@ body {
   border: 0.5px solid var(--border); border-radius: 12px; background: var(--surface);
 }
 
+/* ─── Syntax-highlighted code editor (design handoff #623) ─────────
+ * A transparent <textarea> over a highlighted <pre>; the tokenizers run
+ * client-side (see admin/_code_editor.html). The textarea keeps its name
+ * and value, so the form submits exactly as before — purely a view layer.
+ * VS Code "Dark+" palette, dark in both themes (it's a code surface). */
+.code-editor-wrap {
+  position: relative;
+  border: 1px solid #30363d; border-radius: 10px; overflow: hidden;
+  background: #0d1117;
+  font-family: var(--font-mono); font-size: 12.5px; line-height: 1.65;
+  box-shadow: inset 0 1px 0 rgba(255, 255, 255, 0.04);
+}
+.code-editor-pre, .code-editor-ta {
+  margin: 0; padding: 14px 16px; width: 100%; box-sizing: border-box;
+  font: inherit; line-height: inherit; tab-size: 2;
+  white-space: pre-wrap; word-wrap: break-word; overflow: auto;
+}
+.code-editor-pre {
+  position: absolute; inset: 0; pointer-events: none;
+  color: #e6edf3; border: none; background: transparent; overflow: hidden;
+}
+.code-editor-ta {
+  position: relative; z-index: 1;
+  background: transparent; color: transparent; caret-color: #e6edf3;
+  resize: vertical; border: none; outline: none; min-height: 120px;
+}
+.code-editor-ta::selection { background: rgba(56, 139, 253, 0.3); color: transparent; }
+.code-editor-ta::placeholder { color: #484f58; }
+
+.tok-comment   { color: #6a9955; font-style: italic; }
+.tok-string    { color: #ce9178; }
+.tok-atrule    { color: #c586c0; }
+.tok-selector  { color: #d7ba7d; }
+.tok-prop      { color: #9cdcfe; }
+.tok-number    { color: #b5cea8; }
+.tok-hexcolor  { color: #ce9178; font-weight: 500; }
+.tok-important { color: #f44747; font-weight: 700; }
+.tok-tag       { color: #4ec9b0; }
+.tok-attr      { color: #9cdcfe; }
+
 /* ─── Sticky filter cluster (design handoff #623) ─────────────────
  * Keeps search + filters reachable while scrolling a long catalog. The
  * portal header isn't sticky, so this sticks to the viewport top (top:0)

--- a/crates/ruscker-admin/templates/admin/_code_editor.html
+++ b/crates/ruscker-admin/templates/admin/_code_editor.html
@@ -1,0 +1,112 @@
+{# Syntax-highlighted code editor (design handoff #623).
+
+   Progressive enhancement: any `.code-editor-wrap` on the page gets its
+   transparent `.code-editor-ta` <textarea> highlighted into the sibling
+   `.code-editor-pre`, scroll-synced. The textarea keeps its `name` and
+   value, so the surrounding form submits exactly as before — this is a
+   pure view layer, no backend contract changes. `data-mode` picks the
+   tokenizer ("css" default, or "html"). Single-pass tokenizers ported
+   from the prototype; framework-free so it works on any page. #}
+<script>
+(function () {
+  function escHtml(s) {
+    return s.replace(/&/g, "&amp;").replace(/</g, "&lt;").replace(/>/g, "&gt;");
+  }
+
+  function highlightCSS(raw) {
+    var out = "", i = 0, n = raw.length;
+    while (i < n) {
+      if (raw[i] === "/" && raw[i + 1] === "*") {
+        var e = raw.indexOf("*/", i + 2), end = e < 0 ? n : e + 2;
+        out += '<span class="tok-comment">' + escHtml(raw.slice(i, end)) + "</span>"; i = end; continue;
+      }
+      if (raw[i] === '"' || raw[i] === "'") {
+        var q = raw[i], j = i + 1;
+        while (j < n && raw[j] !== q) { if (raw[j] === "\\") j++; j++; }
+        out += '<span class="tok-string">' + escHtml(raw.slice(i, j + 1)) + "</span>"; i = j + 1; continue;
+      }
+      if (raw[i] === "@") {
+        var ma = raw.slice(i).match(/^@[\w-]+/);
+        if (ma) { out += '<span class="tok-atrule">' + escHtml(ma[0]) + "</span>"; i += ma[0].length; continue; }
+      }
+      if (raw.slice(i, i + 10) === "!important") {
+        out += '<span class="tok-important">!important</span>'; i += 10; continue;
+      }
+      if (raw[i] === "#") {
+        var mh = raw.slice(i).match(/^#[0-9a-fA-F]{3,8}\b/);
+        if (mh) { out += '<span class="tok-hexcolor">' + escHtml(mh[0]) + "</span>"; i += mh[0].length; continue; }
+      }
+      if (/[\w-]/.test(raw[i]) && i > 0) {
+        var mp = raw.slice(i).match(/^([\w-]+)(\s*:(?!:))/);
+        if (mp) {
+          var ctx = raw.slice(0, i).replace(/\/\*[\s\S]*?\*\//g, "");
+          var inBlock = (ctx.match(/[{]/g) || []).length > (ctx.match(/[}]/g) || []).length;
+          if (inBlock) { out += '<span class="tok-prop">' + escHtml(mp[1]) + "</span>"; i += mp[1].length; continue; }
+        }
+      }
+      if (/[\d.]/.test(raw[i]) && (i === 0 || !/[\w#]/.test(raw[i - 1]))) {
+        var mn = raw.slice(i).match(/^-?\d*\.?\d+(px|em|rem|%|vh|vw|s|ms|deg|fr|ch|ex|vmin|vmax|svh)?\b/);
+        if (mn) { out += '<span class="tok-number">' + escHtml(mn[0]) + "</span>"; i += mn[0].length; continue; }
+      }
+      if ((raw[i] === "." || raw[i] === "#") && (i === 0 || /[\n\r,{ ]/.test(raw[i - 1]))) {
+        var ms = raw.slice(i).match(/^[.#][\w-]+/);
+        if (ms) { out += '<span class="tok-selector">' + escHtml(ms[0]) + "</span>"; i += ms[0].length; continue; }
+      }
+      out += escHtml(raw[i++]);
+    }
+    return out + "\n";
+  }
+
+  function highlightHTML(raw) {
+    var out = "", i = 0, n = raw.length;
+    while (i < n) {
+      if (raw.slice(i, i + 4) === "<!--") {
+        var e = raw.indexOf("-->", i + 4), end = e < 0 ? n : e + 3;
+        out += '<span class="tok-comment">' + escHtml(raw.slice(i, end)) + "</span>"; i = end; continue;
+      }
+      if (raw[i] === "<") {
+        var mt = raw.slice(i).match(/^<\/?([\w:-]+)/);
+        if (mt) { out += '<span class="tok-tag">' + escHtml(raw.slice(i, i + mt[0].length)) + "</span>"; i += mt[0].length; continue; }
+      }
+      if (raw[i] === ">" || (raw[i] === "/" && raw[i + 1] === ">")) {
+        var s = raw[i] === "/" ? "/>" : ">";
+        out += '<span class="tok-tag">' + escHtml(s) + "</span>"; i += s.length; continue;
+      }
+      if (raw[i] === '"' || raw[i] === "'") {
+        var q = raw[i], j = i + 1;
+        while (j < n && raw[j] !== q) j++;
+        out += '<span class="tok-string">' + escHtml(raw.slice(i, j + 1)) + "</span>"; i = j + 1; continue;
+      }
+      var am = raw.slice(i).match(/^[\w:-]+(?=\s*=)/);
+      if (am) { out += '<span class="tok-attr">' + escHtml(am[0]) + "</span>"; i += am[0].length; continue; }
+      out += escHtml(raw[i++]);
+    }
+    return out + "\n";
+  }
+
+  function highlight(code, mode) {
+    return mode === "html" ? highlightHTML(code) : highlightCSS(code);
+  }
+
+  function wire(wrap) {
+    if (wrap._wired) return;
+    var ta = wrap.querySelector(".code-editor-ta");
+    var pre = wrap.querySelector(".code-editor-pre");
+    if (!ta || !pre) return;
+    wrap._wired = true;
+    var mode = wrap.getAttribute("data-mode") || "css";
+    function hl() { pre.innerHTML = highlight(ta.value || "", mode); }
+    function sync() { pre.scrollTop = ta.scrollTop; pre.scrollLeft = ta.scrollLeft; }
+    ta.addEventListener("input", hl);
+    ta.addEventListener("scroll", sync);
+    hl();
+  }
+
+  function init() {
+    var nodes = document.querySelectorAll(".code-editor-wrap");
+    for (var k = 0; k < nodes.length; k++) wire(nodes[k]);
+  }
+  if (document.readyState !== "loading") init();
+  else document.addEventListener("DOMContentLoaded", init);
+})();
+</script>

--- a/crates/ruscker-admin/templates/admin/block_form.html
+++ b/crates/ruscker-admin/templates/admin/block_form.html
@@ -32,8 +32,11 @@
 
     <div class="spec-form-field">
       <label class="spec-form-label">{{ self.t("admin-blocks-html") }}</label>
-      <textarea name="html" rows="8" class="spec-form-input spec-form-input--mono"
-                placeholder="&lt;div&gt;…&lt;/div&gt;">{{ html }}</textarea>
+      <div class="code-editor-wrap" data-mode="html">
+        <pre class="code-editor-pre" aria-hidden="true"></pre>
+        <textarea name="html" rows="8" class="code-editor-ta" spellcheck="false"
+                  placeholder="&lt;div&gt;…&lt;/div&gt;">{{ html }}</textarea>
+      </div>
       <div class="spec-form-help">{{ self.t("admin-blocks-html-help") }}</div>
     </div>
 
@@ -62,5 +65,8 @@
     </div>
   </form>
 </div>
+
+{# Syntax highlighting for the HTML block editor (#623). #}
+{% include "admin/_code_editor.html" %}
 
 {% endblock %}

--- a/crates/ruscker-admin/templates/admin/landing.html
+++ b/crates/ruscker-admin/templates/admin/landing.html
@@ -421,9 +421,12 @@
       <div class="spec-form-section-title">{{ self.t("admin-landing-analytics") }}</div>
       <div class="spec-form-field">
         <label class="spec-form-label">{{ self.t("admin-landing-analytics-html") }}</label>
-        <textarea name="analytics_html" rows="3" x-model="form.analytics_html"
-                  placeholder="&lt;script defer data-domain=&quot;...&quot; src=&quot;https://plausible.io/js/script.js&quot;&gt;&lt;/script&gt;"
-                  class="spec-form-input spec-form-input--mono">{{ form.analytics_html }}</textarea>
+        <div class="code-editor-wrap" data-mode="html">
+          <pre class="code-editor-pre" aria-hidden="true"></pre>
+          <textarea name="analytics_html" rows="3" x-model="form.analytics_html" spellcheck="false"
+                    placeholder="&lt;script defer data-domain=&quot;...&quot; src=&quot;https://plausible.io/js/script.js&quot;&gt;&lt;/script&gt;"
+                    class="code-editor-ta">{{ form.analytics_html }}</textarea>
+        </div>
         <div class="spec-form-help">{{ self.t("admin-landing-analytics-html-help") }}</div>
       </div>
       <div class="spec-form-field">
@@ -447,9 +450,12 @@
         </div>
       <div class="spec-form-field">
         <label class="spec-form-label">{{ self.t("admin-landing-custom-css") }}</label>
-        <textarea name="custom_css" rows="6" x-model="form.custom_css"
-                  placeholder=".rcard { border-radius: 6px } &#10;:root { --color-link: #1d9e75 }"
-                  class="spec-form-input spec-form-input--mono">{{ form.custom_css }}</textarea>
+        <div class="code-editor-wrap" data-mode="css">
+          <pre class="code-editor-pre" aria-hidden="true"></pre>
+          <textarea name="custom_css" rows="6" x-model="form.custom_css" spellcheck="false"
+                    placeholder=".rcard { border-radius: 6px } &#10;:root { --color-link: #1d9e75 }"
+                    class="code-editor-ta">{{ form.custom_css }}</textarea>
+        </div>
         <div class="spec-form-help">{{ self.t("admin-landing-custom-css-help") }}</div>
       </div>
       </section>
@@ -590,6 +596,9 @@
 
 {# Custom HTML blocks editor, folded in from the old standalone tab (#242). #}
 {% include "admin/_blocks_editor.html" %}
+
+{# Syntax highlighting for the CSS / analytics-HTML editors (#623). #}
+{% include "admin/_code_editor.html" %}
 
 <script src="{{ base }}/assets/js/alpine.min.js?v={{ crate::APP_VERSION }}" defer></script>
 <script>


### PR DESCRIPTION
**Slice 6 of #623** — a genuinely new, visible component from the handoff.

The design's code surfaces (Appearance → **custom CSS**, **analytics HTML**, and the **custom HTML blocks**) are VS Code-style editors with live syntax highlighting; the product shipped plain monospace textareas. This adds the overlay editor: a **transparent `<textarea>` over a highlighted `<pre>`**, scroll-synced.

- New shared partial `admin/_code_editor.html` — framework-free, single-pass **CSS and HTML tokenizers** (ported from the prototype) + a tiny wiring pass over every `.code-editor-wrap`. The tokenizers **escape input**, so a value can't inject markup into the `<pre>`.
- `.code-editor-wrap`/`-pre`/`-ta` + the `.tok-*` palette (VS Code Dark+) in the global stylesheet.
- Wired three editors: custom CSS (`css`), analytics HTML (`html`), and the HTML block editor.

**Backend-safe:** the textarea keeps its `name`, value and Alpine `x-model` — the form submits exactly as before. Pure view layer.

## Verification
- Admin suite (12 groups) + clippy + i18n green; templates compile (Askama validates the `{% include %}`).
- Tokenizers pass `node --check` and a **behavioral test**: CSS selector/prop/number/hex/`!important`/comment + HTML tag/attr/string highlighted, and a raw `<` is escaped (no injection).
- Visual check to follow on cast.

Part of #623.

🤖 Generated with [Claude Code](https://claude.com/claude-code)