### PR TITLE
chore(release): bump workspace version 0.1.86 → 0.1.87

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2845,7 +2845,7 @@ dependencies = [
 
 [[package]]
 name = "ruscker-admin"
-version = "0.1.86"
+version = "0.1.87"
 dependencies = [
  "aes-gcm",
  "anyhow",
@@ -2895,7 +2895,7 @@ dependencies = [
 
 [[package]]
 name = "ruscker-cli"
-version = "0.1.86"
+version = "0.1.87"
 dependencies = [
  "anyhow",
  "clap",
@@ -2915,7 +2915,7 @@ dependencies = [
 
 [[package]]
 name = "ruscker-config"
-version = "0.1.86"
+version = "0.1.87"
 dependencies = [
  "chrono",
  "ordered-float",
@@ -2930,7 +2930,7 @@ dependencies = [
 
 [[package]]
 name = "ruscker-core"
-version = "0.1.86"
+version = "0.1.87"
 dependencies = [
  "async-trait",
  "chrono",
@@ -2943,7 +2943,7 @@ dependencies = [
 
 [[package]]
 name = "ruscker-docker"
-version = "0.1.86"
+version = "0.1.87"
 dependencies = [
  "anyhow",
  "async-stream",
@@ -2962,7 +2962,7 @@ dependencies = [
 
 [[package]]
 name = "ruscker-proxy"
-version = "0.1.86"
+version = "0.1.87"
 dependencies = [
  "anyhow",
  "axum",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -10,7 +10,7 @@ members = [
 ]
 
 [workspace.package]
-version = "0.1.86"
+version = "0.1.87"
 edition = "2021"
 rust-version = "1.85"
 license = "Apache-2.0"

--- a/book/src/news.md
+++ b/book/src/news.md
@@ -9,6 +9,25 @@ the [GitHub releases page](https://github.com/StrategicProjects/ruscker/releases
 
 ---
 
+## v0.1.87 — 2026-06-07
+
+The redesign's perceived-speed primitives are now live (#623).
+
+**UI**
+- **Top navigation progress bar** — a thin teal bar grows while a page
+  navigation (or form submit) is in flight, across the admin and the
+  public portal. Honors `prefers-reduced-motion`.
+- **Content reveal** — admin pages fade in as they load, and the portal
+  card grid cascades in with a small per-card delay.
+- **Shimmer skeletons** — a replica's CPU/memory cell shows a shimmer
+  while its first live reading is pending, instead of a bare dash, so a
+  loading value reads as loading rather than empty.
+
+These wire up the perceived-speed primitives the #623 handoff defined,
+completing the Design System pass.
+
+---
+
 ## v0.1.86 — 2026-06-07
 
 Web apps pack more sessions per container by default.


### PR DESCRIPTION
Cuts **v0.1.87**.

**What ships:** the perceived-speed primitives the #623 handoff defined,
now wired up (#681) — top navigation progress bar, content fade-in /
portal card stagger reveal, and shimmer skeletons for pending CPU/mem
metric cells. This completes the Design System pass and **closes #623**.

Version bumped across the workspace; `Cargo.lock` refreshed; `news.md`
entry added. Tag `v0.1.87` triggers the release workflow (.deb / musl /
cosign-signed ghcr image / Homebrew formula).

🤖 Generated with [Claude Code](https://claude.com/claude-code)