### PR TITLE
feat(appearance): editable portal footer text (1/9)

### DIFF
--- a/crates/ruscker-admin/assets/i18n/en/landing.ftl
+++ b/crates/ruscker-admin/assets/i18n/en/landing.ftl
@@ -683,6 +683,9 @@ admin-landing-portal-title = Portal title
 admin-landing-portal-title-help = Shown at the top of the landing. Blank uses the config title (proxy.title).
 admin-landing-portal-subtitle = Subtitle
 admin-landing-portal-subtitle-help = The line under the title. Leave blank to hide it.
+admin-landing-footer = Footer
+admin-landing-footer-help = Text in the portal footer. Blank shows the version and wordmark.
+
 admin-landing-theme-colors = Theme colors
 admin-landing-theme-colors-help = Recolor the public portal's light and dark themes. Blank keeps the default.
 admin-landing-theme-light = Light theme

--- a/crates/ruscker-admin/assets/i18n/es/landing.ftl
+++ b/crates/ruscker-admin/assets/i18n/es/landing.ftl
@@ -683,6 +683,9 @@ admin-landing-portal-title = Título del portal
 admin-landing-portal-title-help = Aparece arriba en la landing. En blanco usa el título del config (proxy.title).
 admin-landing-portal-subtitle = Subtítulo
 admin-landing-portal-subtitle-help = La línea bajo el título. Déjalo en blanco para ocultarlo.
+admin-landing-footer = Pie de página
+admin-landing-footer-help = Texto en el pie del portal. En blanco muestra la versión y la marca.
+
 admin-landing-theme-colors = Colores por tema
 admin-landing-theme-colors-help = Recolorea los temas claro y oscuro del portal público. En blanco, mantiene el valor por defecto.
 admin-landing-theme-light = Tema claro

--- a/crates/ruscker-admin/assets/i18n/fr/landing.ftl
+++ b/crates/ruscker-admin/assets/i18n/fr/landing.ftl
@@ -683,6 +683,9 @@ admin-landing-portal-title = Titre du portail
 admin-landing-portal-title-help = Affiché en haut de la landing. Vide : utilise le titre de la config (proxy.title).
 admin-landing-portal-subtitle = Sous-titre
 admin-landing-portal-subtitle-help = La ligne sous le titre. Laissez vide pour le masquer.
+admin-landing-footer = Pied de page
+admin-landing-footer-help = Texte du pied de page du portail. Vide affiche la version et la marque.
+
 admin-landing-theme-colors = Couleurs par thème
 admin-landing-theme-colors-help = Recolorez les thèmes clair et sombre du portail public. Vide : garde la valeur par défaut.
 admin-landing-theme-light = Thème clair

--- a/crates/ruscker-admin/assets/i18n/pt/landing.ftl
+++ b/crates/ruscker-admin/assets/i18n/pt/landing.ftl
@@ -687,6 +687,9 @@ admin-landing-portal-title = Título do portal
 admin-landing-portal-title-help = Aparece no topo da landing. Em branco, usa o título do config (proxy.title).
 admin-landing-portal-subtitle = Subtítulo
 admin-landing-portal-subtitle-help = A linha abaixo do título. Em branco, o subtítulo fica oculto.
+admin-landing-footer = Rodapé
+admin-landing-footer-help = Texto no rodapé do portal. Em branco, mostra a versão e a marca.
+
 admin-landing-theme-colors = Cores por tema
 admin-landing-theme-colors-help = Recolore o tema claro e escuro do portal público. Em branco, mantém o padrão.
 admin-landing-theme-light = Tema claro

--- a/crates/ruscker-admin/migrations/0017_landing_footer.sql
+++ b/crates/ruscker-admin/migrations/0017_landing_footer.sql
@@ -1,0 +1,3 @@
+-- Editable public-portal footer text (appearance editor). NULL → the
+-- built-in version + "ruscker" lockup renders unchanged.
+ALTER TABLE landing_customization ADD COLUMN footer TEXT;

--- a/crates/ruscker-admin/src/db/landing.rs
+++ b/crates/ruscker-admin/src/db/landing.rs
@@ -35,11 +35,12 @@ pub async fn fetch(db: &ConfigDb) -> Result<LandingCustomization> {
         Option<String>, // subtitle
         Option<String>, // theme_colors_json
         Option<bool>,   // show_highlights
+        Option<String>, // footer
     );
     let sql = "SELECT header_bg, header_fg, intro, intro_locales_json,
                 seo_title, seo_description, og_image,
                 analytics_html, analytics_origins, custom_css, logos_json,
