### PR TITLE
feat(admin): floating auto-dismiss toasts for action feedback (#623, slice 9)

### DIFF
--- a/crates/ruscker-admin/assets/tailwind/input.css
+++ b/crates/ruscker-admin/assets/tailwind/input.css
@@ -363,6 +363,23 @@ input[type="range"]::-moz-range-thumb {
   outline: 2px solid var(--color-teal-400); outline-offset: 2px;
 }
 
+/* Floating action toasts (design handoff #623). Server-rendered flash
+ * banners are promoted into these by a small script in admin/_layout.html
+ * and auto-dismiss — no change to how flashes are produced. */
+.toast-wrap {
+  position: fixed; bottom: 22px; left: 50%; transform: translateX(-50%);
+  z-index: 600; display: flex; flex-direction: column; gap: 8px; align-items: center;
+  pointer-events: none;
+}
+.toast {
+  display: flex; align-items: center; gap: 9px;
+  background: var(--text); color: var(--bg);
+  padding: 10px 16px; border-radius: 10px; font-size: 13px;
+  box-shadow: var(--shadow-lg); animation: fade-in 0.25s ease both;
+  transition: opacity 0.3s ease; pointer-events: auto; max-width: 90vw;
+}
+.toast .ti { font-size: 16px; }
+
 /* ─── Syntax-highlighted code editor (design handoff #623) ─────────
  * A transparent <textarea> over a highlighted <pre>; the tokenizers run
  * client-side (see admin/_code_editor.html). The textarea keeps its name

--- a/crates/ruscker-admin/templates/admin/_layout.html
+++ b/crates/ruscker-admin/templates/admin/_layout.html
@@ -241,6 +241,30 @@ window.ruscker.imagePicker = (filenames) => ({
   {% block content %}{% endblock %}
 </main>
 
+{# Floating toasts (#623): promote any server-rendered flash banner into a
+   bottom-centre toast that auto-dismisses. The banner markup is unchanged
+   (still produced server-side from `?flash=…`); this only re-homes it, so
+   pages without JS still show the flash inline. #}
+<div class="toast-wrap" id="ruscker-toasts" aria-live="polite"></div>
+<script>
+  (function () {
+    var wrap = document.getElementById("ruscker-toasts");
+    if (!wrap) return;
+    document.querySelectorAll(".admin-flash-ok").forEach(function (flash) {
+      var toast = document.createElement("div");
+      toast.className = "toast";
+      toast.setAttribute("role", "status");
+      toast.innerHTML = flash.innerHTML;
+      flash.remove();
+      wrap.appendChild(toast);
+      setTimeout(function () {
+        toast.style.opacity = "0";
+        setTimeout(function () { toast.remove(); }, 320);
+      }, 4000);
+    });
+  })();
+</script>
+
 {# Footer trimmed — theme + language pickers moved into the top-right
    chrome cluster in the navbar (#182 + #183). #}
 <footer class="mt-auto border-t border-[color:var(--border)] py-3 px-6 text-xs text-[color:var(--text-muted)] flex items-center justify-end gap-3">


### PR DESCRIPTION
**Slice 9 of #623.** The handoff shows action confirmations as a **floating bottom-centre toast**; the admin showed them as inline flash banners.

Rather than rewrite the flash rendering on all seven pages, a small **shared script** in the admin layout promotes any server-rendered `.admin-flash-ok` banner into a `.toast` inside a fixed `.toast-wrap`, **auto-dismissing after 4s**.

- The flash markup is **untouched** (still produced server-side from `?flash=…`), so a no-JS page still shows it inline — the script only re-homes it.
- **One change** in `_layout.html` covers every admin page.

## Verification
Admin suite (12 groups) + clippy + i18n green; the promotion script passes `node --check` and the toast CSS compiles into the stylesheet.

Part of #623.

🤖 Generated with [Claude Code](https://claude.com/claude-code)