### PR TITLE
feat(dashboard): aggregate CPU/memory + bars on the group head (#623, slice 16)

### DIFF
--- a/crates/ruscker-admin/src/routes/admin/dashboard.rs
+++ b/crates/ruscker-admin/src/routes/admin/dashboard.rs
@@ -166,6 +166,11 @@ struct AppGroup {
     /// Summed across the app's replicas.
     sessions_active: u32,
     sessions_max: u32,
+    /// Aggregate CPU% (sum of the replicas' latest sample) + memory, for the
+    /// collapsed head — empty when no metrics yet. `cpu_pct` drives the bar.
+    cpu_display: String,
+    cpu_pct: f64,
+    memory_display: String,
     replicas: Vec<ReplicaRow>,
 }
 
@@ -207,6 +212,10 @@ fn group_rows(rows: &[ReplicaRow]) -> Vec<AppGroup> {
             let worst = reps.iter().max_by_key(|r| severity(r.state));
             let state_dot = worst.map(|r| r.state_dot).unwrap_or("dot-off");
             let state_label = worst.map(|r| r.state_label.clone()).unwrap_or_default();
+            // Aggregate metrics from each replica's latest sample.
+            let has_metrics = reps.iter().any(|r| r.cpu_display.is_some());
+            let cpu_sum: f64 = reps.iter().filter_map(|r| r.cpu_history.last().copied()).sum();
+            let mem_sum: u64 = reps.iter().filter_map(|r| r.mem_history.last().copied()).sum();
             AppGroup {
                 spec_id: spec_id.to_string(),
                 display_name,
@@ -216,6 +225,9 @@ fn group_rows(rows: &[ReplicaRow]) -> Vec<AppGroup> {
                 state_label,
                 sessions_active: reps.iter().map(|r| r.sessions_active).sum(),
                 sessions_max: reps.iter().map(|r| r.sessions_max).sum(),
+                cpu_display: if has_metrics { format!("{cpu_sum:.0}%") } else { String::new() },
+                cpu_pct: cpu_sum.clamp(0.0, 100.0),
+                memory_display: if mem_sum > 0 { format_bytes(mem_sum) } else { String::new() },
                 replicas: reps,
             }
         })

--- a/crates/ruscker-admin/templates/admin/dashboard.html
+++ b/crates/ruscker-admin/templates/admin/dashboard.html
@@ -102,9 +102,9 @@
       </span>
       <span class="app-group__replicas"><i class="ti ti-stack-2" aria-hidden="true"></i>{{ g.n }}</span>
       <span class="app-group__state"><span class="dot {{ g.state_dot }}"></span>{{ g.state_label }}</span>
-      <span class="metric-cell tnum">{{ g.sessions_active }}<span class="faint">/{{ g.sessions_max }}</span></span>
-      <span></span>
-      <span></span>
+      <span class="metric-cell"><span class="v tnum">{{ g.sessions_active }}<span class="faint">/{{ g.sessions_max }}</span></span><span class="bar-track"><span class="bar-fill" style="background:var(--info);{% if g.sessions_max > 0 %}width:{{ g.sessions_active * 100 / g.sessions_max }}%{% else %}width:0{% endif %}"></span></span></span>
+      <span class="metric-cell">{% if !g.cpu_display.is_empty() %}<span class="v tnum">{{ g.cpu_display }}</span><span class="bar-track"><span class="bar-fill" style="background:var(--color-teal-600);width:{{ g.cpu_pct }}%"></span></span>{% endif %}</span>
+      <span class="metric-cell tnum">{{ g.memory_display }}</span>
     </div>
     <div class="replica-list">
       {% for row in g.replicas %}
@@ -213,19 +213,34 @@
       buckets[r.spec_id].push(r);
     });
     return order.map(function (id) {
-      var reps = buckets[id], worst = reps[0], sa = 0, sm = 0;
+      var reps = buckets[id], worst = reps[0], sa = 0, sm = 0, cpu = 0, mem = 0, hasM = false;
       reps.forEach(function (r) {
         if (severity(r.state) > severity(worst.state)) worst = r;
         sa += r.sessions_active; sm += r.sessions_max;
+        if (r.cpu_history && r.cpu_history.length) cpu += r.cpu_history[r.cpu_history.length - 1];
+        if (r.mem_history && r.mem_history.length) mem += r.mem_history[r.mem_history.length - 1];
+        if (r.cpu_display != null) hasM = true;
       });
       var name = reps[0].display_name || id;
       return {
         spec_id: id, display_name: name,
         initial: (name.charAt(0) || '').toUpperCase(),
         n: reps.length, state_dot: worst.state_dot, state_label: worst.state_label,
-        sessions_active: sa, sessions_max: sm, replicas: reps
+        sessions_active: sa, sessions_max: sm,
+        cpu_display: hasM ? Math.round(cpu) + '%' : '', cpu_pct: Math.max(0, Math.min(100, cpu)),
+        memory_display: mem > 0 ? fmtBytes(mem) : '',
+        replicas: reps
       };
     });
