### PR TITLE
chore(release): bump workspace version 0.1.94 → 0.1.95

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2845,7 +2845,7 @@ dependencies = [
 
 [[package]]
 name = "ruscker-admin"
-version = "0.1.94"
+version = "0.1.95"
 dependencies = [
  "aes-gcm",
  "anyhow",
@@ -2895,7 +2895,7 @@ dependencies = [
 
 [[package]]
 name = "ruscker-cli"
-version = "0.1.94"
+version = "0.1.95"
 dependencies = [
  "anyhow",
  "clap",
@@ -2915,7 +2915,7 @@ dependencies = [
 
 [[package]]
 name = "ruscker-config"
-version = "0.1.94"
+version = "0.1.95"
 dependencies = [
  "chrono",
  "ordered-float",
@@ -2930,7 +2930,7 @@ dependencies = [
 
 [[package]]
 name = "ruscker-core"
-version = "0.1.94"
+version = "0.1.95"
 dependencies = [
  "async-trait",
  "chrono",
@@ -2943,7 +2943,7 @@ dependencies = [
 
 [[package]]
 name = "ruscker-docker"
-version = "0.1.94"
+version = "0.1.95"
 dependencies = [
  "anyhow",
  "async-stream",
@@ -2962,7 +2962,7 @@ dependencies = [
 
 [[package]]
 name = "ruscker-proxy"
-version = "0.1.94"
+version = "0.1.95"
 dependencies = [
  "anyhow",
  "axum",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -10,7 +10,7 @@ members = [
 ]
 
 [workspace.package]
-version = "0.1.94"
+version = "0.1.95"
 edition = "2021"
 rust-version = "1.85"
 license = "Apache-2.0"

--- a/book/src/news.md
+++ b/book/src/news.md
@@ -9,6 +9,20 @@ the [GitHub releases page](https://github.com/StrategicProjects/ruscker/releases
 
 ---
 
+## v0.1.95 — 2026-06-08
+
+**Logo controls behave as expected.** Three appearance-editor logo
+behaviors that read as bugs are fixed:
+
+- The **Logo size / margin** sliders now resize a custom header logo too,
+  not just the built-in mark.
+- A custom header logo in **any** position (left/center/right) now hides
+  the built-in Ruscker mark — no more mark-plus-logo "two logos".
+- The mark is **always brand-colored**; a custom header background no
+  longer turns it grey.
+
+---
+
 ## v0.1.94 — 2026-06-08
 
 **Portal no longer cached + clearer header labels.**


### PR DESCRIPTION
Release **v0.1.95** — logo control fixes (#708). Tag pushed after merge.

🤖 Generated with [Claude Code](https://claude.com/claude-code)