### PR TITLE
feat(admin): live SERP preview in the SEO editor (#623, slice 10)

### DIFF
--- a/crates/ruscker-admin/assets/i18n/en/landing.ftl
+++ b/crates/ruscker-admin/assets/i18n/en/landing.ftl
@@ -325,6 +325,7 @@ admin-landing-preview-help = Approximate look of the header and intro. Cards and
 admin-landing-preview-empty = (no intro text)
 admin-landing-seo = SEO & sharing
 admin-landing-seo-title = Page title (SEO)
+admin-landing-seo-preview = Search preview
 admin-landing-seo-title-placeholder = Default: portal title
 admin-landing-seo-title-help = Sets the browser tab title and og:title. Empty uses the portal's default title.
 admin-landing-seo-description = Description (meta description)

--- a/crates/ruscker-admin/assets/i18n/es/landing.ftl
+++ b/crates/ruscker-admin/assets/i18n/es/landing.ftl
@@ -325,6 +325,7 @@ admin-landing-preview-help = Aproximación visual del encabezado y la introducci
 admin-landing-preview-empty = (sin texto de introducción)
 admin-landing-seo = SEO y compartir
 admin-landing-seo-title = Título de la página (SEO)
+admin-landing-seo-preview = Vista previa de búsqueda
 admin-landing-seo-title-placeholder = Predeterminado: título del portal
 admin-landing-seo-title-help = Define el título de la pestaña y el og:title. Vacío usa el título por defecto del portal.
 admin-landing-seo-description = Descripción (meta description)

--- a/crates/ruscker-admin/assets/i18n/fr/landing.ftl
+++ b/crates/ruscker-admin/assets/i18n/fr/landing.ftl
@@ -325,6 +325,7 @@ admin-landing-preview-help = Approximation visuelle de l'en-tête et de l'intro.
 admin-landing-preview-empty = (pas de texte d'introduction)
 admin-landing-seo = SEO et partage
 admin-landing-seo-title = Titre de la page (SEO)
+admin-landing-seo-preview = Aperçu de recherche
 admin-landing-seo-title-placeholder = Par défaut : titre du portail
 admin-landing-seo-title-help = Définit le titre de l'onglet et og:title. Vide utilise le titre par défaut du portail.
 admin-landing-seo-description = Description (meta description)

--- a/crates/ruscker-admin/assets/i18n/pt/landing.ftl
+++ b/crates/ruscker-admin/assets/i18n/pt/landing.ftl
@@ -329,6 +329,7 @@ admin-landing-preview-help = Aproximação visual do cabeçalho e texto. Cards e
 admin-landing-preview-empty = (sem texto introdutório)
 admin-landing-seo = SEO e compartilhamento
 admin-landing-seo-title = Título da página (SEO)
+admin-landing-seo-preview = Prévia de busca
 admin-landing-seo-title-placeholder = Padrão: título do portal
 admin-landing-seo-title-help = Define o título da aba e o og:title. Vazio usa o título padrão do portal.
 admin-landing-seo-description = Descrição (meta description)

--- a/crates/ruscker-admin/assets/tailwind/input.css
+++ b/crates/ruscker-admin/assets/tailwind/input.css
@@ -380,6 +380,24 @@ input[type="range"]::-moz-range-thumb {
 }
 .toast .ti { font-size: 16px; }
 
+/* Live search-result (SERP) preview in the SEO editor (design handoff
+ * #623). Reads the SEO fields via Alpine — pure presentation. Google's
+ * result colours, with dark-mode variants. */
+.serp {
+  background: var(--surface); border: 0.5px solid var(--border);
+  border-radius: 9px; padding: 12px 14px; margin-top: 4px;
+}
+.serp__url { font-size: 11px; color: #3b7a45; display: flex; align-items: center; gap: 5px; }
+.serp__url .ti { font-size: 12px; }
+.serp__title { font-size: 15px; color: #1a0dab; margin: 3px 0 2px; letter-spacing: -0.01em; }
+.serp__desc { font-size: 11.5px; color: var(--text-muted); line-height: 1.5; word-break: break-word; }
+:root[data-theme="dark"] .serp__title { color: #8ab4f8; }
+:root[data-theme="dark"] .serp__url { color: #6cc18a; }
+@media (prefers-color-scheme: dark) {
+  :root:not([data-theme="light"]) .serp__title { color: #8ab4f8; }
+  :root:not([data-theme="light"]) .serp__url { color: #6cc18a; }
+}
+
 /* ─── Syntax-highlighted code editor (design handoff #623) ─────────
  * A transparent <textarea> over a highlighted <pre>; the tokenizers run
  * client-side (see admin/_code_editor.html). The textarea keeps its name

--- a/crates/ruscker-admin/templates/admin/landing.html
+++ b/crates/ruscker-admin/templates/admin/landing.html
@@ -401,6 +401,16 @@
                   class="spec-form-input">{{ form.seo_description }}</textarea>
         <div class="spec-form-help">{{ self.t("admin-landing-seo-description-help") }}</div>
       </div>
+      {# Live Google-style search-result preview (#623), reacting to the
+         SEO fields above. Presentation only. #}
+      <div class="spec-form-field">
+        <label class="spec-form-label">{{ self.t("admin-landing-seo-preview") }}</label>
+        <div class="serp">
+          <div class="serp__url"><i class="ti ti-world" aria-hidden="true"></i> <span x-text="location.host"></span></div>
+          <div class="serp__title" data-default="{{ portal_title }}" x-text="(form.seo_title || form.title || '').trim() || $el.dataset.default"></div>
+          <div class="serp__desc" x-text="form.seo_description || ''"></div>
+        </div>
+      </div>
       <div class="spec-form-field">
         <label class="spec-form-label">{{ self.t("admin-landing-og-image") }}</label>
         {# Gallery picker (#451 mixin) writes the chosen asset path into


### PR DESCRIPTION
**Slice 10 of #623.** The handoff's Appearance → SEO section shows a **Google-style search-result preview** that updates as you type; the product had the SEO fields but no preview.

Adds a `.serp` card under the SEO description that mirrors the `<title>` / description **live** via the existing Alpine form state (`seo_title` → `title` → portal default), with the host as the result URL.

- **Pure presentation** — no new field, route or data.
- The default title is read from a `data-*` attribute (HTML-escaped) via `$el.dataset`, **never interpolated into the JS expression** (the #521 quote-safety pattern).
- New i18n key `admin-landing-seo-preview` in all four locales.

## Verification
Admin suite (12 groups) + clippy + i18n parity green; the `.serp` styles compile into the stylesheet.

Part of #623.

🤖 Generated with [Claude Code](https://claude.com/claude-code)