### PR TITLE
feat(admin): dashboard — live badge + state/search filter band

### DIFF
--- a/crates/ruscker-admin/assets/i18n/en/landing.ftl
+++ b/crates/ruscker-admin/assets/i18n/en/landing.ftl
@@ -135,6 +135,8 @@ admin-users-flash-exists = A user with that name already exists.
 # Admin dashboard
 admin-dashboard-title = Monitoring dashboard
 admin-dashboard-subtitle = Live container and session state
+admin-dashboard-live = Live
+admin-dashboard-filter-search = Filter app…
 admin-dashboard-metric-containers = Containers
 admin-dashboard-metric-sessions = Active sessions
 admin-dashboard-metric-specs = Apps with replicas

--- a/crates/ruscker-admin/assets/i18n/es/landing.ftl
+++ b/crates/ruscker-admin/assets/i18n/es/landing.ftl
@@ -135,6 +135,8 @@ admin-users-flash-exists = Ya existe un usuario con ese nombre.
 # Admin dashboard
 admin-dashboard-title = Panel de monitoreo
 admin-dashboard-subtitle = Estado de contenedores y sesiones en tiempo real
+admin-dashboard-live = En vivo
+admin-dashboard-filter-search = Filtrar app…
 admin-dashboard-metric-containers = Contenedores
 admin-dashboard-metric-sessions = Sesiones activas
 admin-dashboard-metric-specs = Aplicaciones con réplicas

--- a/crates/ruscker-admin/assets/i18n/fr/landing.ftl
+++ b/crates/ruscker-admin/assets/i18n/fr/landing.ftl
@@ -135,6 +135,8 @@ admin-users-flash-exists = Un utilisateur portant ce nom existe déjà.
 # Admin dashboard
 admin-dashboard-title = Tableau de bord
 admin-dashboard-subtitle = État des conteneurs et des sessions en temps réel
+admin-dashboard-live = En direct
+admin-dashboard-filter-search = Filtrer une app…
 admin-dashboard-metric-containers = Conteneurs
 admin-dashboard-metric-sessions = Sessions actives
 admin-dashboard-metric-specs = Applications avec répliques

--- a/crates/ruscker-admin/assets/i18n/pt/landing.ftl
+++ b/crates/ruscker-admin/assets/i18n/pt/landing.ftl
@@ -139,6 +139,8 @@ admin-users-flash-exists = Já existe um usuário com esse nome.
 # Admin dashboard
 admin-dashboard-title = Painel de monitoramento
 admin-dashboard-subtitle = Estado dos containers e sessões em tempo real
+admin-dashboard-live = Ao vivo
+admin-dashboard-filter-search = Filtrar app…
 admin-dashboard-metric-containers = Containers
 admin-dashboard-metric-sessions = Sessões ativas
 admin-dashboard-metric-specs = Aplicações com réplica

