### PR TITLE
chore(release): bump workspace version 0.1.83 → 0.1.84

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2845,7 +2845,7 @@ dependencies = [
 
 [[package]]
 name = "ruscker-admin"
-version = "0.1.83"
+version = "0.1.84"
 dependencies = [
  "aes-gcm",
  "anyhow",
@@ -2895,7 +2895,7 @@ dependencies = [
 
 [[package]]
 name = "ruscker-cli"
-version = "0.1.83"
+version = "0.1.84"
 dependencies = [
  "anyhow",
  "clap",
@@ -2915,7 +2915,7 @@ dependencies = [
 
 [[package]]
 name = "ruscker-config"
-version = "0.1.83"
+version = "0.1.84"
 dependencies = [
  "chrono",
  "ordered-float",
@@ -2930,7 +2930,7 @@ dependencies = [
 
 [[package]]
 name = "ruscker-core"
-version = "0.1.83"
+version = "0.1.84"
 dependencies = [
  "async-trait",
  "chrono",
@@ -2943,7 +2943,7 @@ dependencies = [
 
 [[package]]
 name = "ruscker-docker"
-version = "0.1.83"
+version = "0.1.84"
 dependencies = [
  "anyhow",
  "async-stream",
@@ -2962,7 +2962,7 @@ dependencies = [
 
 [[package]]
 name = "ruscker-proxy"
-version = "0.1.83"
+version = "0.1.84"
 dependencies = [
  "anyhow",
  "axum",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -10,7 +10,7 @@ members = [
 ]
 
 [workspace.package]
-version = "0.1.83"
+version = "0.1.84"
 edition = "2021"
 rust-version = "1.85"
 license = "Apache-2.0"

--- a/book/src/news.md
+++ b/book/src/news.md
@@ -9,6 +9,19 @@ the [GitHub releases page](https://github.com/StrategicProjects/ruscker/releases
 
 ---
 
+## v0.1.84 — 2026-06-07
+
+Tell visitors when an app is full instead of an endless "Starting…".
+
+**Interface**
+- When an app is at its replica ceiling with every seat taken, a new
+  visitor used to see the same "Starting…" page and wait forever, as if
+  the container were perpetually booting. The waiting page now detects
+  this: while the app can still scale it shows "Starting…" as before, but
+  at capacity it says "<app> is full right now — this page opens
+  automatically as soon as one frees up." Both keep polling, so the visitor
+  is let in the moment a seat frees.
+
 ## v0.1.83 — 2026-06-07
 
 Fix runaway session counts on single-seat interactive apps.


### PR DESCRIPTION
Release **v0.1.84** — capacity-aware waiting page (#675). Bump + Cargo.lock + news.md. Tag triggers the release build.

🤖 Generated with [Claude Code](https://claude.com/claude-code)