### PR TITLE
feat(logs): colour-coded log stream matching the handoff design

### DIFF
--- a/crates/ruscker-admin/assets/i18n/en/landing.ftl
+++ b/crates/ruscker-admin/assets/i18n/en/landing.ftl
@@ -514,7 +514,7 @@ spec-help-inject-base-href = Ruscker always forwards X-Forwarded-Prefix / X-Scri
 spec-form-error-volume = Each volume must be /host:/container (optionally :ro).
 admin-nav-logs = Logs
 admin-proclog-title = Logs
-admin-proclog-subtitle = Recent Ruscker process log (live).
+admin-proclog-subtitle = Event stream from the balancer and replicas
 admin-proclog-unavailable = Log buffer not wired (the server started without the logging layer).
 admin-proclog-empty = No logs captured yet at this level. New events show up here as they happen; run the server with -v to include info-level logs.
 
@@ -606,6 +606,9 @@ admin-proclog-filter-all = All levels
 admin-proclog-search = Search logs…
 admin-proclog-pause = Pause
 admin-proclog-resume = Resume
+admin-proclog-clear = Clear
+admin-proclog-lines = lines
+admin-proclog-filter-app-all = All apps
 
 landing-empty = Nothing here yet.
 

--- a/crates/ruscker-admin/assets/i18n/es/landing.ftl
+++ b/crates/ruscker-admin/assets/i18n/es/landing.ftl
@@ -514,7 +514,7 @@ spec-help-inject-base-href = Ruscker siempre reenvía X-Forwarded-Prefix / X-Scr
 spec-form-error-volume = Cada volumen debe ser /host:/contenedor (opcional :ro).
 admin-nav-logs = Registros
 admin-proclog-title = Registros
-admin-proclog-subtitle = Registro reciente del proceso Ruscker (en vivo).
+admin-proclog-subtitle = Flujo de eventos del balanceador y las réplicas
 admin-proclog-unavailable = Búfer de registro no disponible (el servidor inició sin la capa de logging).
 admin-proclog-empty = Aún no se ha capturado ningún registro en este nivel. Los nuevos eventos aparecen aquí a medida que ocurren; ejecuta el servidor con -v para incluir registros de nivel info.
 
@@ -606,6 +606,9 @@ admin-proclog-filter-all = Todos los niveles
 admin-proclog-search = Buscar en los logs…
 admin-proclog-pause = Pausar
 admin-proclog-resume = Reanudar
+admin-proclog-clear = Limpiar
+admin-proclog-lines = líneas
+admin-proclog-filter-app-all = Todas las apps
 
 landing-empty = Nada por aquí.
 

--- a/crates/ruscker-admin/assets/i18n/fr/landing.ftl
+++ b/crates/ruscker-admin/assets/i18n/fr/landing.ftl
@@ -514,7 +514,7 @@ spec-help-inject-base-href = Ruscker transmet toujours X-Forwarded-Prefix / X-Sc
 spec-form-error-volume = Chaque volume doit être /hôte:/conteneur (optionnel :ro).
 admin-nav-logs = Journaux
 admin-proclog-title = Journaux
-admin-proclog-subtitle = Journal récent du processus Ruscker (en direct).
+admin-proclog-subtitle = Flux d'événements de l'équilibreur et des répliques
 admin-proclog-unavailable = Tampon de journal indisponible (le serveur a démarré sans la couche de journalisation).
 admin-proclog-empty = Aucun journal capturé pour l'instant à ce niveau. Les nouveaux événements apparaissent ici au fur et à mesure ; lancez le serveur avec -v pour inclure les journaux de niveau info.
 
@@ -606,6 +606,9 @@ admin-proclog-filter-all = Tous les niveaux
 admin-proclog-search = Rechercher dans les journaux…
 admin-proclog-pause = Pause
 admin-proclog-resume = Reprendre
+admin-proclog-clear = Effacer
+admin-proclog-lines = lignes
+admin-proclog-filter-app-all = Toutes les apps
 
 landing-empty = Rien ici pour l'instant.
 

