### PR TITLE
chore(release): bump workspace version 0.1.92 → 0.1.93

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2845,7 +2845,7 @@ dependencies = [
 
 [[package]]
 name = "ruscker-admin"
-version = "0.1.92"
+version = "0.1.93"
 dependencies = [
  "aes-gcm",
  "anyhow",
@@ -2895,7 +2895,7 @@ dependencies = [
 
 [[package]]
 name = "ruscker-cli"
-version = "0.1.92"
+version = "0.1.93"
 dependencies = [
  "anyhow",
  "clap",
@@ -2915,7 +2915,7 @@ dependencies = [
 
 [[package]]
 name = "ruscker-config"
-version = "0.1.92"
+version = "0.1.93"
 dependencies = [
  "chrono",
  "ordered-float",
@@ -2930,7 +2930,7 @@ dependencies = [
 
 [[package]]
 name = "ruscker-core"
-version = "0.1.92"
+version = "0.1.93"
 dependencies = [
  "async-trait",
  "chrono",
@@ -2943,7 +2943,7 @@ dependencies = [
 
 [[package]]
 name = "ruscker-docker"
-version = "0.1.92"
+version = "0.1.93"
 dependencies = [
  "anyhow",
  "async-stream",
@@ -2962,7 +2962,7 @@ dependencies = [
 
 [[package]]
 name = "ruscker-proxy"
-version = "0.1.92"
+version = "0.1.93"
 dependencies = [
  "anyhow",
  "axum",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -10,7 +10,7 @@ members = [
 ]
 
 [workspace.package]
-version = "0.1.92"
+version = "0.1.93"
 edition = "2021"
 rust-version = "1.85"
 license = "Apache-2.0"

--- a/book/src/news.md
+++ b/book/src/news.md
@@ -9,6 +9,22 @@ the [GitHub releases page](https://github.com/StrategicProjects/ruscker/releases
 
 ---
 
+## v0.1.93 — 2026-06-08
+
+**Appearance editor fixes.** Two follow-ups from testing the editor:
+
+- **Image picker on screen.** The "Choose image" modal could open
+  centered in the (tall) editor page instead of the viewport — often
+  below the fold, hidden. It now teleports to `<body>` so it always
+  centers on screen.
+- **Live preview reflects every control.** The editor's portal preview
+  used to mirror only a few fields; it now reacts to the per-theme
+  palette and default theme (the whole frame repaints light/dark), logo
+  mode/size, header preset, card-cover style, catalog layout
+  (grid/list/sections) and density, and the visible-section toggles.
+
+---
+
 ## v0.1.92 — 2026-06-08
 
 **Appearance — catalog "Sections" layout + editor card order.** The


### PR DESCRIPTION
Release **v0.1.93** — appearance editor fixes (#704): image-picker modal on screen + live preview reflects every control.

Tag `v0.1.93` pushed after merge to trigger the release workflow.

🤖 Generated with [Claude Code](https://claude.com/claude-code)