### PR TITLE
feat(admin): styled range sliders, toggle switch & checkboxes (#623, slice 8)

### DIFF
--- a/crates/ruscker-admin/assets/tailwind/input.css
+++ b/crates/ruscker-admin/assets/tailwind/input.css
@@ -307,6 +307,62 @@ body {
 .user-cell { display: inline-flex; align-items: center; gap: 10px; }
 .group-badges { display: flex; flex-wrap: wrap; gap: 4px; margin-bottom: 6px; }
 
+/* ─── Form controls: range / switch / checkbox (design handoff #623) ──
+ * All CSS-only and driven by the native input's checked state, so the
+ * field name/value and form submission are unchanged — pure restyle. */
+
+/* Range sliders — teal thumb on a thin track (applies to every range). */
+input[type="range"] {
+  -webkit-appearance: none; appearance: none;
+  height: 4px; border-radius: 2px; background: var(--surface-soft);
+  outline: 0; cursor: pointer;
+}
+input[type="range"]::-webkit-slider-thumb {
+  -webkit-appearance: none; width: 16px; height: 16px; border-radius: 50%;
+  background: var(--color-teal-600); border: 2px solid var(--surface);
+  box-shadow: 0 1px 3px rgba(0, 0, 0, 0.3); cursor: pointer;
+}
+input[type="range"]::-moz-range-thumb {
+  width: 16px; height: 16px; border-radius: 50%;
+  background: var(--color-teal-600); border: 2px solid var(--surface); cursor: pointer;
+}
+
+/* Toggle switch — wraps a hidden checkbox; the track + dot react to it. */
+.switch { display: inline-flex; align-items: center; flex: none; }
+.switch > input { position: absolute; opacity: 0; width: 0; height: 0; }
+.switch__track {
+  width: 40px; height: 23px; border-radius: 999px; flex: none; position: relative;
+  background: var(--border-strong); transition: background 0.15s;
+}
+.switch > input:checked + .switch__track { background: var(--color-teal-600); }
+.switch__dot {
+  position: absolute; top: 2.5px; left: 2.5px; width: 18px; height: 18px;
+  border-radius: 50%; background: #fff; transition: transform 0.15s;
+  box-shadow: 0 1px 2px rgba(0, 0, 0, 0.3);
+}
+.switch > input:checked + .switch__track .switch__dot { transform: translateX(17px); }
+.switch > input:focus-visible + .switch__track {
+  outline: 2px solid var(--color-teal-400); outline-offset: 2px;
+}
+
+/* Styled checkbox — teal box with a check when ticked. */
+.rk-check-wrap { display: inline-flex; align-items: center; cursor: pointer; }
+.rk-check-wrap > input { position: absolute; opacity: 0; width: 0; height: 0; }
+.rk-check {
+  width: 18px; height: 18px; flex: none; border-radius: 5px;
+  border: 1.5px solid var(--border-strong); color: #fff;
+  display: inline-flex; align-items: center; justify-content: center;
+  transition: background 0.12s, border-color 0.12s;
+}
+.rk-check .ti { font-size: 13px; opacity: 0; }
+.rk-check-wrap > input:checked + .rk-check {
+  background: var(--color-teal-600); border-color: var(--color-teal-600);
+}
+.rk-check-wrap > input:checked + .rk-check .ti { opacity: 1; }
+.rk-check-wrap > input:focus-visible + .rk-check {
+  outline: 2px solid var(--color-teal-400); outline-offset: 2px;
+}
+
 /* ─── Syntax-highlighted code editor (design handoff #623) ─────────
  * A transparent <textarea> over a highlighted <pre>; the tokenizers run
  * client-side (see admin/_code_editor.html). The textarea keeps its name

--- a/crates/ruscker-admin/templates/admin/import_preview.html
+++ b/crates/ruscker-admin/templates/admin/import_preview.html
@@ -30,9 +30,11 @@
     <thead>
       <tr>
         <th class="import-check-cell">
-          <input type="checkbox" checked
-                 title="{{ self.t("admin-import-select-all") }}"
-                 onclick="document.querySelectorAll('input[name=ids]').forEach(function(c){c.checked=this.checked}.bind(this))">
+          <label class="rk-check-wrap" title="{{ self.t("admin-import-select-all") }}">
+            <input type="checkbox" checked
+                   onclick="document.querySelectorAll('input[name=ids]').forEach(function(c){c.checked=this.checked}.bind(this))">
+            <span class="rk-check"><i class="ti ti-check" aria-hidden="true"></i></span>
+          </label>
         </th>
         <th>{{ self.t("admin-specs-col-id") }}</th>
         <th>{{ self.t("admin-specs-col-name") }}</th>
@@ -44,7 +46,10 @@
       {% for row in rows %}
       <tr>
         <td class="import-check-cell">
-          <input type="checkbox" name="ids" value="{{ row.id }}" checked>
+          <label class="rk-check-wrap">
+            <input type="checkbox" name="ids" value="{{ row.id }}" checked>
+            <span class="rk-check"><i class="ti ti-check" aria-hidden="true"></i></span>
+          </label>
         </td>
         <td class="id-cell">{{ row.id }}</td>
         <td>{% if row.display_name.is_empty() %}<span class="text-[color:var(--text-faint)]">—</span>{% else %}{{ row.display_name }}{% endif %}</td>

--- a/crates/ruscker-admin/templates/admin/landing.html
+++ b/crates/ruscker-admin/templates/admin/landing.html
@@ -78,8 +78,11 @@
       {# "Featured" carousel toggle (#506) — plain checkbox; the carousel
          only shows when this is on AND at least one app is featured. #}
       <div class="spec-form-field">
-        <label class="spec-form-check">
-          <input type="checkbox" name="show_highlights" value="on" {% if !form.show_highlights.is_empty() %}checked{% endif %}>
+        <label class="spec-form-check" style="cursor:pointer;gap:10px">
+          <span class="switch">
+            <input type="checkbox" name="show_highlights" value="on" {% if !form.show_highlights.is_empty() %}checked{% endif %}>
+            <span class="switch__track"><span class="switch__dot"></span></span>
+          </span>
           <span>{{ self.t("admin-landing-show-highlights") }}</span>
         </label>
         <div class="spec-form-help">{{ self.t("admin-landing-show-highlights-help") }}</div>


### PR DESCRIPTION
**Slice 8 of #623** — a batch of pure-frontend control restyles toward the handoff. **All CSS-only**, driven by the native input's `:checked` state, so field names/values and form submission are unchanged (no backend or JS contract change).

- **Range sliders** → teal thumb on a thin track (every range input — gradient-angle, logo sliders).
- **Featured-carousel toggle** → iOS-style switch (hidden checkbox + track/dot reacting to `:checked`).
- **Import-preview checkboxes** (select-all + per-row) → teal check boxes; the existing select-all `onclick` is untouched, so toggle-all still works and the per-row boxes reflect it via CSS.

The portal header's **chrome icons already match** the handoff — no change needed.

## Verification
Admin suite (12 groups) + clippy + i18n green; the new rules compile into the served stylesheet. CSS-only — no script.

Part of #623.

🤖 Generated with [Claude Code](https://claude.com/claude-code)