### PR TITLE
feat(admin): spec form → handoff widgets (switches, steppers, sliders, env repeater)

### DIFF
--- a/crates/ruscker-admin/assets/i18n/en/landing.ftl
+++ b/crates/ruscker-admin/assets/i18n/en/landing.ftl
@@ -548,6 +548,11 @@ spec-help-access-groups = Groups that may see and reach the app (comma-separated
 spec-form-access-users = Allowed users
 spec-help-access-users = Usernames that may see and reach the app (comma-separated).
 spec-form-access-help = Both blank = card is open to everyone (including anonymous). With any value, only matching logged-in users — and admins always.
+spec-form-access-public = Public
+spec-form-access-add-group = + add group
+spec-form-access-public-hint = empty = visible to everyone
+spec-form-summary-replicas = replicas
+spec-form-summary-sessions = sessions per replica
 spec-form-cpu-request = CPU reservation
 spec-help-cpu-request = Soft CPU reservation in cores (container-cpu-request). Blank = no reservation.
 spec-form-memory-request = Memory reservation

--- a/crates/ruscker-admin/assets/i18n/en/landing.ftl
+++ b/crates/ruscker-admin/assets/i18n/en/landing.ftl
@@ -519,6 +519,10 @@ spec-help-stop-on-logout = Stop the user's container when they log out. Off by d
 spec-form-env-section = Environment + command
 spec-form-container-env = Environment variables
 spec-form-container-env-help = One NAME=value per line. For secrets, reference an environment variable instead of pasting the value.
+spec-form-env-add = Add
+spec-form-env-value = value
+spec-form-env-remove = Remove
+spec-form-env-empty = No environment variables.
 spec-help-container-env = Injected into the container (container-env). Blank = none. For secrets, use environment-variable interpolation.
 spec-form-container-cmd = Command (override)
 spec-form-container-cmd-help = One argument per line. Blank = use the image's CMD.

--- a/crates/ruscker-admin/assets/i18n/es/landing.ftl
+++ b/crates/ruscker-admin/assets/i18n/es/landing.ftl
@@ -519,6 +519,10 @@ spec-help-stop-on-logout = Detiene el contenedor del usuario cuando cierra sesi�
 spec-form-env-section = Entorno + comando
 spec-form-container-env = Variables de entorno
 spec-form-container-env-help = Una por línea, NOMBRE=valor. Para secretos, referencia una variable de entorno en vez de pegar el valor.
+spec-form-env-add = Añadir
+spec-form-env-value = valor
+spec-form-env-remove = Eliminar
+spec-form-env-empty = Sin variables de entorno.
 spec-help-container-env = Inyectadas en el contenedor (container-env). Vacío = ninguna. Para secretos, usa interpolación de variable de entorno.
 spec-form-container-cmd = Comando (sobrescribir)
 spec-form-container-cmd-help = Un argumento por línea. Vacío = usa el CMD de la imagen.

--- a/crates/ruscker-admin/assets/i18n/es/landing.ftl
+++ b/crates/ruscker-admin/assets/i18n/es/landing.ftl
@@ -548,6 +548,11 @@ spec-help-access-groups = Grupos que pueden ver y acceder a la app (separados po
 spec-form-access-users = Usuarios permitidos
 spec-help-access-users = Usuarios que pueden ver y acceder a la app (separados por comas).
 spec-form-access-help = Ambos vacíos = tarjeta abierta a todos (incluido anónimo). Con algún valor, solo usuarios conectados que coincidan — y los admins siempre.
+spec-form-access-public = Público
+spec-form-access-add-group = + añadir grupo
+spec-form-access-public-hint = vacío = visible para todos
+spec-form-summary-replicas = réplicas
+spec-form-summary-sessions = sesiones por réplica
 spec-form-cpu-request = Reserva de CPU
 spec-help-cpu-request = Reserva suave de CPU en núcleos (container-cpu-request). Vacío = sin reserva.
 spec-form-memory-request = Reserva de memoria

--- a/crates/ruscker-admin/assets/i18n/fr/landing.ftl
+++ b/crates/ruscker-admin/assets/i18n/fr/landing.ftl
@@ -519,6 +519,10 @@ spec-help-stop-on-logout = Arrête le conteneur de l'utilisateur à sa déconnex
 spec-form-env-section = Environnement + commande
 spec-form-container-env = Variables d'environnement
 spec-form-container-env-help = Une par ligne, NOM=valeur. Pour les secrets, référencez une variable d'environnement au lieu de coller la valeur.
+spec-form-env-add = Ajouter
+spec-form-env-value = valeur
+spec-form-env-remove = Supprimer
+spec-form-env-empty = Aucune variable d'environnement.
 spec-help-container-env = Injectées dans le conteneur (container-env). Vide = aucune. Pour les secrets, utilisez l'interpolation de variable d'environnement.
 spec-form-container-cmd = Commande (remplacer)
 spec-form-container-cmd-help = Un argument par ligne. Vide = utilise le CMD de l'image.

--- a/crates/ruscker-admin/assets/i18n/fr/landing.ftl
+++ b/crates/ruscker-admin/assets/i18n/fr/landing.ftl
@@ -548,6 +548,11 @@ spec-help-access-groups = Groupes qui peuvent voir et atteindre l'app (séparés
 spec-form-access-users = Utilisateurs autorisés
 spec-help-access-users = Utilisateurs qui peuvent voir et atteindre l'app (séparés par des virgules).
 spec-form-access-help = Les deux vides = carte ouverte à tous (y compris anonyme). Avec une valeur, seuls les utilisateurs connectés correspondants — et toujours les admins.
+spec-form-access-public = Public
+spec-form-access-add-group = + ajouter
+spec-form-access-public-hint = vide = visible par tous
+spec-form-summary-replicas = répliques
+spec-form-summary-sessions = sessions par réplique
 spec-form-cpu-request = Réservation CPU
 spec-help-cpu-request = Réservation souple de CPU en cœurs (container-cpu-request). Vide = pas de réservation.
 spec-form-memory-request = Réservation mémoire

--- a/crates/ruscker-admin/assets/i18n/pt/landing.ftl
+++ b/crates/ruscker-admin/assets/i18n/pt/landing.ftl
@@ -523,6 +523,10 @@ spec-help-stop-on-logout = Para o container do usuário quando ele faz logout. D
 spec-form-env-section = Ambiente + comando
 spec-form-container-env = Variáveis de ambiente
 spec-form-container-env-help = Uma por linha, NOME=valor. Para segredos, referencie uma variável de ambiente em vez de colar o valor.
+spec-form-env-add = Adicionar
+spec-form-env-value = valor
+spec-form-env-remove = Remover
+spec-form-env-empty = Nenhuma variável de ambiente.
 spec-help-container-env = Injetadas no container (container-env). Em branco = nenhuma. Para segredos, use interpolação de variável de ambiente.
 spec-form-container-cmd = Comando (sobrescrever)
 spec-form-container-cmd-help = Um argumento por linha. Em branco = usa o CMD da imagem.

--- a/crates/ruscker-admin/assets/i18n/pt/landing.ftl
+++ b/crates/ruscker-admin/assets/i18n/pt/landing.ftl
@@ -552,6 +552,11 @@ spec-help-access-groups = Grupos que podem ver e acessar o app (separados por v�
 spec-form-access-users = Usuários permitidos
 spec-help-access-users = Usuários que podem ver e acessar o app (separados por vírgula).
 spec-form-access-help = Ambos em branco = card aberto a todos (inclusive anônimos). Com algum valor, só usuários logados que combinam — e admins sempre.
+spec-form-access-public = Público
+spec-form-access-add-group = + add. grupo
+spec-form-access-public-hint = vazio = visível a todos
+spec-form-summary-replicas = réplicas
+spec-form-summary-sessions = sessões por réplica
 spec-form-cpu-request = Reserva de CPU
 spec-help-cpu-request = Reserva suave de CPU em núcleos (container-cpu-request). Em branco = sem reserva.
 spec-form-memory-request = Reserva de memória

--- a/crates/ruscker-admin/assets/tailwind/input.css
+++ b/crates/ruscker-admin/assets/tailwind/input.css
@@ -371,6 +371,32 @@ input[type="range"]::-moz-range-thumb {
   outline: 2px solid var(--color-teal-400); outline-offset: 2px;
 }
 
+/* Spec-form handoff widgets (#623): a full-width toggle row (label + hint
+ * left, switch right), an uppercase section title, and a −/value/+ stepper
+ * for small integer counts. The .switch above provides the toggle visual. */
+.form-section__title {
+  font-size: 11px; text-transform: uppercase; letter-spacing: 0.06em;
+  color: var(--text-faint); font-weight: 600; margin-bottom: 14px;
+}
+.toggle-row {
+  display: flex; align-items: center; justify-content: space-between; gap: 14px;
+  padding: 11px 0; cursor: pointer; border-bottom: 0.5px solid var(--border-soft);
+}
+.toggle-row:first-of-type { padding-top: 0; }
+.toggle-row:last-of-type { border-bottom: 0; }
+.toggle-row__label { font-size: 13px; font-weight: 500; }
+.toggle-row__hint { font-size: 11.5px; color: var(--text-faint); margin-top: 2px; }
+.stepper {
+  display: inline-flex; align-items: center; border: 0.5px solid var(--border);
+  border-radius: 8px; overflow: hidden; align-self: flex-start;
+}
+.stepper button {
+  width: 34px; height: 34px; border: 0; background: var(--surface-soft);
+  color: var(--text); cursor: pointer; display: flex; align-items: center; justify-content: center;
+}
+.stepper button:hover { background: var(--surface); }
+.stepper span { min-width: 44px; text-align: center; font-size: 14px; font-weight: 500; }
+
 /* Styled checkbox — teal box with a check when ticked. */
 .rk-check-wrap { display: inline-flex; align-items: center; cursor: pointer; }
 .rk-check-wrap > input { position: absolute; opacity: 0; width: 0; height: 0; }

--- a/crates/ruscker-admin/assets/tailwind/input.css
+++ b/crates/ruscker-admin/assets/tailwind/input.css
@@ -396,6 +396,40 @@ input[type="range"]::-moz-range-thumb {
 }
 .stepper button:hover { background: var(--surface); }
 .stepper span { min-width: 44px; text-align: center; font-size: 14px; font-weight: 500; }
+/* Hybrid stepper: the middle stays a real, clearable number input so an
+ * empty value (= "use the default") is preserved — the −/+ buttons only
+ * nudge it. The native spinners are hidden so it reads as the design's
+ * −[n]+ pill. */
+.stepper__input {
+  width: 48px; text-align: center; border: 0; background: transparent;
+  color: var(--text); font-size: 14px; font-weight: 500; font-family: inherit;
+  -moz-appearance: textfield; appearance: textfield;
+}
+.stepper__input:focus { outline: 0; }
+.stepper__input::-webkit-outer-spin-button,
+.stepper__input::-webkit-inner-spin-button { -webkit-appearance: none; margin: 0; }
+
+/* Resource slider row (#623): icon+label · range slider · value/field. */
+.res-row {
+  display: grid; grid-template-columns: 130px 1fr 110px;
+  align-items: center; gap: 12px; margin-bottom: 12px;
+}
+.res-row__k { font-size: 12.5px; color: var(--text-muted); display: flex; align-items: center; gap: 6px; }
+.res-row__k .ti { font-size: 15px; color: var(--text-faint); }
+.res-row__v { font-size: 12.5px; font-weight: 500; text-align: right; }
+.rk-range {
+  -webkit-appearance: none; appearance: none; height: 4px; border-radius: 2px;
+  background: var(--surface-soft); outline: 0; cursor: pointer;
+}
+.rk-range::-webkit-slider-thumb {
+  -webkit-appearance: none; width: 16px; height: 16px; border-radius: 50%;
+  background: var(--color-teal-600); border: 2px solid var(--surface);
+  box-shadow: 0 1px 3px rgba(0, 0, 0, 0.3); cursor: pointer;
+}
+.rk-range::-moz-range-thumb {
+  width: 16px; height: 16px; border-radius: 50%;
+  background: var(--color-teal-600); border: 2px solid var(--surface); cursor: pointer;
+}
 
 /* Styled checkbox — teal box with a check when ticked. */
 .rk-check-wrap { display: inline-flex; align-items: center; cursor: pointer; }

--- a/crates/ruscker-admin/assets/tailwind/input.css
+++ b/crates/ruscker-admin/assets/tailwind/input.css
@@ -431,6 +431,26 @@ input[type="range"]::-moz-range-thumb {
   background: var(--color-teal-600); border: 2px solid var(--surface); cursor: pointer;
 }
 
+/* Access-group pill toggle (design handoff #623). The `.on` colour is set
+ * inline per group (fixed role palette / hash) so it matches the badges. */
+.group-toggle {
+  display: inline-flex; align-items: center; gap: 5px; padding: 5px 11px;
+  font-size: 12px; border: 0.5px solid var(--border); border-radius: 999px;
+  background: var(--surface); color: var(--text-muted); cursor: pointer;
+  font-family: inherit; transition: all 0.12s;
+}
+.group-toggle:hover { border-color: var(--border-strong); color: var(--text); }
+.group-toggle.on { font-weight: 500; }
+.group-toggle .ti { font-size: 13px; }
+
+/* Resource/scale summary under the live preview card (design handoff #623). */
+.spec-summary {
+  display: flex; flex-direction: column; gap: 7px;
+  margin-top: 14px; padding-top: 14px; border-top: 0.5px solid var(--border-soft);
+}
+.spec-summary__row { display: flex; align-items: center; gap: 8px; font-size: 11.5px; color: var(--text-muted); }
+.spec-summary__row .ti { font-size: 14px; color: var(--text-faint); width: 16px; }
+
 /* Styled checkbox — teal box with a check when ticked. */
 .rk-check-wrap { display: inline-flex; align-items: center; cursor: pointer; }
 .rk-check-wrap > input { position: absolute; opacity: 0; width: 0; height: 0; }

--- a/crates/ruscker-admin/src/routes/admin/spec_form.rs
+++ b/crates/ruscker-admin/src/routes/admin/spec_form.rs
@@ -847,6 +847,10 @@ struct SpecFormPage<'a> {
     /// `docker-registry-credential` datalist (#351). Empty when no DB
     /// is wired or the listing fails — the field stays free-text.
     credential_names: Vec<String>,
+    /// Known group names (from every spec's `access-groups` + every user's
+    /// memberships), for the access-group pill picker (#623). The field
+    /// still accepts arbitrary names via the "add group" input.
+    available_groups: Vec<String>,
 }
 
 impl<'a> SpecFormPage<'a> {
@@ -879,6 +883,12 @@ impl<'a> SpecFormPage<'a> {
     /// picker so an inline upload can push new thumbnails reactively.
     fn logo_images_json(&self) -> String {
         serde_json::to_string(&self.logo_images).unwrap_or_else(|_| "[]".into())
+    }
+
+    /// Known group names as a JSON array, seeding the access-group pill
+    /// picker (#623).
+    fn available_groups_json(&self) -> String {
+        serde_json::to_string(&self.available_groups).unwrap_or_else(|_| "[]".into())
     }
 
 
@@ -925,6 +935,27 @@ async fn credential_names(state: &AppState) -> Vec<String> {
     }
 }
 
+/// Known group names for the access-group pill picker (#623): the union of
+/// every effective spec's `access-groups` and every user's memberships,
+/// sorted and de-duplicated. Empty when no DB is wired — the picker then
+/// just offers the "add group" input.
+async fn group_names(state: &AppState) -> Vec<String> {
+    let mut set = std::collections::BTreeSet::new();
+    for s in crate::catalog::effective_specs(state.db.as_ref(), &state.config).await {
+        if let Some(groups) = s.access_groups.as_ref() {
+            set.extend(groups.iter().cloned());
+        }
+    }
+    if let Some(db) = state.db.as_ref() {
+        if let Ok(users) = db::users::list_all(db).await {
+            for u in users {
+                set.extend(u.groups);
+            }
+        }
+    }
+    set.into_iter().collect()
+}
+
 async fn new_form(
     editor: RequireEditor,
     State(state): State<AppState>,
@@ -950,6 +981,7 @@ async fn new_form(
         },
         errors: Vec::new(),
         logo_images: logo_filenames(&state).await,
+        available_groups: group_names(&state).await,
         credential_names: credential_names(&state).await,
     };
     super::render(&page)
@@ -985,6 +1017,7 @@ async fn edit_form(
         form: SpecForm::from_spec(&spec),
         errors: Vec::new(),
         logo_images: logo_filenames(&state).await,
+        available_groups: group_names(&state).await,
         credential_names: credential_names(&state).await,
     };
     super::render(&page)
@@ -1051,6 +1084,7 @@ async fn duplicate_form(
         form,
         errors: Vec::new(),
         logo_images: logo_filenames(&state).await,
+        available_groups: group_names(&state).await,
         credential_names: credential_names(&state).await,
     };
     super::render(&page)
@@ -1222,6 +1256,7 @@ async fn render_form_with_errors(
         form,
         errors,
         logo_images: logo_filenames(state).await,
+        available_groups: group_names(state).await,
         credential_names: credential_names(state).await,
     };
     let body = match page.render() {

--- a/crates/ruscker-admin/templates/admin/spec_form.html
+++ b/crates/ruscker-admin/templates/admin/spec_form.html
@@ -563,14 +563,32 @@
 
           {# Environment + command #}
           <div class="spec-form-subsection">{{ self.t("spec-form-env-section") }}</div>
-          <div class="spec-form-field">
-            <div class="spec-form-label-row">
-              <label for="f-env" class="spec-form-label">{{ self.t("spec-form-container-env") }}</label>
-              {% call help(self.t("spec-help-container-env")) %}{% endcall %}
+          <div class="spec-form-field" x-init="envInit()">
+            <div class="spec-form-label-row" style="justify-content:space-between">
+              <span style="display:inline-flex;align-items:center">
+                <label class="spec-form-label">{{ self.t("spec-form-container-env") }}</label>
+                {% call help(self.t("spec-help-container-env")) %}{% endcall %}
+              </span>
+              <button type="button" class="mini-add" @click="envAdd()">
+                <i class="ti ti-plus" aria-hidden="true"></i>{{ self.t("spec-form-env-add") }}
+              </button>
             </div>
-            <textarea id="f-env" name="container_env" rows="3"
-                      placeholder="JUPYTER_TOKEN=&#10;DB_PASSWORD=${DB_PASSWORD}"
-                      class="spec-form-input spec-form-input--mono">{{ form.container_env }}</textarea>
+            <div style="display:flex;flex-direction:column;gap:7px">
+              <template x-for="(row, i) in envRows" :key="i">
+                <div class="env-row">
+                  <input type="text" class="spec-form-input spec-form-input--mono" placeholder="CHAVE"
+                         x-model="row.key" @input="row.key = row.key.toUpperCase().replace(/[^A-Z0-9_]/g, '_'); envSync()">
+                  <span class="env-eq">=</span>
+                  <input type="text" class="spec-form-input spec-form-input--mono" placeholder="{{ self.t("spec-form-env-value") }}"
+                         x-model="row.value" @input="envSync()">
+                  <button type="button" class="star-toggle" style="width:30px;height:30px" @click="envRemove(i)"
+                          title="{{ self.t("spec-form-env-remove") }}"><i class="ti ti-x" style="font-size:14px"></i></button>
+                </div>
+              </template>
+              <p x-show="!envRows.length" class="spec-form-help" style="margin:0">{{ self.t("spec-form-env-empty") }}</p>
+            </div>
+            {# Hidden field actually submitted — kept in sync from the rows. #}
+            <textarea name="container_env" x-model="form.container_env" class="sr-only" tabindex="-1" aria-hidden="true">{{ form.container_env }}</textarea>
             <div class="spec-form-help">{{ self.t("spec-form-container-env-help") }}</div>
           </div>
           <div class="spec-form-field">
@@ -646,16 +664,24 @@
                 <label for="f-min-rep" class="spec-form-label">{{ self.t("spec-form-min-replicas") }}</label>
                 {% call help(self.t("spec-help-min-replicas")) %}{% endcall %}
               </div>
-              <input id="f-min-rep" type="number" name="min_replicas" min="0"
-                     value="{{ form.min_replicas }}" placeholder="0" class="spec-form-input">
+              <div class="stepper">
+                <button type="button" tabindex="-1" @click="form.min_replicas = String(Math.max(0, (parseInt(form.min_replicas, 10) || 0) - 1))"><i class="ti ti-minus" aria-hidden="true"></i></button>
+                <input id="f-min-rep" type="number" name="min_replicas" min="0" placeholder="0"
+                       x-model="form.min_replicas" class="stepper__input">
+                <button type="button" tabindex="-1" @click="form.min_replicas = String((parseInt(form.min_replicas, 10) || 0) + 1)"><i class="ti ti-plus" aria-hidden="true"></i></button>
+              </div>
             </div>
             <div class="spec-form-field">
               <div class="spec-form-label-row">
                 <label for="f-max-rep" class="spec-form-label">{{ self.t("spec-form-max-replicas") }}</label>
                 {% call help(self.t("spec-help-max-replicas")) %}{% endcall %}
               </div>
-              <input id="f-max-rep" type="number" name="max_replicas" min="1"
-                     value="{{ form.max_replicas }}" placeholder="3" class="spec-form-input">
+              <div class="stepper">
+                <button type="button" tabindex="-1" @click="form.max_replicas = String(Math.max(1, (parseInt(form.max_replicas, 10) || 1) - 1))"><i class="ti ti-minus" aria-hidden="true"></i></button>
+                <input id="f-max-rep" type="number" name="max_replicas" min="1" placeholder="3"
+                       x-model="form.max_replicas" class="stepper__input">
+                <button type="button" tabindex="-1" @click="form.max_replicas = String((parseInt(form.max_replicas, 10) || 0) + 1)"><i class="ti ti-plus" aria-hidden="true"></i></button>
+              </div>
             </div>
             <div class="spec-form-field">
               <div class="spec-form-label-row">
@@ -703,24 +729,35 @@
 
           {# Resources — per-container limits #}
           <div class="spec-form-subsection">{{ self.t("spec-form-resources-section") }}</div>
+          {# CPU + memory limits as handoff slider rows (#623). The text
+             input stays the submitted source of truth (free-text, units,
+             empty = no limit); the slider is a bound convenience that reads
+             via memMb()/parseFloat and writes a plain value back. #}
+          <div class="res-row">
+            <span class="res-row__k">
+              <i class="ti ti-cpu" aria-hidden="true"></i> {{ self.t("spec-form-cpu-limit") }}
+              {% call help(self.t("spec-help-cpu-limit")) %}{% endcall %}
+            </span>
+            <input type="range" class="rk-range" min="0" max="8" step="0.25"
+                   :value="parseFloat(form.container_cpu_limit) || 0"
+                   @input="form.container_cpu_limit = $event.target.value">
+            <input id="f-cpu" type="text" name="container_cpu_limit" placeholder="0.5"
+                   x-model="form.container_cpu_limit"
+                   class="spec-form-input spec-form-input--mono" style="text-align:right;padding:7px 10px">
+          </div>
+          <div class="res-row">
+            <span class="res-row__k">
+              <i class="ti ti-database" aria-hidden="true"></i> {{ self.t("spec-form-memory-limit") }}
+              {% call help(self.t("spec-help-memory-limit")) %}{% endcall %}
+            </span>
+            <input type="range" class="rk-range" min="0" max="8192" step="256"
+                   :value="memMb(form.container_memory_limit)"
+                   @input="form.container_memory_limit = $event.target.value + 'm'">
+            <input id="f-mem" type="text" name="container_memory_limit" placeholder="512m"
+                   x-model="form.container_memory_limit"
+                   class="spec-form-input spec-form-input--mono" style="text-align:right;padding:7px 10px">
+          </div>
           <div class="grid grid-cols-2 gap-3">
-            <div class="spec-form-field">
-              <div class="spec-form-label-row">
-                <label for="f-cpu" class="spec-form-label">{{ self.t("spec-form-cpu-limit") }}</label>
-                {% call help(self.t("spec-help-cpu-limit")) %}{% endcall %}
-              </div>
-              <input id="f-cpu" type="text" name="container_cpu_limit"
-                     value="{{ form.container_cpu_limit }}" placeholder="0.5" class="spec-form-input">
-            </div>
-            <div class="spec-form-field">
-              <div class="spec-form-label-row">
-                <label for="f-mem" class="spec-form-label">{{ self.t("spec-form-memory-limit") }}</label>
-                {% call help(self.t("spec-help-memory-limit")) %}{% endcall %}
-              </div>
-              <input id="f-mem" type="text" name="container_memory_limit"
-                     value="{{ form.container_memory_limit }}" placeholder="512m"
-                     class="spec-form-input spec-form-input--mono">
-            </div>
             <div class="spec-form-field">
               <div class="spec-form-label-row">
                 <label for="f-cpu-req" class="spec-form-label">{{ self.t("spec-form-cpu-request") }}</label>
@@ -940,6 +977,37 @@
 window.ruscker = window.ruscker || {};
 window.ruscker.specForm = (initial, logoImages) => ({
   form: initial,
+  // Environment variables as editable KEY=value rows (#623). The repeater
+  // is the editable source; `form.container_env` (a hidden textarea, one
+  // `KEY=value` per line, `${VAR}` preserved verbatim) is rebuilt from it
+  // for submit so the backend contract is unchanged.
+  envRows: [],
+  envInit() {
+    var txt = (this.form.container_env || '').replace(/\r/g, '').trim();
+    this.envRows = txt ? txt.split('\n').map(function (l) {
+      var i = l.indexOf('=');
+      return i < 0 ? { key: l.trim(), value: '' } : { key: l.slice(0, i).trim(), value: l.slice(i + 1) };
+    }) : [];
+  },
+  envSync() {
+    this.form.container_env = this.envRows
+      .filter(function (r) { return (r.key || '').trim(); })
+      .map(function (r) { return r.key.trim() + '=' + (r.value || ''); })
+      .join('\n');
+  },
+  envAdd() { this.envRows.push({ key: '', value: '' }); },
+  envRemove(i) { this.envRows.splice(i, 1); this.envSync(); },
+  // Parse a memory string ("512m" / "2g" / "1024") to MB for the resource
+  // slider (#623). The text field stays the source of truth — the slider
+  // only reads this and writes back "<n>m"; an empty/unparseable value
+  // (= no limit) reads as 0 so the thumb rests at the start.
+  memMb(v) {
+    v = (v || '').toString().trim();
+    var m = v.match(/^(\d+(?:\.\d+)?)\s*([gGmM]?)/);
+    if (!m) return 0;
+    var n = parseFloat(m[1]);
+    return m[2].toLowerCase() === 'g' ? Math.round(n * 1024) : Math.round(n);
+  },
   // Media-library filenames for the logo/cover pickers (#213). Inline
   // uploads unshift new names here so a fresh thumbnail appears at once.
   // Includes the built-in logos, which are seeded into the library (#433).

--- a/crates/ruscker-admin/templates/admin/spec_form.html
+++ b/crates/ruscker-admin/templates/admin/spec_form.html
@@ -17,7 +17,7 @@
 
 {% block content %}
 
-<div x-data="ruscker.specForm({{ form_initial_json() }}, {{ logo_images_json() }})" x-cloak>
+<div x-data="ruscker.specForm({{ form_initial_json() }}, {{ logo_images_json() }}, {{ available_groups_json() }})" x-cloak>
 
   {# ── Header ───────────────────────────────────────────────── #}
   <div class="editor-topbar">
@@ -376,23 +376,48 @@
       {# Access — who may see + reach this app (#155). Promoted out of the
          runtime "Advanced" collapse (#523): visibility is governance/metadata,
          not a runtime knob. #}
-      <div class="grid grid-cols-2 gap-3">
-        <div class="spec-form-field">
-          <div class="spec-form-label-row">
-            <label for="f-acl-groups" class="spec-form-label">{{ self.t("spec-form-access-groups") }}</label>
-            {% call help(self.t("spec-help-access-groups")) %}{% endcall %}
-          </div>
-          <input id="f-acl-groups" type="text" name="access_groups"
-                 value="{{ form.access_groups }}" placeholder="staff, ops" class="spec-form-input">
+      {# Access groups as toggle pills (#623). The submitted value is the
+         hidden comma-joined `access_groups`; pills + the "add group" input
+         toggle entries in it. A known group not yet in `availableGroups`
+         (e.g. a freshly added custom one) still renders via customGroups(). #}
+      <div class="spec-form-field">
+        <div class="spec-form-label-row">
+          <label class="spec-form-label">{{ self.t("spec-form-access-groups") }}
+            <span class="text-[color:var(--text-faint)]" style="font-weight:400">— {{ self.t("spec-form-access-public-hint") }}</span>
+          </label>
+          {% call help(self.t("spec-help-access-groups")) %}{% endcall %}
         </div>
-        <div class="spec-form-field">
-          <div class="spec-form-label-row">
-            <label for="f-acl-users" class="spec-form-label">{{ self.t("spec-form-access-users") }}</label>
-            {% call help(self.t("spec-help-access-users")) %}{% endcall %}
-          </div>
-          <input id="f-acl-users" type="text" name="access_users"
-                 value="{{ form.access_users }}" placeholder="alice, bob" class="spec-form-input">
+        <input type="hidden" name="access_groups" :value="form.access_groups">
+        <div style="display:flex;gap:8px;flex-wrap:wrap;align-items:center">
+          <button type="button" class="group-toggle" :class="!groupArr().length ? 'on' : ''"
+                  @click="form.access_groups = ''"
+                  :style="!groupArr().length ? 'border-color:var(--color-teal-600);background:color-mix(in srgb,var(--color-teal-600) 14%,transparent);color:var(--color-teal-600)' : ''">
+            <i class="ti" :class="!groupArr().length ? 'ti-check' : 'ti-world'"></i>{{ self.t("spec-form-access-public") }}
+          </button>
+          <template x-for="g in availableGroups" :key="g">
+            <button type="button" class="group-toggle" :class="hasGroup(g) ? 'on' : ''" @click="toggleGroup(g)"
+                    :style="hasGroup(g) ? grpStyle(g) : ''">
+              <i class="ti" :class="hasGroup(g) ? 'ti-check' : 'ti-plus'"></i><span x-text="g"></span>
+            </button>
+          </template>
+          <template x-for="g in customGroups()" :key="g">
+            <button type="button" class="group-toggle on" @click="toggleGroup(g)" :style="grpStyle(g)">
+              <i class="ti ti-check"></i><span x-text="g"></span>
+            </button>
+          </template>
+          <input type="text" class="spec-form-input" style="width:140px;padding:6px 10px"
+                 placeholder="{{ self.t("spec-form-access-add-group") }}"
+                 @keydown.enter.prevent="addGroup($event.target.value); $event.target.value = ''">
         </div>
+      </div>
+      <div class="spec-form-field">
+        <div class="spec-form-label-row">
+          <label for="f-acl-users" class="spec-form-label">{{ self.t("spec-form-access-users") }}</label>
+          {% call help(self.t("spec-help-access-users")) %}{% endcall %}
+        </div>
+        <input id="f-acl-users" type="text" name="access_users"
+               value="{{ form.access_users }}" x-model="form.access_users"
+               placeholder="alice, bob" class="spec-form-input">
       </div>
       <div class="spec-form-help">{{ self.t("spec-form-access-help") }}</div>
 
@@ -916,6 +941,22 @@
         </div>
       </div>
 
+      {# Resource/scale summary (#623): reflects the Advanced fields live. #}
+      <div class="spec-summary">
+        <div class="spec-summary__row">
+          <i class="ti ti-cpu" aria-hidden="true"></i>
+          <span x-text="(form.container_cpu_limit || '—') + ' · ' + (form.container_memory_limit || '—')"></span>
+        </div>
+        <div class="spec-summary__row">
+          <i class="ti ti-stack-2" aria-hidden="true"></i>
+          <span x-text="((form.max_replicas || form.min_replicas) ? ((form.min_replicas || '1') + '–' + (form.max_replicas || form.min_replicas)) : '1') + ' {{ self.t("spec-form-summary-replicas") }}'"></span>
+        </div>
+        <div class="spec-summary__row">
+          <i class="ti ti-clock" aria-hidden="true"></i>
+          <span x-text="((form.heartbeat_timeout && form.heartbeat_timeout != '-1') ? (form.heartbeat_timeout + ' min · ') : '') + (form.seats_per_container || '1') + ' {{ self.t("spec-form-summary-sessions") }}'"></span>
+        </div>
+      </div>
+
       <div class="spec-form-help" style="margin-top:8px">
         {{ self.t("spec-form-preview-help") }}
       </div>
@@ -975,8 +1016,44 @@
 <script src="{{ base }}/assets/js/alpine.min.js?v={{ crate::APP_VERSION }}" defer></script>
 <script>
 window.ruscker = window.ruscker || {};
-window.ruscker.specForm = (initial, logoImages) => ({
+window.ruscker.specForm = (initial, logoImages, availableGroups) => ({
   form: initial,
+  // Known group names for the access-group pill picker (#623). The text
+  // value still lives in `form.access_groups` (comma-joined) for submit;
+  // the pills + the "add group" input toggle entries in it. Arbitrary
+  // names are supported — a set group not in this list still renders.
+  availableGroups: Array.isArray(availableGroups) ? availableGroups : [],
+  groupArr() {
+    return (this.form.access_groups || '').split(',').map(function (s) { return s.trim(); }).filter(Boolean);
+  },
+  hasGroup(g) { return this.groupArr().indexOf(g) >= 0; },
+  toggleGroup(g) {
+    var arr = this.groupArr();
+    var i = arr.indexOf(g);
+    if (i >= 0) { arr.splice(i, 1); } else { arr.push(g); }
+    this.form.access_groups = arr.join(', ');
+  },
+  addGroup(name) {
+    var g = (name || '').trim();
+    if (g && !this.hasGroup(g)) { this.form.access_groups = this.groupArr().concat([g]).join(', '); }
+  },
+  customGroups() {
+    var avail = this.availableGroups;
+    return this.groupArr().filter(function (g) { return avail.indexOf(g) < 0; });
+  },
+  // Same fixed-role palette as the Apps/Users/Groups badges (#658): admin
+  // pink / editor cyan / viewer navy, else a stable hash hue.
+  grpColor(s) {
+    var ROLE = { admin: '#ef476f', administrator: '#ef476f', editor: '#06b6d4', viewer: '#26547c' };
+    var k = (s || '').toLowerCase();
+    if (ROLE[k]) return ROLE[k];
+    var h = 0; for (var i = 0; i < s.length; i++) h = (h * 31 + s.charCodeAt(i)) % 360;
+    return 'hsl(' + h + ' 45% 45%)';
+  },
+  grpStyle(g) {
+    var c = this.grpColor(g);
+    return 'border-color:' + c + ';background:color-mix(in srgb,' + c + ' 14%,transparent);color:' + c;
+  },
   // Environment variables as editable KEY=value rows (#623). The repeater
   // is the editable source; `form.container_env` (a hidden textarea, one
   // `KEY=value` per line, `${VAR}` preserved verbatim) is rebuilt from it

--- a/crates/ruscker-admin/templates/admin/spec_form.html
+++ b/crates/ruscker-admin/templates/admin/spec_form.html
@@ -61,12 +61,7 @@
 
       {# Type picker — 6 cards #}
       <section class="editor-card">
-        <div class="editor-card__head">
-          <span class="editor-card__icon"><i class="ti ti-category" aria-hidden="true"></i></span>
-          <div>
-            <div class="editor-card__title">{{ self.t("spec-form-kind") }} {% call help(self.t("spec-help-kind")) %}{% endcall %}</div>
-          </div>
-        </div>
+        <div class="form-section__title">{{ self.t("spec-form-kind") }} {% call help(self.t("spec-help-kind")) %}{% endcall %}</div>
         <div class="kind-picker">
           {% for k in display_type_options() %}
             <label class="kind-picker-card" :class="form.display_type === '{{ k.0 }}' ? 'is-active' : ''">
@@ -80,10 +75,7 @@
 
       {# ── Card: Identity ─────────────────────────────────────── #}
       <section class="editor-card">
-        <div class="editor-card__head">
-          <span class="editor-card__icon"><i class="ti ti-id-badge-2" aria-hidden="true"></i></span>
-          <div><div class="editor-card__title">{{ self.t("spec-form-identity") }}</div></div>
-        </div>
+        <div class="form-section__title">{{ self.t("spec-form-identity") }}</div>
 
       <div class="spec-form-field">
         <div class="spec-form-label-row">
@@ -128,10 +120,7 @@
 
       {# ── Card: Visual ───────────────────────────────────────── #}
       <section class="editor-card">
-        <div class="editor-card__head">
-          <span class="editor-card__icon"><i class="ti ti-photo" aria-hidden="true"></i></span>
-          <div><div class="editor-card__title">{{ self.t("spec-form-visual") }}</div></div>
-        </div>
+        <div class="form-section__title">{{ self.t("spec-form-visual") }}</div>
 
       {# ── Card logo (#213) — pick from the library, upload inline, or
          (advanced) paste a path/URL. Picker-first: no path typing in the
@@ -301,10 +290,7 @@
       {# ── Card: Container (only for container-backed kinds) ───── #}
       <template x-if="needsContainer()">
         <section class="editor-card">
-          <div class="editor-card__head">
-            <span class="editor-card__icon"><i class="ti ti-box" aria-hidden="true"></i></span>
-            <div><div class="editor-card__title">{{ self.t("spec-form-container") }}</div></div>
-          </div>
+          <div class="form-section__title">{{ self.t("spec-form-container") }}</div>
 
           <div class="spec-form-field">
             <div class="spec-form-label-row">
@@ -354,10 +340,7 @@
       {# ── Card: External link (only for external kinds) ──────── #}
       <template x-if="needsLink()">
         <section class="editor-card">
-          <div class="editor-card__head">
-            <span class="editor-card__icon"><i class="ti ti-external-link" aria-hidden="true"></i></span>
-            <div><div class="editor-card__title">{{ self.t("spec-form-link-section") }}</div></div>
-          </div>
+          <div class="form-section__title">{{ self.t("spec-form-link-section") }}</div>
           <div class="spec-form-field">
             <div class="spec-form-label-row">
               <label for="f-link" class="spec-form-label">{{ self.t("spec-form-link") }}</label>
@@ -374,21 +357,21 @@
 
       {# ── Card: Advanced (metadata + all the runtime knobs) ──── #}
       <section class="editor-card">
-        <div class="editor-card__head">
-          <span class="editor-card__icon"><i class="ti ti-adjustments" aria-hidden="true"></i></span>
-          <div><div class="editor-card__title">{{ self.t("spec-form-meta") }}</div></div>
-        </div>
+        <div class="form-section__title">{{ self.t("spec-form-meta") }}</div>
 
       {# Featured carousel flag (#506) — plain checkbox; native submit sends
          `featured=on` only when checked. Lives here (visible metadata band,
          #523) instead of buried under the runtime "Advanced" collapse. #}
-      <div class="spec-form-field">
-        <label class="spec-form-check">
+      <label class="toggle-row">
+        <div>
+          <div class="toggle-row__label">{{ self.t("spec-form-featured") }}</div>
+          <div class="toggle-row__hint">{{ self.t("spec-form-featured-help") }}</div>
+        </div>
+        <span class="switch">
           <input type="checkbox" name="featured" value="on" {% if !form.featured.is_empty() %}checked{% endif %}>
-          <span>{{ self.t("spec-form-featured") }}</span>
-        </label>
-        <div class="spec-form-help">{{ self.t("spec-form-featured-help") }}</div>
-      </div>
+          <span class="switch__track"><span class="switch__dot"></span></span>
+        </span>
+      </label>
 
       {# Access — who may see + reach this app (#155). Promoted out of the
          runtime "Advanced" collapse (#523): visibility is governance/metadata,
@@ -489,14 +472,17 @@
                 </div>
               </div>
 
-              <div class="spec-form-field">
-                <label class="spec-form-check">
+              <label class="toggle-row">
+                <div>
+                  <div class="toggle-row__label">{{ self.t("spec-form-api-cors") }}</div>
+                  <div class="toggle-row__hint">{{ self.t("spec-help-api-cors") }}</div>
+                </div>
+                <span class="switch">
                   <input type="checkbox" name="api_cors" value="on"
                          {% if !form.api_cors.is_empty() %}checked{% endif %}>
-                  {{ self.t("spec-form-api-cors") }}
-                  {% call help(self.t("spec-help-api-cors")) %}{% endcall %}
-                </label>
-              </div>
+                  <span class="switch__track"><span class="switch__dot"></span></span>
+                </span>
+              </label>
             </div>
           </template>
 
@@ -562,14 +548,17 @@
               <input id="f-clife" type="number" name="container_lifetime" min="0"
                      value="{{ form.container_lifetime }}" placeholder="360" class="spec-form-input">
             </div>
-            <div class="spec-form-field" style="align-self:end">
-              <label class="spec-form-check">
+            <label class="toggle-row" style="align-self:end">
+              <div>
+                <div class="toggle-row__label">{{ self.t("spec-form-stop-on-logout") }}</div>
+                <div class="toggle-row__hint">{{ self.t("spec-help-stop-on-logout") }}</div>
+              </div>
+              <span class="switch">
                 <input type="checkbox" name="stop_on_logout" value="on"
                        {% if !form.stop_on_logout.is_empty() %}checked{% endif %}>
-                {{ self.t("spec-form-stop-on-logout") }}
-                {% call help(self.t("spec-help-stop-on-logout")) %}{% endcall %}
-              </label>
-            </div>
+                <span class="switch__track"><span class="switch__dot"></span></span>
+              </span>
+            </label>
           </div>
 
           {# Environment + command #}
@@ -780,15 +769,17 @@
 
           {# Routing — how requests reach the upstream app #}
           <div class="spec-form-subsection">{{ self.t("spec-form-routing-section") }}</div>
-          <div class="spec-form-field">
-            <label class="spec-form-check">
+          <label class="toggle-row">
+            <div>
+              <div class="toggle-row__label">{{ self.t("spec-form-inject-base-href") }}</div>
+              <div class="toggle-row__hint">{{ self.t("spec-form-inject-base-href-help") }}</div>
+            </div>
+            <span class="switch">
               <input type="checkbox" name="inject_base_href" value="on"
                      {% if !form.inject_base_href.is_empty() %}checked{% endif %}>
-              {{ self.t("spec-form-inject-base-href") }}
-              {% call help(self.t("spec-help-inject-base-href")) %}{% endcall %}
-            </label>
-            <div class="spec-form-help">{{ self.t("spec-form-inject-base-href-help") }}</div>
-          </div>
+              <span class="switch__track"><span class="switch__dot"></span></span>
+            </span>
+          </label>
           <div class="grid grid-cols-2 gap-3">
             <div class="spec-form-field">
               <div class="spec-form-label-row">
@@ -815,14 +806,17 @@
               </select>
             </div>
           </div>
-          <div class="spec-form-field">
-            <label class="spec-form-check">
+          <label class="toggle-row">
+            <div>
+              <div class="toggle-row__label">{{ self.t("spec-form-anti-affinity") }}</div>
+              <div class="toggle-row__hint">{{ self.t("spec-help-anti-affinity") }}</div>
+            </div>
+            <span class="switch">
               <input type="checkbox" name="anti_affinity" value="on"
                      {% if !form.anti_affinity.is_empty() %}checked{% endif %}>
-              {{ self.t("spec-form-anti-affinity") }}
-              {% call help(self.t("spec-help-anti-affinity")) %}{% endcall %}
-            </label>
-          </div>
+              <span class="switch__track"><span class="switch__dot"></span></span>
+            </span>
+          </label>
 
           {# Lifecycle #}
           <div class="spec-form-subsection">{{ self.t("spec-form-lifecycle-section") }}</div>
@@ -843,10 +837,7 @@
     {# ── RIGHT: live preview + actions ─────────────────────── #}
     <aside class="spec-form-preview" style="top:96px">
       <div class="editor-card editor-card--preview">
-        <div class="editor-card__head">
-          <span class="editor-card__icon"><i class="ti ti-eye" aria-hidden="true"></i></span>
-          <div><div class="editor-card__title">{{ self.t("spec-form-preview") }}</div></div>
-        </div>
+        <div class="form-section__title"><i class="ti ti-eye" style="font-size:14px;margin-right:6px;vertical-align:-2px" aria-hidden="true"></i>{{ self.t("spec-form-preview") }}</div>
 
       <div class="rcard" style="margin:0">
         <div class="rcover">


### PR DESCRIPTION
## What

Design-handoff pass on the **Apps editor** (`spec_form.html`, screenshot #05 — the biggest screen). Several slices; **every form field name + the Alpine state are preserved**, so submit behaviour is identical.

### Slice 1 — switches + section titles
- 5 boolean checkboxes → full-width `.toggle-row`s (label + hint + pill `.switch`).
- Section headers drop the teal icon chip for the flat uppercase `.form-section__title` (preview keeps its eye icon).

### Slice 2 — env repeater
- `container_env` textarea → editable `KEY=value` repeater (`.env-row` + `.mini-add`); a hidden synced textarea submits, `${VAR}` preserved.

### Slice 3 — replica steppers
- `min_replicas` / `max_replicas` → **hybrid** `.stepper`s: the middle stays a real, clearable number input so **empty still means "use the default"**.

### Slice 4 — CPU/memory sliders
- CPU/memory limits → `.res-row` slider rows; the **text input stays the source of truth** (free-text, units, empty = no limit); the slider is a bound convenience (`memMb()`).

### Slice 5 — access-group pills + preview spec-summary (the two formerly-deferred items)
- **Access-group pills**: the `access-groups` free-text input becomes a `.group-toggle` picker that still supports **arbitrary names**. The route passes `available_groups` (union of specs' `access-groups` + users' memberships) via a new `group_names()` helper; a **Public** pill clears the list, known/custom groups toggle, and an "add group" input appends arbitrary names. Pills use the #658 role palette. Submitted value stays the hidden comma-joined `access_groups`.
- **Live spec-summary**: three rows under the preview card reflect CPU·memory, the replica range, and timeout·seats live.

Ported CSS: `.form-section__title`, `.toggle-row`, `.stepper`(+`__input`), `.res-row`, `.rk-range`, `.group-toggle`, `.spec-summary`. i18n keys × 4 locales.

## Only remaining non-item (data-model mismatch)
- **Runtime kind-picker** — the product has a `platform` field, no "runtime" concept; not added (would be a fake field).

## Gate
- `cargo build -p ruscker-admin` ✅
- `cargo clippy -p ruscker-admin --all-targets` ✅
- `./scripts/i18n-check.sh` ✅
- `cargo test -p ruscker-admin spec_form` ✅ (13 passed)

🤖 Generated with [Claude Code](https://claude.com/claude-code)