### PR TITLE
chore(release): bump workspace version 0.1.97 → 0.1.98

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2845,7 +2845,7 @@ dependencies = [
 
 [[package]]
 name = "ruscker-admin"
-version = "0.1.97"
+version = "0.1.98"
 dependencies = [
  "aes-gcm",
  "anyhow",
@@ -2895,7 +2895,7 @@ dependencies = [
 
 [[package]]
 name = "ruscker-cli"
-version = "0.1.97"
+version = "0.1.98"
 dependencies = [
  "anyhow",
  "clap",
@@ -2915,7 +2915,7 @@ dependencies = [
 
 [[package]]
 name = "ruscker-config"
-version = "0.1.97"
+version = "0.1.98"
 dependencies = [
  "chrono",
  "ordered-float",
@@ -2930,7 +2930,7 @@ dependencies = [
 
 [[package]]
 name = "ruscker-core"
-version = "0.1.97"
+version = "0.1.98"
 dependencies = [
  "async-trait",
  "chrono",
@@ -2943,7 +2943,7 @@ dependencies = [
 
 [[package]]
 name = "ruscker-docker"
-version = "0.1.97"
+version = "0.1.98"
 dependencies = [
  "anyhow",
  "async-stream",
@@ -2962,7 +2962,7 @@ dependencies = [
 
 [[package]]
 name = "ruscker-proxy"
-version = "0.1.97"
+version = "0.1.98"
 dependencies = [
  "anyhow",
  "axum",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -10,7 +10,7 @@ members = [
 ]
 
 [workspace.package]
-version = "0.1.97"
+version = "0.1.98"
 edition = "2021"
 rust-version = "1.85"
 license = "Apache-2.0"

--- a/book/src/news.md
+++ b/book/src/news.md
@@ -9,6 +9,18 @@ the [GitHub releases page](https://github.com/StrategicProjects/ruscker/releases
 
 ---
 
+## v0.1.98 — 2026-06-08
+
+**Apps editor — closer to the design.** The Edit-application form now
+follows the handoff structure: **Identity** (ID + Name side-by-side,
+Subject) → **Kind** → **Description** (its own section) → **Appearance**
+→ Container → Metadata. The Appearance section gets an inline **logo
+gallery** — pick an app logo straight from the media library (or upload
+via the last tile) instead of opening a modal. (More of the editor —
+access/scale toggles, accent colour, monogram — lands next.)
+
+---
+
 ## v0.1.97 — 2026-06-08
 
 **Logs spacing fix.** The log lines gave the app column a fixed width, so


### PR DESCRIPTION
Release **v0.1.98** — Apps editor structure + inline logo gallery (#714, #715). Tag pushed after merge.

🤖 Generated with [Claude Code](https://claude.com/claude-code)