### PR TITLE
feat(appearance): header logo mode/size/margin (5/9)

### DIFF
--- a/crates/ruscker-admin/assets/i18n/en/landing.ftl
+++ b/crates/ruscker-admin/assets/i18n/en/landing.ftl
@@ -692,6 +692,13 @@ admin-landing-show-search = Search bar
 admin-landing-show-filters = Access filters (public/restricted)
 admin-landing-brand-color = Brand color
 admin-landing-brand-color-help = A shortcut for the accent (light and dark). Fine-tune in Appearance.
+admin-landing-logo-card = Logo
+admin-landing-logo-mode-mark = Mark + name
+admin-landing-logo-mode-symbol = Symbol only
+admin-landing-logo-mode-custom = Custom
+admin-landing-logo-size = Logo size
+admin-landing-logo-margin = Logo margin
+
 
 
 

--- a/crates/ruscker-admin/assets/i18n/es/landing.ftl
+++ b/crates/ruscker-admin/assets/i18n/es/landing.ftl
@@ -692,6 +692,13 @@ admin-landing-show-search = Barra de búsqueda
 admin-landing-show-filters = Filtros de acceso (público/restringido)
 admin-landing-brand-color = Color de marca
 admin-landing-brand-color-help = Atajo para el acento (claro y oscuro). Ajuste fino en Apariencia.
+admin-landing-logo-card = Logo
+admin-landing-logo-mode-mark = Marca + nombre
+admin-landing-logo-mode-symbol = Solo símbolo
+admin-landing-logo-mode-custom = Personalizado
+admin-landing-logo-size = Tamaño del logo
+admin-landing-logo-margin = Margen del logo
+
 
 
 

--- a/crates/ruscker-admin/assets/i18n/fr/landing.ftl
+++ b/crates/ruscker-admin/assets/i18n/fr/landing.ftl
@@ -692,6 +692,13 @@ admin-landing-show-search = Barre de recherche
 admin-landing-show-filters = Filtres d'accès (public/restreint)
 admin-landing-brand-color = Couleur de marque
 admin-landing-brand-color-help = Un raccourci pour l'accent (clair et sombre). Réglage fin dans Apparence.
+admin-landing-logo-card = Logo
+admin-landing-logo-mode-mark = Marque + nom
+admin-landing-logo-mode-symbol = Symbole seul
+admin-landing-logo-mode-custom = Personnalisé
+admin-landing-logo-size = Taille du logo
+admin-landing-logo-margin = Marge du logo
+
 
 
 

--- a/crates/ruscker-admin/assets/i18n/pt/landing.ftl
+++ b/crates/ruscker-admin/assets/i18n/pt/landing.ftl
@@ -696,6 +696,13 @@ admin-landing-show-search = Barra de busca
 admin-landing-show-filters = Filtros de acesso (público/restrito)
 admin-landing-brand-color = Cor da marca
 admin-landing-brand-color-help = Atalho para o accent (claro e escuro). Ajuste fino em Aparência.
+admin-landing-logo-card = Logo
+admin-landing-logo-mode-mark = Marca + nome
+admin-landing-logo-mode-symbol = Só símbolo
+admin-landing-logo-mode-custom = Personalizado
+admin-landing-logo-size = Tamanho do logo
+admin-landing-logo-margin = Margem do logo
+
 
 
 

