### PR TITLE
chore(release): bump workspace version 0.1.89 → 0.1.90

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2845,7 +2845,7 @@ dependencies = [
 
 [[package]]
 name = "ruscker-admin"
-version = "0.1.89"
+version = "0.1.90"
 dependencies = [
  "aes-gcm",
  "anyhow",
@@ -2895,7 +2895,7 @@ dependencies = [
 
 [[package]]
 name = "ruscker-cli"
-version = "0.1.89"
+version = "0.1.90"
 dependencies = [
  "anyhow",
  "clap",
@@ -2915,7 +2915,7 @@ dependencies = [
 
 [[package]]
 name = "ruscker-config"
-version = "0.1.89"
+version = "0.1.90"
 dependencies = [
  "chrono",
  "ordered-float",
@@ -2930,7 +2930,7 @@ dependencies = [
 
 [[package]]
 name = "ruscker-core"
-version = "0.1.89"
+version = "0.1.90"
 dependencies = [
  "async-trait",
  "chrono",
@@ -2943,7 +2943,7 @@ dependencies = [
 
 [[package]]
 name = "ruscker-docker"
-version = "0.1.89"
+version = "0.1.90"
 dependencies = [
  "anyhow",
  "async-stream",
@@ -2962,7 +2962,7 @@ dependencies = [
 
 [[package]]
 name = "ruscker-proxy"
-version = "0.1.89"
+version = "0.1.90"
 dependencies = [
  "anyhow",
  "axum",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -10,7 +10,7 @@ members = [
 ]
 
 [workspace.package]
-version = "0.1.89"
+version = "0.1.90"
 edition = "2021"
 rust-version = "1.85"
 license = "Apache-2.0"

--- a/book/src/news.md
+++ b/book/src/news.md
@@ -9,6 +9,31 @@ the [GitHub releases page](https://github.com/StrategicProjects/ruscker/releases
 
 ---
 
+## v0.1.90 — 2026-06-08
+
+Appearance editor rebuilt toward the design handoff, plus a Disk-tab
+polish.
+
+**Appearance editor** (the admin "Portal" tab is now **Appearance**, to
+free "Portal" for the back-to-portal link)
+- **Footer** text is editable; blank keeps the version + wordmark lockup.
+- **Default theme** (light/dark/auto) for a first-time visitor; their own
+  toggle still overrides it.
+- **Visible sections**: toggle the portal search bar and access filters.
+- **Brand color** swatch row sets the accent in one click.
+- **Logo**: header brand mode (mark+name / symbol-only / custom) with size
+  and margin.
+- **Background**: header preset (flat/soft/bold) and card cover style
+  (tinted/gradient).
+- **Catalog layout**: grid or list, comfortable or compact density.
+
+**Disk tab**
+- The table search boxes get a proper inset + search glyph, and the images
+  / containers panels size to their own content (no blank space under the
+  shorter table).
+
+---
+
 ## v0.1.89 — 2026-06-07
 
 Reliable cold starts for scale-to-zero interactive apps (#686).


### PR DESCRIPTION
Cuts **v0.1.90**: the appearance-editor rebuild toward handoff ruscker-06 (#690–#696) + the Disk-tab polish (#689), with the #697 i18n-load fix. Bump + Cargo.lock + news entry.

🤖 Generated with [Claude Code](https://claude.com/claude-code)