### PR TITLE
chore(release): bump workspace version 0.1.84 → 0.1.85

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2845,7 +2845,7 @@ dependencies = [
 
 [[package]]
 name = "ruscker-admin"
-version = "0.1.84"
+version = "0.1.85"
 dependencies = [
  "aes-gcm",
  "anyhow",
@@ -2895,7 +2895,7 @@ dependencies = [
 
 [[package]]
 name = "ruscker-cli"
-version = "0.1.84"
+version = "0.1.85"
 dependencies = [
  "anyhow",
  "clap",
@@ -2915,7 +2915,7 @@ dependencies = [
 
 [[package]]
 name = "ruscker-config"
-version = "0.1.84"
+version = "0.1.85"
 dependencies = [
  "chrono",
  "ordered-float",
@@ -2930,7 +2930,7 @@ dependencies = [
 
 [[package]]
 name = "ruscker-core"
-version = "0.1.84"
+version = "0.1.85"
 dependencies = [
  "async-trait",
  "chrono",
@@ -2943,7 +2943,7 @@ dependencies = [
 
 [[package]]
 name = "ruscker-docker"
-version = "0.1.84"
+version = "0.1.85"
 dependencies = [
  "anyhow",
  "async-stream",
@@ -2962,7 +2962,7 @@ dependencies = [
 
 [[package]]
 name = "ruscker-proxy"
-version = "0.1.84"
+version = "0.1.85"
 dependencies = [
  "anyhow",
  "axum",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -10,7 +10,7 @@ members = [
 ]
 
 [workspace.package]
-version = "0.1.84"
+version = "0.1.85"
 edition = "2021"
 rust-version = "1.85"
 license = "Apache-2.0"

--- a/book/src/news.md
+++ b/book/src/news.md
@@ -9,6 +9,18 @@ the [GitHub releases page](https://github.com/StrategicProjects/ruscker/releases
 
 ---
 
+## v0.1.85 — 2026-06-07
+
+Apps auto-scale to a few independent containers by default.
+
+**Behaviour**
+- A container app that doesn't set `max-replicas` now defaults to **5**
+  (was effectively 1). So a single-seat interactive app (RStudio, Jupyter,
+  Shiny) serves up to 5 concurrent visitors — one isolated container each,
+  started on demand — instead of locking everyone out after the first.
+  Set `max-replicas` per app to raise it (busier app) or lower it
+  (constrained host); `External` apps are unaffected.
+
 ## v0.1.84 — 2026-06-07
 
 Tell visitors when an app is full instead of an endless "Starting…".


### PR DESCRIPTION
Release **v0.1.85** — apps default to max-replicas 5 (#677). Tag triggers the release build.

🤖 Generated with [Claude Code](https://claude.com/claude-code)