--- a/crates/ruscker-admin/assets/i18n/pt/landing.ftl
+++ b/crates/ruscker-admin/assets/i18n/pt/landing.ftl
@@ -518,7 +518,7 @@ spec-help-inject-base-href = O Ruscker sempre encaminha X-Forwarded-Prefix / X-S
 spec-form-error-volume = Cada volume deve ser /host:/container (opcional :ro).
 admin-nav-logs = Logs
 admin-proclog-title = Logs
-admin-proclog-subtitle = Log recente do processo Ruscker (ao vivo).
+admin-proclog-subtitle = Fluxo de eventos do balanceador e das réplicas
 admin-proclog-unavailable = Buffer de log não disponível (o servidor iniciou sem a camada de logging).
 admin-proclog-empty = Nenhum log capturado ainda neste nível. Novos eventos aparecem aqui conforme acontecem; rode o servidor com -v para incluir logs de nível info.
 
@@ -610,6 +610,9 @@ admin-proclog-filter-all = Todos os níveis
 admin-proclog-search = Buscar nos logs…
 admin-proclog-pause = Pausar
 admin-proclog-resume = Retomar
+admin-proclog-clear = Limpar
+admin-proclog-lines = linhas
+admin-proclog-filter-app-all = Todos os apps
 
 landing-empty = Nada por aqui.
 