--- a/crates/ruscker-admin/src/routes/admin/landing.rs
+++ b/crates/ruscker-admin/src/routes/admin/landing.rs
@@ -148,9 +148,10 @@ impl LandingForm {
             // Checkboxes: default-on, so a missing stored value pre-checks.
             show_search: if lc.show_search.unwrap_or(true) { "on".into() } else { String::new() },
             show_filters: if lc.show_filters.unwrap_or(true) { "on".into() } else { String::new() },
-            logo_mode: lc.logo_mode.clone().unwrap_or_default(),
-            logo_size: lc.logo_size.map(|n| n.to_string()).unwrap_or_default(),
-            logo_margin: lc.logo_margin.map(|n| n.to_string()).unwrap_or_default(),
+            logo_mode: lc.logo_mode.clone().unwrap_or_else(|| "mark".into()),
+            // Defaulted so the editor sliders show the effective value.
+            logo_size: lc.logo_size.unwrap_or(28).to_string(),
+            logo_margin: lc.logo_margin.unwrap_or(8).to_string(),
             header_preset: lc.header_preset.clone().unwrap_or_default(),
             card_cover: lc.card_cover.clone().unwrap_or_default(),
             catalog_layout: lc.catalog_layout.clone().unwrap_or_default(),

--- a/crates/ruscker-admin/templates/admin/landing.html
+++ b/crates/ruscker-admin/templates/admin/landing.html
@@ -107,6 +107,29 @@
         </div>
       </section>
 
+      {# ── Card: Logo — header brand presentation + size/margin. #}
+      <section class="editor-card">
+        <div class="form-section__title">{{ self.t("admin-landing-logo-card") }}</div>
+        <input type="hidden" name="logo_mode" :value="form.logo_mode">
+        <input type="hidden" name="logo_size" :value="form.logo_size">
+        <input type="hidden" name="logo_margin" :value="form.logo_margin">
+        <div class="spec-form-field">
+          <div class="seg-control" role="group">
+            <button type="button" :class="{ 'is-active': (form.logo_mode || 'mark') === 'mark' }" @click="form.logo_mode = 'mark'">{{ self.t("admin-landing-logo-mode-mark") }}</button>
+            <button type="button" :class="{ 'is-active': form.logo_mode === 'symbol' }" @click="form.logo_mode = 'symbol'">{{ self.t("admin-landing-logo-mode-symbol") }}</button>
+            <button type="button" :class="{ 'is-active': form.logo_mode === 'custom' }" @click="form.logo_mode = 'custom'">{{ self.t("admin-landing-logo-mode-custom") }}</button>
+          </div>
+        </div>
+        <div class="spec-form-field">
+          <label class="spec-form-label">{{ self.t("admin-landing-logo-size") }} · <span x-text="(form.logo_size || '28') + 'px'"></span></label>
+          <input type="range" min="12" max="64" step="1" x-model="form.logo_size" style="width:100%">
+        </div>
+        <div class="spec-form-field">
+          <label class="spec-form-label">{{ self.t("admin-landing-logo-margin") }} · <span x-text="(form.logo_margin || '8') + 'px'"></span></label>
+          <input type="range" min="0" max="40" step="1" x-model="form.logo_margin" style="width:100%">
+        </div>
+      </section>
+
       {# ── Card: Appearance — header colours + per-theme palettes. #}
       <section class="editor-card">
         <div class="form-section__title">{{ self.t("admin-landing-card-appearance") }}</div>

--- a/crates/ruscker-admin/templates/landing.html
+++ b/crates/ruscker-admin/templates/landing.html
@@ -43,27 +43,33 @@
          surface, or a monochrome `currentColor` mark when a custom header
          background is in play (a brand polygon can collide with the chosen
          background — e.g. teal on teal disappears). #}
+      {# Brand mark: operator header-left logos win; otherwise the built-in
+         mark, unless logo-mode is `custom` (operator logos only). Size and
+         right margin come from the appearance editor (#623). #}
       {% if self.has_logos_at("header", "left") %}
         {% call logos(self.logo_view("header", "left", 28)) %}{% endcall %}
-      {% else %}
+      {% else if logo_mode != "custom" %}
         {% if header_style.is_empty() %}
-        <svg viewBox="0 0 80 80" width="28" height="28" aria-hidden="true" class="flex-none">
+        <svg viewBox="0 0 80 80" width="{{ logo_size }}" height="{{ logo_size }}" style="margin-right:{{ logo_margin }}px" aria-hidden="true" class="flex-none">
           <polygon points="14,52 40,40 66,52 40,64" fill="#0F6E56"/>
           <polygon points="14,40 40,28 66,40 40,52" fill="#1D9E75"/>
           <polygon points="14,28 40,16 66,28 40,40" fill="#5DCAA5"/>
         </svg>
         {% else %}
-        <svg viewBox="0 0 80 80" width="28" height="28" aria-hidden="true" class="flex-none">
+        <svg viewBox="0 0 80 80" width="{{ logo_size }}" height="{{ logo_size }}" style="margin-right:{{ logo_margin }}px" aria-hidden="true" class="flex-none">
           <polygon points="14,52 40,40 66,52 40,64" fill="currentColor" opacity="0.45"/>
           <polygon points="14,40 40,28 66,40 40,52" fill="currentColor" opacity="0.7"/>
           <polygon points="14,28 40,16 66,28 40,40" fill="currentColor" opacity="1"/>
         </svg>
         {% endif %}
       {% endif %}
+      {# Name + subtitle, hidden in `symbol` (mark-only) mode. #}
+      {% if logo_mode != "symbol" %}
       <div>
         <h1 class="text-xl font-medium tracking-tight">{{ header_title }}</h1>
         {% if !header_subtitle.is_empty() %}<p class="text-xs opacity-70 mt-1">{{ header_subtitle }}</p>{% endif %}
       </div>
+      {% endif %}
     </div>
     {# Header-center logo(s) (#468): absolutely centred within the header
        bar (the empty middle between the title and the chrome), so they read


### PR DESCRIPTION
**Roadmap 5/9.** LOGO card (mode mark+name/symbol/custom + size/margin sliders) wired to the portal header: size/margin size the built-in mark; symbol hides the name; custom hides the mark (operator logos only). Green: build · clippy · i18n.

🤖 Generated with [Claude Code](https://claude.com/claude-code)