### PR TITLE
feat(appearance): brand-color swatch row (4/9)

### DIFF
--- a/crates/ruscker-admin/assets/i18n/en/landing.ftl
+++ b/crates/ruscker-admin/assets/i18n/en/landing.ftl
@@ -690,6 +690,9 @@ admin-landing-default-theme-help = The initial theme for a first-time visitor. T
 admin-landing-visible-sections = Visible sections
 admin-landing-show-search = Search bar
 admin-landing-show-filters = Access filters (public/restricted)
+admin-landing-brand-color = Brand color
+admin-landing-brand-color-help = A shortcut for the accent (light and dark). Fine-tune in Appearance.
+
 
 
 

--- a/crates/ruscker-admin/assets/i18n/es/landing.ftl
+++ b/crates/ruscker-admin/assets/i18n/es/landing.ftl
@@ -690,6 +690,9 @@ admin-landing-default-theme-help = El tema inicial para un visitante nuevo. Aún
 admin-landing-visible-sections = Secciones visibles
 admin-landing-show-search = Barra de búsqueda
 admin-landing-show-filters = Filtros de acceso (público/restringido)
+admin-landing-brand-color = Color de marca
+admin-landing-brand-color-help = Atajo para el acento (claro y oscuro). Ajuste fino en Apariencia.
+
 
 
 

--- a/crates/ruscker-admin/assets/i18n/fr/landing.ftl
+++ b/crates/ruscker-admin/assets/i18n/fr/landing.ftl
@@ -690,6 +690,9 @@ admin-landing-default-theme-help = Le thème initial pour un nouveau visiteur. I
 admin-landing-visible-sections = Sections visibles
 admin-landing-show-search = Barre de recherche
 admin-landing-show-filters = Filtres d'accès (public/restreint)
+admin-landing-brand-color = Couleur de marque
+admin-landing-brand-color-help = Un raccourci pour l'accent (clair et sombre). Réglage fin dans Apparence.
+
 
 
 

--- a/crates/ruscker-admin/assets/i18n/pt/landing.ftl
+++ b/crates/ruscker-admin/assets/i18n/pt/landing.ftl
@@ -694,6 +694,9 @@ admin-landing-default-theme-help = O tema inicial para quem nunca escolheu. O vi
 admin-landing-visible-sections = Seções visíveis
 admin-landing-show-search = Barra de busca
 admin-landing-show-filters = Filtros de acesso (público/restrito)
+admin-landing-brand-color = Cor da marca
+admin-landing-brand-color-help = Atalho para o accent (claro e escuro). Ajuste fino em Aparência.
+
 
 
 

--- a/crates/ruscker-admin/assets/tailwind/input.css
+++ b/crates/ruscker-admin/assets/tailwind/input.css
@@ -192,6 +192,20 @@ body {
   .topbar-progress { transition: opacity 0.25s ease; }
 }
 
+/* Brand-color swatch row (appearance editor, ruscker-06): quick-pick
+   accent presets. The active swatch gets a ring; clicking sets the
+   light/dark accent. */
+.brand-swatches { display: flex; flex-wrap: wrap; gap: 10px; }
+.brand-swatch {
+  width: 30px; height: 30px; border-radius: 8px; cursor: pointer;
+  border: 1px solid color-mix(in srgb, var(--text) 12%, transparent);
+  padding: 0; transition: transform 0.1s ease, box-shadow 0.15s ease;
+}
+.brand-swatch:hover { transform: translateY(-1px); }
+.brand-swatch.is-active {
+  box-shadow: 0 0 0 2px var(--surface), 0 0 0 4px currentColor;
+}
+
 /* ─── Dashboard: KPI cards + app-grouped replicas (handoff #623) ───
  * Replaces the flat replica table with metric cards on top and one
  * expandable card per app. Dot classes reuse the server-emitted names

--- a/crates/ruscker-admin/templates/admin/landing.html
+++ b/crates/ruscker-admin/templates/admin/landing.html
@@ -90,6 +90,23 @@
 
       </section>
 
+      {# ── Card: Brand color — quick-pick accent presets (sets the
+         light + dark accent; fine-tune in Appearance below). #}
+      <section class="editor-card">
+        <div class="form-section__title">{{ self.t("admin-landing-brand-color") }}</div>
+        <div class="spec-form-field">
+          <div class="brand-swatches">
+            {% for c in ["#0f6e56", "#2563eb", "#1e3a5f", "#10b981", "#ec4899", "#8b5cf6"] %}
+            <button type="button" class="brand-swatch" style="background:{{ c }};color:{{ c }}"
+                    :class="{ 'is-active': (form.theme_light_accent || '').toLowerCase() === '{{ c }}' }"
+                    @click="form.theme_light_accent = '{{ c }}'; form.theme_dark_accent = '{{ c }}'"
+                    aria-label="{{ c }}"></button>
+            {% endfor %}
+          </div>
+          <div class="spec-form-help">{{ self.t("admin-landing-brand-color-help") }}</div>
+        </div>
+      </section>
+
       {# ── Card: Appearance — header colours + per-theme palettes. #}
       <section class="editor-card">
         <div class="form-section__title">{{ self.t("admin-landing-card-appearance") }}</div>


### PR DESCRIPTION
**Roadmap 4/9.** A BRAND COLOR card: six accent presets as a swatch row; clicking sets the light+dark accent. Editor UI over the existing theme-accent fields, no schema change. Green: build · i18n.

🤖 Generated with [Claude Code](https://claude.com/claude-code)