### PR TITLE
feat(admin): wire the perceived-speed primitives — nav progress bar, reveal, skeletons (#623)

### DIFF
--- a/crates/ruscker-admin/src/routes/admin.rs
+++ b/crates/ruscker-admin/src/routes/admin.rs
@@ -770,4 +770,33 @@ mod tests {
             "setup must link /favicon-32.png"
         );
     }
+
+    // The perceived-speed partial (#623) — the top navigation progress bar
+    // and its MPA driver script — is included by both admin layouts and the
+    // standalone login/setup pages, so every navigable admin page gets it.
+    // Login is standalone (own <body>); render it and assert the bar is
+    // wired (the `.topbar-progress` primitive itself lives in input.css).
+    #[test]
+    fn admin_layout_mounts_nav_progress_bar() {
+        let locales = Locales::load().expect("load locales");
+        let html = LoginPage {
+            locale: Locale::En,
+            theme: Theme::Auto,
+            locales: &locales,
+            locales_all: &Locale::ALL,
+            base: std::sync::Arc::from(""),
+            error: "",
+            bootstrap: false,
+        }
+        .render()
+        .expect("render login");
+        assert!(
+            html.contains(r#"id="ruscker-progress""#),
+            "admin layout must mount the nav progress bar"
+        );
+        assert!(
+            html.contains("topbar-progress"),
+            "nav progress bar must carry the .topbar-progress class"
+        );
+    }
 }

--- a/crates/ruscker-admin/templates/_layout.html
+++ b/crates/ruscker-admin/templates/_layout.html
@@ -21,6 +21,7 @@
 <script>window.RUSCKER_BASE = "{{ base }}";</script>
 </head>
 <body class="min-h-screen flex flex-col">
+{% include "_perceived_speed.html" %}
 
 {% block content %}{% endblock %}
 

