### PR TITLE
chore(release): bump workspace version 0.1.88 → 0.1.89

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2845,7 +2845,7 @@ dependencies = [
 
 [[package]]
 name = "ruscker-admin"
-version = "0.1.88"
+version = "0.1.89"
 dependencies = [
  "aes-gcm",
  "anyhow",
@@ -2895,7 +2895,7 @@ dependencies = [
 
 [[package]]
 name = "ruscker-cli"
-version = "0.1.88"
+version = "0.1.89"
 dependencies = [
  "anyhow",
  "clap",
@@ -2915,7 +2915,7 @@ dependencies = [
 
 [[package]]
 name = "ruscker-config"
-version = "0.1.88"
+version = "0.1.89"
 dependencies = [
  "chrono",
  "ordered-float",
@@ -2930,7 +2930,7 @@ dependencies = [
 
 [[package]]
 name = "ruscker-core"
-version = "0.1.88"
+version = "0.1.89"
 dependencies = [
  "async-trait",
  "chrono",
@@ -2943,7 +2943,7 @@ dependencies = [
 
 [[package]]
 name = "ruscker-docker"
-version = "0.1.88"
+version = "0.1.89"
 dependencies = [
  "anyhow",
  "async-stream",
@@ -2962,7 +2962,7 @@ dependencies = [
 
 [[package]]
 name = "ruscker-proxy"
-version = "0.1.88"
+version = "0.1.89"
 dependencies = [
  "anyhow",
  "axum",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -10,7 +10,7 @@ members = [
 ]
 
 [workspace.package]
-version = "0.1.88"
+version = "0.1.89"
 edition = "2021"
 rust-version = "1.85"
 license = "Apache-2.0"

--- a/book/src/news.md
+++ b/book/src/news.md
@@ -9,6 +9,21 @@ the [GitHub releases page](https://github.com/StrategicProjects/ruscker/releases
 
 ---
 
+## v0.1.89 — 2026-06-07
+
+Reliable cold starts for scale-to-zero interactive apps (#686).
+
+**Fixes**
+- A `min-replicas: 0` interactive app (e.g. an IDE with
+  `seats-per-container: 1`) could fail to open: the scaler reaped the
+  replica it had just spawned for the arriving visitor before they
+  finished the cold-start splash and claimed a seat, leaving them on a
+  dead/again-cold app. A freshly-ready replica is now exempt from idle
+  scale-down for a short grace, so the visitor reliably lands on it.
+  Single-user IDEs can still pin `min-replicas: 1` to stay warm.
+
+---
+
 ## v0.1.88 — 2026-06-07
 
 A spurious "upstream error" on the first open of an interactive app is


### PR DESCRIPTION
Cuts **v0.1.89**.

**What ships:** the scaler fix (#686, PR #687) — a freshly-Ready replica is
exempt from idle scale-down for a short grace, so a cold-start visitor to a
`min-replicas: 0` interactive app reliably claims the replica spawned for
them instead of finding it reaped. This is the software half of the cast
RStudio investigation (the `min-replicas: 1` mitigation is already live on
cast).

Version bumped across the workspace; `Cargo.lock` refreshed; `news.md`
entry added. Tag `v0.1.89` triggers the release workflow.

🤖 Generated with [Claude Code](https://claude.com/claude-code)