### PR TITLE
feat(admin): coloured avatars + group badges on the Users page (#623, slice 7)

### DIFF
--- a/crates/ruscker-admin/assets/tailwind/input.css
+++ b/crates/ruscker-admin/assets/tailwind/input.css
@@ -289,6 +289,24 @@ body {
   border: 0.5px solid var(--border); border-radius: 12px; background: var(--surface);
 }
 
+/* ─── User avatars + group badges (design handoff #623) ───────────
+ * Colour is derived client-side from a hash of the name (see the inline
+ * script in users.html), so it's deterministic per user/group with no
+ * backend or schema involvement. */
+.rk-avatar {
+  flex: none; width: 30px; height: 30px; border-radius: 50%;
+  display: inline-flex; align-items: center; justify-content: center;
+  font-weight: 600; font-size: 12px; color: #fff; line-height: 1;
+  text-transform: uppercase; user-select: none;
+}
+.group-badge {
+  display: inline-flex; align-items: center;
+  padding: 2px 8px; font-size: 10px; border-radius: 999px;
+  font-weight: 500; letter-spacing: 0.02em; white-space: nowrap;
+}
+.user-cell { display: inline-flex; align-items: center; gap: 10px; }
+.group-badges { display: flex; flex-wrap: wrap; gap: 4px; margin-bottom: 6px; }
+
 /* ─── Syntax-highlighted code editor (design handoff #623) ─────────
  * A transparent <textarea> over a highlighted <pre>; the tokenizers run
  * client-side (see admin/_code_editor.html). The textarea keeps its name

--- a/crates/ruscker-admin/templates/admin/users.html
+++ b/crates/ruscker-admin/templates/admin/users.html
@@ -85,9 +85,14 @@
     {% for u in users %}
       <tr style="border-bottom:0.5px solid var(--border)">
         <td class="py-2">
-          <span class="font-medium">{{ u.username }}</span>
-          {% if u.username == me %}<span class="text-xs text-[color:var(--text-faint)]"> ({{ self.t("admin-users-you") }})</span>{% endif %}
-          {% if u.must_change_password %}<i class="ti ti-alert-triangle" title="{{ self.t("admin-users-must-change") }}" style="color:var(--text-faint)"></i>{% endif %}
+          <span class="user-cell">
+            <span class="rk-avatar" data-avatar="{{ u.username }}" aria-hidden="true"></span>
+            <span>
+              <span class="font-medium">{{ u.username }}</span>
+              {% if u.username == me %}<span class="text-xs text-[color:var(--text-faint)]"> ({{ self.t("admin-users-you") }})</span>{% endif %}
+              {% if u.must_change_password %}<i class="ti ti-alert-triangle" title="{{ self.t("admin-users-must-change") }}" style="color:var(--text-faint)"></i>{% endif %}
+            </span>
+          </span>
         </td>
         <td>
           <form method="post" action="{{ base }}/admin/users/{{ u.username }}/role" style="display:flex;gap:6px;align-items:center">
@@ -100,6 +105,11 @@
           </form>
         </td>
         <td>
+          {% if !u.groups.is_empty() %}
+          <div class="group-badges">
+            {% for g in u.groups %}<span class="group-badge" data-group="{{ g }}">{{ g }}</span>{% endfor %}
+          </div>
+          {% endif %}
           <form method="post" action="{{ base }}/admin/users/{{ u.username }}/groups" style="display:flex;gap:6px;align-items:center">
             <input type="text" name="groups" value="{{ u.groups|join(", ") }}" autocapitalize="none"
                    placeholder="{{ self.t("admin-users-groups-placeholder") }}" style="width:160px">
@@ -148,5 +158,29 @@
     var icon = btn.querySelector('i');
     if (icon) icon.className = 'ti ' + (reveal ? 'ti-eye-off' : 'ti-eye');
   });
+
+  // Avatars + group badges (#623): deterministic colour from a name hash,
+  // so each user/group keeps a stable colour with no backend involvement.
+  (function () {
+    function hue(s) {
+      var h = 0;
+      for (var i = 0; i < s.length; i++) h = (h * 31 + s.charCodeAt(i)) % 360;
+      return h;
+    }
+    function initials(s) {
+      var p = s.replace(/[^A-Za-z0-9]+/g, " ").trim().split(" ");
+      return ((p[0] || "").charAt(0) + (p.length > 1 ? (p[1] || "").charAt(0) : "")).toUpperCase() || "?";
+    }
+    document.querySelectorAll(".rk-avatar[data-avatar]").forEach(function (el) {
+      var name = el.getAttribute("data-avatar"), hu = hue(name);
+      el.style.background = "hsl(" + hu + " 48% 42%)";
+      if (!el.textContent) el.textContent = initials(name);
+    });
+    document.querySelectorAll(".group-badge[data-group]").forEach(function (el) {
+      var hu = hue(el.getAttribute("data-group"));
+      el.style.background = "hsl(" + hu + " 70% 92%)";
+      el.style.color = "hsl(" + hu + " 55% 28%)";
+    });
+  })();
 </script>
 {% endblock %}


### PR DESCRIPTION
**Slice 7 of #623.** Brings the Users table closer to the handoff: each user gets a **circular avatar with initials**, and their groups render as **coloured pill badges** above the (still-editable) groups field.

- Colour is derived **client-side from a hash of the name** — stable per user/group, **no backend, schema or data-model change**.
- A tiny inline script (next to the existing password-reveal one) fills the avatar's initials and tints avatars + badges.
- The groups text input and all role/password/delete actions are **untouched**.

## Verification
- Admin suite (12 groups) + clippy + i18n green.
- The colour/initials helpers pass `node --check` and a behavioral test: deterministic + distinct hue in range; `andre.leite` → `AL`, `bob_smith` → `BS`, etc.
- Visual check to follow on cast.

Part of #623.

🤖 Generated with [Claude Code](https://claude.com/claude-code)