+  }
+
+  // Binary-unit byte formatter, matching the server's format_bytes.
+  function fmtBytes(b) {
+    var KIB = 1024, MIB = 1024 * KIB, GIB = 1024 * MIB;
+    if (b < KIB) return b + ' B';
+    if (b < MIB) return Math.floor(b / KIB) + ' KB';
+    if (b < GIB) return Math.floor(b / MIB) + ' MB';
+    return (b / GIB).toFixed(1) + ' GB';
   }
 
   function replicaRowHtml(row) {
@@ -252,8 +267,11 @@
           + '<span class="app-group__id">' + escapeHtml(g.spec_id) + '</span></span></span>'
         + '<span class="app-group__replicas"><i class="ti ti-stack-2"></i>' + g.n + '</span>'
         + '<span class="app-group__state"><span class="dot ' + escapeHtml(g.state_dot) + '"></span>' + escapeHtml(g.state_label) + '</span>'
-        + '<span class="metric-cell tnum">' + g.sessions_active + '<span class="faint">/' + g.sessions_max + '</span></span>'
-        + '<span></span><span></span>'
+        + '<span class="metric-cell"><span class="v tnum">' + g.sessions_active + '<span class="faint">/' + g.sessions_max + '</span></span>'
+          + '<span class="bar-track"><span class="bar-fill" style="background:var(--info);width:' + (g.sessions_max > 0 ? Math.round(g.sessions_active * 100 / g.sessions_max) : 0) + '%"></span></span></span>'
+        + '<span class="metric-cell">' + (g.cpu_display ? '<span class="v tnum">' + g.cpu_display + '</span>'
+          + '<span class="bar-track"><span class="bar-fill" style="background:var(--color-teal-600);width:' + g.cpu_pct + '%"></span></span>' : '') + '</span>'
+        + '<span class="metric-cell tnum">' + escapeHtml(g.memory_display) + '</span>'
       + '</div>'
       + '<div class="replica-list">' + reps + '</div>'
       + '</div>';


### PR DESCRIPTION
The screenshot's collapsed app rows carry the aggregate at a glance — **sessions, CPU%, memory**, each with a little meter. The group head only showed sessions (no bar) and left CPU/memory empty.

`AppGroup` now sums the replicas' latest CPU sample and memory into `cpu_display`/`cpu_pct`/`memory_display`; the head renders sessions, CPU and memory with `.bar-track`/`.bar-fill` meters (sessions = active/max, CPU capped at 100). The SSE patcher computes the same in JS, with a `fmtBytes` mirroring the server's binary-unit `format_bytes`.

## Verification
Admin suite (12 groups, incl. dashboard render tests) + clippy + i18n green; the JS passes `node --check` and a behavioral test (CPU sum 15%, memory 1.4 GB, fmtBytes matches format_bytes).

Part of #623.

🤖 Generated with [Claude Code](https://claude.com/claude-code)