### PR TITLE
fix(i18n): drop duplicate admin-landing-logo-margin (main was broken)

### DIFF
--- a/crates/ruscker-admin/assets/i18n/en/landing.ftl
+++ b/crates/ruscker-admin/assets/i18n/en/landing.ftl
@@ -697,7 +697,6 @@ admin-landing-logo-mode-mark = Mark + name
 admin-landing-logo-mode-symbol = Symbol only
 admin-landing-logo-mode-custom = Custom
 admin-landing-logo-size = Logo size
-admin-landing-logo-margin = Logo margin
 admin-landing-background = Background & gradients
 admin-landing-header-bg-preset = Portal header
 admin-landing-preset-flat = Flat

--- a/crates/ruscker-admin/assets/i18n/es/landing.ftl
+++ b/crates/ruscker-admin/assets/i18n/es/landing.ftl
@@ -697,7 +697,6 @@ admin-landing-logo-mode-mark = Marca + nombre
 admin-landing-logo-mode-symbol = Solo símbolo
 admin-landing-logo-mode-custom = Personalizado
 admin-landing-logo-size = Tamaño del logo
-admin-landing-logo-margin = Margen del logo
 admin-landing-background = Fondo y degradados
 admin-landing-header-bg-preset = Cabecera del portal
 admin-landing-preset-flat = Plano

--- a/crates/ruscker-admin/assets/i18n/fr/landing.ftl
+++ b/crates/ruscker-admin/assets/i18n/fr/landing.ftl
@@ -697,7 +697,6 @@ admin-landing-logo-mode-mark = Marque + nom
 admin-landing-logo-mode-symbol = Symbole seul
 admin-landing-logo-mode-custom = Personnalisé
 admin-landing-logo-size = Taille du logo
-admin-landing-logo-margin = Marge du logo
 admin-landing-background = Fond et dégradés
 admin-landing-header-bg-preset = En-tête du portail
 admin-landing-preset-flat = Plat

--- a/crates/ruscker-admin/assets/i18n/pt/landing.ftl
+++ b/crates/ruscker-admin/assets/i18n/pt/landing.ftl
@@ -701,7 +701,6 @@ admin-landing-logo-mode-mark = Marca + nome
 admin-landing-logo-mode-symbol = Só símbolo
 admin-landing-logo-mode-custom = Personalizado
 admin-landing-logo-size = Tamanho do logo
-admin-landing-logo-margin = Margem do logo
 admin-landing-background = Fundo e gradientes
 admin-landing-header-bg-preset = Cabeçalho do portal
 admin-landing-preset-flat = Plano


### PR DESCRIPTION
The logo slice (#695) duplicated an existing `admin-landing-logo-margin` message; Fluent rejects duplicate ids, so `Locales::load()` failed at runtime — main has been broken since #695. The parity gate doesn't catch intra-locale dups; the loader test does. Fix removes the dupe (slider reuses the existing key). All tests green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)