### PR TITLE
chore(release): bump workspace version 0.1.81 → 0.1.82

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2845,7 +2845,7 @@ dependencies = [
 
 [[package]]
 name = "ruscker-admin"
-version = "0.1.81"
+version = "0.1.82"
 dependencies = [
  "aes-gcm",
  "anyhow",
@@ -2895,7 +2895,7 @@ dependencies = [
 
 [[package]]
 name = "ruscker-cli"
-version = "0.1.81"
+version = "0.1.82"
 dependencies = [
  "anyhow",
  "clap",
@@ -2915,7 +2915,7 @@ dependencies = [
 
 [[package]]
 name = "ruscker-config"
-version = "0.1.81"
+version = "0.1.82"
 dependencies = [
  "chrono",
  "ordered-float",
@@ -2930,7 +2930,7 @@ dependencies = [
 
 [[package]]
 name = "ruscker-core"
-version = "0.1.81"
+version = "0.1.82"
 dependencies = [
  "async-trait",
  "chrono",
@@ -2943,7 +2943,7 @@ dependencies = [
 
 [[package]]
 name = "ruscker-docker"
-version = "0.1.81"
+version = "0.1.82"
 dependencies = [
  "anyhow",
  "async-stream",
@@ -2962,7 +2962,7 @@ dependencies = [
 
 [[package]]
 name = "ruscker-proxy"
-version = "0.1.81"
+version = "0.1.82"
 dependencies = [
  "anyhow",
  "axum",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -10,7 +10,7 @@ members = [
 ]
 
 [workspace.package]
-version = "0.1.81"
+version = "0.1.82"
 edition = "2021"
 rust-version = "1.85"
 license = "Apache-2.0"

--- a/book/src/news.md
+++ b/book/src/news.md
@@ -9,6 +9,20 @@ the [GitHub releases page](https://github.com/StrategicProjects/ruscker/releases
 
 ---
 
+## v0.1.82 — 2026-06-07
+
+Fix single-seat apps (RStudio, Jupyter) getting stuck on the starting
+splash.
+
+**Fixes**
+- A `seats: 1` interactive app could trap the visitor on the "Starting…"
+  splash forever, even with the container up: the first request reserved
+  the app's only seat for that session, so the app's own follow-up
+  navigation (RStudio → its sign-in page, Jupyter → its lab) re-entered
+  the splash gate, found no *free* seat, and was shown the splash again —
+  waiting on the seat it already held. The splash now lets a session that
+  already holds a seat on a ready replica proxy straight through.
+
 ## v0.1.81 — 2026-06-06
 
 The hi-fi design system reaches every admin screen, plus a new live YAML


### PR DESCRIPTION
Release **v0.1.82** — fixes single-seat apps (RStudio/Jupyter) stuck on the cold-start splash (#671). Bumps version + Cargo.lock + news.md. Tagging `v0.1.82` after merge triggers the release build.

🤖 Generated with [Claude Code](https://claude.com/claude-code)