### PR TITLE
chore(release): bump workspace version 0.1.96 → 0.1.97

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2845,7 +2845,7 @@ dependencies = [
 
 [[package]]
 name = "ruscker-admin"
-version = "0.1.96"
+version = "0.1.97"
 dependencies = [
  "aes-gcm",
  "anyhow",
@@ -2895,7 +2895,7 @@ dependencies = [
 
 [[package]]
 name = "ruscker-cli"
-version = "0.1.96"
+version = "0.1.97"
 dependencies = [
  "anyhow",
  "clap",
@@ -2915,7 +2915,7 @@ dependencies = [
 
 [[package]]
 name = "ruscker-config"
-version = "0.1.96"
+version = "0.1.97"
 dependencies = [
  "chrono",
  "ordered-float",
@@ -2930,7 +2930,7 @@ dependencies = [
 
 [[package]]
 name = "ruscker-core"
-version = "0.1.96"
+version = "0.1.97"
 dependencies = [
  "async-trait",
  "chrono",
@@ -2943,7 +2943,7 @@ dependencies = [
 
 [[package]]
 name = "ruscker-docker"
-version = "0.1.96"
+version = "0.1.97"
 dependencies = [
  "anyhow",
  "async-stream",
@@ -2962,7 +2962,7 @@ dependencies = [
 
 [[package]]
 name = "ruscker-proxy"
-version = "0.1.96"
+version = "0.1.97"
 dependencies = [
  "anyhow",
  "axum",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -10,7 +10,7 @@ members = [
 ]
 
 [workspace.package]
-version = "0.1.96"
+version = "0.1.97"
 edition = "2021"
 rust-version = "1.85"
 license = "Apache-2.0"

--- a/book/src/news.md
+++ b/book/src/news.md
@@ -9,6 +9,15 @@ the [GitHub releases page](https://github.com/StrategicProjects/ruscker/releases
 
 ---
 
+## v0.1.97 — 2026-06-08
+
+**Logs spacing fix.** The log lines gave the app column a fixed width, so
+lines without an app (most infra events) showed a large empty gap between
+the level and the message. The column now collapses when empty, so the
+message sits right after the level.
+
+---
+
 ## v0.1.96 — 2026-06-08
 
 **Logs tab — colour-coded event stream.** The Logs view rendered every


### PR DESCRIPTION
Release **v0.1.97** — Logs spacing fix (#712). Tag pushed after merge.

🤖 Generated with [Claude Code](https://claude.com/claude-code)