### PR TITLE
feat(admin): live 2-pane YAML import editor

### DIFF
--- a/crates/ruscker-admin/assets/i18n/en/landing.ftl
+++ b/crates/ruscker-admin/assets/i18n/en/landing.ftl
@@ -745,3 +745,6 @@ admin-import-badge-new-help = Will be created (not in the panel)
 admin-import-badge-update = Updates
 admin-import-badge-update-help = Overwrites an app already in the panel
 admin-import-confirm = Import selected
+admin-import-load-file = Load file
+admin-import-editor-placeholder = Paste your application.yml here…
+admin-import-editor-empty = The preview appears here as you type.

--- a/crates/ruscker-admin/assets/i18n/es/landing.ftl
+++ b/crates/ruscker-admin/assets/i18n/es/landing.ftl
@@ -745,3 +745,6 @@ admin-import-badge-new-help = Se creará (no está en el panel)
 admin-import-badge-update = Actualiza
 admin-import-badge-update-help = Sobrescribe una app ya existente en el panel
 admin-import-confirm = Importar seleccionados
+admin-import-load-file = Cargar archivo
+admin-import-editor-placeholder = Pega tu application.yml aquí…
+admin-import-editor-empty = La vista previa aparece aquí mientras escribes.

--- a/crates/ruscker-admin/assets/i18n/fr/landing.ftl
+++ b/crates/ruscker-admin/assets/i18n/fr/landing.ftl
@@ -745,3 +745,6 @@ admin-import-badge-new-help = Sera créé (absent du panneau)
 admin-import-badge-update = Met à jour
 admin-import-badge-update-help = Écrase une app déjà dans le panneau
 admin-import-confirm = Importer la sélection
+admin-import-load-file = Charger un fichier
+admin-import-editor-placeholder = Collez votre application.yml ici…
+admin-import-editor-empty = L'aperçu apparaît ici au fur et à mesure.

--- a/crates/ruscker-admin/assets/i18n/pt/landing.ftl
+++ b/crates/ruscker-admin/assets/i18n/pt/landing.ftl
@@ -749,3 +749,6 @@ admin-import-badge-new-help = Será criado (não existe no painel)
 admin-import-badge-update = Atualiza
 admin-import-badge-update-help = Sobrescreve um app já existente no painel
 admin-import-confirm = Importar selecionados
+admin-import-load-file = Carregar arquivo
+admin-import-editor-placeholder = Cole seu application.yml aqui…
+admin-import-editor-empty = O preview aparece aqui conforme você digita.

--- a/crates/ruscker-admin/assets/tailwind/input.css
+++ b/crates/ruscker-admin/assets/tailwind/input.css
@@ -641,6 +641,41 @@ input[type="range"]::-moz-range-thumb {
   font-family: var(--font-mono); font-size: 12.5px; line-height: 1.65;
   box-shadow: inset 0 1px 0 rgba(255, 255, 255, 0.04);
 }
