### PR TITLE
chore(release): bump workspace version 0.1.90 → 0.1.91

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2845,7 +2845,7 @@ dependencies = [
 
 [[package]]
 name = "ruscker-admin"
-version = "0.1.90"
+version = "0.1.91"
 dependencies = [
  "aes-gcm",
  "anyhow",
@@ -2895,7 +2895,7 @@ dependencies = [
 
 [[package]]
 name = "ruscker-cli"
-version = "0.1.90"
+version = "0.1.91"
 dependencies = [
  "anyhow",
  "clap",
@@ -2915,7 +2915,7 @@ dependencies = [
 
 [[package]]
 name = "ruscker-config"
-version = "0.1.90"
+version = "0.1.91"
 dependencies = [
  "chrono",
  "ordered-float",
@@ -2930,7 +2930,7 @@ dependencies = [
 
 [[package]]
 name = "ruscker-core"
-version = "0.1.90"
+version = "0.1.91"
 dependencies = [
  "async-trait",
  "chrono",
@@ -2943,7 +2943,7 @@ dependencies = [
 
 [[package]]
 name = "ruscker-docker"
-version = "0.1.90"
+version = "0.1.91"
 dependencies = [
  "anyhow",
  "async-stream",
@@ -2962,7 +2962,7 @@ dependencies = [
 
 [[package]]
 name = "ruscker-proxy"
-version = "0.1.90"
+version = "0.1.91"
 dependencies = [
  "anyhow",
  "axum",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -10,7 +10,7 @@ members = [
 ]
 
 [workspace.package]
-version = "0.1.90"
+version = "0.1.91"
 edition = "2021"
 rust-version = "1.85"
 license = "Apache-2.0"

--- a/book/src/news.md
+++ b/book/src/news.md
@@ -9,6 +9,16 @@ the [GitHub releases page](https://github.com/StrategicProjects/ruscker/releases
 
 ---
 
+## v0.1.91 — 2026-06-08
+
+**Appearance — analytics provider picker.** The appearance editor's
+Analytics section now offers a provider picker (Google Analytics 4,
+Plausible, or Matomo) plus a site-key field; the portal builds the
+standard snippet from provider + key and opens the matching CSP origins.
+The raw analytics-HTML field stays as an escape hatch for anything else.
+
+---
+
 ## v0.1.90 — 2026-06-08
 
 Appearance editor rebuilt toward the design handoff, plus a Disk-tab


### PR DESCRIPTION
Cuts v0.1.91: appearance analytics provider picker (#699). Bump + Cargo.lock + news.

🤖 Generated with [Claude Code](https://claude.com/claude-code)