### PR TITLE
feat(admin): logs polish — live badge + unify per-replica tail

### DIFF
--- a/crates/ruscker-admin/templates/admin/logs.html
+++ b/crates/ruscker-admin/templates/admin/logs.html
@@ -5,20 +5,10 @@
 {% block content %}
 
 <style>
-  .logs-pre {
-    background: var(--color-background-secondary, #1113);
-    border: 0.5px solid var(--color-border-tertiary, rgba(120,120,120,0.2));
-    border-radius: 10px;
-    padding: 14px 16px;
-    font-family: ui-monospace, SFMono-Regular, "SF Mono", Menlo, monospace;
-    font-size: 12px;
-    line-height: 1.5;
-    white-space: pre-wrap;
-    word-break: break-word;
-    max-height: 70vh;
-    overflow-y: auto;
-    margin: 0;
-  }
+  /* Per-replica container logs share the global terminal frame (.log-body,
+     #623) — container stdout is raw (not the server's ts/level/target/msg
+     format), so it stays a wrapped text dump rather than per-line cells. */
+  .logs-pre { white-space: pre-wrap; word-break: break-word; padding: 10px 14px; margin: 0; }
   .logs-empty {
     padding: 32px 16px;
     text-align: center;
@@ -60,7 +50,7 @@
 
 <div id="logs-empty" class="logs-empty"{% if !lines.is_empty() %} style="display:none"{% endif %}>{{ self.t("admin-logs-empty") }}</div>
 <p id="logs-note" class="text-xs text-[color:var(--text-faint)] mb-2"{% if lines.is_empty() %} style="display:none"{% endif %}>{{ self.t("admin-logs-tail-note") }}</p>
-<pre class="logs-pre" id="logs-pre"{% if lines.is_empty() %} style="display:none"{% endif %}>{% for line in lines %}{{ line }}
+<pre class="log-body logs-pre" id="logs-pre"{% if lines.is_empty() %} style="display:none"{% endif %}>{% for line in lines %}{{ line }}
 {% endfor %}</pre>
 
 <script>

--- a/crates/ruscker-admin/templates/admin/process_logs.html
+++ b/crates/ruscker-admin/templates/admin/process_logs.html
@@ -11,6 +11,8 @@
   </div>
   {% if available %}
   <div class="text-xs text-[color:var(--text-muted)] flex items-center gap-3">
+    {# Live-stream badge (#623): the SSE follow keeps this terminal current. #}
+    <span class="live-badge"><span class="live-dot"></span>{{ self.t("admin-dashboard-live") }}</span>
     {% if self.truncated() %}
     <span>{{ self.t("admin-proclog-tail-note") }} ({{ lines.len() }}/{{ total }})</span>
     {% endif %}


### PR DESCRIPTION
## What

The global server-log viewer (`/admin/logs` → `process_logs.html`) **already** matched the handoff (level/search/pause/download toolbar + colour-coded `.log-body` lines over SSE) — the earlier triage looked at the wrong template. Two light touches:

- Add the `.live-dot` **live badge** to the process-logs header (reusing the dashboard "Live" label).
- The **per-replica** container-log tail (`logs.html`, opened from the Dashboard) was a bespoke dark `.logs-pre`; switch it to the shared `.log-body` terminal frame so the two log views read alike. Container stdout is raw (not the server's ts/level/target/msg format), so it stays a wrapped text dump — no fake levels.

## Gate
- `cargo build -p ruscker-admin` ✅
- `./scripts/i18n-check.sh` ✅

🤖 Generated with [Claude Code](https://claude.com/claude-code)