### PR TITLE
feat(admin): richer live portal preview — accent-tinted mock cards (#623, slice 13)

### DIFF
--- a/crates/ruscker-admin/assets/tailwind/input.css
+++ b/crates/ruscker-admin/assets/tailwind/input.css
@@ -1849,23 +1849,27 @@ textarea.spec-form-input { resize: vertical; min-height: 64px; }
   color: var(--text-muted);
   margin: 0;
 }
+/* Preview search pill + accent-tinted mock cards (design handoff #623):
+ * makes the live portal preview read like the real catalogue instead of
+ * empty boxes, and reacts to the configured accent colour. */
 .landing-preview-mockfilter {
-  height: 22px;
-  background: var(--surface);
-  border: 0.5px solid var(--border);
-  border-radius: 999px;
+  height: 22px; display: flex; align-items: center; gap: 6px; padding: 0 9px;
+  background: var(--surface); border: 0.5px solid var(--border); border-radius: 999px;
+  color: var(--text-faint);
 }
+.landing-preview-mockfilter .ti { font-size: 11px; }
+.lp-search-ph { height: 4px; width: 46%; border-radius: 2px; background: var(--border); }
 .landing-preview-mockgrid {
-  display: grid;
-  grid-template-columns: repeat(2, 1fr);
-  gap: 4px;
+  display: grid; grid-template-columns: repeat(2, 1fr); gap: 5px;
 }
-.landing-preview-mockgrid > div {
-  height: 36px;
+.lp-card {
+  border: 0.5px solid var(--border); border-radius: 5px; overflow: hidden;
   background: var(--surface);
-  border: 0.5px solid var(--border);
-  border-radius: 4px;
 }
+.lp-card-cover { height: 24px; }
+.lp-card-meta { padding: 4px 5px; display: flex; flex-direction: column; gap: 3px; }
+.lp-card-name { height: 4px; width: 72%; border-radius: 2px; background: var(--border-strong); }
+.lp-card-tag { height: 4px; width: 26%; border-radius: 2px; opacity: 0.85; }
 /* Live preview: logos in the header/footer chrome + a faithful footer. */
 .lp-head-side { display: flex; align-items: center; gap: 5px; min-width: 0; }
 .lp-logo { display: block; width: auto; object-fit: contain; }

--- a/crates/ruscker-admin/templates/admin/landing.html
+++ b/crates/ruscker-admin/templates/admin/landing.html
@@ -531,9 +531,19 @@
           <p class="landing-preview-intro"
              x-text="previewIntro()"
              :class="!previewIntro() ? 'opacity-40 italic' : ''"></p>
-          <div class="landing-preview-mockfilter"></div>
+          <div class="landing-preview-mockfilter"><i class="ti ti-search" aria-hidden="true"></i><span class="lp-search-ph"></span></div>
+          {# Mock cards: cover tinted with the configured accent, name/tag
+             placeholders. Reacts live to the accent colour. #}
           <div class="landing-preview-mockgrid">
-            <div></div><div></div><div></div><div></div>
+            <template x-for="i in [1, 2, 3, 4]" :key="i">
+              <div class="lp-card">
+                <div class="lp-card-cover" :style="'background:color-mix(in srgb, ' + (form.theme_light_accent || '#0f6e56') + ' 14%, var(--surface))'"></div>
+                <div class="lp-card-meta">
+                  <div class="lp-card-name"></div>
+                  <div class="lp-card-tag" :style="'background:' + (form.theme_light_accent || '#0f6e56')"></div>
+                </div>
+              </div>
+            </template>
           </div>
         </div>
 


### PR DESCRIPTION
**Slice 13 of #623.** The Appearance editor's live preview had a faithful header/footer but a **bare body**. Brings it closer to the handoff's mini-portal: a **search pill** + four **mock cards** whose covers and type tags are **tinted with the configured accent colour**, reacting live.

Pure presentation, reusing the existing Alpine `form` state. Admin suite (12) + clippy + i18n green.

Part of #623.

🤖 Generated with [Claude Code](https://claude.com/claude-code)