### PR TITLE
feat(admin): design touches on Groups + Credentials (#623, slice 14)

### DIFF
--- a/crates/ruscker-admin/assets/tailwind/input.css
+++ b/crates/ruscker-admin/assets/tailwind/input.css
@@ -1849,23 +1849,27 @@ textarea.spec-form-input { resize: vertical; min-height: 64px; }
   color: var(--text-muted);
   margin: 0;
 }
+/* Preview search pill + accent-tinted mock cards (design handoff #623):
+ * makes the live portal preview read like the real catalogue instead of
+ * empty boxes, and reacts to the configured accent colour. */
 .landing-preview-mockfilter {
-  height: 22px;
-  background: var(--surface);
-  border: 0.5px solid var(--border);
-  border-radius: 999px;
+  height: 22px; display: flex; align-items: center; gap: 6px; padding: 0 9px;
+  background: var(--surface); border: 0.5px solid var(--border); border-radius: 999px;
+  color: var(--text-faint);
 }
+.landing-preview-mockfilter .ti { font-size: 11px; }
+.lp-search-ph { height: 4px; width: 46%; border-radius: 2px; background: var(--border); }
 .landing-preview-mockgrid {
-  display: grid;
-  grid-template-columns: repeat(2, 1fr);
-  gap: 4px;
+  display: grid; grid-template-columns: repeat(2, 1fr); gap: 5px;
 }
-.landing-preview-mockgrid > div {
-  height: 36px;
+.lp-card {
+  border: 0.5px solid var(--border); border-radius: 5px; overflow: hidden;
   background: var(--surface);
-  border: 0.5px solid var(--border);
-  border-radius: 4px;
 }
+.lp-card-cover { height: 24px; }
+.lp-card-meta { padding: 4px 5px; display: flex; flex-direction: column; gap: 3px; }
+.lp-card-name { height: 4px; width: 72%; border-radius: 2px; background: var(--border-strong); }
+.lp-card-tag { height: 4px; width: 26%; border-radius: 2px; opacity: 0.85; }
 /* Live preview: logos in the header/footer chrome + a faithful footer. */
 .lp-head-side { display: flex; align-items: center; gap: 5px; min-width: 0; }
 .lp-logo { display: block; width: auto; object-fit: contain; }

--- a/crates/ruscker-admin/assets/tailwind/input.css
+++ b/crates/ruscker-admin/assets/tailwind/input.css
@@ -1653,6 +1653,23 @@ textarea.spec-form-input { resize: vertical; min-height: 64px; }
   display: grid; grid-template-columns: repeat(auto-fill, minmax(280px, 1fr));
   gap: 14px;
 }
+/* Coloured left accent bar per group card (design handoff #623) — hue from
+ * the group-name hash (set inline by the page script), matching the group
+ * badges on the Users page so the same group reads the same colour. */
+.group-card { position: relative; overflow: hidden; }
+.group-card__bar { position: absolute; left: 0; top: 0; bottom: 0; width: 4px; background: var(--color-teal-600); }
+.group-card > .editor-card__head, .group-card > .group-col { padding-left: 6px; }
+
+/* Credential name tile (design handoff #623): a small teal key icon next
+ * to the credential name. */
+.cred-cell { display: inline-flex; align-items: center; gap: 9px; }
+.cred-ico {
+  width: 28px; height: 28px; border-radius: 7px; flex: none;
+  display: flex; align-items: center; justify-content: center;
+  background: color-mix(in srgb, var(--color-teal-400) 14%, var(--surface));
+  color: var(--color-teal-600);
+}
+.cred-ico .ti { font-size: 15px; }
 .group-col { margin-top: 12px; }
 .group-col-title {
   font-size: 11px; font-weight: 600; color: var(--text-muted);

--- a/crates/ruscker-admin/templates/admin/credentials.html
+++ b/crates/ruscker-admin/templates/admin/credentials.html
@@ -105,7 +105,7 @@
     <tbody>
       {% for c in credentials %}
         <tr>
-          <td class="id-cell">{{ c.name }}</td>
+          <td class="id-cell"><span class="cred-cell"><span class="cred-ico"><i class="ti ti-key" aria-hidden="true"></i></span>{{ c.name }}</span></td>
           <td class="text-[color:var(--text-muted)]">{{ c.registry }}</td>
           <td>{{ c.username }}</td>
           <td class="text-[color:var(--text-muted)]">{{ c.created_at.format("%d/%m/%Y") }}</td>

--- a/crates/ruscker-admin/templates/admin/groups.html
+++ b/crates/ruscker-admin/templates/admin/groups.html
@@ -49,6 +49,7 @@
   <div class="groups-grid">
     {% for g in groups %}
     <section class="editor-card group-card">
+      <span class="group-card__bar" data-group="{{ g.name }}"></span>
       <div class="editor-card__head">
         <span class="editor-card__icon"><i class="ti ti-users-group" aria-hidden="true"></i></span>
         <div class="flex-1"><div class="editor-card__title">{{ g.name }}</div></div>
@@ -132,5 +133,17 @@
   .group-pill-x:hover { color: var(--color-lock); }
   .group-add-member { display: flex; align-items: center; gap: 6px; margin-top: 8px; }
 </style>
+
+<script>
+  // Colour each group card's accent bar from a hash of the group name —
+  // same hue function as the Users-page group badges, so a group reads the
+  // same colour everywhere (#623).
+  (function () {
+    function hue(s) { var h = 0; for (var i = 0; i < s.length; i++) h = (h * 31 + s.charCodeAt(i)) % 360; return h; }
+    document.querySelectorAll('.group-card__bar[data-group]').forEach(function (el) {
+      el.style.background = 'hsl(' + hue(el.getAttribute('data-group')) + ' 55% 45%)';
+    });
+  })();
+</script>
 
 {% endblock %}

--- a/crates/ruscker-admin/templates/admin/landing.html
+++ b/crates/ruscker-admin/templates/admin/landing.html
@@ -531,9 +531,19 @@
           <p class="landing-preview-intro"
              x-text="previewIntro()"
              :class="!previewIntro() ? 'opacity-40 italic' : ''"></p>
-          <div class="landing-preview-mockfilter"></div>
+          <div class="landing-preview-mockfilter"><i class="ti ti-search" aria-hidden="true"></i><span class="lp-search-ph"></span></div>
+          {# Mock cards: cover tinted with the configured accent, name/tag
+             placeholders. Reacts live to the accent colour. #}
           <div class="landing-preview-mockgrid">
-            <div></div><div></div><div></div><div></div>
+            <template x-for="i in [1, 2, 3, 4]" :key="i">
+              <div class="lp-card">
+                <div class="lp-card-cover" :style="'background:color-mix(in srgb, ' + (form.theme_light_accent || '#0f6e56') + ' 14%, var(--surface))'"></div>
+                <div class="lp-card-meta">
+                  <div class="lp-card-name"></div>
+                  <div class="lp-card-tag" :style="'background:' + (form.theme_light_accent || '#0f6e56')"></div>
+                </div>
+              </div>
+            </template>
           </div>
         </div>
 


### PR DESCRIPTION
Sweep of the remaining admin screens toward the handoff. **Groups**: coloured left bar per card (hue from the group name, same hash as the Users-page badges). **Credentials**: teal key-icon tile per row. Audit/Media/Users/Appearance already in the design. Pure presentation. Admin suite (12) + clippy + i18n green.

Part of #623.

🤖 Generated with [Claude Code](https://claude.com/claude-code)