### PR TITLE
feat(appearance): analytics provider picker (GA4/Plausible/Matomo)

### DIFF
--- a/crates/ruscker-admin/assets/i18n/en/landing.ftl
+++ b/crates/ruscker-admin/assets/i18n/en/landing.ftl
@@ -347,6 +347,11 @@ admin-landing-analytics-html = Analytics snippet
 admin-landing-analytics-html-help = HTML injected into the landing <head> (e.g. a Plausible/Matomo/GA <script> tag). Rendered unescaped — only use trusted sources.
 admin-landing-analytics-origins = Allowed origins (CSP)
 admin-landing-analytics-origins-help = Space-separated domains (e.g. https://plausible.io) allowed in the landing CSP so the script can load and report.
+admin-landing-analytics-provider = Provider
+admin-landing-provider-none = None
+admin-landing-analytics-key = Site key
+admin-landing-analytics-key-help = GA4 measurement id (G-XXXX), Plausible domain, or Matomo URL|siteId.
+
 
 # Admin audit log
 admin-audit-title = Audit log

--- a/crates/ruscker-admin/assets/i18n/es/landing.ftl
+++ b/crates/ruscker-admin/assets/i18n/es/landing.ftl
@@ -347,6 +347,11 @@ admin-landing-analytics-html = Snippet de analytics
 admin-landing-analytics-html-help = HTML inyectado en el <head> de la landing (p. ej. una etiqueta <script> de Plausible/Matomo/GA). Se renderiza sin escapar — usa solo fuentes de confianza.
 admin-landing-analytics-origins = Orígenes permitidos (CSP)
 admin-landing-analytics-origins-help = Dominios separados por espacios (p. ej. https://plausible.io) permitidos en la CSP de la landing para que el script cargue y reporte.
+admin-landing-analytics-provider = Proveedor
+admin-landing-provider-none = Ninguno
+admin-landing-analytics-key = Clave del sitio
+admin-landing-analytics-key-help = ID de medición de GA4 (G-XXXX), dominio de Plausible, o URL|siteId de Matomo.
+
 
 # Admin audit log
 admin-audit-title = Auditoría

--- a/crates/ruscker-admin/assets/i18n/fr/landing.ftl
+++ b/crates/ruscker-admin/assets/i18n/fr/landing.ftl
@@ -347,6 +347,11 @@ admin-landing-analytics-html = Snippet analytics
 admin-landing-analytics-html-help = HTML injecté dans le <head> de la landing (ex. une balise <script> Plausible/Matomo/GA). Rendu sans échappement — n'utilisez que des sources de confiance.
 admin-landing-analytics-origins = Origines autorisées (CSP)
 admin-landing-analytics-origins-help = Domaines séparés par des espaces (ex. https://plausible.io) autorisés dans la CSP de la landing pour que le script se charge et envoie ses données.
+admin-landing-analytics-provider = Fournisseur
+admin-landing-provider-none = Aucun
+admin-landing-analytics-key = Clé du site
+admin-landing-analytics-key-help = ID de mesure GA4 (G-XXXX), domaine Plausible, ou URL|siteId Matomo.
+
 
 # Admin audit log
 admin-audit-title = Journal d'audit

--- a/crates/ruscker-admin/assets/i18n/pt/landing.ftl
+++ b/crates/ruscker-admin/assets/i18n/pt/landing.ftl
@@ -351,6 +351,11 @@ admin-landing-analytics-html = Snippet de analytics
 admin-landing-analytics-html-help = HTML inserido no <head> da landing (ex.: tag <script> do Plausible/Matomo/GA). Renderizado sem escape — use só fontes confiáveis.
 admin-landing-analytics-origins = Origens permitidas (CSP)
 admin-landing-analytics-origins-help = Domínios separados por espaço (ex.: https://plausible.io) liberados na CSP da landing para o script carregar e reportar.
+admin-landing-analytics-provider = Provedor
+admin-landing-provider-none = Nenhum
+admin-landing-analytics-key = Chave do site
+admin-landing-analytics-key-help = ID de medição do GA4 (G-XXXX), domínio do Plausible, ou URL|siteId do Matomo.
+
 
 # Admin audit log
 admin-audit-title = Auditoria

--- a/crates/ruscker-admin/migrations/0020_landing_analytics_key.sql
+++ b/crates/ruscker-admin/migrations/0020_landing_analytics_key.sql
@@ -1,0 +1,4 @@
+-- Site key for the appearance editor's analytics provider picker:
+-- a GA4 measurement id, a Plausible domain, or a Matomo "url|siteId".
+-- NULL → no provider snippet (raw analytics-html still applies).
+ALTER TABLE landing_customization ADD COLUMN analytics_key TEXT;

--- a/crates/ruscker-admin/src/db/landing.rs
+++ b/crates/ruscker-admin/src/db/landing.rs
@@ -52,6 +52,7 @@ pub async fn fetch(db: &ConfigDb) -> Result<LandingCustomization> {
         catalog_layout: Option<String>,
         catalog_density: Option<String>,
         analytics_provider: Option<String>,
+        analytics_key: Option<String>,
     }
     let sql = "SELECT header_bg, header_fg, intro, intro_locales_json,
                 seo_title, seo_description, og_image,
@@ -59,7 +60,8 @@ pub async fn fetch(db: &ConfigDb) -> Result<LandingCustomization> {
                 title, subtitle, theme_colors_json, show_highlights, footer,
                 default_theme, show_search, show_filters, logo_mode,
                 logo_size, logo_margin, header_preset, card_cover,
-                catalog_layout, catalog_density, analytics_provider
+                catalog_layout, catalog_density, analytics_provider,
+                analytics_key
            FROM landing_customization WHERE id = 1";
     let row: Option<Row> = match db {
         ConfigDb::Sqlite(pool) => sqlx::query_as(sql).fetch_optional(pool).await,
@@ -119,6 +121,7 @@ pub async fn fetch(db: &ConfigDb) -> Result<LandingCustomization> {
                 catalog_layout: r.catalog_layout,
                 catalog_density: r.catalog_density,
                 analytics_provider: r.analytics_provider,
+                analytics_key: r.analytics_key,
             })
         }
     }
@@ -190,7 +193,8 @@ pub(crate) async fn update_in_tx(
                 default_theme = ?, show_search = ?, show_filters = ?,
                 logo_mode = ?, logo_size = ?, logo_margin = ?,
                 header_preset = ?, card_cover = ?, catalog_layout = ?,
-                catalog_density = ?, analytics_provider = ?, updated_at = ?
+                catalog_density = ?, analytics_provider = ?,
+                analytics_key = ?, updated_at = ?
           WHERE id = 1",
     )
     .bind(none_if_empty(&lc.header_bg))
@@ -220,6 +224,7 @@ pub(crate) async fn update_in_tx(
     .bind(none_if_empty(&lc.catalog_layout))
     .bind(none_if_empty(&lc.catalog_density))
     .bind(none_if_empty(&lc.analytics_provider))
+    .bind(none_if_empty(&lc.analytics_key))
     .bind(now)
     .execute(&mut **tx)
     .await
@@ -262,7 +267,8 @@ pub(crate) async fn update_in_tx_pg(
                 show_search = $18, show_filters = $19, logo_mode = $20,
                 logo_size = $21, logo_margin = $22, header_preset = $23,
                 card_cover = $24, catalog_layout = $25, catalog_density = $26,
-                analytics_provider = $27, updated_at = $28
+                analytics_provider = $27, analytics_key = $28,
+                updated_at = $29
           WHERE id = 1",
     )
     .bind(none_if_empty(&lc.header_bg))
@@ -292,6 +298,7 @@ pub(crate) async fn update_in_tx_pg(
     .bind(none_if_empty(&lc.catalog_layout))
     .bind(none_if_empty(&lc.catalog_density))
     .bind(none_if_empty(&lc.analytics_provider))
+    .bind(none_if_empty(&lc.analytics_key))
     .bind(now)
     .execute(&mut **tx)
     .await

--- a/crates/ruscker-admin/src/routes/admin/landing.rs
+++ b/crates/ruscker-admin/src/routes/admin/landing.rs
@@ -104,6 +104,7 @@ pub struct LandingForm {
     pub catalog_layout: String,
     pub catalog_density: String,
     pub analytics_provider: String,
+    pub analytics_key: String,
     // Per-theme color overrides (#475); blank ⇒ keep the theme default.
     pub theme_light_bg: String,
     pub theme_light_text: String,
@@ -157,6 +158,7 @@ impl LandingForm {
             catalog_layout: lc.catalog_layout.clone().unwrap_or_default(),
             catalog_density: lc.catalog_density.clone().unwrap_or_default(),
             analytics_provider: lc.analytics_provider.clone().unwrap_or_default(),
+            analytics_key: lc.analytics_key.clone().unwrap_or_default(),
             theme_light_bg: s(&tc.light.bg),
             theme_light_text: s(&tc.light.text),
             theme_light_accent: s(&tc.light.accent),
@@ -234,6 +236,7 @@ impl LandingForm {
             catalog_layout: empty_to_none(self.catalog_layout),
             catalog_density: empty_to_none(self.catalog_density),
             analytics_provider: empty_to_none(self.analytics_provider),
+            analytics_key: empty_to_none(self.analytics_key),
             theme_colors,
             header_bg: empty_to_none(self.header_bg),
             header_fg: empty_to_none(self.header_fg),

--- a/crates/ruscker-admin/src/routes/landing.rs
+++ b/crates/ruscker-admin/src/routes/landing.rs
@@ -293,7 +293,24 @@ async fn index(
     } else {
         og_raw
     };
-    let analytics_html = not_blank(&lc.analytics_html).unwrap_or_default();
+    // Analytics: a provider snippet (GA/Plausible/Matomo) built from the
+    // picker, prepended to any raw `analytics-html` escape hatch. The
+    // provider's CSP origins are folded into `origins` below.
+    let mut analytics_html = not_blank(&lc.analytics_html).unwrap_or_default();
+    let provider_origins = match analytics_provider_snippet(
+        lc.effective_analytics_provider(),
+        lc.analytics_key.as_deref().unwrap_or_default(),
+    ) {
+        Some((snippet, origins)) => {
+            analytics_html = if analytics_html.is_empty() {
+                snippet
+            } else {
+                format!("{snippet}\n{analytics_html}")
+            };
+            origins
+        }
+        None => String::new(),
+    };
     let custom_css = not_blank(&lc.custom_css).unwrap_or_default();
 
     // Custom HTML blocks (DB-only). Split into the two slots; collect
@@ -301,6 +318,12 @@ async fn index(
     // content can load.
     let (mut blocks_top, mut blocks_bottom) = (Vec::new(), Vec::new());
     let mut origins = not_blank(&lc.analytics_origins).unwrap_or_default();
+    if !provider_origins.is_empty() {
+        if !origins.is_empty() {
+            origins.push(' ');
+        }
+        origins.push_str(&provider_origins);
+    }
     if let Some(db) = state.db.as_ref() {
         match crate::db::landing_blocks::list_enabled(db).await {
             Ok(blocks) => {
@@ -423,6 +446,107 @@ fn render<T: Template>(t: &T) -> Response {
             tracing::error!(error = ?err, "template render failed");
             (StatusCode::INTERNAL_SERVER_ERROR, "template error").into_response()
         }
+    }
+}
+
+/// Build the standard analytics snippet + CSP origins for a provider + site
+/// key (appearance editor, ruscker-06). Returns `None` for `none`/blank or
+/// a key that fails the provider's charset — the key is admin-trusted but
+/// still lands in a `<script>`, so we keep it to the strict shape each
+/// provider expects. The raw `analytics-html` escape hatch is unaffected.
+fn analytics_provider_snippet(provider: &str, key: &str) -> Option<(String, String)> {
+    let key = key.trim();
+    if key.is_empty() {
+        return None;
+    }
+    match provider {
+        // GA4 measurement id, e.g. G-XXXXXXX.
+        "ga" => {
+            if !key.chars().all(|c| c.is_ascii_alphanumeric() || c == '-') {
+                return None;
+            }
+            let html = format!(
+                "<script async src=\"https://www.googletagmanager.com/gtag/js?id={id}\"></script>\
+                 <script>window.dataLayer=window.dataLayer||[];function gtag(){{dataLayer.push(arguments);}}\
+                 gtag('js',new Date());gtag('config','{id}');</script>",
+                id = key
+            );
+            Some((
+                html,
+                "https://www.googletagmanager.com https://www.google-analytics.com".into(),
+            ))
+        }
+        // Plausible domain, e.g. example.com.
+        "plausible" => {
+            if !key.chars().all(|c| c.is_ascii_alphanumeric() || c == '.' || c == '-') {
+                return None;
+            }
+            let html = format!(
+                "<script defer data-domain=\"{d}\" src=\"https://plausible.io/js/script.js\"></script>",
+                d = key
+            );
+            Some((html, "https://plausible.io".into()))
+        }
+        // Matomo: key is "https://matomo.host|siteId".
+        "matomo" => {
+            let (url, site) = key.split_once('|')?;
+            let url = url.trim().trim_end_matches('/');
+            let site = site.trim();
+            let clean_url = url.starts_with("https://")
+                && !url
+                    .chars()
+                    .any(|c| c.is_whitespace() || matches!(c, '"' | '\'' | '<' | '>'));
+            if !clean_url || site.is_empty() || !site.chars().all(|c| c.is_ascii_digit()) {
+                return None;
+            }
+            let html = format!(
+                "<script>var _paq=window._paq=window._paq||[];_paq.push(['trackPageView']);\
+                 _paq.push(['enableLinkTracking']);(function(){{var u=\"{url}/\";\
+                 _paq.push(['setTrackerUrl',u+'matomo.php']);_paq.push(['setSiteId','{site}']);\
+                 var d=document,g=d.createElement('script'),s=d.getElementsByTagName('script')[0];\
+                 g.async=true;g.src=u+'matomo.js';s.parentNode.insertBefore(g,s);}})();</script>",
+                url = url, site = site
+            );
+            Some((html, url.to_string()))
+        }
+        _ => None,
+    }
+}
+
+#[cfg(test)]
+mod analytics_tests {
+    use super::analytics_provider_snippet;
+
+    #[test]
+    fn ga_snippet_built_from_measurement_id() {
+        let (html, origins) = analytics_provider_snippet("ga", "G-ABC123").unwrap();
+        assert!(html.contains("gtag/js?id=G-ABC123"));
+        assert!(origins.contains("googletagmanager.com"));
+    }
+
+    #[test]
+    fn plausible_snippet_built_from_domain() {
+        let (html, origins) = analytics_provider_snippet("plausible", "example.com").unwrap();
+        assert!(html.contains("data-domain=\"example.com\""));
+        assert_eq!(origins, "https://plausible.io");
+    }
+
+    #[test]
+    fn matomo_needs_url_and_numeric_site() {
+        let (html, origins) =
+            analytics_provider_snippet("matomo", "https://m.example.com|7").unwrap();
+        assert!(html.contains("setSiteId','7'"));
+        assert_eq!(origins, "https://m.example.com");
+        // Bad shapes are rejected.
+        assert!(analytics_provider_snippet("matomo", "https://m.example.com|abc").is_none());
+        assert!(analytics_provider_snippet("matomo", "ftp://x|1").is_none());
+    }
+
+    #[test]
+    fn rejects_blank_and_injection_chars() {
+        assert!(analytics_provider_snippet("ga", "").is_none());
+        assert!(analytics_provider_snippet("ga", "G-X\"><script>").is_none());
+        assert!(analytics_provider_snippet("none", "x").is_none());
     }
 }
 

--- a/crates/ruscker-admin/templates/admin/landing.html
+++ b/crates/ruscker-admin/templates/admin/landing.html
@@ -537,6 +537,23 @@
       </div>
 
       <div class="spec-form-section-title">{{ self.t("admin-landing-analytics") }}</div>
+      <input type="hidden" name="analytics_provider" :value="form.analytics_provider">
+      <div class="spec-form-field">
+        <label class="spec-form-label">{{ self.t("admin-landing-analytics-provider") }}</label>
+        <div class="seg-control" role="group">
+          <button type="button" :class="{ 'is-active': (form.analytics_provider || 'none') === 'none' }" @click="form.analytics_provider = 'none'">{{ self.t("admin-landing-provider-none") }}</button>
+          <button type="button" :class="{ 'is-active': form.analytics_provider === 'ga' }" @click="form.analytics_provider = 'ga'">Google Analytics</button>
+          <button type="button" :class="{ 'is-active': form.analytics_provider === 'plausible' }" @click="form.analytics_provider = 'plausible'">Plausible</button>
+          <button type="button" :class="{ 'is-active': form.analytics_provider === 'matomo' }" @click="form.analytics_provider = 'matomo'">Matomo</button>
+        </div>
+      </div>
+      <div class="spec-form-field" x-show="form.analytics_provider && form.analytics_provider !== 'none'" x-cloak>
+        <label class="spec-form-label">{{ self.t("admin-landing-analytics-key") }}</label>
+        <input type="text" name="analytics_key" x-model="form.analytics_key"
+               :placeholder="form.analytics_provider === 'ga' ? 'G-XXXXXXX' : (form.analytics_provider === 'plausible' ? 'example.com' : 'https://matomo.host|1')"
+               class="spec-form-input spec-form-input--mono" value="{{ form.analytics_key }}">
+        <div class="spec-form-help">{{ self.t("admin-landing-analytics-key-help") }}</div>
+      </div>
       <div class="spec-form-field">
         <label class="spec-form-label">{{ self.t("admin-landing-analytics-html") }}</label>
         <div class="code-editor-wrap" data-mode="html">

--- a/crates/ruscker-config/src/schema.rs
+++ b/crates/ruscker-config/src/schema.rs
@@ -415,6 +415,14 @@ pub struct LandingCustomization {
     #[serde(default, rename = "analytics-provider")]
     pub analytics_provider: Option<String>,
 
+    /// Site key for the chosen [`Self::analytics_provider`]: a GA4
+    /// measurement id (`G-XXXX`), a Plausible domain (`example.com`), or
+    /// a Matomo `https://matomo.host|siteId`. The portal builds the
+    /// standard snippet from provider + key (raw `analytics-html` still
+    /// works for anything else). Admin-managed.
+    #[serde(default, rename = "analytics-key")]
+    pub analytics_key: Option<String>,
+
     /// Free-form intro paragraph rendered between the header and
     /// the filter section. Operator-authored, plain text (no HTML).
     ///


### PR DESCRIPTION
Completes a deferred appearance feature. Provider picker (None/GA/Plausible/Matomo) + site-key; the portal builds the standard snippet from provider+key and adds the provider's CSP origins. Raw analytics-html escape hatch unchanged. `analytics_key` field + migration 0020 + dual-backend; sanitized per-provider snippet builder (unit-tested incl. injection rejection); editor seg-control + key input. Green: full suite (24 binaries) · clippy · i18n.

🤖 Generated with [Claude Code](https://claude.com/claude-code)