### PR TITLE
feat(admin): credentials — handoff primary button

### DIFF
--- a/crates/ruscker-admin/templates/admin/credentials.html
+++ b/crates/ruscker-admin/templates/admin/credentials.html
@@ -77,8 +77,7 @@
   </div>
 
   <div class="flex justify-end gap-2 mt-2">
-    <button type="submit" class="admin-login-btn"
-            style="padding:8px 14px;font-size:12px"
+    <button type="submit" class="btn btn--primary"
             {% if key_missing %}disabled{% endif %}>
       <i class="ti ti-device-floppy" aria-hidden="true"></i>
       {{ self.t("admin-creds-save") }}


### PR DESCRIPTION
## What

Per the decision to **style the existing registry-credential store** (not build the prototype's API-token model — that would be a new Bearer-auth security surface Ruscker has no infrastructure for), the credentials screen needed almost nothing: it already uses the shared `.admin-table`, the **teal-tinted `.cred-ico`** name tile, and the spec-form field styling.

The only remaining handoff token touch: the **Save button → `.btn--primary`**.

The screen stays a registry-credential store (name / registry / username / AES-encrypted password). The prototype's scope pills / masked token / reveal-copy / revoke are a **different feature** and intentionally not added.

## Gate
- `cargo build -p ruscker-admin` ✅
- `./scripts/i18n-check.sh` ✅

🤖 Generated with [Claude Code](https://claude.com/claude-code)