### PR TITLE
chore(release): bump workspace version 0.1.98 → 0.1.99

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2845,7 +2845,7 @@ dependencies = [
 
 [[package]]
 name = "ruscker-admin"
-version = "0.1.98"
+version = "0.1.99"
 dependencies = [
  "aes-gcm",
  "anyhow",
@@ -2895,7 +2895,7 @@ dependencies = [
 
 [[package]]
 name = "ruscker-cli"
-version = "0.1.98"
+version = "0.1.99"
 dependencies = [
  "anyhow",
  "clap",
@@ -2915,7 +2915,7 @@ dependencies = [
 
 [[package]]
 name = "ruscker-config"
-version = "0.1.98"
+version = "0.1.99"
 dependencies = [
  "chrono",
  "ordered-float",
@@ -2930,7 +2930,7 @@ dependencies = [
 
 [[package]]
 name = "ruscker-core"
-version = "0.1.98"
+version = "0.1.99"
 dependencies = [
  "async-trait",
  "chrono",
@@ -2943,7 +2943,7 @@ dependencies = [
 
 [[package]]
 name = "ruscker-docker"
-version = "0.1.98"
+version = "0.1.99"
 dependencies = [
  "anyhow",
  "async-stream",
@@ -2962,7 +2962,7 @@ dependencies = [
 
 [[package]]
 name = "ruscker-proxy"
-version = "0.1.98"
+version = "0.1.99"
 dependencies = [
  "anyhow",
  "axum",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -10,7 +10,7 @@ members = [
 ]
 
 [workspace.package]
-version = "0.1.98"
+version = "0.1.99"
 edition = "2021"
 rust-version = "1.85"
 license = "Apache-2.0"

--- a/book/src/news.md
+++ b/book/src/news.md
@@ -9,6 +9,17 @@ the [GitHub releases page](https://github.com/StrategicProjects/ruscker/releases
 
 ---
 
+## v0.1.99 — 2026-06-08
+
+**Apps editor — Access & scale.** The old "Metadata" section is now
+**Access & scale**, matching the design: a **Restricted access** toggle
+(off = public, and turning it off clears the group/user lists), the
+**Initial replicas** stepper surfaced alongside access, and an
+**Autoscaling** toggle (in Advanced) that gates the replica ceiling and
+thresholds. (Still to come: accent colour + monogram.)
+
+---
+
 ## v0.1.98 — 2026-06-08
 
 **Apps editor — closer to the design.** The Edit-application form now


### PR DESCRIPTION
Release **v0.1.99** — Apps editor Access & scale section (#717). Tag pushed after merge.

🤖 Generated with [Claude Code](https://claude.com/claude-code)