### PR TITLE
fix(admin): bug-audit fixes across the design-fidelity pass

### DIFF
--- a/crates/ruscker-admin/assets/tailwind/input.css
+++ b/crates/ruscker-admin/assets/tailwind/input.css
@@ -74,6 +74,13 @@
   --border: #e8e6df;
   --border-soft: #f0eee8;
   --border-strong: #c0c0bb;
+  /* Status accents (#623 audit): several design-pass rules used
+     `var(--ok)`/`var(--warn)` bare, but the tokens were never defined — so
+     those `color-mix`/`color` declarations were silently dropped. Define
+     them once, matching the fallbacks used elsewhere. (`--font-mono` is
+     already provided by Tailwind's default theme, so it needs no def.) */
+  --ok: #10b981;
+  --warn: #f59e0b;
   --shadow-sm: 0 1px 2px rgba(0, 0, 0, 0.04);
   --shadow-md: 0 4px 24px rgba(0, 0, 0, 0.06);
   --shadow-lg: 0 10px 40px rgba(0, 0, 0, 0.16);

--- a/crates/ruscker-admin/src/routes/admin/groups.rs
+++ b/crates/ruscker-admin/src/routes/admin/groups.rs
@@ -135,10 +135,11 @@ async fn index(
         })
         .collect();
 
-    // Specs with no (or empty) access-groups are public — visible to all.
+    // Truly public specs — open to everyone — need BOTH access-groups and
+    // access-users empty (#623 audit: a users-only-gated spec is not public).
     let mut public_apps: Vec<AppRef> = specs
         .iter()
