### PR TITLE
feat(spec-form): Access & scale section with toggles (PR A pt.3)

### DIFF
--- a/crates/ruscker-admin/assets/i18n/en/landing.ftl
+++ b/crates/ruscker-admin/assets/i18n/en/landing.ftl
@@ -242,7 +242,12 @@ spec-form-lifetime = Max lifetime (min)
 spec-form-lifetime-help = 360 = 6 hours
 spec-form-link-section = External link
 spec-form-link = Target URL
-spec-form-meta = Metadata
+spec-form-meta = Access & scale
+spec-form-restricted = Restricted access
+spec-form-restricted-hint = Requires sign-in to open
+spec-form-initial-replicas = Initial replicas
+spec-form-autoscaling = Autoscaling
+spec-form-autoscaling-hint = Scales replicas with demand
 spec-form-updated = Updated on
 spec-form-updated-help = Leave empty to use today's date.
 spec-form-preview = Card preview

--- a/crates/ruscker-admin/assets/i18n/es/landing.ftl
+++ b/crates/ruscker-admin/assets/i18n/es/landing.ftl
@@ -242,7 +242,12 @@ spec-form-lifetime = Vida máx. (min)
 spec-form-lifetime-help = 360 = 6 horas
 spec-form-link-section = Enlace externo
 spec-form-link = URL destino
-spec-form-meta = Metadatos
+spec-form-meta = Acceso y escala
+spec-form-restricted = Acceso restringido
+spec-form-restricted-hint = Requiere iniciar sesión para abrir
+spec-form-initial-replicas = Réplicas iniciales
+spec-form-autoscaling = Autoescalado
+spec-form-autoscaling-hint = Escala réplicas según la demanda
 spec-form-updated = Actualizado el
 spec-form-updated-help = Vacío para usar la fecha de hoy.
 spec-form-preview = Vista previa

--- a/crates/ruscker-admin/assets/i18n/fr/landing.ftl
+++ b/crates/ruscker-admin/assets/i18n/fr/landing.ftl
@@ -242,7 +242,12 @@ spec-form-lifetime = Durée max. (min)
 spec-form-lifetime-help = 360 = 6 heures
 spec-form-link-section = Lien externe
 spec-form-link = URL cible
-spec-form-meta = Métadonnées
+spec-form-meta = Accès et échelle
+spec-form-restricted = Accès restreint
+spec-form-restricted-hint = Nécessite une connexion pour ouvrir
+spec-form-initial-replicas = Répliques initiales
+spec-form-autoscaling = Mise à l'échelle automatique
+spec-form-autoscaling-hint = Adapte les répliques à la demande
 spec-form-updated = Mis à jour le
 spec-form-updated-help = Vide pour utiliser la date d'aujourd'hui.
 spec-form-preview = Aperçu de la carte

--- a/crates/ruscker-admin/assets/i18n/pt/landing.ftl
+++ b/crates/ruscker-admin/assets/i18n/pt/landing.ftl
@@ -246,7 +246,12 @@ spec-form-lifetime = Vida máx. (min)
 spec-form-lifetime-help = 360 = 6 horas
 spec-form-link-section = Link externo
 spec-form-link = URL de destino
-spec-form-meta = Metadados
+spec-form-meta = Acesso & escala
+spec-form-restricted = Acesso restrito
+spec-form-restricted-hint = Exige login para abrir
+spec-form-initial-replicas = Réplicas iniciais
+spec-form-autoscaling = Autoescalonamento
+spec-form-autoscaling-hint = Escala réplicas conforme a demanda
 spec-form-updated = Atualizado em
 spec-form-updated-help = Vazio para usar a data de hoje.
 spec-form-preview = Prévia do card

--- a/crates/ruscker-admin/templates/admin/spec_form.html
+++ b/crates/ruscker-admin/templates/admin/spec_form.html
@@ -374,9 +374,22 @@
         </span>
       </label>
 
