### PR TITLE
feat(appearance): header presets, card covers, catalog layout + density (6-7/9)

### DIFF
--- a/crates/ruscker-admin/assets/i18n/en/landing.ftl
+++ b/crates/ruscker-admin/assets/i18n/en/landing.ftl
@@ -698,6 +698,20 @@ admin-landing-logo-mode-symbol = Symbol only
 admin-landing-logo-mode-custom = Custom
 admin-landing-logo-size = Logo size
 admin-landing-logo-margin = Logo margin
+admin-landing-background = Background & gradients
+admin-landing-header-bg-preset = Portal header
+admin-landing-preset-flat = Flat
+admin-landing-preset-soft = Soft
+admin-landing-preset-bold = Bold
+admin-landing-card-covers = Card covers
+admin-landing-cover-tinted = Tinted
+admin-landing-cover-gradient = Gradient
+admin-landing-catalog-layout = Catalog layout
+admin-landing-layout-grid = Grid
+admin-landing-layout-list = List
+admin-landing-density-comfortable = Comfortable
+admin-landing-density-compact = Compact
+
 
 
 

--- a/crates/ruscker-admin/assets/i18n/es/landing.ftl
+++ b/crates/ruscker-admin/assets/i18n/es/landing.ftl
@@ -698,6 +698,20 @@ admin-landing-logo-mode-symbol = Solo símbolo
 admin-landing-logo-mode-custom = Personalizado
 admin-landing-logo-size = Tamaño del logo
 admin-landing-logo-margin = Margen del logo
+admin-landing-background = Fondo y degradados
+admin-landing-header-bg-preset = Cabecera del portal
+admin-landing-preset-flat = Plano
+admin-landing-preset-soft = Suave
+admin-landing-preset-bold = Intenso
+admin-landing-card-covers = Portadas de tarjetas
+admin-landing-cover-tinted = Tintada
+admin-landing-cover-gradient = Degradado
+admin-landing-catalog-layout = Diseño del catálogo
+admin-landing-layout-grid = Cuadrícula
+admin-landing-layout-list = Lista
+admin-landing-density-comfortable = Cómodo
+admin-landing-density-compact = Compacto
+
 
 
 

--- a/crates/ruscker-admin/assets/i18n/fr/landing.ftl
+++ b/crates/ruscker-admin/assets/i18n/fr/landing.ftl
@@ -698,6 +698,20 @@ admin-landing-logo-mode-symbol = Symbole seul
 admin-landing-logo-mode-custom = Personnalisé
 admin-landing-logo-size = Taille du logo
 admin-landing-logo-margin = Marge du logo
+admin-landing-background = Fond et dégradés
+admin-landing-header-bg-preset = En-tête du portail
+admin-landing-preset-flat = Plat
+admin-landing-preset-soft = Doux
+admin-landing-preset-bold = Marqué
+admin-landing-card-covers = Couvertures des cartes
+admin-landing-cover-tinted = Teintée
+admin-landing-cover-gradient = Dégradé
+admin-landing-catalog-layout = Disposition du catalogue
+admin-landing-layout-grid = Grille
+admin-landing-layout-list = Liste
+admin-landing-density-comfortable = Confortable
+admin-landing-density-compact = Compact
+
 
 
 

--- a/crates/ruscker-admin/assets/i18n/pt/landing.ftl
+++ b/crates/ruscker-admin/assets/i18n/pt/landing.ftl
@@ -702,6 +702,20 @@ admin-landing-logo-mode-symbol = Só símbolo
 admin-landing-logo-mode-custom = Personalizado
 admin-landing-logo-size = Tamanho do logo
 admin-landing-logo-margin = Margem do logo
+admin-landing-background = Fundo e gradientes
+admin-landing-header-bg-preset = Cabeçalho do portal
+admin-landing-preset-flat = Plano
+admin-landing-preset-soft = Suave
+admin-landing-preset-bold = Forte
+admin-landing-card-covers = Capas dos cards
+admin-landing-cover-tinted = Tonalizada
+admin-landing-cover-gradient = Gradiente
+admin-landing-catalog-layout = Layout do catálogo
+admin-landing-layout-grid = Grade
+admin-landing-layout-list = Lista
+admin-landing-density-comfortable = Confortável
+admin-landing-density-compact = Compacto
+
 
 
 

