### PR TITLE
feat(admin): media library search as the handoff search-pill

### DIFF
--- a/crates/ruscker-admin/templates/admin/images.html
+++ b/crates/ruscker-admin/templates/admin/images.html
@@ -71,9 +71,11 @@
      `&quot;` back to `"` before Alpine parses it. #}
   <div x-data="ruscker.mediaGallery({{ self.images_json() }})" x-cloak>
     <div class="mt-6 mb-4 flex flex-wrap items-center gap-2">
-      <input type="search" x-model="q"
-             placeholder="{{ self.t("admin-images-search") }}"
-             class="admin-table-search">
+      {# Search as the handoff pill (#623) — leading icon + rounded field. #}
+      <label class="search-pill" style="max-width:320px;flex:0 1 320px">
+        <i class="ti ti-search" aria-hidden="true"></i>
+        <input type="search" x-model="q" placeholder="{{ self.t("admin-images-search") }}" autocomplete="off">
+      </label>
       {# Type filter — options derived from the images actually present
          (typically SVG + WebP), so it adapts and never offers an empty
          filter. Hidden when there's only one type. #}


### PR DESCRIPTION
## What

Design-handoff pass on the **Media library** (`images.html`, screenshot #07). Small, clean slice.

- The gallery search becomes the rounded **`.search-pill`** with a leading magnifier (same control now on Apps / Dashboard), wrapping the existing `x-model="q"` input. Markup-only — `.search-pill` already ships from the portal; the gallery grid, tiles and in-use badges already matched the design.

Not changed: per-tile **accent tint** — the handoff tints each tile by the asset's accent, which only the built-in logos carry; arbitrary uploads have none, so the uniform tile stays (honest, not a fabricated colour).

## Gate
- `cargo build -p ruscker-admin` ✅
- `./scripts/i18n-check.sh` ✅

🤖 Generated with [Claude Code](https://claude.com/claude-code)