### PR TITLE
chore(release): bump workspace version 0.1.87 → 0.1.88

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2845,7 +2845,7 @@ dependencies = [
 
 [[package]]
 name = "ruscker-admin"
-version = "0.1.87"
+version = "0.1.88"
 dependencies = [
  "aes-gcm",
  "anyhow",
@@ -2895,7 +2895,7 @@ dependencies = [
 
 [[package]]
 name = "ruscker-cli"
-version = "0.1.87"
+version = "0.1.88"
 dependencies = [
  "anyhow",
  "clap",
@@ -2915,7 +2915,7 @@ dependencies = [
 
 [[package]]
 name = "ruscker-config"
-version = "0.1.87"
+version = "0.1.88"
 dependencies = [
  "chrono",
  "ordered-float",
@@ -2930,7 +2930,7 @@ dependencies = [
 
 [[package]]
 name = "ruscker-core"
-version = "0.1.87"
+version = "0.1.88"
 dependencies = [
  "async-trait",
  "chrono",
@@ -2943,7 +2943,7 @@ dependencies = [
 
 [[package]]
 name = "ruscker-docker"
-version = "0.1.87"
+version = "0.1.88"
 dependencies = [
  "anyhow",
  "async-stream",
@@ -2962,7 +2962,7 @@ dependencies = [
 
 [[package]]
 name = "ruscker-proxy"
-version = "0.1.87"
+version = "0.1.88"
 dependencies = [
  "anyhow",
  "axum",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -10,7 +10,7 @@ members = [
 ]
 
 [workspace.package]
-version = "0.1.87"
+version = "0.1.88"
 edition = "2021"
 rust-version = "1.85"
 license = "Apache-2.0"

--- a/book/src/news.md
+++ b/book/src/news.md
@@ -9,6 +9,22 @@ the [GitHub releases page](https://github.com/StrategicProjects/ruscker/releases
 
 ---
 
+## v0.1.88 — 2026-06-07
+
+A spurious "upstream error" on the first open of an interactive app is
+fixed (#683).
+
+**Fixes**
+- Opening RStudio Server (or any interactive app) could show a bare
+  **"upstream error"** on the first navigation, then work on a retry.
+  Cause was a hyper connection-pool race: app servers close idle
+  keep-alive connections quickly, and the proxy could dispatch a request
+  onto a socket the app had already closed. The proxy now evicts idle
+  pooled connections promptly and retries an idempotent (GET/HEAD)
+  forward once on a fresh connection, so the first open just works.
+
+---
+
 ## v0.1.87 — 2026-06-07
 
 The redesign's perceived-speed primitives are now live (#623).


### PR DESCRIPTION
Cuts **v0.1.88**.

**What ships:** the proxy fix for the spurious **"upstream error"** on
the first open of an interactive app (RStudio/Shiny) — a hyper
connection-pool race (#683, PR #684). The proxy now evicts idle pooled
connections promptly and retries an idempotent forward once on a fresh
connection.

Version bumped across the workspace; `Cargo.lock` refreshed; `news.md`
entry added. Tag `v0.1.88` triggers the release workflow (.deb / musl /
cosign-signed ghcr image / Homebrew formula).

🤖 Generated with [Claude Code](https://claude.com/claude-code)