### PR TITLE
feat(appearance): operator default portal theme (2/9)

### DIFF
--- a/crates/ruscker-admin/assets/i18n/en/landing.ftl
+++ b/crates/ruscker-admin/assets/i18n/en/landing.ftl
@@ -685,6 +685,9 @@ admin-landing-portal-subtitle = Subtitle
 admin-landing-portal-subtitle-help = The line under the title. Leave blank to hide it.
 admin-landing-footer = Footer
 admin-landing-footer-help = Text in the portal footer. Blank shows the version and wordmark.
+admin-landing-default-theme = Default theme
+admin-landing-default-theme-help = The initial theme for a first-time visitor. They can still switch.
+
 
 admin-landing-theme-colors = Theme colors
 admin-landing-theme-colors-help = Recolor the public portal's light and dark themes. Blank keeps the default.

--- a/crates/ruscker-admin/assets/i18n/es/landing.ftl
+++ b/crates/ruscker-admin/assets/i18n/es/landing.ftl
@@ -685,6 +685,9 @@ admin-landing-portal-subtitle = Subtítulo
 admin-landing-portal-subtitle-help = La línea bajo el título. Déjalo en blanco para ocultarlo.
 admin-landing-footer = Pie de página
 admin-landing-footer-help = Texto en el pie del portal. En blanco muestra la versión y la marca.
+admin-landing-default-theme = Tema predeterminado
+admin-landing-default-theme-help = El tema inicial para un visitante nuevo. Aún puede cambiarlo.
+
 
 admin-landing-theme-colors = Colores por tema
 admin-landing-theme-colors-help = Recolorea los temas claro y oscuro del portal público. En blanco, mantiene el valor por defecto.

--- a/crates/ruscker-admin/assets/i18n/fr/landing.ftl
+++ b/crates/ruscker-admin/assets/i18n/fr/landing.ftl
@@ -685,6 +685,9 @@ admin-landing-portal-subtitle = Sous-titre
 admin-landing-portal-subtitle-help = La ligne sous le titre. Laissez vide pour le masquer.
 admin-landing-footer = Pied de page
 admin-landing-footer-help = Texte du pied de page du portail. Vide affiche la version et la marque.
+admin-landing-default-theme = Thème par défaut
+admin-landing-default-theme-help = Le thème initial pour un nouveau visiteur. Il peut toujours en changer.
+
 
 admin-landing-theme-colors = Couleurs par thème
 admin-landing-theme-colors-help = Recolorez les thèmes clair et sombre du portail public. Vide : garde la valeur par défaut.

--- a/crates/ruscker-admin/assets/i18n/pt/landing.ftl
+++ b/crates/ruscker-admin/assets/i18n/pt/landing.ftl
@@ -689,6 +689,9 @@ admin-landing-portal-subtitle = Subtítulo
 admin-landing-portal-subtitle-help = A linha abaixo do título. Em branco, o subtítulo fica oculto.
 admin-landing-footer = Rodapé
 admin-landing-footer-help = Texto no rodapé do portal. Em branco, mostra a versão e a marca.
+admin-landing-default-theme = Tema padrão
+admin-landing-default-theme-help = O tema inicial para quem nunca escolheu. O visitante ainda pode trocar.
+
 
 admin-landing-theme-colors = Cores por tema
 admin-landing-theme-colors-help = Recolore o tema claro e escuro do portal público. Em branco, mantém o padrão.

--- a/crates/ruscker-admin/migrations/0018_landing_default_theme.sql
+++ b/crates/ruscker-admin/migrations/0018_landing_default_theme.sql
@@ -1,0 +1,3 @@
+-- Default portal theme for a cookieless visitor (appearance editor):
+-- 'light' | 'dark' | 'auto'. NULL/'auto' → OS prefers-color-scheme.
+ALTER TABLE landing_customization ADD COLUMN default_theme TEXT;

