### PR TITLE
chore(release): bump workspace version 0.1.85 → 0.1.86

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2845,7 +2845,7 @@ dependencies = [
 
 [[package]]
 name = "ruscker-admin"
-version = "0.1.85"
+version = "0.1.86"
 dependencies = [
  "aes-gcm",
  "anyhow",
@@ -2895,7 +2895,7 @@ dependencies = [
 
 [[package]]
 name = "ruscker-cli"
-version = "0.1.85"
+version = "0.1.86"
 dependencies = [
  "anyhow",
  "clap",
@@ -2915,7 +2915,7 @@ dependencies = [
 
 [[package]]
 name = "ruscker-config"
-version = "0.1.85"
+version = "0.1.86"
 dependencies = [
  "chrono",
  "ordered-float",
@@ -2930,7 +2930,7 @@ dependencies = [
 
 [[package]]
 name = "ruscker-core"
-version = "0.1.85"
+version = "0.1.86"
 dependencies = [
  "async-trait",
  "chrono",
@@ -2943,7 +2943,7 @@ dependencies = [
 
 [[package]]
 name = "ruscker-docker"
-version = "0.1.85"
+version = "0.1.86"
 dependencies = [
  "anyhow",
  "async-stream",
@@ -2962,7 +2962,7 @@ dependencies = [
 
 [[package]]
 name = "ruscker-proxy"
-version = "0.1.85"
+version = "0.1.86"
 dependencies = [
  "anyhow",
  "axum",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -10,7 +10,7 @@ members = [
 ]
 
 [workspace.package]
-version = "0.1.85"
+version = "0.1.86"
 edition = "2021"
 rust-version = "1.85"
 license = "Apache-2.0"

--- a/book/src/news.md
+++ b/book/src/news.md
@@ -9,6 +9,20 @@ the [GitHub releases page](https://github.com/StrategicProjects/ruscker/releases
 
 ---
 
+## v0.1.86 — 2026-06-07
+
+Web apps pack more sessions per container by default.
+
+**Behaviour**
+- `seats-per-container` now defaults to **10** for web-framework apps
+  (Shiny, Streamlit, Dash, Voilà) — they serve many concurrent sessions
+  from one process, so a container per visitor was wasteful (the demo
+  Shiny showed "1/1"). APIs keep 100. **Single-user IDEs** (RStudio,
+  Jupyter) are the exception: set `seats-per-container: 1` on those so each
+  visitor gets an isolated container, with concurrency from `max-replicas`.
+- The app-editor's greyed hints now match the real defaults
+  (sessions/container 10, min-replicas 1, max-replicas 5).
+
 ## v0.1.85 — 2026-06-07
 
 Apps auto-scale to a few independent containers by default.


### PR DESCRIPTION
Release **v0.1.86** — web apps default to 10 sessions/container; form hints aligned (#679). Tag triggers the build.

🤖 Generated with [Claude Code](https://claude.com/claude-code)