-                title, subtitle, theme_colors_json, show_highlights
+                title, subtitle, theme_colors_json, show_highlights, footer
            FROM landing_customization WHERE id = 1";
     let row: Option<Row> = match db {
         ConfigDb::Sqlite(pool) => sqlx::query_as(sql).fetch_optional(pool).await,
@@ -64,6 +65,7 @@ pub async fn fetch(db: &ConfigDb) -> Result<LandingCustomization> {
             subtitle,
             theme_colors_json,
             show_highlights,
+            footer,
         )) => {
             let intro_locales =
                 serde_json::from_str(&locales_json).context("parse intro_locales_json")?;
@@ -103,6 +105,7 @@ pub async fn fetch(db: &ConfigDb) -> Result<LandingCustomization> {
                 subtitle,
                 theme_colors,
                 show_highlights,
+                footer,
             })
         }
     }
@@ -170,7 +173,8 @@ pub(crate) async fn update_in_tx(
                 intro_locales_json = ?, seo_title = ?, seo_description = ?,
                 og_image = ?, analytics_html = ?, analytics_origins = ?,
                 custom_css = ?, logos_json = ?, title = ?, subtitle = ?,
-                theme_colors_json = ?, show_highlights = ?, updated_at = ?
+                theme_colors_json = ?, show_highlights = ?, footer = ?,
+                updated_at = ?
           WHERE id = 1",
     )
     .bind(none_if_empty(&lc.header_bg))
