### PR TITLE
chore(release): bump workspace version 0.1.91 → 0.1.92

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2845,7 +2845,7 @@ dependencies = [
 
 [[package]]
 name = "ruscker-admin"
-version = "0.1.91"
+version = "0.1.92"
 dependencies = [
  "aes-gcm",
  "anyhow",
@@ -2895,7 +2895,7 @@ dependencies = [
 
 [[package]]
 name = "ruscker-cli"
-version = "0.1.91"
+version = "0.1.92"
 dependencies = [
  "anyhow",
  "clap",
@@ -2915,7 +2915,7 @@ dependencies = [
 
 [[package]]
 name = "ruscker-config"
-version = "0.1.91"
+version = "0.1.92"
 dependencies = [
  "chrono",
  "ordered-float",
@@ -2930,7 +2930,7 @@ dependencies = [
 
 [[package]]
 name = "ruscker-core"
-version = "0.1.91"
+version = "0.1.92"
 dependencies = [
  "async-trait",
  "chrono",
@@ -2943,7 +2943,7 @@ dependencies = [
 
 [[package]]
 name = "ruscker-docker"
-version = "0.1.91"
+version = "0.1.92"
 dependencies = [
  "anyhow",
  "async-stream",
@@ -2962,7 +2962,7 @@ dependencies = [
 
 [[package]]
 name = "ruscker-proxy"
-version = "0.1.91"
+version = "0.1.92"
 dependencies = [
  "anyhow",
  "axum",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -10,7 +10,7 @@ members = [
 ]
 
 [workspace.package]
-version = "0.1.91"
+version = "0.1.92"
 edition = "2021"
 rust-version = "1.85"
 license = "Apache-2.0"

--- a/book/src/news.md
+++ b/book/src/news.md
@@ -9,6 +9,18 @@ the [GitHub releases page](https://github.com/StrategicProjects/ruscker/releases
 
 ---
 
+## v0.1.92 — 2026-06-08
+
+**Appearance — catalog "Sections" layout + editor card order.** The
+catalog-layout picker gains a third option, **Sections**: the portal
+catalog grouped by app type, each group under a heading that hides itself
+when the live filters (search / access / status / type) empty it. Grid
+and List are unchanged. The appearance editor's cards are also reordered
+to match the design handoff (logo controls grouped together, default
+theme ahead of catalog layout).
+
+---
+
 ## v0.1.91 — 2026-06-08
 
 **Appearance — analytics provider picker.** The appearance editor's


### PR DESCRIPTION
Release **v0.1.92** — appearance: catalog "Sections" layout + editor card reorder (#701).

- `Cargo.toml` / `Cargo.lock` → 0.1.92
- `book/src/news.md` → v0.1.92 entry

Tag `v0.1.92` is pushed after merge to trigger the release workflow (.deb / musl / cosign-signed ghcr image).

🤖 Generated with [Claude Code](https://claude.com/claude-code)