--- a/crates/ruscker-admin/templates/_perceived_speed.html
+++ b/crates/ruscker-admin/templates/_perceived_speed.html
@@ -1,0 +1,88 @@
+{# Perceived-speed: top navigation progress bar (#623).
+
+   The redesign's stated focus is *perceived* speed. The `.topbar-progress`
+   primitive lives in input.css; this partial mounts the element and drives
+   it. Included once near <body> in both layouts (admin + portal).
+
+   We're a server-rendered MPA, so a full-page navigation tears down the
+   DOM: the bar grows on the OLD page while the next page is fetched (that
+   in-flight growth *is* the cue), then the fresh page paints with the bar
+   reset by the CSS default. We complete-and-fade only on bfcache restore
+   (`pageshow.persisted`) so a back/forward feels instant too. HTMX/Alpine
+   AJAX swaps (no page tear-down) are driven by the htmx:* hooks, which are
+   harmless no-ops when HTMX isn't on the page. A safety timeout finishes a
+   stuck bar if a click ends up not navigating (download, prevented). All
+   motion honors prefers-reduced-motion via the CSS. #}
+<div class="topbar-progress" id="ruscker-progress" aria-hidden="true"></div>
+<script>
+(function () {
+  var bar = document.getElementById("ruscker-progress");
+  if (!bar) return;
+  var timer = null, safety = null, width = 0;
+
+  function start() {
+    if (timer) return;            // already running for this navigation
+    width = 8;
+    bar.classList.add("is-active");
+    bar.style.width = width + "%";
+    timer = setInterval(function () {
+      // Ease toward 90% and hold there; the page load (or done()) finishes it.
+      width += Math.max(0.5, (90 - width) * 0.08);
+      if (width >= 90) { width = 90; clearInterval(timer); timer = null; }
+      bar.style.width = width + "%";
+    }, 120);
+    // If the "navigation" never happens (prevented click, download), don't
+    // leave the bar hanging.
+    clearTimeout(safety);
+    safety = setTimeout(done, 8000);
+  }
+
+  function done() {
+    clearTimeout(safety);
+    if (timer) { clearInterval(timer); timer = null; }
+    bar.style.width = "100%";
+    setTimeout(function () {
+      bar.classList.remove("is-active");
+      setTimeout(function () { bar.style.width = "0"; }, 250);
+    }, 150);
+  }
+
+  // A plain left-click on a same-origin, same-tab link is a full-page nav.
+  // Bubble phase (not capture) so an onclick that returns false / prevents
+  // default has already marked the event — we won't start a bar that never
+  // navigates. stopPropagation on a link is rare; the cost there is just no
+  // bar, which beats a stuck one.
+  document.addEventListener("click", function (e) {
+    if (e.defaultPrevented || e.button !== 0 ||
+        e.metaKey || e.ctrlKey || e.shiftKey || e.altKey) return;
+    var a = e.target.closest ? e.target.closest("a[href]") : null;
+    if (!a || a.hasAttribute("download")) return;
+    if (a.target && a.target !== "_self") return;
+    var href = a.getAttribute("href");
+    if (!href || href.charAt(0) === "#" ||
+        /^(mailto:|tel:|javascript:)/i.test(href)) return;
+    if (a.origin && a.origin !== location.origin) return;   // external
+    // Same-page anchor (only the hash changes) → no navigation.
+    if (a.pathname === location.pathname && a.search === location.search && a.hash) return;
+    start();
+  });
+
+  // A form submit that navigates. Bubble phase so a cancelled
+  // `onsubmit="return confirm(...)"` (defaultPrevented) is skipped. Opt out
+  // with data-no-progress for an Alpine/fetch-hijacked form that stays put.
+  document.addEventListener("submit", function (e) {
+    if (e.defaultPrevented) return;
+    var f = e.target;
+    if (f && f.hasAttribute("data-no-progress")) return;
+    start();
+  });
+
+  // bfcache restore: the old bar comes back mid-animation — finish it.
+  window.addEventListener("pageshow", function (e) { if (e.persisted) done(); });
+  window.addEventListener("pagehide", function () { clearTimeout(safety); });
+
+  // HTMX AJAX swaps (no page tear-down) — no-ops if HTMX isn't present.
+  document.addEventListener("htmx:beforeRequest", start);
+  document.addEventListener("htmx:afterRequest", done);
+})();
+</script>

--- a/crates/ruscker-admin/templates/admin/_layout.html
+++ b/crates/ruscker-admin/templates/admin/_layout.html
@@ -21,6 +21,7 @@
 <script>window.RUSCKER_BASE = "{{ base }}";</script>
 </head>
 <body class="min-h-screen flex flex-col">
+{% include "_perceived_speed.html" %}
 
 {% block navbar %}
 <nav class="admin-navbar">
@@ -237,7 +238,7 @@ window.ruscker.imagePicker = (filenames) => ({
 });
 </script>
 
-<main class="flex-1 px-6 py-6 max-w-7xl mx-auto w-full">
+<main class="flex-1 px-6 py-6 max-w-7xl mx-auto w-full fade-in">
   {% block content %}{% endblock %}
 </main>
 

--- a/crates/ruscker-admin/templates/admin/dashboard.html
+++ b/crates/ruscker-admin/templates/admin/dashboard.html
@@ -22,6 +22,11 @@
   }
   /* Inline CPU/memory trend sparkline in a replica row. */
   .dash-spark { vertical-align: middle; margin-left: 6px; opacity: 0.75; }
+  /* Shimmer placeholder for a CPU/mem cell whose first reading hasn't
+     arrived yet (#623 perceived-speed). Replaces the bare "—": a loading
+     reading reads as loading, not as a zero/empty value. `.sk` (the
+     shimmer) lives in the global stylesheet. */
+  .metric-sk { display: inline-block; width: 34px; height: 11px; vertical-align: middle; }
 </style>
 
 <div class="flex items-end justify-between mb-5">
@@ -139,8 +144,8 @@
         <span class="mono faint">{{ row.uptime }}</span>
         <span class="muted">{{ row.state_label }}</span>
         <span class="metric-cell tnum">{{ row.sessions_active }}<span class="faint">/{{ row.sessions_max }}</span></span>
-        <span class="metric-cell tnum">{% match row.cpu_display %}{% when Some with (s) %}{{ s }}{% when None %}<span class="faint" title="{{ self.t("admin-dashboard-metrics-pending") }}">—</span>{% endmatch %}</span>
-        <span class="metric-cell tnum">{% match row.memory_display %}{% when Some with (s) %}{{ s }}{% when None %}<span class="faint">—</span>{% endmatch %}</span>
+        <span class="metric-cell tnum">{% match row.cpu_display %}{% when Some with (s) %}{{ s }}{% when None %}<span class="sk sk-line metric-sk" title="{{ self.t("admin-dashboard-metrics-pending") }}"></span>{% endmatch %}</span>
+        <span class="metric-cell tnum">{% match row.memory_display %}{% when Some with (s) %}{{ s }}{% when None %}<span class="sk sk-line metric-sk"></span>{% endmatch %}</span>
         <span class="replica-actions">
           {% if role.can_manage() %}
           <a href="{{ base }}/admin/dashboard/logs/{{ row.replica_id }}" title="{{ self.t("admin-logs-title") }}"><i class="ti ti-file-text" aria-hidden="true"></i></a>