-        .filter(|s| s.access_groups.as_ref().is_none_or(|g| g.is_empty()))
+        .filter(|s| s.is_open())
         .map(|s| AppRef {
             id: s.id.clone(),
             name: s.display_name.clone().unwrap_or_else(|| s.id.clone()),

--- a/crates/ruscker-admin/templates/admin/dashboard.html
+++ b/crates/ruscker-admin/templates/admin/dashboard.html
@@ -80,6 +80,7 @@
     <button type="button" class="chip on-all" data-state="all">{{ self.t("type-all") }}</button>
     <button type="button" class="chip" data-state="dot-on"><span class="dot dot-on"></span>{{ self.t("admin-dashboard-state-ready") }}</button>
     <button type="button" class="chip" data-state="dot-pulse"><span class="dot dot-pulse"></span>{{ self.t("admin-dashboard-state-starting") }}</button>
+    <button type="button" class="chip" data-state="dot-warm"><span class="dot dot-warm"></span>{{ self.t("admin-dashboard-state-draining") }}</button>
     <button type="button" class="chip" data-state="dot-off"><span class="dot dot-off"></span>{{ self.t("admin-dashboard-state-stopped") }}</button>
   </div>
   <span class="flex-1"></span>

--- a/crates/ruscker-admin/templates/admin/import_editor.html
+++ b/crates/ruscker-admin/templates/admin/import_editor.html
@@ -91,10 +91,15 @@
         </template>
       </div>
 
-      {# Empty state #}
-      <template x-if="!rows.length && !error">
-        <p class="text-xs text-[color:var(--text-faint)] py-6 text-center"
-           x-text="yaml.trim() ? '{{ self.t("admin-import-preview-none") }}' : '{{ self.t("admin-import-editor-empty") }}'"></p>
+      {# Empty state. Two plain-text branches rather than an `x-text`
+         ternary — inlining a translation into a single-quoted JS string
+         breaks on locales whose value contains an apostrophe (e.g. fr
+         "L'aperçu…"). #}
+      <template x-if="!rows.length && !error && yaml.trim()">
+        <p class="text-xs text-[color:var(--text-faint)] py-6 text-center">{{ self.t("admin-import-preview-none") }}</p>
+      </template>
+      <template x-if="!rows.length && !error && !yaml.trim()">
+        <p class="text-xs text-[color:var(--text-faint)] py-6 text-center">{{ self.t("admin-import-editor-empty") }}</p>
       </template>
 
       {# Summary footer #}

--- a/crates/ruscker-admin/templates/admin/spec_form.html
+++ b/crates/ruscker-admin/templates/admin/spec_form.html
@@ -525,6 +525,7 @@
                 </div>
                 <input id="f-seats" type="number" name="seats_per_container"
                        value="{{ form.seats_per_container }}"
+                       x-model="form.seats_per_container"
                        min="1"
                        placeholder="10"
                        class="spec-form-input">
@@ -765,7 +766,7 @@
             </span>
             <input type="range" class="rk-range" min="0" max="8" step="0.25"
                    :value="parseFloat(form.container_cpu_limit) || 0"
-                   @input="form.container_cpu_limit = $event.target.value">
+                   @input="form.container_cpu_limit = $event.target.value === '0' ? '' : $event.target.value">
             <input id="f-cpu" type="text" name="container_cpu_limit" placeholder="0.5"
                    x-model="form.container_cpu_limit"
                    class="spec-form-input spec-form-input--mono" style="text-align:right;padding:7px 10px">
@@ -777,7 +778,7 @@
             </span>
             <input type="range" class="rk-range" min="0" max="8192" step="256"
                    :value="memMb(form.container_memory_limit)"
-                   @input="form.container_memory_limit = $event.target.value + 'm'">
+                   @input="form.container_memory_limit = $event.target.value === '0' ? '' : ($event.target.value + 'm')">
             <input id="f-mem" type="text" name="container_memory_limit" placeholder="512m"
                    x-model="form.container_memory_limit"
                    class="spec-form-input spec-form-input--mono" style="text-align:right;padding:7px 10px">
@@ -888,7 +889,8 @@
               {% call help(self.t("spec-help-heartbeat")) %}{% endcall %}
             </div>
             <input id="f-heartbeat" type="number" name="heartbeat_timeout" min="-1"
-                   value="{{ form.heartbeat_timeout }}" placeholder="3600000" class="spec-form-input">
+                   value="{{ form.heartbeat_timeout }}" x-model="form.heartbeat_timeout"
+                   placeholder="3600000" class="spec-form-input">
           </div>
         </div>
       </div>
@@ -953,7 +955,7 @@
         </div>
         <div class="spec-summary__row">
           <i class="ti ti-clock" aria-hidden="true"></i>
-          <span x-text="((form.heartbeat_timeout && form.heartbeat_timeout != '-1') ? (form.heartbeat_timeout + ' min · ') : '') + (form.seats_per_container || '1') + ' {{ self.t("spec-form-summary-sessions") }}'"></span>
+          <span x-text="((form.heartbeat_timeout && form.heartbeat_timeout != '-1') ? (Math.round(parseInt(form.heartbeat_timeout, 10) / 60000) + ' min · ') : '') + (form.seats_per_container || '1') + ' {{ self.t("spec-form-summary-sessions") }}'"></span>
         </div>
       </div>
 


### PR DESCRIPTION
## What

Adversarial bug audit (4 parallel review agents) of the 12-PR design-fidelity pass. **No security, crash, or data-loss issues** — the submitted-field contracts and the DB-mutating paths all held up. These are the confirmed correctness + display bugs:

| Area | Bug | Fix | Sev |
|---|---|---|---|
| **CSS** | `--ok`/`--warn` used bare but **never defined** → `.char-count.over`, `.disk-hero__pct.is-high`, `.is-unused` row tint, `.use-badge` pills silently dropped their colour | define both in `:root` | med |
| **Groups** | "Public apps" rail listed `access-users`-only-gated specs as public | filter on `Spec::is_open()` (groups **and** users empty) | med |
| **Spec form** | spec-summary showed `heartbeat_timeout` ms labelled "min" ("3600000 min") | convert ms→min | low |
| **Spec form** | summary not live for seats/heartbeat | add `x-model` | low |
| **Spec form** | CPU/mem sliders dragged fully left wrote `"0"`/`"0m"` (CPU fails validation; mem = 0-byte limit) | snap slider-zero → empty | low |
| **Import editor** | empty-state hint inlined a translation into a single-quoted JS `x-text` → **breaks under French** (`L'aperçu…`) | split into two plain-text `x-if` branches | low-med |
| **Dashboard** | no "draining" (`dot-warm`) state chip → draining groups unreachable by filter | add the chip | low |

`--font-mono` was reported missing too, but Tailwind v4 already ships it — **false positive**, no change.

## Gate
- `cargo build` + `cargo clippy --all-targets` + `i18n-check` + `cargo test -p ruscker-admin groups` ✅
- Verified the compiled CSS now resolves `--ok`/`--warn` (`.char-count.over{color:var(--warn)}` → #f59e0b).

🤖 Generated with [Claude Code](https://claude.com/claude-code)