### PR TITLE
chore(release): bump workspace version 0.1.95 → 0.1.96

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2845,7 +2845,7 @@ dependencies = [
 
 [[package]]
 name = "ruscker-admin"
-version = "0.1.95"
+version = "0.1.96"
 dependencies = [
  "aes-gcm",
  "anyhow",
@@ -2895,7 +2895,7 @@ dependencies = [
 
 [[package]]
 name = "ruscker-cli"
-version = "0.1.95"
+version = "0.1.96"
 dependencies = [
  "anyhow",
  "clap",
@@ -2915,7 +2915,7 @@ dependencies = [
 
 [[package]]
 name = "ruscker-config"
-version = "0.1.95"
+version = "0.1.96"
 dependencies = [
  "chrono",
  "ordered-float",
@@ -2930,7 +2930,7 @@ dependencies = [
 
 [[package]]
 name = "ruscker-core"
-version = "0.1.95"
+version = "0.1.96"
 dependencies = [
  "async-trait",
  "chrono",
@@ -2943,7 +2943,7 @@ dependencies = [
 
 [[package]]
 name = "ruscker-docker"
-version = "0.1.95"
+version = "0.1.96"
 dependencies = [
  "anyhow",
  "async-stream",
@@ -2962,7 +2962,7 @@ dependencies = [
 
 [[package]]
 name = "ruscker-proxy"
-version = "0.1.95"
+version = "0.1.96"
 dependencies = [
  "anyhow",
  "axum",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -10,7 +10,7 @@ members = [
 ]
 
 [workspace.package]
-version = "0.1.95"
+version = "0.1.96"
 edition = "2021"
 rust-version = "1.85"
 license = "Apache-2.0"

--- a/book/src/news.md
+++ b/book/src/news.md
@@ -9,6 +9,17 @@ the [GitHub releases page](https://github.com/StrategicProjects/ruscker/releases
 
 ---
 
+## v0.1.96 — 2026-06-08
+
+**Logs tab — colour-coded event stream.** The Logs view rendered every
+line in flat grey because the parser expected a log format the server
+doesn't emit. It now colours each level (INFO blue, WARN amber, ERROR
+red), shows the app name and a millisecond timestamp, and the toolbar
+matches the design: a Pause button, Info/Warn/Error level chips, an
+"All apps" filter, a live line count, clear, and download — in one card.
+
+---
+
 ## v0.1.95 — 2026-06-08
 
 **Logo controls behave as expected.** Three appearance-editor logo


### PR DESCRIPTION
Release **v0.1.96** — Logs tab colour-coded stream (#710). Tag pushed after merge.

🤖 Generated with [Claude Code](https://claude.com/claude-code)