### PR TITLE
fix(admin): fixed role-colour palette + handoff badge/avatar style

### DIFF
--- a/crates/ruscker-admin/assets/tailwind/input.css
+++ b/crates/ruscker-admin/assets/tailwind/input.css
@@ -1683,7 +1683,7 @@ textarea.spec-form-input { resize: vertical; min-height: 64px; }
  * the group-name hash (set inline by the page script), matching the group
  * badges on the Users page so the same group reads the same colour. */
 .group-card { position: relative; overflow: hidden; }
-.group-card__bar { position: absolute; left: 0; top: 0; bottom: 0; width: 4px; background: var(--color-teal-600); }
+.group-card__bar { position: absolute; left: 0; top: 0; bottom: 0; width: 5px; background: var(--color-teal-600); }
 .group-card > .editor-card__head, .group-card > .group-col { padding-left: 6px; }
 
 /* Credential name tile (design handoff #623): a small teal key icon next

--- a/crates/ruscker-admin/templates/admin/groups.html
+++ b/crates/ruscker-admin/templates/admin/groups.html
@@ -139,9 +139,23 @@
   // same hue function as the Users-page group badges, so a group reads the
   // same colour everywhere (#623).
   (function () {
-    function hue(s) { var h = 0; for (var i = 0; i < s.length; i++) h = (h * 31 + s.charCodeAt(i)) % 360; return h; }
+    // Canonical roles use the design-handoff fixed palette (admin pink /
+    // editor cyan / viewer navy); other groups hash to a stable colour, so
+    // a group reads the same colour everywhere (#623).
+    var ROLE = { admin: '#ef476f', administrator: '#ef476f', editor: '#06b6d4', viewer: '#26547c' };
+    function groupColor(s) {
+      var k = s.toLowerCase();
+      if (ROLE[k]) return ROLE[k];
+      var h = 0; for (var i = 0; i < s.length; i++) h = (h * 31 + s.charCodeAt(i)) % 360;
+      return 'hsl(' + h + ' 55% 45%)';
+    }
     document.querySelectorAll('.group-card__bar[data-group]').forEach(function (el) {
-      el.style.background = 'hsl(' + hue(el.getAttribute('data-group')) + ' 55% 45%)';
+      el.style.background = groupColor(el.getAttribute('data-group'));
+    });
+    document.querySelectorAll('.group-badge[data-group]').forEach(function (el) {
+      var c = groupColor(el.getAttribute('data-group'));
+      el.style.background = 'color-mix(in srgb, ' + c + ' 16%, transparent)';
+      el.style.color = c;
     });
   })();
 </script>

--- a/crates/ruscker-admin/templates/admin/specs.html
+++ b/crates/ruscker-admin/templates/admin/specs.html
@@ -241,11 +241,20 @@
   // hue function as the Users/Groups pages, so a group reads the same
   // colour across the admin (#623).
   (function () {
-    function hue(s) { var h = 0; for (var i = 0; i < s.length; i++) h = (h * 31 + s.charCodeAt(i)) % 360; return h; }
+    // Canonical roles get the design-handoff fixed palette; any other
+    // group falls back to a stable hash hue. Badge style matches the
+    // handoff: a faint colour-mix tint with full-strength text (#623).
+    var ROLE = { admin: '#ef476f', administrator: '#ef476f', editor: '#06b6d4', viewer: '#26547c' };
+    function groupColor(s) {
+      var k = s.toLowerCase();
+      if (ROLE[k]) return ROLE[k];
+      var h = 0; for (var i = 0; i < s.length; i++) h = (h * 31 + s.charCodeAt(i)) % 360;
+      return 'hsl(' + h + ' 45% 45%)';
+    }
     document.querySelectorAll('.group-badge[data-group]').forEach(function (el) {
-      var hu = hue(el.getAttribute('data-group'));
-      el.style.background = 'hsl(' + hu + ' 70% 92%)';
-      el.style.color = 'hsl(' + hu + ' 55% 28%)';
+      var c = groupColor(el.getAttribute('data-group'));
+      el.style.background = 'color-mix(in srgb, ' + c + ' 16%, transparent)';
+      el.style.color = c;
     });
   })();
 </script>

--- a/crates/ruscker-admin/templates/admin/users.html
+++ b/crates/ruscker-admin/templates/admin/users.html
@@ -162,24 +162,31 @@
   // Avatars + group badges (#623): deterministic colour from a name hash,
   // so each user/group keeps a stable colour with no backend involvement.
   (function () {
-    function hue(s) {
-      var h = 0;
-      for (var i = 0; i < s.length; i++) h = (h * 31 + s.charCodeAt(i)) % 360;
-      return h;
+    // Canonical roles use the design-handoff fixed palette; everything
+    // else hashes to a stable colour. Avatars and group badges both render
+    // as a faint colour-mix tint with full-strength text, per the handoff
+    // (soft pastel circles + coloured initials, not solid dark) (#623).
+    var ROLE = { admin: '#ef476f', administrator: '#ef476f', editor: '#06b6d4', viewer: '#26547c' };
+    function color(s) {
+      var k = s.toLowerCase();
+      if (ROLE[k]) return ROLE[k];
+      var h = 0; for (var i = 0; i < s.length; i++) h = (h * 31 + s.charCodeAt(i)) % 360;
+      return 'hsl(' + h + ' 55% 45%)';
     }
     function initials(s) {
       var p = s.replace(/[^A-Za-z0-9]+/g, " ").trim().split(" ");
       return ((p[0] || "").charAt(0) + (p.length > 1 ? (p[1] || "").charAt(0) : "")).toUpperCase() || "?";
     }
     document.querySelectorAll(".rk-avatar[data-avatar]").forEach(function (el) {
-      var name = el.getAttribute("data-avatar"), hu = hue(name);
-      el.style.background = "hsl(" + hu + " 48% 42%)";
+      var name = el.getAttribute("data-avatar"), c = color(name);
+      el.style.background = "color-mix(in srgb, " + c + " 18%, var(--surface))";
+      el.style.color = c;
       if (!el.textContent) el.textContent = initials(name);
     });
     document.querySelectorAll(".group-badge[data-group]").forEach(function (el) {
-      var hu = hue(el.getAttribute("data-group"));
-      el.style.background = "hsl(" + hu + " 70% 92%)";
-      el.style.color = "hsl(" + hu + " 55% 28%)";
+      var c = color(el.getAttribute("data-group"));
+      el.style.background = "color-mix(in srgb, " + c + " 16%, transparent)";
+      el.style.color = c;
     });
   })();
 </script>


### PR DESCRIPTION
## What

Cross-screen design-fidelity fix flagged on **Apps**, **Users** and **Groups**: the badges/avatars/accent-bars hashed every name to an arbitrary HSL hue, so the canonical roles never matched the handoff colours.

- Canonical roles → **fixed handoff palette**: Admin `#ef476f` (pink), Editor `#06b6d4` (cyan), Viewer `#26547c` (navy). Custom group names still hash to a stable colour.
- Badges → faint `color-mix(… 16%, transparent)` tint + full-strength text (was pastel `hsl 70%/92%`).
- Avatars → soft `color-mix(… 18%, surface)` tint + coloured initials (was solid dark circle + white text).
- Group accent bar 4px → 5px.

Applied consistently in `specs.html`, `users.html`, `groups.html` (same `ROLE`/`groupColor` helper) + one `input.css` width tweak.

## Gate
- `cargo build -p ruscker-admin` ✅
- `./scripts/i18n-check.sh` ✅

Part of the broader design-handoff fidelity pass (see triage summary in the thread).

🤖 Generated with [Claude Code](https://claude.com/claude-code)