### PR TITLE
fix(appearance): logo size on custom logo, custom logo replaces mark, mark always colored

### DIFF
--- a/crates/ruscker-admin/src/routes/landing.rs
+++ b/crates/ruscker-admin/src/routes/landing.rs
@@ -170,6 +170,32 @@ impl<'a> LandingPage<'a> {
         self.logos.iter().any(|l| l.slot == slot && l.align == align)
     }
 
+    /// Any logo at all in the header (any alignment)? When true the
+    /// built-in Ruscker mark steps aside entirely, so an operator logo in
+    /// the center/right slot no longer renders alongside the mark (#701
+    /// follow-up — "custom logo hides the mark").
+    fn has_any_header_logo(&self) -> bool {
+        self.logos.iter().any(|l| l.slot == "header")
+    }
+
+    /// The header-left "brand" logo(s), sized by the appearance editor's
+    /// logo-size / logo-margin rather than each logo's own `height` — so
+    /// the size slider that drives the built-in mark also drives the
+    /// operator's brand logo (#701 follow-up). Other slots
+    /// (center/right/footer) keep their per-logo height via [`logo_view`].
+    fn brand_logo_view(&self) -> Vec<LogoView> {
+        self.logos
+            .iter()
+            .filter(|l| l.slot == "header" && l.align == "left")
+            .map(|l| LogoView {
+                src: self.logo_src(l),
+                link: l.link.clone(),
+                height: self.logo_size.max(1) as u32,
+                margin: Some(self.logo_margin.max(0) as u32),
+            })
+            .collect()
+    }
+
     /// Group the cards for the catalog area (#701). See [`CatalogGroup`].
     /// In `grid`/`list` layout this is a single unlabeled group holding
     /// every card; in `sections` layout it's one labeled group per