@@ -188,6 +192,7 @@ pub(crate) async fn update_in_tx(
     .bind(none_if_empty(&lc.subtitle))
     .bind(&theme_colors_json)
     .bind(lc.show_highlights)
+    .bind(none_if_empty(&lc.footer))
     .bind(now)
     .execute(&mut **tx)
     .await
@@ -226,7 +231,7 @@ pub(crate) async fn update_in_tx_pg(
                 og_image = $7, analytics_html = $8, analytics_origins = $9,
                 custom_css = $10, logos_json = $11, title = $12,
                 subtitle = $13, theme_colors_json = $14,
-                show_highlights = $15, updated_at = $16
+                show_highlights = $15, footer = $16, updated_at = $17
           WHERE id = 1",
     )
     .bind(none_if_empty(&lc.header_bg))
@@ -244,6 +249,7 @@ pub(crate) async fn update_in_tx_pg(
     .bind(none_if_empty(&lc.subtitle))
     .bind(&theme_colors_json)
     .bind(lc.show_highlights)
+    .bind(none_if_empty(&lc.footer))
     .bind(now)
     .execute(&mut **tx)
     .await
@@ -336,6 +342,18 @@ mod tests {
         let got = fetch(&ConfigDb::Sqlite(pool.clone())).await.unwrap();
         assert_eq!(got.analytics_html.as_deref(), Some(snippet));
         assert_eq!(got.analytics_origins.as_deref(), Some(origins));
+    }
+
+    #[tokio::test]
+    async fn footer_roundtrips() {
+        let pool = open_memory().await.unwrap();
+        let lc = LandingCustomization {
+            footer: Some("© 2026 Acme".into()),
+            ..Default::default()
+        };
+        update(&ConfigDb::Sqlite(pool.clone()), &lc, Some("admin")).await.unwrap();
+        let got = fetch(&ConfigDb::Sqlite(pool.clone())).await.unwrap();
+        assert_eq!(got.footer.as_deref(), Some("© 2026 Acme"));
     }
 
     #[tokio::test]

--- a/crates/ruscker-admin/src/routes/admin/landing.rs
+++ b/crates/ruscker-admin/src/routes/admin/landing.rs
@@ -90,6 +90,7 @@ impl<'a> LandingPage<'a> {
 pub struct LandingForm {
     pub title: String,
     pub subtitle: String,
+    pub footer: String,
     // Per-theme color overrides (#475); blank ⇒ keep the theme default.
     pub theme_light_bg: String,
     pub theme_light_text: String,
@@ -129,6 +130,7 @@ impl LandingForm {
         Self {
             title: lc.title.clone().unwrap_or_default(),
             subtitle: lc.subtitle.clone().unwrap_or_default(),
+            footer: lc.footer.clone().unwrap_or_default(),
             theme_light_bg: s(&tc.light.bg),
             theme_light_text: s(&tc.light.text),
             theme_light_accent: s(&tc.light.accent),
@@ -186,6 +188,7 @@ impl LandingForm {
         LandingCustomization {
             title: empty_to_none(self.title),
             subtitle: empty_to_none(self.subtitle),
+            footer: empty_to_none(self.footer),
             theme_colors,
             header_bg: empty_to_none(self.header_bg),
             header_fg: empty_to_none(self.header_fg),

--- a/crates/ruscker-admin/src/routes/landing.rs
+++ b/crates/ruscker-admin/src/routes/landing.rs
@@ -51,6 +51,9 @@ struct LandingPage<'a> {
     /// Header subtitle — `landing-customization.subtitle` override, else
     /// the localized `landing-subtitle` (#468).
     header_subtitle: String,
+    /// Footer text — `landing-customization.footer` override. Empty ⇒ the
+    /// built-in version + wordmark lockup renders unchanged.
+    footer: String,
     /// `<style>` body setting the theme CSS variables from the operator's
     /// per-theme color overrides (#475). Empty ⇒ no `<style>` emitted.
     theme_style: String,
@@ -334,6 +337,8 @@ async fn index(
         intro,
         header_title,
         header_subtitle,
+        // Footer override (blank ⇒ the default version+wordmark lockup).
+        footer: lc.footer.clone().unwrap_or_default(),
         theme_style,
         header_style,
         page_title,

--- a/crates/ruscker-admin/templates/_layout.html
+++ b/crates/ruscker-admin/templates/_layout.html
@@ -36,9 +36,15 @@
   {# Footer-center logos: absolutely centred over the footer (#468). #}
   {% block footer_logos_center %}{% endblock %}
   <div class="flex items-center gap-3">
+    {# Footer text: the operator's `landing-customization.footer` override
+       when set, else the built-in release-notes version link. #}
+    {% if !footer.is_empty() %}
+    <span class="opacity-70">{{ footer }}</span>
+    {% else %}
     <a class="opacity-60 hover:opacity-100 transition-opacity"
        href="https://github.com/StrategicProjects/ruscker/releases/tag/v{{ crate::APP_VERSION }}"
        title="Release notes">v{{ crate::APP_VERSION }}</a>
+    {% endif %}
     <a class="inline-flex items-center gap-2 opacity-70 hover:opacity-100 transition-opacity"
        href="https://github.com/StrategicProjects/ruscker"
        aria-label="Ruscker">

--- a/crates/ruscker-admin/templates/admin/landing.html
+++ b/crates/ruscker-admin/templates/admin/landing.html
@@ -69,6 +69,12 @@
                placeholder="{{ self.t("landing-subtitle") }}" class="spec-form-input">
         <div class="spec-form-help">{{ self.t("admin-landing-portal-subtitle-help") }}</div>
       </div>
+      <div class="spec-form-field">
+        <label class="spec-form-label">{{ self.t("admin-landing-footer") }}</label>
+        <input type="text" name="footer" x-model="form.footer" maxlength="200"
+               placeholder="v{{ crate::APP_VERSION }} · Ruscker" class="spec-form-input">
+        <div class="spec-form-help">{{ self.t("admin-landing-footer-help") }}</div>
+      </div>
       {# "Featured" carousel toggle (#506) — plain checkbox; the carousel
          only shows when this is on AND at least one app is featured. #}
       <div class="spec-form-field">

--- a/crates/ruscker-config/src/schema.rs
+++ b/crates/ruscker-config/src/schema.rs
@@ -353,6 +353,12 @@ pub struct LandingCustomization {
     #[serde(default)]
     pub subtitle: Option<String>,
 
+    /// Footer text shown in the public portal footer. Blank ⇒ the
+    /// built-in version + "ruscker" lockup. Admin-managed via the
+    /// appearance editor; survives import/export.
+    #[serde(default)]
+    pub footer: Option<String>,
+
     /// Free-form intro paragraph rendered between the header and
     /// the filter section. Operator-authored, plain text (no HTML).
     ///


### PR DESCRIPTION
**Roadmap 1/9** of the appearance-editor rebuild toward handoff ruscker-06 (you opted to build the new features for real, not just restyle).

Makes the **portal footer text** operator-editable:
- `LandingCustomization.footer` (ruscker-config, additive optional field) + migration `0017` + dual-backend load/save (`db::landing`, sqlite + postgres).
- `LandingForm` plumbing; the IDENTITY card gains a **Footer** input under Tagline.
- The public portal renders the custom footer when set, else the built-in version + wordmark lockup.
- i18n (pt/en/es/fr); footer round-trip test.

Validation: `cargo test -p ruscker-config -p ruscker-admin` green · `clippy --all-targets` 0 warnings · i18n parity OK.

Next slices: default theme, visible-section toggles, brand-color swatches, logo mode/size/margin, backgrounds + card covers, catalog layout, analytics provider, final restyle.

🤖 Generated with [Claude Code](https://claude.com/claude-code)