### PR TITLE
feat(spec-form): inline logo gallery in Appearance (PR A pt.2)

### DIFF
--- a/crates/ruscker-admin/assets/tailwind/input.css
+++ b/crates/ruscker-admin/assets/tailwind/input.css
@@ -1915,6 +1915,28 @@ textarea.spec-form-input { resize: vertical; min-height: 64px; }
 .image-picker-tile.is-builtin img { object-fit: contain; padding: 8px; }
 .image-picker-empty { padding: 0 18px 18px; font-size: 13px; color: var(--text-muted); }
 
+/* Inline logo gallery on the spec form (#701) — pick from the media
+   library without opening the modal; the last tile uploads. */
+.logo-grid {
+  display: grid; grid-template-columns: repeat(auto-fill, minmax(64px, 1fr));
+  gap: 8px; margin-top: 6px; max-height: 248px; overflow-y: auto; padding: 2px;
+}
+.logo-tile {
+  position: relative; aspect-ratio: 1; border-radius: 10px; overflow: hidden;
+  border: 2px solid var(--border); background: var(--surface-soft); cursor: pointer; padding: 0;
+}
+.logo-tile:hover { border-color: var(--border-strong); }
+.logo-tile.is-sel { border-color: var(--color-teal-600); }
+.logo-tile img { width: 100%; height: 100%; object-fit: contain; padding: 8px; display: block; }
+.logo-tile__check {
+  position: absolute; top: 3px; right: 3px; width: 16px; height: 16px; border-radius: 999px;
+  background: var(--color-teal-600); color: #fff; font-size: 11px;
+  display: inline-flex; align-items: center; justify-content: center;
+}
+.logo-tile--upload { display: flex; align-items: center; justify-content: center; color: var(--text-faint); border-style: dashed; }
+.logo-tile--upload:hover { color: var(--text); border-color: var(--border-strong); }
+.logo-tile--upload.is-busy { opacity: 0.5; pointer-events: none; }
+
 /* Landing logos editor row */
 .landing-logo-row {
   display: flex; align-items: center; gap: 8px; flex-wrap: wrap; margin-bottom: 8px;

--- a/crates/ruscker-admin/templates/admin/spec_form.html
+++ b/crates/ruscker-admin/templates/admin/spec_form.html
@@ -151,19 +151,23 @@
            clear / advanced path field below. #}
         <input type="hidden" name="logo" x-model="form.logo">
 
-        {# Picker-first: a preview + a "Choose image" button that opens the
-           shared modal gallery (uploads + built-ins + upload), so the field
-           stays compact no matter how big the library grows. #}
-        <div class="flex items-center gap-3" x-cloak>
-          <div class="w-12 h-12 rounded-md border-2 border-[color:var(--border)] overflow-hidden flex items-center justify-center bg-[color:var(--surface-soft)]"
-               x-show="form.logo">
-            <img :src="assetUrl(form.logo) + (form.logo.startsWith('/assets/img/') ? '?thumb' : '')" alt="" class="w-full h-full object-contain">
-          </div>
-          <button type="button" class="admin-login-btn" style="padding:8px 14px;font-size:13px"
-                  @click="openPicker('logo')">
-            <i class="ti ti-photo" aria-hidden="true"></i>
-            {{ self.t("spec-form-choose-image") }}
-          </button>
+        {# Inline gallery (#701): pick a logo straight from the media
+           library (click a tile; click it again to clear) or upload via
+           the last tile. The submitted value is the hidden `logo` input. #}
+        <div class="logo-grid" x-cloak>
+          <template x-for="name in logoImages" :key="name">
+            <button type="button" :title="name"
+                    @click="form.logo = (form.logo === ('/assets/img/' + name) ? '' : '/assets/img/' + name)"
+                    class="logo-tile" :class="form.logo === ('/assets/img/' + name) ? 'is-sel' : ''">
+              <img :src="assetUrl('/assets/img/' + name) + '?thumb'" :alt="name" loading="lazy">
+              <span class="logo-tile__check" x-show="form.logo === ('/assets/img/' + name)" x-cloak><i class="ti ti-check" aria-hidden="true"></i></span>
+            </button>
+          </template>
+          <label class="logo-tile logo-tile--upload" :class="imgUploading ? 'is-busy' : ''"
+                 title="{{ self.t("admin-images-choose") }}">
+            <i class="ti" :class="imgUploading ? 'ti-loader-2 animate-spin' : 'ti-plus'" aria-hidden="true"></i>
+            <input type="file" accept="image/*" class="hidden" @change="uploadImage($event, 'logo')">
+          </label>
         </div>
 
         {# Upload error (e.g. unsupported type / too large) #}


### PR DESCRIPTION
Replaces the "Choose image" modal button with an inline media-library thumbnail grid (click to pick, click again to clear, last tile uploads) — matching the handoff's App-logo grid. Reuses existing `logoImages`/`uploadImage` state; submitted `logo` value unchanged. Verified live.

🤖 Generated with [Claude Code](https://claude.com/claude-code)