-      {# Access — who may see + reach this app (#155). Promoted out of the
-         runtime "Advanced" collapse (#523): visibility is governance/metadata,
-         not a runtime knob. #}
+      {# Restricted access (#701) — a toggle over the access lists. Off ⇒
+         public (lists cleared); on ⇒ reveal the group/user pickers. #}
+      <label class="toggle-row">
+        <div>
+          <div class="toggle-row__label">{{ self.t("spec-form-restricted") }}</div>
+          <div class="toggle-row__hint">{{ self.t("spec-form-restricted-hint") }}</div>
+        </div>
+        <span class="switch">
+          <input type="checkbox" x-model="restricted"
+                 @change="if (!restricted) { form.access_groups = ''; form.access_users = ''; }">
+          <span class="switch__track"><span class="switch__dot"></span></span>
+        </span>
+      </label>
+
+      <div x-show="restricted" x-cloak>
+      {# Access — who may see + reach this app (#155). #}
       {# Access groups as toggle pills (#623). The submitted value is the
          hidden comma-joined `access_groups`; pills + the "add group" input
          toggle entries in it. A known group not yet in `availableGroups`
@@ -421,6 +434,25 @@
                placeholder="alice, bob" class="spec-form-input">
       </div>
       <div class="spec-form-help">{{ self.t("spec-form-access-help") }}</div>
+      </div>{# /x-show restricted #}
+
+      {# Initial replicas (#701) — the always-on pool floor (min_replicas),
+         surfaced here as part of "scale". Container-backed kinds only; the
+         autoscaling ceiling + thresholds stay in Advanced. #}
+      <template x-if="needsContainer()">
+      <div class="spec-form-field">
+        <div class="spec-form-label-row">
+          <label for="f-init-rep" class="spec-form-label">{{ self.t("spec-form-initial-replicas") }}</label>
+          {% call help(self.t("spec-help-min-replicas")) %}{% endcall %}
+        </div>
+        <div class="stepper">
+          <button type="button" tabindex="-1" @click="form.min_replicas = String(Math.max(0, (parseInt(form.min_replicas, 10) || 0) - 1))"><i class="ti ti-minus" aria-hidden="true"></i></button>
+          <input id="f-init-rep" type="number" name="min_replicas" min="0" placeholder="1"
+                 x-model="form.min_replicas" class="stepper__input">
+          <button type="button" tabindex="-1" @click="form.min_replicas = String((parseInt(form.min_replicas, 10) || 0) + 1)"><i class="ti ti-plus" aria-hidden="true"></i></button>
+        </div>
+      </div>
+      </template>
 
       <div class="spec-form-field">
         <div class="spec-form-label-row">
@@ -683,21 +715,22 @@
           <div class="spec-form-help" style="color:var(--color-lock)">{{ self.t("spec-form-registry-inline-note") }}</div>
           {% endif %}
 
-          {# Scaling — replica pool #}
+          {# Scaling — autoscaling ceiling + thresholds. The floor is the
+             "Initial replicas" stepper up in Access & scale (#701). #}
           <div class="spec-form-subsection">{{ self.t("spec-form-scaling-section") }}</div>
-          <div class="grid grid-cols-3 gap-3">
-            <div class="spec-form-field">
-              <div class="spec-form-label-row">
-                <label for="f-min-rep" class="spec-form-label">{{ self.t("spec-form-min-replicas") }}</label>
-                {% call help(self.t("spec-help-min-replicas")) %}{% endcall %}
-              </div>
-              <div class="stepper">
-                <button type="button" tabindex="-1" @click="form.min_replicas = String(Math.max(0, (parseInt(form.min_replicas, 10) || 0) - 1))"><i class="ti ti-minus" aria-hidden="true"></i></button>
-                <input id="f-min-rep" type="number" name="min_replicas" min="0" placeholder="1"
-                       x-model="form.min_replicas" class="stepper__input">
-                <button type="button" tabindex="-1" @click="form.min_replicas = String((parseInt(form.min_replicas, 10) || 0) + 1)"><i class="ti ti-plus" aria-hidden="true"></i></button>
-              </div>
+          <label class="toggle-row">
+            <div>
+              <div class="toggle-row__label">{{ self.t("spec-form-autoscaling") }}</div>
+              <div class="toggle-row__hint">{{ self.t("spec-form-autoscaling-hint") }}</div>
             </div>
+            <span class="switch">
+              <input type="checkbox" x-model="autoscaling"
+                     @change="if (!autoscaling) { form.max_replicas = ''; form.scale_up_threshold = ''; form.scale_down_threshold = ''; form.scale_down_grace = ''; }">
+              <span class="switch__track"><span class="switch__dot"></span></span>
+            </span>
+          </label>
+          <div x-show="autoscaling" x-cloak>
+          <div class="grid grid-cols-2 gap-3">
             <div class="spec-form-field">
               <div class="spec-form-label-row">
                 <label for="f-max-rep" class="spec-form-label">{{ self.t("spec-form-max-replicas") }}</label>
@@ -753,6 +786,7 @@
                      value="{{ form.drain_timeout }}" placeholder="30" class="spec-form-input">
             </div>
           </div>
+          </div>{# /x-show autoscaling #}
 
           {# Resources — per-container limits #}
           <div class="spec-form-subsection">{{ self.t("spec-form-resources-section") }}</div>
@@ -1184,6 +1218,12 @@ window.ruscker.specForm = (initial, logoImages, availableGroups) => ({
   // has advanced config set — so the form opens clean and uncluttered
   // (operator request). Click the toggle to reveal it.
   advancedOpen: false,
+  // Restricted-access toggle (#701): on when the spec already has any
+  // group/user access list; off ⇒ public. Toggling off clears the lists.
+  restricted: !((initial.access_groups || '').trim() === '' && (initial.access_users || '').trim() === ''),
+  // Autoscaling toggle (#701): on when a max-replicas ceiling above 1 is
+  // set. Off ⇒ the ceiling + thresholds are cleared (run at the floor).
+  autoscaling: (parseInt(initial.max_replicas, 10) || 0) > 1,
   // Card-cover editing mode: 'auto' (kind tint, empty cover),
   // 'solid' (color), 'gradient' (builder). Seeded from any
   // existing `cover` value.


### PR DESCRIPTION
Reworks the former "Metadata" section into the handoff's **Access & scale**: renamed; **Restricted access** toggle (wrapper over the group/user lists — off ⇒ public + clears lists); **Initial replicas** stepper (`min_replicas`) surfaced here (moved out of Advanced so there's a single field, no duplicate name); **Autoscaling** toggle in Advanced gating the max ceiling + thresholds. New i18n (en/pt/es/fr). Verified live: restricted-off clears + persists groups; min_replicas round-trips.

🤖 Generated with [Claude Code](https://claude.com/claude-code)