### PR TITLE
chore(release): bump workspace version 0.1.93 → 0.1.94

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2845,7 +2845,7 @@ dependencies = [
 
 [[package]]
 name = "ruscker-admin"
-version = "0.1.93"
+version = "0.1.94"
 dependencies = [
  "aes-gcm",
  "anyhow",
@@ -2895,7 +2895,7 @@ dependencies = [
 
 [[package]]
 name = "ruscker-cli"
-version = "0.1.93"
+version = "0.1.94"
 dependencies = [
  "anyhow",
  "clap",
@@ -2915,7 +2915,7 @@ dependencies = [
 
 [[package]]
 name = "ruscker-config"
-version = "0.1.93"
+version = "0.1.94"
 dependencies = [
  "chrono",
  "ordered-float",
@@ -2930,7 +2930,7 @@ dependencies = [
 
 [[package]]
 name = "ruscker-core"
-version = "0.1.93"
+version = "0.1.94"
 dependencies = [
  "async-trait",
  "chrono",
@@ -2943,7 +2943,7 @@ dependencies = [
 
 [[package]]
 name = "ruscker-docker"
-version = "0.1.93"
+version = "0.1.94"
 dependencies = [
  "anyhow",
  "async-stream",
@@ -2962,7 +2962,7 @@ dependencies = [
 
 [[package]]
 name = "ruscker-proxy"
-version = "0.1.93"
+version = "0.1.94"
 dependencies = [
  "anyhow",
  "axum",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -10,7 +10,7 @@ members = [
 ]
 
 [workspace.package]
-version = "0.1.93"
+version = "0.1.94"
 edition = "2021"
 rust-version = "1.85"
 license = "Apache-2.0"

--- a/book/src/news.md
+++ b/book/src/news.md
@@ -9,6 +9,22 @@ the [GitHub releases page](https://github.com/StrategicProjects/ruscker/releases
 
 ---
 
+## v0.1.94 — 2026-06-08
+
+**Portal no longer cached + clearer header labels.**
+
+- The public portal is now served `Cache-Control: private, no-cache`, so
+  appearance changes (catalog layout, colors, …) show on the next load
+  instead of being masked by a browser or proxy cache — and a shared
+  cache can no longer replay one visitor's access-filtered view to
+  another. Bundled assets stay cached as before.
+- Renamed two header controls that read alike: the preset is now **Header
+  style** (was "Portal header") and the explicit color is **Custom
+  background color** (was "Background color"), with a note that the
+  custom color overrides the preset.
+
+---
+
 ## v0.1.93 — 2026-06-08
 
 **Appearance editor fixes.** Two follow-ups from testing the editor:


### PR DESCRIPTION
Release **v0.1.94** — portal no-cache + clearer header labels (#706). Tag pushed after merge.

🤖 Generated with [Claude Code](https://claude.com/claude-code)