### PR TITLE
feat(appearance): catalog "sections" layout + editor card reorder (#701)

### DIFF
--- a/crates/ruscker-admin/assets/i18n/en/landing.ftl
+++ b/crates/ruscker-admin/assets/i18n/en/landing.ftl
@@ -713,6 +713,7 @@ admin-landing-cover-gradient = Gradient
 admin-landing-catalog-layout = Catalog layout
 admin-landing-layout-grid = Grid
 admin-landing-layout-list = List
+admin-landing-layout-sections = Sections
 admin-landing-density-comfortable = Comfortable
 admin-landing-density-compact = Compact
 

--- a/crates/ruscker-admin/assets/i18n/es/landing.ftl
+++ b/crates/ruscker-admin/assets/i18n/es/landing.ftl
@@ -713,6 +713,7 @@ admin-landing-cover-gradient = Degradado
 admin-landing-catalog-layout = Diseño del catálogo
 admin-landing-layout-grid = Cuadrícula
 admin-landing-layout-list = Lista
+admin-landing-layout-sections = Secciones
 admin-landing-density-comfortable = Cómodo
 admin-landing-density-compact = Compacto
 

--- a/crates/ruscker-admin/assets/i18n/fr/landing.ftl
+++ b/crates/ruscker-admin/assets/i18n/fr/landing.ftl
@@ -713,6 +713,7 @@ admin-landing-cover-gradient = Dégradé
 admin-landing-catalog-layout = Disposition du catalogue
 admin-landing-layout-grid = Grille
 admin-landing-layout-list = Liste
+admin-landing-layout-sections = Sections
 admin-landing-density-comfortable = Confortable
 admin-landing-density-compact = Compact
 

--- a/crates/ruscker-admin/assets/i18n/pt/landing.ftl
+++ b/crates/ruscker-admin/assets/i18n/pt/landing.ftl
@@ -717,6 +717,7 @@ admin-landing-cover-gradient = Gradiente
 admin-landing-catalog-layout = Layout do catálogo
 admin-landing-layout-grid = Grade
 admin-landing-layout-list = Lista
+admin-landing-layout-sections = Seções
 admin-landing-density-comfortable = Confortável
 admin-landing-density-compact = Compacto
 

--- a/crates/ruscker-admin/assets/tailwind/input.css
+++ b/crates/ruscker-admin/assets/tailwind/input.css
@@ -235,6 +235,29 @@ body {
 .cards-grid.is-list .rcard { display: grid; grid-template-columns: 120px 1fr; align-items: stretch; }
 .cards-grid.is-list .rcover { height: 100%; min-height: 64px; }
 
+/* Appearance: `sections` layout (#701) — the catalog grouped by app
+   type, each group under a heading. In grid/list layout the catalog is a
+   single, unlabeled `.catalog-group`, so these rules stay visually inert
+   (no heading, single child ⇒ the sibling margin never applies). */
+.catalog--sections .catalog-group + .catalog-group { margin-top: 26px; }
+.catalog-group__head {
+  display: flex;
+  align-items: baseline;
+  gap: 8px;
+  margin: 0 0 12px;
+  padding-bottom: 6px;
+  border-bottom: 1px solid var(--border);
+  font-size: 13px;
+  font-weight: 600;
+  letter-spacing: 0.01em;
+  color: var(--text);
+}
+.catalog-group__count {
+  font-size: 11px;
+  font-weight: 500;
+  color: var(--text-faint);
+}
+
 /* ─── Dashboard: KPI cards + app-grouped replicas (handoff #623) ───
  * Replaces the flat replica table with metric cards on top and one
  * expandable card per app. Dot classes reuse the server-emitted names

--- a/crates/ruscker-admin/src/routes/landing.rs
+++ b/crates/ruscker-admin/src/routes/landing.rs
@@ -18,7 +18,7 @@ use crate::auth::{MaybeSession, Role};
 use crate::i18n::{Locale, Locales};
 use crate::theme::Theme;
 use crate::view_model::{
-    build_type_chips, sort_by_recent, unique_subjects, CardCounts, CardCtx, TypeChip,
+    build_type_chips, sort_by_recent, unique_subjects, CardCounts, CardCtx, DisplayType, TypeChip,
 };
 use crate::AppState;
 
@@ -127,6 +127,27 @@ struct LogoView {
     margin: Option<u32>,
 }
 
+/// One group of catalog cards for the landing's card area (#701).
+///
+/// The template renders the card markup exactly once, inside a group;
+/// the two catalog layouts differ only in how many groups there are:
+///   - `grid`/`list` ⇒ a single, unlabeled group with every card;
+///   - `sections`     ⇒ one labeled group per [`DisplayType`], in the
+///     canonical type order, with empty types omitted.
+///
+/// `key`/`label_key` are empty for the single grid/list group, which is
+/// how the template decides whether to draw a heading and the per-section
+/// `x-show` count binding. Cards keep their original recent-first order
+/// within each group (the parent `cards` vec is already sorted).
+struct CatalogGroup<'r, 'a> {
+    /// Stable `DisplayType::key()` used by the Alpine per-section count
+    /// lookup (`sections['app']`). Empty ⇒ the single grid/list group.
+    key: &'static str,
+    /// Fluent key for the section heading. Empty ⇒ no heading rendered.
+    label_key: &'static str,
+    cards: Vec<&'r CardCtx<'a>>,
+}
+
 impl<'a> LandingPage<'a> {
     /// Translation helper used by the template as `self.t("key")`.
     /// Centralizing here keeps templates clean of explicit
@@ -147,6 +168,43 @@ impl<'a> LandingPage<'a> {
 
     fn has_logos_at(&self, slot: &str, align: &str) -> bool {
         self.logos.iter().any(|l| l.slot == slot && l.align == align)
+    }
+
+    /// Group the cards for the catalog area (#701). See [`CatalogGroup`].
+    /// In `grid`/`list` layout this is a single unlabeled group holding
+    /// every card; in `sections` layout it's one labeled group per
+    /// [`DisplayType`] (canonical order, empty types dropped). The card
+    /// markup in the template is shared across both via this one seam.
+    fn catalog_groups(&self) -> Vec<CatalogGroup<'_, 'a>> {
+        if self.catalog_layout != "sections" {
+            return vec![CatalogGroup {
+                key: "",
+                label_key: "",
+                cards: self.cards.iter().collect(),
+            }];
+        }
+        // Same canonical order as the filter chips (`build_type_chips`)
+        // so the sections read top-to-bottom in the same sequence the
+        // chip bar reads left-to-right.
+        [
+            DisplayType::App,
+            DisplayType::Talk,
+            DisplayType::Report,
+            DisplayType::Package,
+            DisplayType::Api,
+            DisplayType::Link,
+        ]
+        .into_iter()
+        .filter_map(|dt| {
+            let cards: Vec<&CardCtx<'a>> =
+                self.cards.iter().filter(|c| c.display_type == dt).collect();
+            (!cards.is_empty()).then_some(CatalogGroup {
+                key: dt.key(),
+                label_key: dt.label_key(),
+                cards,
+            })
+        })
+        .collect()
     }
 
     /// Resolve a logo's `<img src>`: an absolute/protocol-relative URL is
@@ -513,43 +571,6 @@ fn analytics_provider_snippet(provider: &str, key: &str) -> Option<(String, Stri
     }
 }
 
-#[cfg(test)]
-mod analytics_tests {
-    use super::analytics_provider_snippet;
-
-    #[test]
-    fn ga_snippet_built_from_measurement_id() {
-        let (html, origins) = analytics_provider_snippet("ga", "G-ABC123").unwrap();
-        assert!(html.contains("gtag/js?id=G-ABC123"));
-        assert!(origins.contains("googletagmanager.com"));
-    }
-
-    #[test]
-    fn plausible_snippet_built_from_domain() {
-        let (html, origins) = analytics_provider_snippet("plausible", "example.com").unwrap();
-        assert!(html.contains("data-domain=\"example.com\""));
-        assert_eq!(origins, "https://plausible.io");
-    }
-
-    #[test]
-    fn matomo_needs_url_and_numeric_site() {
-        let (html, origins) =
-            analytics_provider_snippet("matomo", "https://m.example.com|7").unwrap();
-        assert!(html.contains("setSiteId','7'"));
-        assert_eq!(origins, "https://m.example.com");
-        // Bad shapes are rejected.
-        assert!(analytics_provider_snippet("matomo", "https://m.example.com|abc").is_none());
-        assert!(analytics_provider_snippet("matomo", "ftp://x|1").is_none());
-    }
-
-    #[test]
-    fn rejects_blank_and_injection_chars() {
-        assert!(analytics_provider_snippet("ga", "").is_none());
-        assert!(analytics_provider_snippet("ga", "G-X\"><script>").is_none());
-        assert!(analytics_provider_snippet("none", "x").is_none());
-    }
-}
-
 /// Accept a CSS color value only if it's plausibly a color and can't
 /// break out of a `{ }` declaration block — even though the editor is
 /// Admin-only, a stray `}`/`;`/`<` would corrupt the whole `<style>`.
@@ -593,4 +614,41 @@ fn build_theme_style(tc: &ruscker_config::ThemeColors) -> String {
         css.push_str(&format!(":root[data-theme=\"dark\"]{{{dark}}}"));
     }
     css
+}
+
+#[cfg(test)]
+mod analytics_tests {
+    use super::analytics_provider_snippet;
+
+    #[test]
+    fn ga_snippet_built_from_measurement_id() {
+        let (html, origins) = analytics_provider_snippet("ga", "G-ABC123").unwrap();
+        assert!(html.contains("gtag/js?id=G-ABC123"));
+        assert!(origins.contains("googletagmanager.com"));
+    }
+
+    #[test]
+    fn plausible_snippet_built_from_domain() {
+        let (html, origins) = analytics_provider_snippet("plausible", "example.com").unwrap();
+        assert!(html.contains("data-domain=\"example.com\""));
+        assert_eq!(origins, "https://plausible.io");
+    }
+
+    #[test]
+    fn matomo_needs_url_and_numeric_site() {
+        let (html, origins) =
+            analytics_provider_snippet("matomo", "https://m.example.com|7").unwrap();
+        assert!(html.contains("setSiteId','7'"));
+        assert_eq!(origins, "https://m.example.com");
+        // Bad shapes are rejected.
+        assert!(analytics_provider_snippet("matomo", "https://m.example.com|abc").is_none());
+        assert!(analytics_provider_snippet("matomo", "ftp://x|1").is_none());
+    }
+
+    #[test]
+    fn rejects_blank_and_injection_chars() {
+        assert!(analytics_provider_snippet("ga", "").is_none());
+        assert!(analytics_provider_snippet("ga", "G-X\"><script>").is_none());
+        assert!(analytics_provider_snippet("none", "x").is_none());
+    }
 }

--- a/crates/ruscker-admin/templates/admin/landing.html
+++ b/crates/ruscker-admin/templates/admin/landing.html
@@ -130,6 +130,77 @@
         </div>
       </section>
 
+      {# ── Card: Header / footer logos (#468). #}
+      <section class="editor-card">
+        <div class="form-section__title">{{ self.t("admin-landing-logos") }}</div>
+      <div class="spec-form-field">
+        {# Submitted as one hidden JSON field; the rows below edit the array. #}
+        <input type="hidden" name="logos_json" :value="JSON.stringify(logos)">
+        <template x-for="(logo, i) in logos" :key="i">
+          <div class="landing-logo-card">
+            <div class="landing-logo-card__head">
+              {# Preview thumbnail, or a placeholder icon when no URL yet. #}
+              <img :src="assetUrl(logo.url)" alt="" class="landing-logo-thumb" x-show="logo.url">
+              <span class="landing-logo-thumb landing-logo-thumb--empty" x-show="!logo.url"><i class="ti ti-photo" aria-hidden="true"></i></span>
+              {# Image field: shared gallery picker (#451) writes only `url`,
+                 leaving the other fields intact; the input stays editable
+                 for an external/manual URL. #}
+              <div class="landing-logo-field" style="flex:1;min-width:0">
+                <label>{{ self.t("admin-landing-logo-image") }}</label>
+                <div class="landing-logo-image-row">
+                  <button type="button" class="admin-login-btn landing-logo-pick"
+                          @click="openImagePicker((v) => { logo.url = v }, logo.url)">
+                    <i class="ti ti-photo" aria-hidden="true"></i>
+                    {{ self.t("spec-form-choose-image") }}
+                  </button>
+                  <input type="text" x-model="logo.url" placeholder="/assets/img/logo.png"
+                         class="spec-form-input spec-form-input--mono" style="flex:1;min-width:0">
+                </div>
+              </div>
+              <button type="button" class="landing-logo-card__remove admin-nav-link" @click="logos.splice(i, 1)"
+                      title="{{ self.t("admin-landing-clear") }}"><i class="ti ti-trash" aria-hidden="true"></i></button>
+            </div>
+            <div class="landing-logo-card__grid">
+              {# Slot — segmented pill (header / footer). #}
+              <div class="landing-logo-field">
+                <label>{{ self.t("admin-landing-logo-slot-label") }}</label>
+                <div class="seg-control" role="group">
+                  <button type="button" :class="{ 'is-active': logo.slot === 'header' }" @click="logo.slot = 'header'">{{ self.t("admin-landing-logo-header") }}</button>
+                  <button type="button" :class="{ 'is-active': logo.slot === 'footer' }" @click="logo.slot = 'footer'">{{ self.t("admin-landing-logo-footer") }}</button>
+                </div>
+              </div>
+              {# Alignment — segmented icon pill (left / center / right). #}
+              <div class="landing-logo-field">
+                <label>{{ self.t("admin-landing-logo-align-label") }}</label>
+                <div class="seg-control" role="group">
+                  <button type="button" :class="{ 'is-active': logo.align === 'left' }" @click="logo.align = 'left'" title="{{ self.t("admin-landing-logo-left") }}"><i class="ti ti-align-left" aria-hidden="true"></i></button>
+                  <button type="button" :class="{ 'is-active': logo.align === 'center' }" @click="logo.align = 'center'" title="{{ self.t("admin-landing-logo-center") }}"><i class="ti ti-align-center" aria-hidden="true"></i></button>
+                  <button type="button" :class="{ 'is-active': logo.align === 'right' }" @click="logo.align = 'right'" title="{{ self.t("admin-landing-logo-right") }}"><i class="ti ti-align-right" aria-hidden="true"></i></button>
+                </div>
+              </div>
+              <div class="landing-logo-field">
+                <label>{{ self.t("admin-landing-logo-link") }}</label>
+                <input type="url" x-model="logo.link" placeholder="https://…" class="spec-form-input">
+              </div>
+              <div class="landing-logo-field">
+                <label>{{ self.t("admin-landing-logo-height") }}</label>
+                <input type="number" x-model.number="logo.height" min="8" max="240" placeholder="32" class="spec-form-input">
+              </div>
+              <div class="landing-logo-field">
+                <label>{{ self.t("admin-landing-logo-margin") }}</label>
+                <input type="number" x-model.number="logo.margin" min="0" max="120" placeholder="0" class="spec-form-input">
+              </div>
+            </div>
+          </div>
+        </template>
+        <button type="button" class="admin-nav-link mt-2"
+                @click="logos.push({ url: '', slot: 'header', align: 'left', link: null, height: 32, margin: null })">
+          <i class="ti ti-plus" aria-hidden="true"></i> {{ self.t("admin-landing-logo-add") }}
+        </button>
+      </div>
+
+      </section>
+
       {# ── Card: Background — header preset + card cover style. #}
       <section class="editor-card">
         <div class="form-section__title">{{ self.t("admin-landing-background") }}</div>
@@ -148,26 +219,6 @@
           <div class="seg-control" role="group">
             <button type="button" :class="{ 'is-active': (form.card_cover || 'tinted') === 'tinted' }" @click="form.card_cover = 'tinted'">{{ self.t("admin-landing-cover-tinted") }}</button>
             <button type="button" :class="{ 'is-active': form.card_cover === 'gradient' }" @click="form.card_cover = 'gradient'">{{ self.t("admin-landing-cover-gradient") }}</button>
-          </div>
-        </div>
-      </section>
-
-      {# ── Card: Catalog layout — grid/list + density. #}
-      <section class="editor-card">
-        <div class="form-section__title">{{ self.t("admin-landing-catalog-layout") }}</div>
-        <input type="hidden" name="catalog_layout" :value="form.catalog_layout">
-        <input type="hidden" name="catalog_density" :value="form.catalog_density">
-        <div class="spec-form-field">
-          <div class="seg-control" role="group">
-            <button type="button" :class="{ 'is-active': (form.catalog_layout || 'grid') === 'grid' }" @click="form.catalog_layout = 'grid'">{{ self.t("admin-landing-layout-grid") }}</button>
-            <button type="button" :class="{ 'is-active': form.catalog_layout === 'list' }" @click="form.catalog_layout = 'list'">{{ self.t("admin-landing-layout-list") }}</button>
-            <button type="button" :class="{ 'is-active': form.catalog_layout === 'sections' }" @click="form.catalog_layout = 'sections'">{{ self.t("admin-landing-layout-sections") }}</button>
-          </div>
-        </div>
-        <div class="spec-form-field">
-          <div class="seg-control" role="group">
-            <button type="button" :class="{ 'is-active': (form.catalog_density || 'comfortable') === 'comfortable' }" @click="form.catalog_density = 'comfortable'">{{ self.t("admin-landing-density-comfortable") }}</button>
-            <button type="button" :class="{ 'is-active': form.catalog_density === 'compact' }" @click="form.catalog_density = 'compact'">{{ self.t("admin-landing-density-compact") }}</button>
           </div>
         </div>
       </section>
@@ -344,6 +395,26 @@
         </div>
       </section>
 
+      {# ── Card: Catalog layout — grid/list + density. #}
+      <section class="editor-card">
+        <div class="form-section__title">{{ self.t("admin-landing-catalog-layout") }}</div>
+        <input type="hidden" name="catalog_layout" :value="form.catalog_layout">
+        <input type="hidden" name="catalog_density" :value="form.catalog_density">
+        <div class="spec-form-field">
+          <div class="seg-control" role="group">
+            <button type="button" :class="{ 'is-active': (form.catalog_layout || 'grid') === 'grid' }" @click="form.catalog_layout = 'grid'">{{ self.t("admin-landing-layout-grid") }}</button>
+            <button type="button" :class="{ 'is-active': form.catalog_layout === 'list' }" @click="form.catalog_layout = 'list'">{{ self.t("admin-landing-layout-list") }}</button>
+            <button type="button" :class="{ 'is-active': form.catalog_layout === 'sections' }" @click="form.catalog_layout = 'sections'">{{ self.t("admin-landing-layout-sections") }}</button>
+          </div>
+        </div>
+        <div class="spec-form-field">
+          <div class="seg-control" role="group">
+            <button type="button" :class="{ 'is-active': (form.catalog_density || 'comfortable') === 'comfortable' }" @click="form.catalog_density = 'comfortable'">{{ self.t("admin-landing-density-comfortable") }}</button>
+            <button type="button" :class="{ 'is-active': form.catalog_density === 'compact' }" @click="form.catalog_density = 'compact'">{{ self.t("admin-landing-density-compact") }}</button>
+          </div>
+        </div>
+      </section>
+
       {# ── Card: Visible sections — toggle portal chrome on/off. #}
       <section class="editor-card">
         <div class="form-section__title">{{ self.t("admin-landing-visible-sections") }}</div>
@@ -365,77 +436,6 @@
             <span>{{ self.t("admin-landing-show-filters") }}</span>
           </label>
         </div>
-      </section>
-
-      {# ── Card: Header / footer logos (#468). #}
-      <section class="editor-card">
-        <div class="form-section__title">{{ self.t("admin-landing-logos") }}</div>
-      <div class="spec-form-field">
-        {# Submitted as one hidden JSON field; the rows below edit the array. #}
-        <input type="hidden" name="logos_json" :value="JSON.stringify(logos)">
-        <template x-for="(logo, i) in logos" :key="i">
-          <div class="landing-logo-card">
-            <div class="landing-logo-card__head">
-              {# Preview thumbnail, or a placeholder icon when no URL yet. #}
-              <img :src="assetUrl(logo.url)" alt="" class="landing-logo-thumb" x-show="logo.url">
-              <span class="landing-logo-thumb landing-logo-thumb--empty" x-show="!logo.url"><i class="ti ti-photo" aria-hidden="true"></i></span>
-              {# Image field: shared gallery picker (#451) writes only `url`,
-                 leaving the other fields intact; the input stays editable
-                 for an external/manual URL. #}
-              <div class="landing-logo-field" style="flex:1;min-width:0">
-                <label>{{ self.t("admin-landing-logo-image") }}</label>
-                <div class="landing-logo-image-row">
-                  <button type="button" class="admin-login-btn landing-logo-pick"
-                          @click="openImagePicker((v) => { logo.url = v }, logo.url)">
-                    <i class="ti ti-photo" aria-hidden="true"></i>
-                    {{ self.t("spec-form-choose-image") }}
-                  </button>
-                  <input type="text" x-model="logo.url" placeholder="/assets/img/logo.png"
-                         class="spec-form-input spec-form-input--mono" style="flex:1;min-width:0">
-                </div>
-              </div>
-              <button type="button" class="landing-logo-card__remove admin-nav-link" @click="logos.splice(i, 1)"
-                      title="{{ self.t("admin-landing-clear") }}"><i class="ti ti-trash" aria-hidden="true"></i></button>
-            </div>
-            <div class="landing-logo-card__grid">
-              {# Slot — segmented pill (header / footer). #}
-              <div class="landing-logo-field">
-                <label>{{ self.t("admin-landing-logo-slot-label") }}</label>
-                <div class="seg-control" role="group">
-                  <button type="button" :class="{ 'is-active': logo.slot === 'header' }" @click="logo.slot = 'header'">{{ self.t("admin-landing-logo-header") }}</button>
-                  <button type="button" :class="{ 'is-active': logo.slot === 'footer' }" @click="logo.slot = 'footer'">{{ self.t("admin-landing-logo-footer") }}</button>
-                </div>
-              </div>
-              {# Alignment — segmented icon pill (left / center / right). #}
-              <div class="landing-logo-field">
-                <label>{{ self.t("admin-landing-logo-align-label") }}</label>
-                <div class="seg-control" role="group">
-                  <button type="button" :class="{ 'is-active': logo.align === 'left' }" @click="logo.align = 'left'" title="{{ self.t("admin-landing-logo-left") }}"><i class="ti ti-align-left" aria-hidden="true"></i></button>
-                  <button type="button" :class="{ 'is-active': logo.align === 'center' }" @click="logo.align = 'center'" title="{{ self.t("admin-landing-logo-center") }}"><i class="ti ti-align-center" aria-hidden="true"></i></button>
-                  <button type="button" :class="{ 'is-active': logo.align === 'right' }" @click="logo.align = 'right'" title="{{ self.t("admin-landing-logo-right") }}"><i class="ti ti-align-right" aria-hidden="true"></i></button>
-                </div>
-              </div>
-              <div class="landing-logo-field">
-                <label>{{ self.t("admin-landing-logo-link") }}</label>
-                <input type="url" x-model="logo.link" placeholder="https://…" class="spec-form-input">
-              </div>
-              <div class="landing-logo-field">
-                <label>{{ self.t("admin-landing-logo-height") }}</label>
-                <input type="number" x-model.number="logo.height" min="8" max="240" placeholder="32" class="spec-form-input">
-              </div>
-              <div class="landing-logo-field">
-                <label>{{ self.t("admin-landing-logo-margin") }}</label>
-                <input type="number" x-model.number="logo.margin" min="0" max="120" placeholder="0" class="spec-form-input">
-              </div>
-            </div>
-          </div>
-        </template>
-        <button type="button" class="admin-nav-link mt-2"
-                @click="logos.push({ url: '', slot: 'header', align: 'left', link: null, height: 32, margin: null })">
-          <i class="ti ti-plus" aria-hidden="true"></i> {{ self.t("admin-landing-logo-add") }}
-        </button>
-      </div>
-
       </section>
 
       {# ── Card: Content — intro text (default + per-locale). #}

--- a/crates/ruscker-admin/templates/admin/landing.html
+++ b/crates/ruscker-admin/templates/admin/landing.html
@@ -161,6 +161,7 @@
           <div class="seg-control" role="group">
             <button type="button" :class="{ 'is-active': (form.catalog_layout || 'grid') === 'grid' }" @click="form.catalog_layout = 'grid'">{{ self.t("admin-landing-layout-grid") }}</button>
             <button type="button" :class="{ 'is-active': form.catalog_layout === 'list' }" @click="form.catalog_layout = 'list'">{{ self.t("admin-landing-layout-list") }}</button>
+            <button type="button" :class="{ 'is-active': form.catalog_layout === 'sections' }" @click="form.catalog_layout = 'sections'">{{ self.t("admin-landing-layout-sections") }}</button>
           </div>
         </div>
         <div class="spec-form-field">

--- a/crates/ruscker-admin/templates/landing.html
+++ b/crates/ruscker-admin/templates/landing.html
@@ -275,9 +275,23 @@
   </div>
   </div>{# /portal-sticky #}
 
-  {# ── Card grid (fixed-width cards, columns auto-fill) ──────── #}
-  <section class="cards-grid stagger{% if catalog_layout == "list" %} is-list{% endif %}{% if catalog_density == "compact" %} is-compact{% endif %}" x-ref="grid">
-    {% for card in cards %}
+  {# ── Card area (#701): one or more groups. `grid`/`list` renders a
+     single unlabeled group with every card; `sections` renders one
+     labeled group per app type, each heading hidden via x-show when the
+     live filters empty it (`sections[type]` count, kept by recount()).
+     The fixed-width card markup is emitted once inside the inner loop,
+     shared by every layout (see `LandingPage::catalog_groups`). #}
+  <div class="catalog{% if catalog_layout == "sections" %} catalog--sections{% endif %}" x-ref="grid">
+    {% for sec in self.catalog_groups() %}
+    <section class="catalog-group"{% if !sec.key.is_empty() %} x-show="(sections['{{ sec.key }}'] || 0) > 0" x-cloak{% endif %}>
+      {% if !sec.label_key.is_empty() %}
+      <h2 class="catalog-group__head">
+        <span>{{ self.t(sec.label_key) }}</span>
+        <span class="catalog-group__count" x-text="sections['{{ sec.key }}'] || 0"></span>
+      </h2>
+      {% endif %}
+      <div class="cards-grid stagger{% if catalog_layout == "list" %} is-list{% endif %}{% if catalog_density == "compact" %} is-compact{% endif %}">
+        {% for card in sec.cards %}
       <a class="rcard {% if !card.active %}inactive{% endif %}"
          href="{% if card.active %}{{ card.href }}{% else %}#{% endif %}"
          data-type="{{ card.display_type.key() }}"
@@ -348,8 +362,11 @@
           </div>
         </div>
       </a>
+        {% endfor %}
+      </div>
+    </section>
     {% endfor %}
-  </section>
+  </div>
 
   {# ── Empty state ───────────────────────────────────────────── #}
   {# `x-cloak` so it stays hidden until Alpine has computed `visible`
@@ -386,6 +403,10 @@ window.ruscker.landing = () => ({
   sort: 'recent',
   visible: 0,
   counts: { all: 0 },
+  // Per-type count of cards passing ALL filters (incl. the type chip),
+  // keyed by DisplayType::key(). Drives the `sections` layout (#701):
+  // a section's heading hides via x-show when its count drops to 0.
+  sections: {},
 
   init() {
     this.$watch('search', () => this.recount());
@@ -406,8 +427,12 @@ window.ruscker.landing = () => ({
 
   recount() {
     const counts = { all: 0 };
+    const sections = {};
     let visible = 0;
-    for (const el of this.$refs.grid.children) {
+    // Query `.rcard` (not `.children`) so this works whether the cards
+    // sit directly in the grid (grid/list layout) or nested one level
+    // down inside per-type sections (#701).
+    for (const el of this._cards()) {
       const passesType = this.matchType(el);
       const passesRest = this.matchExceptType(el);
       if (passesRest) {
@@ -415,10 +440,20 @@ window.ruscker.landing = () => ({
         const t = el.dataset.type;
         counts[t] = (counts[t] || 0) + 1;
       }
-      if (passesType && passesRest) visible += 1;
+      if (passesType && passesRest) {
+        visible += 1;
+        const t = el.dataset.type;
+        sections[t] = (sections[t] || 0) + 1;
+      }
     }
     this.counts = counts;
+    this.sections = sections;
     this.visible = visible;
+  },
+
+  // All catalog cards under the grid wrapper, across every layout.
+  _cards() {
+    return this.$refs.grid.querySelectorAll('.rcard');
   },
 
   match(el) {
@@ -469,7 +504,7 @@ window.ruscker.landing = () => ({
   },
 
   _computeNameRanks() {
-    const list = Array.from(this.$refs.grid.children);
+    const list = Array.from(this._cards());
     list.sort((a, b) =>
       (a.dataset.name || '').localeCompare(b.dataset.name || ''));
     this._nameRanks = new Map(list.map((el, i) => [el, i]));

--- a/crates/ruscker-admin/tests/landing_render.rs
+++ b/crates/ruscker-admin/tests/landing_render.rs
@@ -19,7 +19,14 @@ fn app_state() -> AppState {
     // The fixture references ${DOCKER_REGISTRY_PASSWORD}; provide a
     // dummy so parsing succeeds.
     std::env::set_var("DOCKER_REGISTRY_PASSWORD", "test");
-    let config = Config::from_yaml(&yaml).expect("parse config");
+    state_from_yaml(&yaml)
+}
+
+/// Build an `AppState` (no DB, so the YAML `landing-customization` is the
+/// source of truth) from an inline config. Used by the sections-layout
+/// test, which needs a config that sets `catalog-layout: sections`.
+fn state_from_yaml(yaml: &str) -> AppState {
+    let config = Config::from_yaml(yaml).expect("parse config");
     let locales = Locales::load().expect("load locales");
     AppState {
         config: Arc::new(config),
@@ -72,6 +79,88 @@ async fn landing_renders_default_locale() {
     // 8 specs in examples/application.yml → 8 cards rendered.
     // Cards are <a class="rcard"> in the v2 layout.
     assert_eq!(body.matches(r#"class="rcard"#).count(), 8);
+}
+
+#[tokio::test]
+async fn sections_layout_groups_cards_by_type() {
+    // `catalog-layout: sections` (#701) renders one labeled group per
+    // app type, in canonical order, each heading carrying the Alpine
+    // per-section count binding so it hides when filters empty it.
+    let yaml = r#"
+proxy:
+  title: Sections Test
+  landing-customization:
+    catalog-layout: sections
+  specs:
+    - id: alpha
+      display-name: Alpha
+      container-image: img:1
+      template-properties:
+        type: app
+    - id: beta
+      display-name: Beta
+      container-image: img:2
+      template-properties:
+        type: report
+    - id: gamma
+      display-name: Gamma
+      container-image: img:3
+      template-properties:
+        type: app
+"#;
+    let app = router(state_from_yaml(yaml));
+    let response = app
+        .oneshot(Request::builder().uri("/").body(Body::empty()).unwrap())
+        .await
+        .unwrap();
+    assert_eq!(response.status(), StatusCode::OK);
+    let body = axum::body::to_bytes(response.into_body(), 1024 * 1024)
+        .await
+        .unwrap();
+    let body = String::from_utf8(body.to_vec()).unwrap();
+
+    // Sections wrapper + exactly the two present types get a heading
+    // (app, report) — empty types (talk/package/api/link) are omitted.
+    assert!(body.contains("catalog--sections"), "sections wrapper class");
+    assert_eq!(
+        body.matches("catalog-group__head").count(),
+        2,
+        "one heading per present type (app, report) only"
+    );
+    // Per-section x-show count bindings drive heading visibility.
+    assert!(body.contains(r#"x-show="(sections['app'] || 0) > 0""#));
+    assert!(body.contains(r#"x-show="(sections['report'] || 0) > 0""#));
+    // All three cards still render (2 app + 1 report).
+    assert_eq!(body.matches(r#"class="rcard"#).count(), 3);
+}
+
+#[tokio::test]
+async fn grid_layout_is_a_single_unlabeled_group() {
+    // The default (no `catalog-layout`) renders one group with no
+    // heading and no per-section binding — the sections wrappers stay
+    // visually inert (#701).
+    let yaml = r#"
+proxy:
+  title: Grid Test
+  specs:
+    - id: alpha
+      display-name: Alpha
+      container-image: img:1
+      template-properties:
+        type: app
+"#;
+    let app = router(state_from_yaml(yaml));
+    let response = app
+        .oneshot(Request::builder().uri("/").body(Body::empty()).unwrap())
+        .await
+        .unwrap();
+    let body = axum::body::to_bytes(response.into_body(), 1024 * 1024)
+        .await
+        .unwrap();
+    let body = String::from_utf8(body.to_vec()).unwrap();
+    assert!(!body.contains("catalog--sections"), "no sections modifier in grid");
+    assert_eq!(body.matches("catalog-group__head").count(), 0, "no headings in grid");
+    assert!(!body.contains("sections['"), "no per-section binding in grid");
 }
 
 #[tokio::test]


### PR DESCRIPTION
Closes #701 — the two pieces of handoff **ruscker-06** left out of the v0.1.90/91 appearance rebuild. Two commits, one per part of the issue.

## Part 1 — Catalog "Sections" layout (`b40b100`)
The portal catalog grouped by app type, each group under a heading. The `catalog-layout` picker already shipped **Grid** + **List**; this fills in **Sections** (the schema's `effective_catalog_layout` already accepted the value — the control just never offered it).

- **Handler** — `LandingPage::catalog_groups()` yields the card area as one or more groups: a single *unlabeled* group for grid/list, one *labeled* group per `DisplayType` (canonical order, empty types dropped) for `sections`. The card markup stays in **one place** in the template, shared across all three layouts.
- **Template** — a per-group `<section>` whose heading hides via `x-show` driven by a per-type visible count, so a section emptied by the live search/access/status/type filters drops its heading too. `recount()` now keeps `sections[type]` alongside `counts`, and walks `.rcard` (`querySelectorAll`) instead of `grid.children` so it works whether cards sit directly in the grid or nested under sections.
- **Editor** — third **Sections** button on the CATALOG LAYOUT seg-control + `admin-landing-layout-sections` in all four locales.
- **CSS** — `.catalog-group` / `.catalog-group__head` (inert for the single grid/list group).
- **Tests** — sections grouping + grid single-group render assertions.

**Drive-by:** moved the `analytics_tests` module to the end of `routes/landing.rs` — it sat before two helper fns, tripping `clippy::items_after_test_module` under `--all-targets` (a latent red since the v0.1.91 analytics batch; `cargo clippy --all-targets` was failing on `main` before this).

## Part 2 — Editor card reorder (`50e5873`)
Reorder the appearance-editor cards to the exact handoff sequence. Two `<section class="editor-card">` blocks moved (everything else was already in the right relative order):
- HEADER / FOOTER LOGOS up to just after LOGO;
- CATALOG LAYOUT down to just after DEFAULT THEME.

Final order: Identity · Brand color · Logo · Header/footer logos · Background & gradients · Appearance · Default theme · Catalog layout · Visible sections · Content · SEO & analytics · Custom CSS · HTML blocks. The three cards the handoff list doesn't name (Appearance, Header/footer logos, Content) are placed by affinity. Pure template cut/paste — no logic, no field/name changes; the Alpine `landingForm` scope is unchanged.

## Verification
- Gate green: full `cargo test`, `cargo clippy --all-targets -- -D warnings`, `./scripts/i18n-check.sh` (incl. the `load_default_succeeds` Fluent-duplicate guard).
- **Real smoke** (live `serve`):
  - Public portal — `sections` groups 4 cards into app/report/api in order, empty types omitted; grid + list unchanged (single group, no heading).
  - Admin editor — rendered heading order matches the target 1:1; the moved logos card keeps its picker wiring; Grade/Lista/**Seções** all present.

🤖 Generated with [Claude Code](https://claude.com/claude-code)