### PR TITLE
feat(config): default web apps to 10 sessions/container; align form hints

### DIFF
--- a/crates/ruscker-admin/templates/admin/spec_form.html
+++ b/crates/ruscker-admin/templates/admin/spec_form.html
@@ -692,7 +692,7 @@
               </div>
               <div class="stepper">
                 <button type="button" tabindex="-1" @click="form.min_replicas = String(Math.max(0, (parseInt(form.min_replicas, 10) || 0) - 1))"><i class="ti ti-minus" aria-hidden="true"></i></button>
-                <input id="f-min-rep" type="number" name="min_replicas" min="0" placeholder="0"
+                <input id="f-min-rep" type="number" name="min_replicas" min="0" placeholder="1"
                        x-model="form.min_replicas" class="stepper__input">
                 <button type="button" tabindex="-1" @click="form.min_replicas = String((parseInt(form.min_replicas, 10) || 0) + 1)"><i class="ti ti-plus" aria-hidden="true"></i></button>
               </div>
@@ -704,7 +704,7 @@
               </div>
               <div class="stepper">
                 <button type="button" tabindex="-1" @click="form.max_replicas = String(Math.max(1, (parseInt(form.max_replicas, 10) || 1) - 1))"><i class="ti ti-minus" aria-hidden="true"></i></button>
-                <input id="f-max-rep" type="number" name="max_replicas" min="1" placeholder="3"
+                <input id="f-max-rep" type="number" name="max_replicas" min="1" placeholder="5"
                        x-model="form.max_replicas" class="stepper__input">
                 <button type="button" tabindex="-1" @click="form.max_replicas = String((parseInt(form.max_replicas, 10) || 0) + 1)"><i class="ti ti-plus" aria-hidden="true"></i></button>
               </div>

--- a/crates/ruscker-config/src/schema.rs
+++ b/crates/ruscker-config/src/schema.rs
@@ -898,6 +898,15 @@ pub enum SpecKind {
 /// the first. Override per spec with `max-replicas`.
 pub const DEFAULT_MAX_REPLICAS: u32 = 5;
 
+/// Default `seats-per-container` for web-framework specs (Shiny, Streamlit,
+/// Dash, Voilà — `SpecKind::Shiny`/`InteractiveApp`). These frameworks
+/// serve many concurrent sessions from one process, so packing ~10 per
+/// container is far cheaper than one container per user. A **single-user
+/// IDE** (RStudio, Jupyter) is the exception — set `seats-per-container: 1`
+/// on those so each visitor gets an isolated container (concurrency then
+/// comes from `max-replicas`). APIs keep 100.
+pub const DEFAULT_SEATS_PER_APP: u32 = 10;
+
 impl Spec {
     /// Container environment as Docker `NAME=value` strings, sorted for
     /// determinism (the field is a `BTreeMap`). Empty when no
@@ -966,7 +975,7 @@ impl Spec {
     pub fn effective_seats(&self) -> u32 {
         self.seats_per_container.unwrap_or_else(|| match self.kind() {
             SpecKind::Api => 100,
-            SpecKind::Shiny | SpecKind::InteractiveApp => 1,
+            SpecKind::Shiny | SpecKind::InteractiveApp => DEFAULT_SEATS_PER_APP,
             SpecKind::External => 0,
         })
     }

--- a/docs/YAML_SCHEMA.md
+++ b/docs/YAML_SCHEMA.md
@@ -571,8 +571,10 @@ The kind controls:
 - Whether sticky session cookies are issued (`shiny`, `streamlit`,
   `dash`, `voila` — yes; `api`, `external` — no)
 - Default routing strategy
-- Default `seats-per-container` (1 for interactive, 100 for API,
-  0 for external)
+- Default `seats-per-container` (10 for web-framework apps — Shiny,
+  Streamlit, Dash, Voilà — which serve many sessions per process; 100 for
+  API; 0 for external). A single-user IDE (RStudio, Jupyter) should set
+  `seats-per-container: 1` so each visitor gets an isolated container.
 - Whether WebSocket forwarding is attempted
 
 ## Environment variable interpolation


### PR DESCRIPTION
## What

- **`seats-per-container` default for web frameworks** (Shiny / Streamlit / Dash / Voilà — `SpecKind::Shiny`/`InteractiveApp`) → **10** (was 1), via new `DEFAULT_SEATS_PER_APP`. These serve many concurrent sessions per process, so ~10/container beats a container per user (the cast Shiny demo showed `1/1` and spawned a replica per visitor). API keeps 100; External 0.
- **Form hints aligned to defaults**: seats stays `10` (now correct), min-replicas `0`→`1`, max-replicas `3`→`5`.

## Caveat (documented)
Single-user IDEs (**RStudio, Jupyter**) must set `seats-per-container: 1` for isolation — one container per visitor; concurrency comes from `max-replicas` (default 5). Everything else (web apps) benefits from the 10 default.

## Gate
- cargo test (config + admin) + clippy + i18n ✅

🤖 Generated with [Claude Code](https://claude.com/claude-code)