--- a/crates/ruscker-admin/assets/tailwind/input.css
+++ b/crates/ruscker-admin/assets/tailwind/input.css
@@ -206,6 +206,35 @@ body {
   box-shadow: 0 0 0 2px var(--surface), 0 0 0 4px currentColor;
 }
 
+/* Appearance: portal header background presets (ruscker-06). A custom
+   `header-bg` (inline style) still overrides these. Tints keep the header
+   text readable, so `bold` is a stronger tint, not a saturated fill. */
+.lp-hdr-flat { background: var(--surface); }
+.lp-hdr-soft {
+  background: linear-gradient(180deg,
+    color-mix(in srgb, #0f6e56 7%, var(--surface)), var(--surface));
+}
+.lp-hdr-bold {
+  background: linear-gradient(120deg,
+    color-mix(in srgb, #0f6e56 17%, var(--surface)),
+    color-mix(in srgb, #5dcaa5 12%, var(--surface)));
+}
+
+/* Appearance: card cover style. `tinted` is the default flat tint;
+   `gradient` lays a directional shade over each cover for depth. */
+.cover-gradient .rcover-bg {
+  background-image: linear-gradient(135deg, rgba(255,255,255,0.10), rgba(0,0,0,0.16));
+}
+
+/* Appearance: catalog density — `compact` tightens the card grid. */
+.cards-grid.is-compact { gap: 10px; }
+.cards-grid.is-compact .rcover { height: 84px; }
+
+/* Appearance: `list` layout — one card per row, cover left, meta right. */
+.cards-grid.is-list { grid-template-columns: 1fr; gap: 8px; }
+.cards-grid.is-list .rcard { display: grid; grid-template-columns: 120px 1fr; align-items: stretch; }
+.cards-grid.is-list .rcover { height: 100%; min-height: 64px; }
+
 /* ─── Dashboard: KPI cards + app-grouped replicas (handoff #623) ───
  * Replaces the flat replica table with metric cards on top and one
  * expandable card per app. Dot classes reuse the server-emitted names

--- a/crates/ruscker-admin/templates/admin/landing.html
+++ b/crates/ruscker-admin/templates/admin/landing.html
@@ -130,6 +130,47 @@
         </div>
       </section>
 
+      {# ── Card: Background — header preset + card cover style. #}
+      <section class="editor-card">
+        <div class="form-section__title">{{ self.t("admin-landing-background") }}</div>
+        <input type="hidden" name="header_preset" :value="form.header_preset">
+        <input type="hidden" name="card_cover" :value="form.card_cover">
+        <div class="spec-form-field">
+          <label class="spec-form-label">{{ self.t("admin-landing-header-bg-preset") }}</label>
+          <div class="seg-control" role="group">
+            <button type="button" :class="{ 'is-active': (form.header_preset || 'soft') === 'flat' }" @click="form.header_preset = 'flat'">{{ self.t("admin-landing-preset-flat") }}</button>
+            <button type="button" :class="{ 'is-active': (form.header_preset || 'soft') === 'soft' }" @click="form.header_preset = 'soft'">{{ self.t("admin-landing-preset-soft") }}</button>
+            <button type="button" :class="{ 'is-active': form.header_preset === 'bold' }" @click="form.header_preset = 'bold'">{{ self.t("admin-landing-preset-bold") }}</button>
+          </div>
+        </div>
+        <div class="spec-form-field">
+          <label class="spec-form-label">{{ self.t("admin-landing-card-covers") }}</label>
+          <div class="seg-control" role="group">
+            <button type="button" :class="{ 'is-active': (form.card_cover || 'tinted') === 'tinted' }" @click="form.card_cover = 'tinted'">{{ self.t("admin-landing-cover-tinted") }}</button>
+            <button type="button" :class="{ 'is-active': form.card_cover === 'gradient' }" @click="form.card_cover = 'gradient'">{{ self.t("admin-landing-cover-gradient") }}</button>
+          </div>
+        </div>
+      </section>
+
+      {# ── Card: Catalog layout — grid/list + density. #}
+      <section class="editor-card">
+        <div class="form-section__title">{{ self.t("admin-landing-catalog-layout") }}</div>
+        <input type="hidden" name="catalog_layout" :value="form.catalog_layout">
+        <input type="hidden" name="catalog_density" :value="form.catalog_density">
+        <div class="spec-form-field">
+          <div class="seg-control" role="group">
+            <button type="button" :class="{ 'is-active': (form.catalog_layout || 'grid') === 'grid' }" @click="form.catalog_layout = 'grid'">{{ self.t("admin-landing-layout-grid") }}</button>
+            <button type="button" :class="{ 'is-active': form.catalog_layout === 'list' }" @click="form.catalog_layout = 'list'">{{ self.t("admin-landing-layout-list") }}</button>
+          </div>
+        </div>
+        <div class="spec-form-field">
+          <div class="seg-control" role="group">
+            <button type="button" :class="{ 'is-active': (form.catalog_density || 'comfortable') === 'comfortable' }" @click="form.catalog_density = 'comfortable'">{{ self.t("admin-landing-density-comfortable") }}</button>
+            <button type="button" :class="{ 'is-active': form.catalog_density === 'compact' }" @click="form.catalog_density = 'compact'">{{ self.t("admin-landing-density-compact") }}</button>
+          </div>
+        </div>
+      </section>
+
       {# ── Card: Appearance — header colours + per-theme palettes. #}
       <section class="editor-card">
         <div class="form-section__title">{{ self.t("admin-landing-card-appearance") }}</div>

--- a/crates/ruscker-admin/templates/landing.html
+++ b/crates/ruscker-admin/templates/landing.html
@@ -32,7 +32,7 @@
 
 {% block content %}
 
-<header class="border-b border-[color:var(--border)]"
+<header class="border-b border-[color:var(--border)] lp-hdr-{{ header_preset }}"
         {% if !header_style.is_empty() %}style="{{ header_style }}"{% endif %}>
   <div class="max-w-6xl mx-auto px-6 py-5 flex items-center justify-between gap-6 relative">
     <div class="flex items-center gap-3">
@@ -96,7 +96,7 @@
 <section class="landing-block landing-block--top px-6 max-w-6xl mx-auto w-full">{{ b.html|safe }}</section>
 {% endfor %}
 
-<main class="flex-1 px-6 py-6 max-w-6xl mx-auto w-full"
+<main class="flex-1 px-6 py-6 max-w-6xl mx-auto w-full cover-{{ card_cover }}"
       x-data="ruscker.landing()" x-cloak>
 
   {% if !intro.is_empty() %}
@@ -276,7 +276,7 @@
   </div>{# /portal-sticky #}
 
   {# ── Card grid (fixed-width cards, columns auto-fill) ──────── #}
-  <section class="cards-grid stagger" x-ref="grid">
+  <section class="cards-grid stagger{% if catalog_layout == "list" %} is-list{% endif %}{% if catalog_density == "compact" %} is-compact{% endif %}" x-ref="grid">
     {% for card in cards %}
       <a class="rcard {% if !card.active %}inactive{% endif %}"
          href="{% if card.active %}{{ card.href }}{% else %}#{% endif %}"


### PR DESCRIPTION
**Roadmap 6-7/9.** BACKGROUND card (header preset flat/soft/bold + card cover tinted/gradient) and CATALOG LAYOUT card (grid/list + comfortable/compact density), wired to the portal via scoped CSS classes on the header, main, and `.cards-grid`. Built on the foundation fields. 'Sections' layout + analytics-provider snippet are deferred follow-ups (no dead controls). Green: build · i18n.

🤖 Generated with [Claude Code](https://claude.com/claude-code)