### PR TITLE
fix(config): cold-start spec (min-replicas:0) could never spawn a container

### DIFF
--- a/crates/ruscker-config/src/schema.rs
+++ b/crates/ruscker-config/src/schema.rs
@@ -1014,10 +1014,19 @@ impl Spec {
         })
     }
 
-    /// Effective maximum replicas (defaults to `min_replicas`, so no
-    /// auto-scaling unless the operator opts in).
+    /// Effective maximum replicas. Defaults to `min-replicas`, so there's
+    /// no auto-scaling unless the operator opts in — **but never below 1
+    /// for a containerized spec.** A cold-start app sets `min-replicas: 0`
+    /// (don't pre-spawn) and usually leaves `max-replicas` unset; without
+    /// this floor that resolves to `max = 0`, and the on-demand spawn path
+    /// (`spawn_one`'s `live >= max` cap) would refuse to ever start a
+    /// container — the cold-start splash then polls forever. `External`
+    /// specs have no container, so they stay at 0.
     pub fn effective_max_replicas(&self) -> u32 {
-        self.max_replicas.unwrap_or_else(|| self.effective_min_replicas())
+        self.max_replicas.unwrap_or_else(|| match self.kind() {
+            SpecKind::External => 0,
+            _ => self.effective_min_replicas().max(1),
+        })
     }
 
     /// Hard lifetime cap in **seconds** (`max-lifetime` is authored in
@@ -1598,6 +1607,28 @@ proxy:
         assert_eq!(config.proxy.title, "Test");
         assert_eq!(config.proxy.specs.len(), 1);
         assert_eq!(config.proxy.specs[0].id, "hello");
+    }
+
+    #[test]
+    fn cold_start_spec_still_scales_to_one() {
+        // A cold-start app sets `min-replicas: 0` (don't pre-spawn) and
+        // usually leaves `max-replicas` unset. effective-max must NOT
+        // resolve to 0 — that would make the on-demand spawn a no-op
+        // (`spawn_one`'s `live >= max` cap) and hang the cold-start splash
+        // forever. A containerized spec floors at 1.
+        let yaml = "proxy:\n  specs:\n    - id: cold\n      container-image: nginx:alpine\n      min-replicas: 0\n";
+        let spec = &serde_yaml_ng::from_str::<Config>(yaml).unwrap().proxy.specs[0];
+        assert_eq!(spec.effective_min_replicas(), 0, "cold start: no pre-spawn");
+        assert_eq!(spec.effective_max_replicas(), 1, "but can scale to one on demand");
+
+        // Defaults unchanged when nothing is set (min 1 ⇒ max 1) and an
+        // explicit max is still honoured.
+        let dflt = "proxy:\n  specs:\n    - id: d\n      container-image: nginx\n";
+        let s = &serde_yaml_ng::from_str::<Config>(dflt).unwrap().proxy.specs[0];
+        assert_eq!(s.effective_max_replicas(), 1);
+        let cap = "proxy:\n  specs:\n    - id: c\n      container-image: nginx\n      min-replicas: 0\n      max-replicas: 4\n";
+        let s = &serde_yaml_ng::from_str::<Config>(cap).unwrap().proxy.specs[0];
+        assert_eq!(s.effective_max_replicas(), 4, "explicit max is honoured");
     }
 
     #[test]


### PR DESCRIPTION
## The bug
A showcase/cold-start spec sets **`min-replicas: 0`** (don't pre-spawn) and leaves `max-replicas` unset. `effective_max_replicas()` defaulted to `max_replicas.unwrap_or(effective_min_replicas())` → the explicit min of **0** → **`max = 0`**.

The on-demand spawn path `scaler::spawn_one` caps with `if live >= max { return }` → at `max 0`, `0 >= 0` → **no-op, no container ever created**. A browser navigation then showed the "container is booting…" splash and polled `/__ruscker_ready` **forever**.

(The proxy's `pick_or_spawn` falls through and spawns anyway when nothing is reusable, which masked the bug for non-HTML requests — but the splash's background `spawn_one` does not, which is why browser users were stuck while a plain `curl` worked.)

## Fix
Floor the default at 1 for containerized specs:
```rust
max_replicas.unwrap_or_else(|| match kind() {
    External => 0,
    _ => effective_min_replicas().max(1),
})
```
So `min:0, max:unset` ⇒ `max:1` (cold-start, scale to one on demand). `External` specs stay at 0; an explicit `max-replicas` is still honoured.

## Verification
- Found live on cast (every showcase app seeded with `min-replicas: 0`): browser-like cold GET showed the splash but spawned **0** containers; a plain GET spawned 1.
- New unit test: `min:0, max:unset` → `effective_max_replicas() == 1`; defaults and explicit caps unchanged.
- Full workspace tests (24 groups) + clippy + i18n green; the scaler min/max tests still pass.

This is the second half of the cold-start breakage the user hit (the first was the #582 splash-probe regression, fixed in v0.1.72).

🤖 Generated with [Claude Code](https://claude.com/claude-code)