### PR TITLE
chore(release): bump workspace version 0.1.82 → 0.1.83

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2845,7 +2845,7 @@ dependencies = [
 
 [[package]]
 name = "ruscker-admin"
-version = "0.1.82"
+version = "0.1.83"
 dependencies = [
  "aes-gcm",
  "anyhow",
@@ -2895,7 +2895,7 @@ dependencies = [
 
 [[package]]
 name = "ruscker-cli"
-version = "0.1.82"
+version = "0.1.83"
 dependencies = [
  "anyhow",
  "clap",
@@ -2915,7 +2915,7 @@ dependencies = [
 
 [[package]]
 name = "ruscker-config"
-version = "0.1.82"
+version = "0.1.83"
 dependencies = [
  "chrono",
  "ordered-float",
@@ -2930,7 +2930,7 @@ dependencies = [
 
 [[package]]
 name = "ruscker-core"
-version = "0.1.82"
+version = "0.1.83"
 dependencies = [
  "async-trait",
  "chrono",
@@ -2943,7 +2943,7 @@ dependencies = [
 
 [[package]]
 name = "ruscker-docker"
-version = "0.1.82"
+version = "0.1.83"
 dependencies = [
  "anyhow",
  "async-stream",
@@ -2962,7 +2962,7 @@ dependencies = [
 
 [[package]]
 name = "ruscker-proxy"
-version = "0.1.82"
+version = "0.1.83"
 dependencies = [
  "anyhow",
  "axum",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -10,7 +10,7 @@ members = [
 ]
 
 [workspace.package]
-version = "0.1.82"
+version = "0.1.83"
 edition = "2021"
 rust-version = "1.85"
 license = "Apache-2.0"

--- a/book/src/news.md
+++ b/book/src/news.md
@@ -9,6 +9,21 @@ the [GitHub releases page](https://github.com/StrategicProjects/ruscker/releases
 
 ---
 
+## v0.1.83 — 2026-06-07
+
+Fix runaway session counts on single-seat interactive apps.
+
+**Fixes**
+- A single browser visit to a `seats: 1` app (RStudio, Jupyter) could
+  inflate `sessions_active` to 7–9 and climbing, filling the seat and
+  trapping the visitor (and any second visitor) on the starting splash.
+  An app's `crossorigin` script bundles and credential-less requests
+  arrive without the sticky cookie, and each was being counted as a new
+  session. Now only a real visit — a top-level page navigation — opens a
+  session and takes a seat; subresources ride the existing replica without
+  counting. This also makes `max-replicas` scale-out behave: N concurrent
+  visitors now map to N containers instead of one visit spawning several.
+
 ## v0.1.82 — 2026-06-07
 
 Fix single-seat apps (RStudio, Jupyter) getting stuck on the starting


### PR DESCRIPTION
Release **v0.1.83** — fixes runaway session counts on single-seat interactive apps (#673). Bump + Cargo.lock + news.md. Tagging `v0.1.83` after merge triggers the release build.

🤖 Generated with [Claude Code](https://claude.com/claude-code)