--- a/crates/ruscker-admin/templates/admin/landing.html
+++ b/crates/ruscker-admin/templates/admin/landing.html
@@ -617,11 +617,15 @@
             <div class="lp-head-side">
               {# Header-left logos replace the Ruscker mark (faithful to #468);
                  a small mark shows when none are set. #}
+              {# Brand-left logos are sized by the logo-size slider (pvLogoPx),
+                 matching the real landing's brand_logo_view (#701 follow-up). #}
               <template x-for="(logo, i) in logos.filter(l => l.url && l.slot === 'header' && l.align === 'left')" :key="i">
-                <img class="lp-logo" :src="assetUrl(logo.url)" :style="'height:' + Math.min((logo.height || 24), 16) + 'px'" alt="">
+                <img class="lp-logo" :src="assetUrl(logo.url)" :style="'height:' + pvLogoPx() + 'px;margin-right:' + pvLogoMarginPx() + 'px'" alt="">
               </template>
+              {# Mark steps aside for ANY header logo (not just left) and is
+                 always brand-coloured — mirrors has_any_header_logo (#701). #}
               <svg class="lp-mark"
-                   x-show="form.logo_mode !== 'custom' && !logos.some(l => l.url && l.slot === 'header' && l.align === 'left')"
+                   x-show="form.logo_mode !== 'custom' && !logos.some(l => l.url && l.slot === 'header')"
                    :style="'width:' + pvLogoPx() + 'px;height:' + pvLogoPx() + 'px;margin-right:' + pvLogoMarginPx() + 'px'"
                    viewBox="0 0 80 80" aria-hidden="true">
                 <polygon points="14,52 40,40 66,52 40,64" fill="#0F6E56"/>

--- a/crates/ruscker-admin/templates/landing.html
+++ b/crates/ruscker-admin/templates/landing.html
@@ -36,32 +36,24 @@
         {% if !header_style.is_empty() %}style="{{ header_style }}"{% endif %}>
   <div class="max-w-6xl mx-auto px-6 py-5 flex items-center justify-between gap-6 relative">
     <div class="flex items-center gap-3">
-      {# Header-left identity. When the operator configured header-left
-         logo(s) (#468) they REPLACE the Ruscker mark — the title/subtitle
-         text stays (operators customise those via #468 slice A). Otherwise
-         the built-in Ruscker mark renders (#182): brand teal on the default
-         surface, or a monochrome `currentColor` mark when a custom header
-         background is in play (a brand polygon can collide with the chosen
-         background — e.g. teal on teal disappears). #}
-      {# Brand mark: operator header-left logos win; otherwise the built-in
-         mark, unless logo-mode is `custom` (operator logos only). Size and
-         right margin come from the appearance editor (#623). #}
+      {# Header-left identity (#468, revised #701 follow-up). The brand
+         slot resolves to ONE of:
+           - operator header-left logo(s) — REPLACE the mark, and are now
+             sized by the appearance editor's logo-size/-margin (so the
+             size slider controls the operator's logo, not just the mark);
+           - otherwise the built-in Ruscker mark, but ONLY when there's no
+             operator header logo anywhere and logo-mode isn't `custom`
+             (so a center/right logo no longer shows the mark too).
+         The mark is always rendered in brand colours — a custom header
+         background no longer forces a monochrome (grey) mark. #}
       {% if self.has_logos_at("header", "left") %}
-        {% call logos(self.logo_view("header", "left", 28)) %}{% endcall %}
-      {% else if logo_mode != "custom" %}
-        {% if header_style.is_empty() %}
+        {% call logos(self.brand_logo_view()) %}{% endcall %}
+      {% else if logo_mode != "custom" && !self.has_any_header_logo() %}
         <svg viewBox="0 0 80 80" width="{{ logo_size }}" height="{{ logo_size }}" style="margin-right:{{ logo_margin }}px" aria-hidden="true" class="flex-none">
           <polygon points="14,52 40,40 66,52 40,64" fill="#0F6E56"/>
           <polygon points="14,40 40,28 66,40 40,52" fill="#1D9E75"/>
           <polygon points="14,28 40,16 66,28 40,40" fill="#5DCAA5"/>
         </svg>
-        {% else %}
-        <svg viewBox="0 0 80 80" width="{{ logo_size }}" height="{{ logo_size }}" style="margin-right:{{ logo_margin }}px" aria-hidden="true" class="flex-none">
-          <polygon points="14,52 40,40 66,52 40,64" fill="currentColor" opacity="0.45"/>
-          <polygon points="14,40 40,28 66,40 40,52" fill="currentColor" opacity="0.7"/>
-          <polygon points="14,28 40,16 66,28 40,40" fill="currentColor" opacity="1"/>
-        </svg>
-        {% endif %}
       {% endif %}
       {# Name + subtitle, hidden in `symbol` (mark-only) mode. #}
       {% if logo_mode != "symbol" %}


### PR DESCRIPTION
Three logo behaviors reported from cast that read as bugs (all confirmed by reproduction, all #468 "by design" but confusing). Fixed per the requested behavior:

1. **"Logo size" now resizes a custom logo.** The size/margin sliders only sized the built-in Ruscker mark, so they did nothing to an operator's own header logo. The header-left brand logo is now sized by `logo_size`/`logo_margin` (`brand_logo_view`), so the slider controls whichever brand logo is shown. *(Verified: custom left logo renders `height:60px` at slider 60, ignoring its own height.)*
2. **A custom logo now replaces the mark.** The mark only stepped aside for a header-*left* logo, so a center/right logo showed alongside it ("two logos"). It now hides for **any** header logo (`has_any_header_logo`). *(Verified: center logo → 0 built-in marks, 1 custom logo.)*
3. **The mark is always brand-colored.** A custom header background forced a monochrome `currentColor` (grey) mark; now it's always the teal brand. *(Verified: custom bg → `fill="#0F6E56"`, no `currentColor`.)*

Editor preview updated to match (brand-left logo sized by the slider, mark hidden for any header logo, always colored). Verified on the real landing **and** the live preview with a headless-Chromium probe.

Gate: full `cargo test`, `cargo clippy --all-targets -- -D warnings`, `i18n-check` green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)