@@ -195,12 +200,12 @@
     if (el && el.textContent !== String(value)) el.textContent = value;
   }
 
-  // A metric cell's text, or a faint "—" placeholder when the reading
-  // hasn't arrived yet.
+  // A metric cell's text, or a shimmer skeleton when the reading hasn't
+  // arrived yet (#623). Mirrors the server-rendered pending placeholder.
   function cell(display) {
     return display !== null && display !== undefined
       ? escapeHtml(display)
-      : '<span class="faint" title="' + escapeHtml(pendingLabel) + '">—</span>';
+      : '<span class="sk sk-line metric-sk" title="' + escapeHtml(pendingLabel) + '"></span>';
   }
 
   function actionsHtml(row) {

--- a/crates/ruscker-admin/templates/admin/login.html
+++ b/crates/ruscker-admin/templates/admin/login.html
@@ -11,6 +11,7 @@
 <link rel="stylesheet" href="{{ base }}/assets/icons/tabler-icons.min.css?v={{ crate::APP_VERSION }}">
 </head>
 <body class="min-h-screen flex flex-col items-center justify-center px-4 relative">
+{% include "_perceived_speed.html" %}
 
 {# Top-right chrome cluster (#182 + #183). Lives outside the login form
    so its POSTs to /__set/{theme,locale} aren't shadowed by the outer

--- a/crates/ruscker-admin/templates/admin/setup.html
+++ b/crates/ruscker-admin/templates/admin/setup.html
@@ -11,6 +11,7 @@
 <link rel="stylesheet" href="{{ base }}/assets/icons/tabler-icons.min.css?v={{ crate::APP_VERSION }}">
 </head>
 <body class="min-h-screen flex flex-col items-center justify-center px-4 relative">
+{% include "_perceived_speed.html" %}
 
 {# Top-right chrome cluster (#182 + #183). Outside the outer form. #}
 <div class="absolute top-4 right-4 z-50">

--- a/crates/ruscker-admin/templates/landing.html
+++ b/crates/ruscker-admin/templates/landing.html
@@ -266,7 +266,7 @@
   </div>{# /portal-sticky #}
 
   {# ── Card grid (fixed-width cards, columns auto-fill) ──────── #}
-  <section class="cards-grid" x-ref="grid">
+  <section class="cards-grid stagger" x-ref="grid">
     {% for card in cards %}
       <a class="rcard {% if !card.active %}inactive{% endif %}"
          href="{% if card.active %}{{ card.href }}{% else %}#{% endif %}"


### PR DESCRIPTION
Closes the last sliver of **#623**. The design handoff vendored the
perceived-speed CSS primitives into `input.css`, but **no template ever
used them** (0 usages of `.topbar-progress` / `.sk` / `.fade-in` /
`.stagger`). This wires them up so the redesign's stated focus —
*perceived* speed — is actually live.

### What's wired
- **Top nav progress bar** — new `_perceived_speed.html` partial mounts
  `.topbar-progress` + a small MPA-aware driver; included by both layouts
  and the standalone login/setup pages. Grows while a full-page nav /
  HTMX swap / form submit is in flight; resets when the fresh page paints.
  Bubble-phase listeners skip prevented/cancelled actions (e.g. a
  cancelled `confirm()`); 8 s safety finishes a stuck bar; bfcache restore
  completes it. Honors `prefers-reduced-motion`.
- **Content reveal** — `.fade-in` on the admin `<main>`.
- **Card cascade** — `.stagger` on the portal card grid. Deliberately
  **off** the dashboard groups (the SSE patcher rebuilds them each tick →
  would replay the animation every second).
- **Shimmer skeletons** — a CPU/mem replica cell awaiting its first
  reading now shows a `.sk` shimmer instead of a bare `—`, in both the
  server template and the JS that mirrors it on each SSE rebuild.

### Validation
- `cargo build` (regenerates `styles.css`; primitives present), `cargo
  clippy -p ruscker-admin --all-targets` → 0 warnings, `./scripts/i18n-check.sh` → OK.
- `cargo test -p ruscker-admin` → all green; new test asserts the nav bar
  is wired into a rendered page.

🤖 Generated with [Claude Code](https://claude.com/claude-code)