+
+/* Live import editor (design handoff #623): a YAML pane + a parsed-row
+ * preview. The header/editor frame and the per-app rows. */
+.yaml-head {
+  display: flex; align-items: center; justify-content: space-between;
+  font-size: 12px; font-family: var(--font-mono); color: var(--text-muted);
+  padding: 10px 14px; background: var(--surface-soft);
+  border: 0.5px solid var(--border); border-bottom: 0; border-radius: 12px 12px 0 0;
+}
+.yaml-editor {
+  width: 100%; box-sizing: border-box; height: 60vh; min-height: 420px; resize: vertical;
+  background: var(--surface); color: var(--text);
+  border: 0.5px solid var(--border); border-radius: 0 0 12px 12px;
+  padding: 14px; font-family: var(--font-mono); font-size: 12.5px; line-height: 1.65;
+  outline: 0; tab-size: 2;
+}
+.yaml-editor:focus { border-color: var(--color-teal-600); }
+.parsed-row {
+  display: flex; align-items: center; gap: 10px; padding: 9px 10px;
+  border: 0.5px solid var(--border); border-radius: 9px; background: var(--surface-soft); cursor: pointer;
+}
+.parsed-row.is-off { opacity: 0.5; }
+.parsed-row__ico {
+  width: 30px; height: 30px; border-radius: 7px; flex: none;
+  display: flex; align-items: center; justify-content: center;
+}
+.parsed-row__ico .ti { font-size: 15px; }
+.import-tag {
+  font-size: 9px; font-weight: 600; padding: 2px 6px; border-radius: 999px;
+  text-transform: uppercase; letter-spacing: 0.03em; white-space: nowrap;
+}
+.import-tag--new { background: color-mix(in srgb, var(--ok, #10b981) 16%, transparent); color: #047857; }
+.import-tag--update { background: color-mix(in srgb, var(--warn, #f59e0b) 18%, transparent); color: #92600a; }
+[data-theme="dark"] .import-tag--new { color: #34d399; }
+[data-theme="dark"] .import-tag--update { color: #fbbf24; }
 .code-editor-pre, .code-editor-ta {
   margin: 0; padding: 14px 16px; width: 100%; box-sizing: border-box;
   font: inherit; line-height: inherit; tab-size: 2;

--- a/crates/ruscker-admin/src/routes/admin/specs.rs
+++ b/crates/ruscker-admin/src/routes/admin/specs.rs
@@ -13,7 +13,7 @@ use axum::{
     Json, Router,
 };
 use chrono::{DateTime, Utc};
-use serde::Deserialize;
+use serde::{Deserialize, Serialize};
 use sqlx::FromRow;
 
 use crate::auth::{RequireEditor, Role};
@@ -29,7 +29,8 @@ const IMPORT_BODY_LIMIT: usize = 2 * 1024 * 1024;
 pub fn routes() -> Router<AppState> {
     Router::new()
         .route("/admin/specs", get(index))
-        .route("/admin/specs/import", post(import))
+        .route("/admin/specs/import", get(import_editor).post(import))
+        .route("/admin/specs/import/preview", post(import_preview))
         .route("/admin/specs/import/confirm", post(import_confirm))
         .route(
             "/admin/specs/{id}/featured/toggle",
@@ -173,7 +174,9 @@ impl<'a> SpecsPage<'a> {
     }
 }
 
-/// One row in the import preview (#557).
+/// One row in the import preview (#557). `Serialize` feeds the live
+/// 2-pane editor's JSON preview endpoint (#623).
+#[derive(Serialize)]
 struct ImportRow {
     id: String,
     display_name: String,
@@ -181,6 +184,53 @@ struct ImportRow {
     /// `true` ⇒ the import would **update** a spec already in the DB;
     /// `false` ⇒ it's **new**.
     exists: bool,
+}
+
+/// Parse `raw` YAML and diff it against the DB — the shared core behind
+/// both the upload preview and the live-editor reparse (#623). Returns the
+/// per-app rows + the total warning count, or a human error string.
+async fn build_import_rows(
+    pool: &crate::db::ConfigDb,
+    raw: &str,
+) -> Result<(Vec<ImportRow>, usize), String> {
+    let config = ruscker_config::Config::from_yaml(raw).map_err(|e| format!("{e}"))?;
+    let report = ruscker_config::validate::run(&config);
+    let warning_count = report.warnings.len() + config.raw_warnings.len();
+    let existing: std::collections::HashSet<String> = crate::db::specs::list_all(pool)
+        .await
+        .unwrap_or_default()
+        .into_iter()
+        .map(|s| s.id)
+        .collect();
+    let rows = config
+        .proxy
+        .specs
+        .iter()
+        .map(|s| ImportRow {
+            exists: existing.contains(&s.id),
+            kind: match s.kind() {
+                ruscker_config::SpecKind::Shiny => "shiny",
+                ruscker_config::SpecKind::InteractiveApp => "interactive",
+                ruscker_config::SpecKind::Api => "api",
+                ruscker_config::SpecKind::External => "external",
+            },
+            display_name: s.display_name.clone().unwrap_or_default(),
+            id: s.id.clone(),
+        })
+        .collect();
+    Ok((rows, warning_count))
+}
+
+/// JSON shape returned by `POST /admin/specs/import/preview` for the live
+/// editor: either an error (parse failure) or the parsed rows + warnings.
+#[derive(Serialize)]
+struct ImportPreviewJson {
+    ok: bool,
+    error: Option<String>,
+    warning_count: usize,
+    rows: Vec<ImportRow>,
+    new_count: usize,
+    update_count: usize,
 }
 
 #[derive(Template)]
@@ -203,6 +253,27 @@ struct ImportPreviewPage<'a> {
 }
 
 impl<'a> ImportPreviewPage<'a> {
+    fn t(&self, key: &str) -> String {
+        self.locales.t(self.locale, key, None)
+    }
+}
+
+/// The live 2-pane import editor page (#623): an editable YAML pane on the
+/// left, a preview rebuilt over fetch on the right. Seeded empty; the
+/// reparse + confirm reuse the same handlers as the upload flow.
+#[derive(Template)]
+#[template(path = "admin/import_editor.html")]
+struct ImportEditorPage<'a> {
+    locale: Locale,
+    theme: Theme,
+    locales: &'a Locales,
+    locales_all: &'static [Locale],
+    base: std::sync::Arc<str>,
+    nav_section: &'static str,
+    role: Role,
+}
+
+impl<'a> ImportEditorPage<'a> {
     fn t(&self, key: &str) -> String {
         self.locales.t(self.locale, key, None)
     }
@@ -428,39 +499,11 @@ async fn import(
         return redirect_err("no file selected");
     };
 
-    // Parse (env-interpolation + raw-text credential scan happen inside
-    // from_yaml; parse failure → error flash).
-    let config = match ruscker_config::Config::from_yaml(&raw) {
-        Ok(c) => c,
+    // Parse + diff via the shared core (#623). Parse failure → error flash.
+    let (rows, warning_count) = match build_import_rows(pool, &raw).await {
+        Ok(v) => v,
         Err(e) => return redirect_err(&format!("YAML parse failed: {e}")),
     };
-    let report = ruscker_config::validate::run(&config);
-    let warning_count = report.warnings.len() + config.raw_warnings.len();
-
-    // Which ids already exist in the DB (→ "updates", vs "new").
-    let existing: std::collections::HashSet<String> = crate::db::specs::list_all(pool)
-        .await
-        .unwrap_or_default()
-        .into_iter()
-        .map(|s| s.id)
-        .collect();
-
-    let rows: Vec<ImportRow> = config
-        .proxy
-        .specs
-        .iter()
-        .map(|s| ImportRow {
-            exists: existing.contains(&s.id),
-            kind: match s.kind() {
-                ruscker_config::SpecKind::Shiny => "shiny",
-                ruscker_config::SpecKind::InteractiveApp => "interactive",
-                ruscker_config::SpecKind::Api => "api",
-                ruscker_config::SpecKind::External => "external",
-            },
-            display_name: s.display_name.clone().unwrap_or_default(),
-            id: s.id.clone(),
-        })
-        .collect();
 
     let page = ImportPreviewPage {
         locale: loc,
@@ -475,6 +518,79 @@ async fn import(
         warning_count,
     };
     super::render(&page)
+}
+
+/// `GET /admin/specs/import` — the live 2-pane import editor (#623).
+async fn import_editor(
+    editor: RequireEditor,
+    State(state): State<AppState>,
+    loc: Locale,
+    theme: Theme,
+) -> Response {
+    let page = ImportEditorPage {
+        locale: loc,
+        theme,
+        locales: &state.locales,
+        locales_all: &Locale::ALL,
+        base: state.base_path.clone(),
+        nav_section: "specs",
+        role: editor.role,
+    };
+    super::render(&page)
+}
+
+/// `POST /admin/specs/import/preview` — reparse the YAML in the editor's
+/// left pane and return the preview as JSON (#623). Read-only: nothing is
+/// written to the DB. A parse failure is a 200 with `ok:false` + `error`
+/// so the editor can show it inline without a transport error.
+#[derive(Deserialize)]
+struct PreviewForm {
+    yaml: String,
+}
+
+async fn import_preview(
+    _: RequireEditor,
+    State(state): State<AppState>,
+    axum::Form(form): axum::Form<PreviewForm>,
+) -> Response {
+    let Some(pool) = state.db.as_ref() else {
+        return (StatusCode::SERVICE_UNAVAILABLE, "no db").into_response();
+    };
+    if form.yaml.trim().is_empty() {
+        return Json(ImportPreviewJson {
+            ok: true,
+            error: None,
+            warning_count: 0,
+            rows: Vec::new(),
+            new_count: 0,
+            update_count: 0,
+        })
+        .into_response();
+    }
+    match build_import_rows(pool, &form.yaml).await {
+        Ok((rows, warning_count)) => {
+            let update_count = rows.iter().filter(|r| r.exists).count();
+            let new_count = rows.len() - update_count;
+            Json(ImportPreviewJson {
+                ok: true,
+                error: None,
+                warning_count,
+                rows,
+                new_count,
+                update_count,
+            })
+            .into_response()
+        }
+        Err(e) => Json(ImportPreviewJson {
+            ok: false,
+            error: Some(e),
+            warning_count: 0,
+            rows: Vec::new(),
+            new_count: 0,
+            update_count: 0,
+        })
+        .into_response(),
+    }
 }
 
 /// Step 2 of the import (#557): import only the **checked** specs. The

--- a/crates/ruscker-admin/templates/admin/import_editor.html
+++ b/crates/ruscker-admin/templates/admin/import_editor.html
@@ -1,0 +1,183 @@
+{% extends "admin/_layout.html" %}
+
+{% block title %}{{ self.t("admin-import-title") }} · Ruscker{% endblock %}
+
+{% block content %}
+
+<div x-data="ruscker.importEditor()" x-cloak>
+
+  {# ── Crumb + header ───────────────────────────────────────── #}
+  <div class="text-[11px] text-[color:var(--text-faint)] uppercase tracking-wide mb-1">
+    <a href="{{ base }}/admin/specs" class="hover:underline">{{ self.t("admin-nav-apps") }}</a>
+    · {{ self.t("admin-import-button") }}
+  </div>
+  <div class="flex items-end justify-between mb-4 gap-3 flex-wrap">
+    <div>
+      <h1 class="text-xl font-medium tracking-tight">{{ self.t("admin-import-title") }}</h1>
+      <p class="text-xs text-[color:var(--text-muted)] mt-1" style="max-width:46rem">{{ self.t("admin-import-help") }}</p>
+    </div>
+    <div class="flex items-center gap-2">
+      <label class="btn" style="cursor:pointer">
+        <i class="ti ti-file-upload" aria-hidden="true"></i> {{ self.t("admin-import-load-file") }}
+        <input type="file" accept=".yml,.yaml" class="hidden" @change="loadFile($event)">
+      </label>
+      <a href="{{ base }}/admin/specs" class="btn">{{ self.t("admin-import-cancel") }}</a>
+      {# Confirm reuses the existing multipart handler: hidden yaml + one
+         `ids` per selected row (disabled ones don't submit). #}
+      <form method="post" enctype="multipart/form-data" action="{{ base }}/admin/specs/import/confirm" style="display:inline">
+        <textarea name="yaml" x-model="yaml" class="hidden" aria-hidden="true"></textarea>
+        <template x-for="row in rows" :key="'sel-' + row.id">
+          <input type="hidden" name="ids" :value="row.id" :disabled="!selected[row.id]">
+        </template>
+        <button type="submit" class="btn btn--primary" :disabled="!selectedCount()">
+          <i class="ti ti-check" aria-hidden="true"></i>
+          {{ self.t("admin-import-confirm") }}<span x-show="selectedCount()" x-text="' · ' + selectedCount()"></span>
+        </button>
+      </form>
+    </div>
+  </div>
+
+  <div class="spec-form-layout">
+    {# ── LEFT: editable YAML ────────────────────────────────── #}
+    <div>
+      <div class="yaml-head">
+        <span><i class="ti ti-file-code" aria-hidden="true"></i> application.yml</span>
+        <span class="text-[color:var(--text-faint)]" x-show="loading">…</span>
+      </div>
+      <textarea class="yaml-editor" x-model="yaml" @input="reparse()" spellcheck="false"
+                placeholder="{{ self.t("admin-import-editor-placeholder") }}"></textarea>
+    </div>
+
+    {# ── RIGHT: live preview ────────────────────────────────── #}
+    <aside class="spec-form-preview" style="top:80px">
+      <div class="form-section__title">{{ self.t("admin-import-preview-title") }}</div>
+
+      {# Parse error #}
+      <template x-if="error">
+        <div class="admin-login-error" role="alert" style="margin-bottom:10px">
+          <i class="ti ti-alert-circle" aria-hidden="true"></i>
+          <span class="dash-mono" style="font-size:11px" x-text="error"></span>
+        </div>
+      </template>
+
+      {# Select-all + count #}
+      <template x-if="rows.length">
+        <div class="flex items-center justify-between mb-2" style="font-size:11.5px;color:var(--text-faint)">
+          <label style="display:inline-flex;align-items:center;gap:6px;cursor:pointer">
+            <input type="checkbox" :checked="selectedCount() === rows.length" @change="toggleAll($event.target.checked)">
+            {{ self.t("admin-import-select-all") }}
+          </label>
+          <span><span class="tnum" x-text="selectedCount()"></span>/<span class="tnum" x-text="rows.length"></span></span>
+        </div>
+      </template>
+
+      {# Parsed rows #}
+      <div style="display:flex;flex-direction:column;gap:6px">
+        <template x-for="row in rows" :key="row.id">
+          <label class="parsed-row" :class="!selected[row.id] ? 'is-off' : ''">
+            <input type="checkbox" x-model="selected[row.id]">
+            <span class="parsed-row__ico" :style="'background:color-mix(in srgb,' + kindColor(row.kind) + ' 14%,var(--surface));color:' + kindColor(row.kind)">
+              <i class="ti" :class="kindIcon(row.kind)" aria-hidden="true"></i>
+            </span>
+            <span style="min-width:0;flex:1">
+              <span style="display:flex;align-items:center;gap:6px">
+                <code class="dash-mono" style="font-size:12px;font-weight:500" x-text="row.display_name || row.id"></code>
+                <span class="import-tag" :class="row.exists ? 'import-tag--update' : 'import-tag--new'"
+                      x-text="row.exists ? '{{ self.t("admin-import-badge-update") }}' : '{{ self.t("admin-import-badge-new") }}'"></span>
+              </span>
+              <span class="dash-mono text-[color:var(--text-faint)]" style="font-size:11px" x-text="row.id" x-show="row.display_name"></span>
+            </span>
+          </label>
+        </template>
+      </div>
+
+      {# Empty state #}
+      <template x-if="!rows.length && !error">
+        <p class="text-xs text-[color:var(--text-faint)] py-6 text-center"
+           x-text="yaml.trim() ? '{{ self.t("admin-import-preview-none") }}' : '{{ self.t("admin-import-editor-empty") }}'"></p>
+      </template>
+
+      {# Summary footer #}
+      <template x-if="rows.length">
+        <div class="import-summary" style="margin-top:12px;padding-top:12px;border-top:0.5px solid var(--border)">
+          <span><b class="tnum" x-text="newCount"></b> {{ self.t("admin-import-badge-new") }}</span>
+          <span>· <b class="tnum" x-text="updateCount"></b> {{ self.t("admin-import-badge-update") }}</span>
+          <template x-if="warnings">
+            <span>· <b class="tnum" x-text="warnings"></b> {{ self.t("admin-import-warnings-label") }}</span>
+          </template>
+        </div>
+      </template>
+    </aside>
+  </div>
+</div>
+
+<script src="{{ base }}/assets/js/alpine.min.js?v={{ crate::APP_VERSION }}" defer></script>
+<script>
+window.ruscker = window.ruscker || {};
+window.ruscker.importEditor = () => ({
+  yaml: '',
+  rows: [],
+  selected: {},
+  warnings: 0,
+  newCount: 0,
+  updateCount: 0,
+  error: '',
+  loading: false,
+  _timer: null,
+
+  // Debounced reparse — POSTs the YAML to the read-only preview endpoint.
+  reparse() {
+    clearTimeout(this._timer);
+    this._timer = setTimeout(() => this.fetchPreview(), 400);
+  },
+  async fetchPreview() {
+    var text = (this.yaml || '').trim();
+    if (!text) { this.rows = []; this.error = ''; this.warnings = 0; this.newCount = 0; this.updateCount = 0; return; }
+    this.loading = true;
+    try {
+      var body = new URLSearchParams();
+      body.set('yaml', this.yaml);
+      var r = await fetch((window.RUSCKER_BASE || '') + '/admin/specs/import/preview', {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/x-www-form-urlencoded' },
+        body: body.toString(),
+      });
+      var d = await r.json();
+      if (d.ok) {
+        this.error = '';
+        this.rows = d.rows;
+        this.warnings = d.warning_count;
+        this.newCount = d.new_count;
+        this.updateCount = d.update_count;
+        // Default every freshly-seen app to selected.
+        var sel = this.selected;
+        d.rows.forEach(function (row) { if (!(row.id in sel)) sel[row.id] = true; });
+      } else {
+        this.error = d.error || 'parse error';
+        this.rows = [];
+      }
+    } catch (e) {
+      this.error = String(e);
+    } finally {
+      this.loading = false;
+    }
+  },
+  loadFile(ev) {
+    var f = ev.target.files && ev.target.files[0];
+    if (!f) return;
+    var self = this, rd = new FileReader();
+    rd.onload = function () { self.yaml = rd.result; self.fetchPreview(); };
+    rd.readAsText(f);
+  },
+  selectedCount() { var s = this.selected; return this.rows.filter(function (r) { return s[r.id]; }).length; },
+  toggleAll(v) { var s = this.selected; this.rows.forEach(function (r) { s[r.id] = v; }); },
+  kindIcon(k) {
+    return { shiny: 'ti-brand-r', interactive: 'ti-app-window', api: 'ti-api', external: 'ti-external-link' }[k] || 'ti-package';
+  },
+  kindColor(k) {
+    return { shiny: '#06d6a0', interactive: '#06d6a0', api: '#06b6d4', external: '#26547c' }[k] || '#26547c';
+  },
+});
+</script>
+
+{% endblock %}

--- a/crates/ruscker-admin/templates/admin/specs.html
+++ b/crates/ruscker-admin/templates/admin/specs.html
@@ -10,12 +10,11 @@
     <p class="text-xs text-[color:var(--text-muted)] mt-1">{{ self.t("admin-specs-subtitle") }}</p>
   </div>
   <div class="flex items-center gap-2">
-    <button type="button" class="btn"
-            title="{{ self.t("admin-import-title") }}"
-            onclick="document.getElementById('import-modal').showModal()">
+    <a href="{{ base }}/admin/specs/import" class="btn"
+       title="{{ self.t("admin-import-title") }}">
       <i class="ti ti-file-upload" aria-hidden="true"></i>
       {{ self.t("admin-import-button") }}
-    </button>
+    </a>
     <a href="{{ base }}/admin/specs/new" class="btn btn--primary">
       <i class="ti ti-plus" aria-hidden="true"></i>
       {{ self.t("admin-specs-add") }}
@@ -29,42 +28,10 @@
   {% when None %}
 {% endmatch %}
 
-<dialog id="import-modal" class="import-dialog">
-  <form method="post" action="{{ base }}/admin/specs/import" enctype="multipart/form-data" class="import-form"
-        x-data="{ name: '', drag: false }">
-    <h2 class="import-h2">{{ self.t("admin-import-title") }}</h2>
-    <p class="import-sub">{{ self.t("admin-import-help") }}</p>
-
-    {# Custom dropzone: hides the native file input (whose "Choose file"
-       button can't be localized — it follows the browser UI language) and
-       renders our own PT/EN/ES/FR prompt. Clicking the <label> opens the
-       picker natively; a drop sets the hidden input's `files`. #}
-    <label class="import-dropzone" :class="{ 'is-drag': drag }"
-           @dragover.prevent="drag = true" @dragleave.prevent="drag = false"
-           @drop.prevent="drag = false; if ($event.dataTransfer.files.length) { $refs.file.files = $event.dataTransfer.files; name = $refs.file.files[0].name }">
-      <input type="file" name="file" accept=".yml,.yaml" required x-ref="file" class="import-dz-input"
-             @change="name = $refs.file.files.length ? $refs.file.files[0].name : ''" />
-      <svg class="import-dz-ico" viewBox="0 0 24 24" fill="none" stroke="currentColor"
-           stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true">
-        <path d="M21 15v4a2 2 0 0 1-2 2H5a2 2 0 0 1-2-2v-4"/>
-        <path d="M7 10l5-5 5 5"/><path d="M12 5v12"/>
-      </svg>
-      <p class="import-dz-prompt" x-show="!name">{{ self.t("admin-import-drop") }}</p>
-      <p class="import-dz-file" x-show="name" x-text="name" x-cloak></p>
-      <p class="import-dz-hint">{{ self.t("admin-import-file") }}</p>
-    </label>
-    <div class="flex justify-end gap-2 mt-4">
-      <button type="button" class="admin-nav-link" style="font-size:12px"
-              onclick="document.getElementById('import-modal').close()">
-        {{ self.t("admin-import-cancel") }}
-      </button>
-      <button type="submit" class="admin-login-btn" style="padding:6px 12px;font-size:12px">
-        <i class="ti ti-file-upload" aria-hidden="true"></i>
-        {{ self.t("admin-import-submit") }}
-      </button>
-    </div>
-  </form>
-</dialog>
+{# The "Import YAML" button now opens the live 2-pane editor at
+   /admin/specs/import (#623); the old upload modal was retired. The
+   multipart upload route stays for back-compat (the editor's "Load file"
+   reads into the textarea instead). #}
 
 <style>
   .import-flash {


### PR DESCRIPTION
## What

Replaces the upload→preview modal with the handoff's **live 2-pane editor** (screenshot #14): an editable YAML pane on the left, a preview that **reparses as you type** on the right.

### Backend (read-only preview — the DB-writing confirm path is untouched)
- Extract the parse+diff into a shared `build_import_rows()` (used by both the existing upload preview and the new live reparse).
- `GET /admin/specs/import` → editor page; `POST …/import/preview` → reparse posted YAML, return rows + new/update/warning counts as JSON. Nothing is written; a parse failure is a `200` with `ok:false` + a helpful `error` shown inline.
- Existing multipart upload + `…/confirm` routes unchanged. The Apps "Import YAML" button now opens the editor; "Load file" reads a file into the textarea client-side.

### UI (`import_editor.html`, Alpine)
`.yaml-editor` left pane (debounced fetch reparse) + `.spec-form-preview` right pane with `.parsed-row` cards (kind-tinted icon + `.import-tag` new/update badge + select checkbox), select-all + count, summary footer. Confirm reuses the multipart handler via a hidden yaml textarea + one disabled-unless-selected `ids` input per row.

Ported CSS: `.yaml-head`, `.yaml-editor`, `.parsed-row`, `.import-tag`. 3 i18n keys × 4 locales.

## Decision context
This is the one "build the new feature" item the user opted into. The Credentials API-token store was declined (would be a new Bearer-auth surface); Logs was already on-design.

## Gate + real smoke
- `cargo build` + `cargo clippy --all-targets` + `i18n-check` + `cargo test -p ruscker-admin specs` (14) ✅
- **Local binary smoke** (break-glass auth): editor renders; preview of the real `examples/application.yml` → **8 rows, 8 updates**; a malformed spec id → `ok:false` with `"proxy.specs[0].id: invalid type…"`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)