### PR TITLE
fix(logs): collapse the app column when a line has no app

### DIFF
--- a/crates/ruscker-admin/assets/tailwind/input.css
+++ b/crates/ruscker-admin/assets/tailwind/input.css
@@ -740,9 +740,14 @@ input[type="range"]::-moz-range-thumb {
   :root:not([data-theme="light"]) .log-viewer { background: #121212; }
 }
 .log-line {
-  display: grid; grid-template-columns: 92px 52px 150px 1fr; gap: 12px;
+  /* App column is `auto`: it collapses to 0 when a line carries no app
+     (most infra lines have no `spec=`), so the message sits right after
+     the level instead of across a fixed gap; it grows to the app name
+     when present, keeping rows aligned. */
+  display: grid; grid-template-columns: 92px 50px auto 1fr; gap: 10px;
   padding: 1px 14px; white-space: nowrap; animation: log-in 0.25s ease;
 }
+.log-app:not(:empty) { margin-right: 4px; }
 .log-line:hover { background: var(--surface-soft); }
 @keyframes log-in { from { opacity: 0; transform: translateY(2px); } to { opacity: 1; transform: none; } }
 @media (prefers-reduced-motion: reduce) { .log-line { animation: none; } }


### PR DESCRIPTION
The log grid gave the app column a fixed 150px, so infra lines (no `spec=`) showed a big empty gap between the level and the message. The app column is now `auto` — collapses to ~0 when empty, grows to the app name when present. Level→message gap: ~174px → ~20px on app-less lines (verified live).

🤖 Generated with [Claude Code](https://claude.com/claude-code)