--- a/crates/ruscker-admin/assets/tailwind/input.css
+++ b/crates/ruscker-admin/assets/tailwind/input.css
@@ -687,29 +687,60 @@ input[type="range"]::-moz-range-thumb {
 /* Live server-log terminal (design handoff #623): the existing SSE feed,
  * rendered as level-coloured lines with level/text filters. Content is
  * set via textContent only — never parsed as HTML. */
-.log-toolbar { display: flex; align-items: center; gap: 8px; flex-wrap: wrap; margin-bottom: 0; }
+/* Logs viewer (handoff design): toolbar + colour-coded stream in one card. */
+.log-viewer {
+  border: 0.5px solid var(--border); border-radius: 14px;
+  background: var(--surface); overflow: hidden;
+}
+.log-toolbar {
+  display: flex; align-items: center; gap: 10px; flex-wrap: wrap;
+  padding: 12px 16px; border-bottom: 0.5px solid var(--border);
+}
+.log-toolbar__sep { width: 1px; height: 20px; background: var(--border); flex: none; }
+.log-toolbar__spacer { flex: 1 1 auto; }
+.log-pause {
+  display: inline-flex; align-items: center; gap: 6px; font-size: 12px;
+  color: var(--text); cursor: pointer; background: var(--surface);
+  border: 0.5px solid var(--border); border-radius: 999px; padding: 7px 14px; outline: 0;
+}
+.log-pause:hover { border-color: var(--border-strong); }
+.log-pause.is-paused { color: var(--color-teal-600); border-color: var(--color-teal-600); }
+.log-chips { display: inline-flex; align-items: center; gap: 6px; }
+.log-chip {
+  font-size: 12px; cursor: pointer; background: var(--surface);
+  border: 0.5px solid var(--border); border-radius: 999px; padding: 6px 12px;
+  color: var(--text-muted); outline: 0; transition: opacity 0.12s ease;
+}
+.log-chip::before {
+  content: ""; display: inline-block; width: 6px; height: 6px; border-radius: 999px;
+  margin-right: 6px; vertical-align: 1px; background: currentColor;
+}
+.log-chip--info { color: #3b82f6; }
+.log-chip--warn { color: #d97706; }
+.log-chip--error { color: #ef4444; }
+.log-chip.is-off { opacity: 0.4; }
 .log-select {
   font-family: inherit; font-size: 12px; color: var(--text-muted);
   background: var(--surface); border: 0.5px solid var(--border);
   border-radius: 999px; padding: 6px 12px; cursor: pointer; outline: 0;
 }
-.log-search {
-  font-family: var(--font-mono); font-size: 12px; color: var(--text);
-  background: var(--surface); border: 0.5px solid var(--border);
-  border-radius: 999px; padding: 6px 12px; outline: 0; flex: 1; min-width: 140px;
+.log-count { font-size: 12px; color: var(--text-faint); white-space: nowrap; }
+.log-iconbtn {
+  display: inline-flex; align-items: center; justify-content: center;
+  width: 30px; height: 30px; border-radius: 8px; color: var(--text-faint);
+  border: 0.5px solid transparent; background: transparent; cursor: pointer;
 }
-.log-search:focus { border-color: var(--text); }
+.log-iconbtn:hover { color: var(--text); background: var(--surface-soft); }
 .log-body {
-  height: 64vh; overflow-y: auto; margin-top: 10px;
-  background: var(--surface); border: 0.5px solid var(--border); border-radius: 12px;
-  padding: 10px 4px; font-family: var(--font-mono); font-size: 12px; line-height: 1.7;
+  height: 62vh; overflow-y: auto; padding: 8px 6px;
+  font-family: var(--font-mono); font-size: 12px; line-height: 1.7;
 }
-:root[data-theme="dark"] .log-body { background: #121212; }
+:root[data-theme="dark"] .log-viewer { background: #121212; }
 @media (prefers-color-scheme: dark) {
-  :root:not([data-theme="light"]) .log-body { background: #121212; }
+  :root:not([data-theme="light"]) .log-viewer { background: #121212; }
 }
 .log-line {
-  display: grid; grid-template-columns: 78px 48px 150px 1fr; gap: 10px;
+  display: grid; grid-template-columns: 92px 52px 150px 1fr; gap: 12px;
   padding: 1px 14px; white-space: nowrap; animation: log-in 0.25s ease;
 }
 .log-line:hover { background: var(--surface-soft); }

--- a/crates/ruscker-admin/templates/admin/process_logs.html
+++ b/crates/ruscker-admin/templates/admin/process_logs.html
@@ -4,93 +4,133 @@
 
 {% block content %}
 
-<div class="flex items-end justify-between mb-1">
+<div class="flex items-end justify-between mb-4">
   <div>
-    <h1 class="text-xl font-medium tracking-tight">{{ self.t("admin-proclog-title") }}</h1>
-    <p class="text-xs text-[color:var(--text-muted)] mt-1">{{ self.t("admin-proclog-subtitle") }}</p>
+    <h1 class="text-2xl font-medium tracking-tight">{{ self.t("admin-proclog-title") }}</h1>
+    <p class="text-sm text-[color:var(--text-muted)] mt-1">{{ self.t("admin-proclog-subtitle") }}</p>
   </div>
   {% if available %}
-  <div class="text-xs text-[color:var(--text-muted)] flex items-center gap-3">
-    {# Live-stream badge (#623): the SSE follow keeps this terminal current. #}
-    <span class="live-badge"><span class="live-dot"></span>{{ self.t("admin-dashboard-live") }}</span>
-    {% if self.truncated() %}
-    <span>{{ self.t("admin-proclog-tail-note") }} ({{ lines.len() }}/{{ total }})</span>
-    {% endif %}
-    <a href="{{ base }}/admin/logs/download" class="admin-nav-link" download>
-      <i class="ti ti-download" aria-hidden="true"></i> {{ self.t("admin-proclog-download") }}
-    </a>
-  </div>
+  {# Live-stream badge (#623): the SSE follow keeps this terminal current. #}
+  <span class="live-badge"><span class="live-dot"></span>{{ self.t("admin-dashboard-live") }}</span>
   {% endif %}
 </div>
 
 {% if !available %}
   <p class="text-sm text-[color:var(--text-faint)] py-8 text-center">{{ self.t("admin-proclog-unavailable") }}</p>
 {% else %}
-  {# Buffer is wired but empty — say so explicitly so an operator can
-     tell "nothing logged yet" from a broken tab (#452). New lines still
-     stream into the <pre> below as they happen. #}
-  {% if lines.is_empty() %}
-  <p class="text-sm text-[color:var(--text-faint)] py-6 text-center">{{ self.t("admin-proclog-empty") }}</p>
-  {% endif %}
-  <div class="log-toolbar">
-    <select id="log-level" class="log-select" aria-label="{{ self.t("admin-proclog-filter-level") }}">
-      <option value="">{{ self.t("admin-proclog-filter-all") }}</option>
-      <option value="ERROR">ERROR</option>
-      <option value="WARN">WARN</option>
-      <option value="INFO">INFO</option>
-      <option value="DEBUG">DEBUG</option>
-    </select>
-    <input type="search" id="log-search" class="log-search" placeholder="{{ self.t("admin-proclog-search") }}">
-    <button type="button" id="log-pause" class="admin-nav-link" aria-pressed="false"
-            data-pause="{{ self.t("admin-proclog-pause") }}" data-resume="{{ self.t("admin-proclog-resume") }}">
-      <i class="ti ti-player-pause" aria-hidden="true"></i> <span>{{ self.t("admin-proclog-pause") }}</span>
-    </button>
-  </div>
+  <div class="log-viewer">
+    {# Toolbar: pause · level chips · app filter · (right) count + clear +
+       download — matches the handoff Logs design. #}
+    <div class="log-toolbar">
+      <button type="button" id="log-pause" class="log-pause" aria-pressed="false"
+              data-pause="{{ self.t("admin-proclog-pause") }}" data-resume="{{ self.t("admin-proclog-resume") }}">
+        <i class="ti ti-player-pause" aria-hidden="true"></i> <span>{{ self.t("admin-proclog-pause") }}</span>
+      </button>
+      <span class="log-toolbar__sep" aria-hidden="true"></span>
+      {# Level chips toggle each level's visibility (all on by default).
+         Labels are the literal log levels, coloured to match the stream. #}
+      <div class="log-chips" role="group" aria-label="{{ self.t("admin-proclog-filter-level") }}">
+        <button type="button" class="log-chip log-chip--info"  data-level="INFO">Info</button>
+        <button type="button" class="log-chip log-chip--warn"  data-level="WARN">Warn</button>
+        <button type="button" class="log-chip log-chip--error" data-level="ERROR">Error</button>
+      </div>
+      <select id="log-app" class="log-select" aria-label="{{ self.t("admin-proclog-filter-app-all") }}">
+        <option value="">{{ self.t("admin-proclog-filter-app-all") }}</option>
+      </select>
+      <span class="log-toolbar__spacer"></span>
+      <span class="log-count"><span id="log-count-n">0</span> {{ self.t("admin-proclog-lines") }}</span>
+      <button type="button" id="log-clear" class="log-iconbtn"
+              title="{{ self.t("admin-proclog-clear") }}" aria-label="{{ self.t("admin-proclog-clear") }}">
+        <i class="ti ti-eraser" aria-hidden="true"></i>
+      </button>
+      <a href="{{ base }}/admin/logs/download" class="log-iconbtn" download
+         title="{{ self.t("admin-proclog-download") }}" aria-label="{{ self.t("admin-proclog-download") }}">
+        <i class="ti ti-download" aria-hidden="true"></i>
+      </a>
+    </div>
 
-  {# Raw lines for the JS to colour/parse on load; the <pre> is replaced by
-     the terminal below. Hidden — never shown directly. #}
-  <pre id="proclog-seed" hidden>{% for line in lines %}{{ line }}
+    {# Buffer wired but empty — say so explicitly so an operator can tell
+       "nothing logged yet" from a broken tab (#452). New lines still stream
+       in below as they happen. #}
+    {% if lines.is_empty() %}
+    <p id="log-empty" class="text-sm text-[color:var(--text-faint)] py-8 text-center">{{ self.t("admin-proclog-empty") }}</p>
+    {% endif %}
+
+    {# Raw lines for the JS to colour/parse on load; the <pre> is replaced by
+       the terminal below. Hidden — never shown directly. #}
+    <pre id="proclog-seed" hidden>{% for line in lines %}{{ line }}
 {% endfor %}</pre>
-  <div id="proclog" class="log-body"></div>
+    <div id="proclog" class="log-body" role="log" aria-live="polite"></div>
+  </div>
+  {% if self.truncated() %}
+  <p class="text-[11px] text-[color:var(--text-faint)] mt-2">{{ self.t("admin-proclog-tail-note") }} ({{ lines.len() }}/{{ total }})</p>
+  {% endif %}
 
   <script>
   (function () {
     var box = document.getElementById('proclog');
     var seed = document.getElementById('proclog-seed');
-    var levelSel = document.getElementById('log-level');
-    var searchIn = document.getElementById('log-search');
+    var appSel = document.getElementById('log-app');
     var pauseBtn = document.getElementById('log-pause');
+    var clearBtn = document.getElementById('log-clear');
+    var countN = document.getElementById('log-count-n');
+    var emptyHint = document.getElementById('log-empty');
+    var chips = Array.prototype.slice.call(document.querySelectorAll('.log-chip'));
     var paused = false;
+    var hiddenLevels = {};   // level -> true when its chip is toggled off
+    var knownApps = {};      // app name -> true, to dedupe the app <select>
 
     function cell(cls, text) { var s = document.createElement('span'); s.className = cls; s.textContent = text; return s; }
+
+    // A row matches when its level chip is on AND the app filter allows it.
     function matches(el) {
-      var lv = levelSel.value, q = searchIn.value.toLowerCase();
-      return (!lv || el.dataset.level === lv) && (!q || (el.dataset.text || '').indexOf(q) >= 0);
+      var lv = el.dataset.level;
+      if (lv && hiddenLevels[lv]) return false;
+      var app = appSel.value;
+      if (app && el.dataset.app !== app) return false;
+      return true;
     }
+    function refilter() {
+      var rows = box.children;
+      for (var i = 0; i < rows.length; i++) rows[i].style.display = matches(rows[i]) ? '' : 'none';
+    }
+    function updateCount() { countN.textContent = box.children.length; }
+    function addAppOption(app) {
+      var o = document.createElement('option'); o.value = app; o.textContent = app; appSel.appendChild(o);
+    }
+
     function append(raw) {
-      // Strip ANSI colour codes, then split into ts / level / target / msg.
+      // Strip ANSI, then split into  <ts>  LEVEL  <message>. The tracing
+      // stream carries no `target:` prefix, so the level is always the 2nd
+      // token; the friendly app name comes from a `spec=`/`app=` field.
       var clean = raw.replace(/\x1b\[[0-9;]*m/g, '').replace(/\s+$/, '');
       if (!clean) return;
-      var m = clean.match(/^(\S+)\s+(ERROR|WARN|INFO|DEBUG|TRACE)\s+([\w:._-]+):\s?([\s\S]*)$/);
+      if (emptyHint) { emptyHint.remove(); emptyHint = null; }
+      var m = clean.match(/^(\S+)\s+(ERROR|WARN|INFO|DEBUG|TRACE)\s+([\s\S]*)$/);
       var div = document.createElement('div');
       div.className = 'log-line';
-      div.dataset.level = m ? m[2] : '';
-      div.dataset.text = clean.toLowerCase();
       if (m) {
-        div.appendChild(cell('log-ts', m[1].replace(/^.*T/, '').replace(/\..*$/, '')));
-        div.appendChild(cell('log-lvl log-lvl-' + m[2].toLowerCase(), m[2]));
-        div.appendChild(cell('log-app', m[3]));
-        div.appendChild(cell('log-msg', m[4]));
+        var level = m[2], rest = m[3], app = '';
+        var sm = rest.match(/\b(?:spec|app|name)=["']?([A-Za-z0-9][A-Za-z0-9._-]*)/);
+        if (sm) app = sm[1];
+        div.dataset.level = level;
+        div.dataset.app = app;
+        div.dataset.text = clean.toLowerCase();
+        // HH:MM:SS.mmm (keep millis like the design; drop the date + tz).
+        var ts = m[1].replace(/^.*T/, '').replace(/(\.\d{3})\d*Z?$/, '$1').replace(/Z$/, '');
+        div.appendChild(cell('log-ts', ts));
+        div.appendChild(cell('log-lvl log-lvl-' + level.toLowerCase(), level));
+        div.appendChild(cell('log-app', app));
+        div.appendChild(cell('log-msg', rest));
+        if (app && !knownApps[app]) { knownApps[app] = true; addAppOption(app); }
       } else {
+        div.dataset.level = ''; div.dataset.app = ''; div.dataset.text = clean.toLowerCase();
         div.style.gridTemplateColumns = '1fr';
         div.appendChild(cell('log-msg', clean));
       }
       div.style.display = matches(div) ? '' : 'none';
       box.appendChild(div);
-    }
-    function refilter() {
-      var rows = box.children;
-      for (var i = 0; i < rows.length; i++) rows[i].style.display = matches(rows[i]) ? '' : 'none';
+      updateCount();
     }
     var nearBottom = function () { return box.scrollHeight - box.scrollTop - box.clientHeight < 48; };
 
@@ -99,10 +139,26 @@
     seed.remove();
     box.scrollTop = box.scrollHeight;
 
-    levelSel.addEventListener('change', refilter);
-    searchIn.addEventListener('input', refilter);
+    chips.forEach(function (chip) {
+      chip.addEventListener('click', function () {
+        var lv = chip.dataset.level;
+        hiddenLevels[lv] = !hiddenLevels[lv];
+        chip.classList.toggle('is-off', !!hiddenLevels[lv]);
+        chip.setAttribute('aria-pressed', hiddenLevels[lv] ? 'false' : 'true');
+        refilter();
+      });
+    });
+    appSel.addEventListener('change', refilter);
+    clearBtn.addEventListener('click', function () {
+      box.textContent = '';
+      knownApps = {};
+      appSel.selectedIndex = 0;
+      while (appSel.options.length > 1) appSel.remove(1);
+      updateCount();
+    });
     pauseBtn.addEventListener('click', function () {
       paused = !paused;
+      pauseBtn.classList.toggle('is-paused', paused);
       pauseBtn.setAttribute('aria-pressed', paused ? 'true' : 'false');
       var icon = pauseBtn.querySelector('i'), label = pauseBtn.querySelector('span');
       if (icon) icon.className = 'ti ' + (paused ? 'ti-player-play' : 'ti-player-pause');
@@ -114,7 +170,7 @@
       es.onmessage = function (e) {
         if (paused) return;
         var stick = nearBottom();
-        append(e.data);
+        e.data.split('\n').forEach(append);
         if (stick) box.scrollTop = box.scrollHeight;
       };
       es.onerror = function () { /* EventSource auto-reconnects */ };


### PR DESCRIPTION
The Logs tab rendered every line in flat grey. **Root cause:** the line parser required a `target:` segment (`<ts> LEVEL target: msg`), but Ruscker's tracing stream is `<ts>  LEVEL  message` with no target — so the regex matched **0 lines** and everything fell to the uncoloured fallback. The level colours already existed in CSS; nothing ever reached them.

- **Parser fix** (the colours): level is the 2nd token, always extracted and coloured — INFO blue / WARN amber / ERROR red. App name comes from a `spec=`/`app=` field; timestamp keeps millis (HH:MM:SS.mmm).
- **Toolbar → handoff design:** Pause · Info/Warn/Error colour-dotted level chips (toggle each level) · an "All apps" filter populated live from the stream · line count · clear · download — all in one bordered viewer card.
- Subtitle → "Event stream from the balancer and replicas". New i18n (en/pt/es/fr).

**Verified** live (headless Chromium): 7/7 lines now parse with a coloured level (INFO computed `rgb(59,130,246)`) vs 0 before; toolbar + card match the mockup.

Gate: full `cargo test`, `clippy --all-targets -D warnings`, `i18n-check` green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)