--- a/crates/ruscker-admin/src/db/landing.rs
+++ b/crates/ruscker-admin/src/db/landing.rs
@@ -19,28 +19,35 @@ use ruscker_config::LandingCustomization;
 /// SELECT carries no placeholders and reads only TEXT columns, so the
 /// SQL is identical on both backends — only the pool differs.
 pub async fn fetch(db: &ConfigDb) -> Result<LandingCustomization> {
-    type Row = (
-        Option<String>, // header_bg
-        Option<String>, // header_fg
-        Option<String>, // intro
-        String,         // intro_locales_json
-        Option<String>, // seo_title
-        Option<String>, // seo_description
-        Option<String>, // og_image
-        Option<String>, // analytics_html
-        Option<String>, // analytics_origins
-        Option<String>, // custom_css
-        Option<String>, // logos_json
-        Option<String>, // title
-        Option<String>, // subtitle
-        Option<String>, // theme_colors_json
-        Option<bool>,   // show_highlights
-        Option<String>, // footer
-    );
+    // A named FromRow struct rather than a tuple: sqlx only implements
+    // FromRow for tuples up to 16 columns, and this row has outgrown that.
+    // Field names must match the SELECT's column names. The derive is
+    // generic over the backend, so one struct serves sqlite + postgres.
+    #[derive(sqlx::FromRow)]
+    struct Row {
+        header_bg: Option<String>,
+        header_fg: Option<String>,
+        intro: Option<String>,
+        intro_locales_json: String,
+        seo_title: Option<String>,
+        seo_description: Option<String>,
+        og_image: Option<String>,
+        analytics_html: Option<String>,
+        analytics_origins: Option<String>,
+        custom_css: Option<String>,
+        logos_json: Option<String>,
+        title: Option<String>,
+        subtitle: Option<String>,
+        theme_colors_json: Option<String>,
+        show_highlights: Option<bool>,
+        footer: Option<String>,
+        default_theme: Option<String>,
+    }
     let sql = "SELECT header_bg, header_fg, intro, intro_locales_json,
                 seo_title, seo_description, og_image,
                 analytics_html, analytics_origins, custom_css, logos_json,
-                title, subtitle, theme_colors_json, show_highlights, footer
+                title, subtitle, theme_colors_json, show_highlights, footer,
+                default_theme
            FROM landing_customization WHERE id = 1";
     let row: Option<Row> = match db {
         ConfigDb::Sqlite(pool) => sqlx::query_as(sql).fetch_optional(pool).await,
@@ -49,51 +56,34 @@ pub async fn fetch(db: &ConfigDb) -> Result<LandingCustomization> {
     .context("load landing_customization")?;
     match row {
         None => Ok(LandingCustomization::default()),
-        Some((
-            bg,
-            fg,
-            intro,
-            locales_json,
-            seo_title,
-            seo_description,
-            og_image,
-            analytics_html,
-            analytics_origins,
-            custom_css,
-            logos_json,
-            title,
-            subtitle,
-            theme_colors_json,
-            show_highlights,
-            footer,
-        )) => {
+        Some(r) => {
             let intro_locales =
-                serde_json::from_str(&locales_json).context("parse intro_locales_json")?;
+                serde_json::from_str(&r.intro_locales_json).context("parse intro_locales_json")?;
             // `logos_json` is NULL on rows created before migration 0010.
-            let logos = match logos_json {
+            let logos = match r.logos_json {
                 Some(j) if !j.trim().is_empty() => {
                     serde_json::from_str(&j).context("parse logos_json")?
                 }
                 _ => Vec::new(),
             };
             // `theme_colors_json` is NULL before migration 0012.
-            let theme_colors = match theme_colors_json {
+            let theme_colors = match r.theme_colors_json {
                 Some(j) if !j.trim().is_empty() => {
                     serde_json::from_str(&j).context("parse theme_colors_json")?
                 }
                 _ => Default::default(),
             };
             Ok(LandingCustomization {
-                header_bg: bg,
-                header_fg: fg,
-                intro,
+                header_bg: r.header_bg,
+                header_fg: r.header_fg,
+                intro: r.intro,
                 intro_locales,
-                seo_title,
-                seo_description,
-                og_image,
-                analytics_html,
-                analytics_origins,
-                custom_css,
+                seo_title: r.seo_title,
+                seo_description: r.seo_description,
+                og_image: r.og_image,
+                analytics_html: r.analytics_html,
+                analytics_origins: r.analytics_origins,
+                custom_css: r.custom_css,
                 // Blocks live in their own table; callers that render
                 // or export them load via `landing_blocks`.
                 blocks: Vec::new(),
@@ -101,11 +91,12 @@ pub async fn fetch(db: &ConfigDb) -> Result<LandingCustomization> {
                 // DB-backed editable customization.
                 show_admin_link: None,
                 logos,
-                title,
-                subtitle,
+                title: r.title,
+                subtitle: r.subtitle,
                 theme_colors,
-                show_highlights,
-                footer,
+                show_highlights: r.show_highlights,
+                footer: r.footer,
+                default_theme: r.default_theme,
             })
         }
     }
@@ -174,7 +165,7 @@ pub(crate) async fn update_in_tx(
                 og_image = ?, analytics_html = ?, analytics_origins = ?,
                 custom_css = ?, logos_json = ?, title = ?, subtitle = ?,
                 theme_colors_json = ?, show_highlights = ?, footer = ?,
-                updated_at = ?
+                default_theme = ?, updated_at = ?
           WHERE id = 1",
     )
     .bind(none_if_empty(&lc.header_bg))
@@ -193,6 +184,7 @@ pub(crate) async fn update_in_tx(
     .bind(&theme_colors_json)
     .bind(lc.show_highlights)
     .bind(none_if_empty(&lc.footer))
+    .bind(none_if_empty(&lc.default_theme))
     .bind(now)
     .execute(&mut **tx)
     .await
@@ -231,7 +223,8 @@ pub(crate) async fn update_in_tx_pg(
                 og_image = $7, analytics_html = $8, analytics_origins = $9,
                 custom_css = $10, logos_json = $11, title = $12,
                 subtitle = $13, theme_colors_json = $14,
-                show_highlights = $15, footer = $16, updated_at = $17
+                show_highlights = $15, footer = $16, default_theme = $17,
+                updated_at = $18
           WHERE id = 1",
     )
     .bind(none_if_empty(&lc.header_bg))
@@ -250,6 +243,7 @@ pub(crate) async fn update_in_tx_pg(
     .bind(&theme_colors_json)
     .bind(lc.show_highlights)
     .bind(none_if_empty(&lc.footer))
+    .bind(none_if_empty(&lc.default_theme))
     .bind(now)
     .execute(&mut **tx)
     .await
@@ -354,6 +348,18 @@ mod tests {
         update(&ConfigDb::Sqlite(pool.clone()), &lc, Some("admin")).await.unwrap();
         let got = fetch(&ConfigDb::Sqlite(pool.clone())).await.unwrap();
         assert_eq!(got.footer.as_deref(), Some("© 2026 Acme"));
+    }
+
+    #[tokio::test]
+    async fn default_theme_roundtrips() {
+        let pool = open_memory().await.unwrap();
+        let lc = LandingCustomization {
+            default_theme: Some("dark".into()),
+            ..Default::default()
+        };
+        update(&ConfigDb::Sqlite(pool.clone()), &lc, Some("admin")).await.unwrap();
+        let got = fetch(&ConfigDb::Sqlite(pool.clone())).await.unwrap();
+        assert_eq!(got.default_theme.as_deref(), Some("dark"));
     }
 
     #[tokio::test]

--- a/crates/ruscker-admin/src/routes/admin/landing.rs
+++ b/crates/ruscker-admin/src/routes/admin/landing.rs
@@ -91,6 +91,7 @@ pub struct LandingForm {
     pub title: String,
     pub subtitle: String,
     pub footer: String,
+    pub default_theme: String,
     // Per-theme color overrides (#475); blank ⇒ keep the theme default.
     pub theme_light_bg: String,
     pub theme_light_text: String,
@@ -131,6 +132,7 @@ impl LandingForm {
             title: lc.title.clone().unwrap_or_default(),
             subtitle: lc.subtitle.clone().unwrap_or_default(),
             footer: lc.footer.clone().unwrap_or_default(),
+            default_theme: lc.default_theme.clone().unwrap_or_default(),
             theme_light_bg: s(&tc.light.bg),
             theme_light_text: s(&tc.light.text),
             theme_light_accent: s(&tc.light.accent),
@@ -189,6 +191,13 @@ impl LandingForm {
             title: empty_to_none(self.title),
             subtitle: empty_to_none(self.subtitle),
             footer: empty_to_none(self.footer),
+            // Only an explicit light/dark is a real override; auto/blank
+            // means "let the OS decide", stored as NULL.
+            default_theme: match self.default_theme.trim() {
+                "light" => Some("light".into()),
+                "dark" => Some("dark".into()),
+                _ => None,
+            },
             theme_colors,
             header_bg: empty_to_none(self.header_bg),
             header_fg: empty_to_none(self.header_fg),

--- a/crates/ruscker-admin/src/routes/landing.rs
+++ b/crates/ruscker-admin/src/routes/landing.rs
@@ -324,6 +324,19 @@ async fn index(
     // theme CSS variables for light / dark / OS-auto.
     let theme_style = build_theme_style(&lc.theme_colors);
 
+    // Operator default theme for a cookieless visitor: when the request
+    // carries no explicit light/dark choice (Auto), honor the configured
+    // `default-theme`. The visitor's own toggle still overrides it (it sets
+    // the cookie, which makes `theme` non-Auto here).
+    let theme = if theme.is_auto() {
+        match lc.default_theme.as_deref() {
+            Some("light") => Theme::Light,
+            Some("dark") => Theme::Dark,
+            _ => theme,
+        }
+    } else {
+        theme
+    };
     let page = LandingPage {
         locale: loc,
         theme,

--- a/crates/ruscker-admin/templates/admin/landing.html
+++ b/crates/ruscker-admin/templates/admin/landing.html
@@ -184,7 +184,7 @@
       <div class="spec-form-help" style="margin-bottom:8px">{{ self.t("admin-landing-theme-colors-help") }}</div>
       <div class="grid grid-cols-2 gap-4">
         <div>
-          <div class="spec-form-label" style="margin-bottom:6px">☀️ {{ self.t("admin-landing-theme-light") }}</div>
+          <div class="spec-form-label" style="margin-bottom:6px">☀️ {{ self.t("theme-light") }}</div>
           <div class="spec-form-field">
             <label class="spec-form-label">{{ self.t("admin-landing-theme-bg") }}</label>
             <div class="color-input">
@@ -211,7 +211,7 @@
           </div>
         </div>
         <div>
-          <div class="spec-form-label" style="margin-bottom:6px">🌙 {{ self.t("admin-landing-theme-dark") }}</div>
+          <div class="spec-form-label" style="margin-bottom:6px">🌙 {{ self.t("theme-dark") }}</div>
           <div class="spec-form-field">
             <label class="spec-form-label">{{ self.t("admin-landing-theme-bg") }}</label>
             <div class="color-input">
@@ -239,6 +239,27 @@
         </div>
       </div>
 
+      </section>
+
+      {# ── Card: Default theme — the portal theme a cookieless visitor
+         gets first (their own toggle still overrides it). #}
+      <section class="editor-card">
+        <div class="form-section__title">{{ self.t("admin-landing-default-theme") }}</div>
+        <input type="hidden" name="default_theme" :value="form.default_theme">
+        <div class="spec-form-field">
+          <div class="seg-control" role="group">
+            <button type="button" :class="{ 'is-active': form.default_theme === 'light' }" @click="form.default_theme = 'light'">
+              <i class="ti ti-sun" aria-hidden="true"></i> {{ self.t("theme-light") }}
+            </button>
+            <button type="button" :class="{ 'is-active': form.default_theme === 'dark' }" @click="form.default_theme = 'dark'">
+              <i class="ti ti-moon" aria-hidden="true"></i> {{ self.t("theme-dark") }}
+            </button>
+            <button type="button" :class="{ 'is-active': form.default_theme !== 'light' && form.default_theme !== 'dark' }" @click="form.default_theme = 'auto'">
+              <i class="ti ti-device-desktop" aria-hidden="true"></i> {{ self.t("theme-auto") }}
+            </button>
+          </div>
+          <div class="spec-form-help">{{ self.t("admin-landing-default-theme-help") }}</div>
+        </div>
       </section>
 
       {# ── Card: Header / footer logos (#468). #}

--- a/crates/ruscker-config/src/schema.rs
+++ b/crates/ruscker-config/src/schema.rs
@@ -359,6 +359,13 @@ pub struct LandingCustomization {
     #[serde(default)]
     pub footer: Option<String>,
 
+    /// Default portal theme for a visitor with no theme cookie:
+    /// `"light"`, `"dark"`, or `"auto"` (let the OS decide). Blank/`auto`
+    /// ⇒ OS `prefers-color-scheme`. Admin-managed via the appearance
+    /// editor; the visitor's own toggle still overrides it.
+    #[serde(default, rename = "default-theme")]
+    pub default_theme: Option<String>,
+
     /// Free-form intro paragraph rendered between the header and
     /// the filter section. Operator-authored, plain text (no HTML).
     ///


### PR DESCRIPTION
**Roadmap 2/9.** A `default-theme` (light/dark/auto) sets the portal theme a cookieless visitor sees first; their own toggle still wins. Schema + migration + dual-backend persistence; `db::landing::fetch` moved off the 16-tuple FromRow ceiling to a named FromRow struct (future-proofs the remaining columns); DEFAULT THEME segmented control; portal applies it when the request theme is Auto. i18n + round-trip test. Green: build · clippy · i18n · tests.

🤖 Generated with [Claude Code](https://claude.com/claude-code)