--- a/crates/ruscker-admin/assets/tailwind/input.css
+++ b/crates/ruscker-admin/assets/tailwind/input.css
@@ -220,6 +220,24 @@ body {
 @keyframes dash-pulse { 0%, 100% { opacity: 1; } 50% { opacity: 0.35; } }
 @media (prefers-reduced-motion: reduce) { .dot-pulse { animation: none; } }
 
+/* Live-stream badge (design handoff #623): a green dot with an expanding
+ * ring, shown next to the dashboard title while the SSE feed is open. */
+.live-dot {
+  width: 7px; height: 7px; border-radius: 50%; background: var(--ok, #10b981);
+  display: inline-block; position: relative;
+}
+.live-dot::after {
+  content: ""; position: absolute; inset: -4px; border-radius: 50%;
+  border: 1.5px solid var(--ok, #10b981); opacity: 0.6; animation: live-ring 1.8s ease-out infinite;
+}
+@keyframes live-ring { 0% { transform: scale(0.6); opacity: 0.7; } 100% { transform: scale(1.6); opacity: 0; } }
+.live-badge {
+  display: inline-flex; align-items: center; gap: 7px; font-size: 12px; color: var(--text-muted);
+}
+.live-badge.is-down .live-dot { background: var(--text-faint); }
+.live-badge.is-down .live-dot::after { animation: none; border-color: var(--text-faint); }
+@media (prefers-reduced-motion: reduce) { .live-dot::after { animation: none; } }
+
 .bar-track {
   height: 4px; background: var(--surface-soft); border-radius: 2px; overflow: hidden;
   width: 100%; margin-top: 4px;

--- a/crates/ruscker-admin/templates/admin/dashboard.html
+++ b/crates/ruscker-admin/templates/admin/dashboard.html
@@ -29,6 +29,9 @@
     <h1 class="text-xl font-medium tracking-tight">{{ self.t("admin-dashboard-title") }}</h1>
     <p class="text-xs text-[color:var(--text-muted)] mt-1">{{ self.t("admin-dashboard-subtitle") }}</p>
   </div>
+  {# Live-stream badge (#623): the pulsing ring shows while the SSE feed
+     is connected; the JS flips `.is-down` on error. #}
+  <span class="live-badge" id="dash-live"><span class="live-dot"></span>{{ self.t("admin-dashboard-live") }}</span>
 </div>
 
 {% if !backend_connected %}
@@ -66,6 +69,21 @@
 
 <div class="dash-toolbar">
   <h2 class="dash-toolbar__title">{{ self.t("admin-dashboard-replicas-heading") }}<span class="dash-toolbar__sub">{{ self.t("admin-dashboard-grouped-by") }}</span></h2>
+  {# Filter band (#623): live search + state chips over the grouped cards.
+     A MutationObserver re-applies it after every SSE rebuild (the JS at
+     the foot), so it survives live updates. #}
+  <label class="search-pill" style="max-width:240px;flex:0 1 240px">
+    <i class="ti ti-search" aria-hidden="true"></i>
+    <input type="search" id="dash-search" autocomplete="off" placeholder="{{ self.t("admin-dashboard-filter-search") }}">
+  </label>
+  <div class="flex items-center gap-2 flex-wrap" id="dash-state-chips">
+    <button type="button" class="chip on-all" data-state="all">{{ self.t("type-all") }}</button>
+    <button type="button" class="chip" data-state="dot-on"><span class="dot dot-on"></span>{{ self.t("admin-dashboard-state-ready") }}</button>
+    <button type="button" class="chip" data-state="dot-pulse"><span class="dot dot-pulse"></span>{{ self.t("admin-dashboard-state-starting") }}</button>
+    <button type="button" class="chip" data-state="dot-off"><span class="dot dot-off"></span>{{ self.t("admin-dashboard-state-stopped") }}</button>
+  </div>
+  <span class="flex-1"></span>
+  <span class="text-xs text-[color:var(--text-faint)] tnum" id="dash-count"></span>
   <button type="button" id="dash-expand-all" class="admin-nav-link"
           data-expand="{{ self.t("admin-dashboard-expand-all") }}" data-collapse="{{ self.t("admin-dashboard-collapse-all") }}">
     <i class="ti ti-chevrons-down" aria-hidden="true"></i> <span>{{ self.t("admin-dashboard-expand-all") }}</span>
@@ -388,12 +406,59 @@
   ['containers', 'specs', 'sessions', 'tracker'].forEach(countUp);
 
   if (!window.EventSource) return;
+  var live = document.getElementById('dash-live');
   var es = new EventSource((window.RUSCKER_BASE || '') + '/admin/dashboard/events');
+  es.onopen = function () { if (live) live.classList.remove('is-down'); };
   es.onmessage = function (e) {
+    if (live) live.classList.remove('is-down');
     try { apply(JSON.parse(e.data)); } catch (_) { /* ignore */ }
   };
-  // No retry handling needed — EventSource auto-reconnects
-  // on network errors. We just let it.
+  // EventSource auto-reconnects on network errors; we just dim the Live
+  // badge while it's down.
+  es.onerror = function () { if (live) live.classList.add('is-down'); };
+})();
+
+// Dashboard filter band (#623): live search + state chips over the
+// grouped cards. Decoupled from the SSE patcher via a MutationObserver,
+// so it re-applies after every innerHTML rebuild without touching it.
+(function () {
+  var container = document.getElementById('dash-groups');
+  var search = document.getElementById('dash-search');
+  var chips = document.querySelectorAll('#dash-state-chips .chip[data-state]');
+  var countEl = document.getElementById('dash-count');
+  if (!container) return;
+  var state = 'all';
+
+  function applyFilter() {
+    var q = (search && search.value || '').trim().toLowerCase();
+    var shown = 0, total = 0;
+    container.querySelectorAll('.app-group').forEach(function (g) {
+      total++;
+      var id = (g.getAttribute('data-spec-id') || '').toLowerCase();
+      var nameEl = g.querySelector('.app-group__name');
+      var name = (nameEl ? nameEl.textContent : '').toLowerCase();
+      var okText = !q || id.indexOf(q) >= 0 || name.indexOf(q) >= 0;
+      var dot = g.querySelector('.app-group__state .dot');
+      var okState = state === 'all' || (dot && dot.classList.contains(state));
+      var ok = okText && okState;
+      g.style.display = ok ? '' : 'none';
+      if (ok) shown++;
+    });
+    if (countEl) countEl.textContent = shown + '/' + total;
+  }
+
+  chips.forEach(function (chip) {
+    chip.addEventListener('click', function () {
+      state = chip.getAttribute('data-state');
+      chips.forEach(function (c) { c.classList.toggle('on-all', c === chip); });
+      applyFilter();
+    });
+  });
+  if (search) search.addEventListener('input', applyFilter);
+  // Re-apply after every SSE rebuild (childList changes), not on the style
+  // toggles applyFilter itself makes (those are attribute mutations).
+  new MutationObserver(applyFilter).observe(container, { childList: true });
+  applyFilter();
 })();
 </script>
 


### PR DESCRIPTION
## What

Design-handoff pass on the **monitoring dashboard** (`dashboard.html`, screenshot #03). Two missing handoff elements:

- **Live badge** next to the title — a green `.live-dot` with an expanding ring while the SSE feed is connected; the JS flips `.is-down` (dimmed, no ring) on `es.onerror` and restores it on the next message.
- **Filter band** in the toolbar — a `search-pill` ("Filter app…") + state `chip`s (All / Ready / Starting / Stopped, each with a real `.dot` swatch) + a shown/total count. Hides `.app-group` cards by spec id/name + the head's state-dot class.

The filter is **decoupled from the SSE patcher via a MutationObserver** on `#dash-groups` childList, so it re-applies after every innerHTML rebuild without touching the patcher (and the `style.display` toggles it makes are attribute mutations → no observer loop).

Ported CSS: `.live-dot` (+ ring keyframes), `.live-badge`. Reuses existing `.chip` / `.search-pill` and the `admin-dashboard-state-*` labels; 2 new i18n keys × 4 locales.

## Gate
- `cargo build -p ruscker-admin` ✅
- `cargo clippy -p ruscker-admin --all-targets` ✅
- `./scripts/i18n-check.sh` ✅

🤖 Generated with [Claude Code](https://claude.com/claude-code)