### PR TITLE
feat(admin): live log terminal with level colours + filters (#623, slice 12)

### DIFF
--- a/crates/ruscker-admin/assets/i18n/en/landing.ftl
+++ b/crates/ruscker-admin/assets/i18n/en/landing.ftl
@@ -575,6 +575,11 @@ spec-form-cover-image = Image
 spec-form-cover-image-help = Pick a library image (or upload one) as the card background.
 admin-proclog-tail-note = Showing the most recent lines
 admin-proclog-download = Download full log
+admin-proclog-filter-level = Filter by level
+admin-proclog-filter-all = All levels
+admin-proclog-search = Search logs…
+admin-proclog-pause = Pause
+admin-proclog-resume = Resume
 
 landing-empty = Nothing here yet.
 

--- a/crates/ruscker-admin/assets/i18n/es/landing.ftl
+++ b/crates/ruscker-admin/assets/i18n/es/landing.ftl
@@ -575,6 +575,11 @@ spec-form-cover-image = Imagen
 spec-form-cover-image-help = Elige una imagen de la biblioteca (o sube una) como fondo de la tarjeta.
 admin-proclog-tail-note = Mostrando las líneas más recientes
 admin-proclog-download = Descargar log completo
+admin-proclog-filter-level = Filtrar por nivel
+admin-proclog-filter-all = Todos los niveles
+admin-proclog-search = Buscar en los logs…
+admin-proclog-pause = Pausar
+admin-proclog-resume = Reanudar
 
 landing-empty = Nada por aquí.
 

--- a/crates/ruscker-admin/assets/i18n/fr/landing.ftl
+++ b/crates/ruscker-admin/assets/i18n/fr/landing.ftl
@@ -575,6 +575,11 @@ spec-form-cover-image = Image
 spec-form-cover-image-help = Choisissez une image de la bibliothèque (ou téléversez-en une) comme fond de la carte.
 admin-proclog-tail-note = Affichage des lignes les plus récentes
 admin-proclog-download = Télécharger le journal complet
+admin-proclog-filter-level = Filtrer par niveau
+admin-proclog-filter-all = Tous les niveaux
+admin-proclog-search = Rechercher dans les journaux…
+admin-proclog-pause = Pause
+admin-proclog-resume = Reprendre
 
 landing-empty = Rien ici pour l'instant.
 

--- a/crates/ruscker-admin/assets/i18n/pt/landing.ftl
+++ b/crates/ruscker-admin/assets/i18n/pt/landing.ftl
@@ -579,6 +579,11 @@ spec-form-cover-image = Imagem
 spec-form-cover-image-help = Escolha uma imagem da biblioteca (ou envie uma) como fundo do card.
 admin-proclog-tail-note = Mostrando as linhas mais recentes
 admin-proclog-download = Baixar log completo
+admin-proclog-filter-level = Filtrar por nível
+admin-proclog-filter-all = Todos os níveis
+admin-proclog-search = Buscar nos logs…
+admin-proclog-pause = Pausar
+admin-proclog-resume = Retomar
 
 landing-empty = Nada por aqui.
 

--- a/crates/ruscker-admin/assets/tailwind/input.css
+++ b/crates/ruscker-admin/assets/tailwind/input.css
@@ -425,6 +425,46 @@ input[type="range"]::-moz-range-thumb {
 .disk-legend__dot { width: 9px; height: 9px; border-radius: 3px; flex: none; }
 .disk-legend__val { margin-left: 4px; color: var(--text); font-weight: 500; }
 
+/* Live server-log terminal (design handoff #623): the existing SSE feed,
+ * rendered as level-coloured lines with level/text filters. Content is
+ * set via textContent only — never parsed as HTML. */
+.log-toolbar { display: flex; align-items: center; gap: 8px; flex-wrap: wrap; margin-bottom: 0; }
+.log-select {
+  font-family: inherit; font-size: 12px; color: var(--text-muted);
+  background: var(--surface); border: 0.5px solid var(--border);
+  border-radius: 999px; padding: 6px 12px; cursor: pointer; outline: 0;
+}
+.log-search {
+  font-family: var(--font-mono); font-size: 12px; color: var(--text);
+  background: var(--surface); border: 0.5px solid var(--border);
+  border-radius: 999px; padding: 6px 12px; outline: 0; flex: 1; min-width: 140px;
+}
+.log-search:focus { border-color: var(--text); }
+.log-body {
+  height: 64vh; overflow-y: auto; margin-top: 10px;
+  background: var(--surface); border: 0.5px solid var(--border); border-radius: 12px;
+  padding: 10px 4px; font-family: var(--font-mono); font-size: 12px; line-height: 1.7;
+}
+:root[data-theme="dark"] .log-body { background: #121212; }
+@media (prefers-color-scheme: dark) {
+  :root:not([data-theme="light"]) .log-body { background: #121212; }
+}
+.log-line {
+  display: grid; grid-template-columns: 78px 48px 150px 1fr; gap: 10px;
+  padding: 1px 14px; white-space: nowrap; animation: log-in 0.25s ease;
+}
+.log-line:hover { background: var(--surface-soft); }
+@keyframes log-in { from { opacity: 0; transform: translateY(2px); } to { opacity: 1; transform: none; } }
+@media (prefers-reduced-motion: reduce) { .log-line { animation: none; } }
+.log-ts { color: var(--text-faint); }
+.log-lvl { font-weight: 600; font-size: 10px; letter-spacing: 0.04em; align-self: center; }
+.log-lvl-info { color: #3b82f6; }
+.log-lvl-warn { color: #d97706; }
+.log-lvl-error { color: #ef4444; }
+.log-lvl-debug, .log-lvl-trace { color: var(--text-faint); }
+.log-app { color: var(--color-teal-600); overflow: hidden; text-overflow: ellipsis; }
+.log-msg { color: var(--text-muted); overflow: hidden; text-overflow: ellipsis; }
+
 /* ─── Syntax-highlighted code editor (design handoff #623) ─────────
  * A transparent <textarea> over a highlighted <pre>; the tokenizers run
  * client-side (see admin/_code_editor.html). The textarea keeps its name

--- a/crates/ruscker-admin/templates/admin/process_logs.html
+++ b/crates/ruscker-admin/templates/admin/process_logs.html
@@ -4,24 +4,6 @@
 
 {% block content %}
 
-<style>
-  .proclog-pre {
-    background: var(--surface-soft, #1113);
-    border: 0.5px solid var(--border);
-    border-radius: 10px;
-    padding: 14px 16px;
-    margin-top: 12px;
-    font-family: ui-monospace, SFMono-Regular, Menlo, monospace;
-    font-size: 12px;
-    line-height: 1.5;
-    color: var(--text);
-    height: 70vh;
-    overflow: auto;
-    white-space: pre-wrap;
-    word-break: break-word;
-  }
-</style>
-
 <div class="flex items-end justify-between mb-1">
   <div>
     <h1 class="text-xl font-medium tracking-tight">{{ self.t("admin-proclog-title") }}</h1>
@@ -48,22 +30,93 @@
   {% if lines.is_empty() %}
   <p class="text-sm text-[color:var(--text-faint)] py-6 text-center">{{ self.t("admin-proclog-empty") }}</p>
   {% endif %}
-  <pre id="proclog" class="proclog-pre">{% for line in lines %}{{ line }}
+  <div class="log-toolbar">
+    <select id="log-level" class="log-select" aria-label="{{ self.t("admin-proclog-filter-level") }}">
+      <option value="">{{ self.t("admin-proclog-filter-all") }}</option>
+      <option value="ERROR">ERROR</option>
+      <option value="WARN">WARN</option>
+      <option value="INFO">INFO</option>
+      <option value="DEBUG">DEBUG</option>
+    </select>
+    <input type="search" id="log-search" class="log-search" placeholder="{{ self.t("admin-proclog-search") }}">
+    <button type="button" id="log-pause" class="admin-nav-link" aria-pressed="false"
+            data-pause="{{ self.t("admin-proclog-pause") }}" data-resume="{{ self.t("admin-proclog-resume") }}">
+      <i class="ti ti-player-pause" aria-hidden="true"></i> <span>{{ self.t("admin-proclog-pause") }}</span>
+    </button>
+  </div>
+
+  {# Raw lines for the JS to colour/parse on load; the <pre> is replaced by
+     the terminal below. Hidden — never shown directly. #}
+  <pre id="proclog-seed" hidden>{% for line in lines %}{{ line }}
 {% endfor %}</pre>
+  <div id="proclog" class="log-body"></div>
 
   <script>
   (function () {
-    const box = document.getElementById('proclog');
-    const nearBottom = () => box.scrollHeight - box.scrollTop - box.clientHeight < 48;
-    box.scrollTop = box.scrollHeight; // start pinned to the newest line
-    const es = new EventSource((window.RUSCKER_BASE || '') + '/admin/logs/stream');
-    es.onmessage = (e) => {
-      const stick = nearBottom();
-      // Append as text nodes — never parse log content as HTML.
-      box.appendChild(document.createTextNode(e.data + '\n'));
-      if (stick) box.scrollTop = box.scrollHeight;
-    };
-    es.onerror = () => { /* EventSource auto-reconnects */ };
+    var box = document.getElementById('proclog');
+    var seed = document.getElementById('proclog-seed');
+    var levelSel = document.getElementById('log-level');
+    var searchIn = document.getElementById('log-search');
+    var pauseBtn = document.getElementById('log-pause');
+    var paused = false;
+
+    function cell(cls, text) { var s = document.createElement('span'); s.className = cls; s.textContent = text; return s; }
+    function matches(el) {
+      var lv = levelSel.value, q = searchIn.value.toLowerCase();
+      return (!lv || el.dataset.level === lv) && (!q || (el.dataset.text || '').indexOf(q) >= 0);
+    }
+    function append(raw) {
+      // Strip ANSI colour codes, then split into ts / level / target / msg.
+      var clean = raw.replace(/\x1b\[[0-9;]*m/g, '').replace(/\s+$/, '');
+      if (!clean) return;
+      var m = clean.match(/^(\S+)\s+(ERROR|WARN|INFO|DEBUG|TRACE)\s+([\w:._-]+):\s?([\s\S]*)$/);
+      var div = document.createElement('div');
+      div.className = 'log-line';
+      div.dataset.level = m ? m[2] : '';
+      div.dataset.text = clean.toLowerCase();
+      if (m) {
+        div.appendChild(cell('log-ts', m[1].replace(/^.*T/, '').replace(/\..*$/, '')));
+        div.appendChild(cell('log-lvl log-lvl-' + m[2].toLowerCase(), m[2]));
+        div.appendChild(cell('log-app', m[3]));
+        div.appendChild(cell('log-msg', m[4]));
+      } else {
+        div.style.gridTemplateColumns = '1fr';
+        div.appendChild(cell('log-msg', clean));
+      }
+      div.style.display = matches(div) ? '' : 'none';
+      box.appendChild(div);
+    }
+    function refilter() {
+      var rows = box.children;
+      for (var i = 0; i < rows.length; i++) rows[i].style.display = matches(rows[i]) ? '' : 'none';
+    }
+    var nearBottom = function () { return box.scrollHeight - box.scrollTop - box.clientHeight < 48; };
+
+    // Render the server-rendered seed lines, then drop the raw <pre>.
+    (seed.textContent || '').split('\n').forEach(append);
+    seed.remove();
+    box.scrollTop = box.scrollHeight;
+
+    levelSel.addEventListener('change', refilter);
+    searchIn.addEventListener('input', refilter);
+    pauseBtn.addEventListener('click', function () {
+      paused = !paused;
+      pauseBtn.setAttribute('aria-pressed', paused ? 'true' : 'false');
+      var icon = pauseBtn.querySelector('i'), label = pauseBtn.querySelector('span');
+      if (icon) icon.className = 'ti ' + (paused ? 'ti-player-play' : 'ti-player-pause');
+      if (label) label.textContent = paused ? pauseBtn.dataset.resume : pauseBtn.dataset.pause;
+    });
+
+    if (window.EventSource) {
+      var es = new EventSource((window.RUSCKER_BASE || '') + '/admin/logs/stream');
+      es.onmessage = function (e) {
+        if (paused) return;
+        var stick = nearBottom();
+        append(e.data);
+        if (stick) box.scrollTop = box.scrollHeight;
+      };
+      es.onerror = function () { /* EventSource auto-reconnects */ };
+    }
   })();
   </script>
 {% endif %}


### PR DESCRIPTION
**Slice 12 of #623** — the second backend-backed redesign item, which turned out to be **frontend-only**: the live SSE feed already existed (`/admin/logs/stream`, #100/#452); the server-logs tab just rendered it as a plain follow-along `<pre>`.

Now each line is parsed (**ANSI stripped**) into **timestamp · level · target · message** and rendered as a level-coloured `.log-line` (red/amber/blue/faint), with:
- a **level dropdown** filter,
- a **free-text search**,
- a **pause/resume** toggle,

all client-side over the existing stream. Unparseable lines fall back to a single message cell.

**XSS-safe:** content is set via `textContent` only — log text is never parsed as HTML; the pause labels come from `data-*` (HTML-escaped), not JS interpolation.

**No backend change.**

## Verification
Admin suite (12 groups) + clippy + i18n green; the parser passes `node --check` and a **behavioral test** on real ANSI-coloured tracing lines (ts/level/target/message extracted; plain lines too; unstructured lines fall back).

Part of #623.

🤖 Generated with [Claude Code](https://claude.com/claude-code)