### PR TITLE
feat(spec-form): per-app accent colour + monogram (PR B)

### DIFF
--- a/crates/ruscker-admin/assets/i18n/en/landing.ftl
+++ b/crates/ruscker-admin/assets/i18n/en/landing.ftl
@@ -242,6 +242,11 @@ spec-form-lifetime = Max lifetime (min)
 spec-form-lifetime-help = 360 = 6 hours
 spec-form-link-section = External link
 spec-form-link = Target URL
+spec-form-accent = Accent color
+spec-form-accent-help = Tints the card cover (when no cover is set).
+spec-form-monogram = Monogram
+spec-form-monogram-ph = AB
+spec-form-monogram-help = Shown on the cover when there's no logo.
 spec-form-meta = Access & scale
 spec-form-restricted = Restricted access
 spec-form-restricted-hint = Requires sign-in to open

--- a/crates/ruscker-admin/assets/i18n/es/landing.ftl
+++ b/crates/ruscker-admin/assets/i18n/es/landing.ftl
@@ -242,6 +242,11 @@ spec-form-lifetime = Vida máx. (min)
 spec-form-lifetime-help = 360 = 6 horas
 spec-form-link-section = Enlace externo
 spec-form-link = URL destino
+spec-form-accent = Color de acento
+spec-form-accent-help = Tiñe la portada del card (cuando no hay cover).
+spec-form-monogram = Monograma
+spec-form-monogram-ph = AB
+spec-form-monogram-help = Se muestra en la portada cuando no hay logo.
 spec-form-meta = Acceso y escala
 spec-form-restricted = Acceso restringido
 spec-form-restricted-hint = Requiere iniciar sesión para abrir

--- a/crates/ruscker-admin/assets/i18n/fr/landing.ftl
+++ b/crates/ruscker-admin/assets/i18n/fr/landing.ftl
@@ -242,6 +242,11 @@ spec-form-lifetime = Durée max. (min)
 spec-form-lifetime-help = 360 = 6 heures
 spec-form-link-section = Lien externe
 spec-form-link = URL cible
+spec-form-accent = Couleur d'accent
+spec-form-accent-help = Teinte la couverture du card (sans cover défini).
+spec-form-monogram = Monogramme
+spec-form-monogram-ph = AB
+spec-form-monogram-help = Affiché sur la couverture sans logo.
 spec-form-meta = Accès et échelle
 spec-form-restricted = Accès restreint
 spec-form-restricted-hint = Nécessite une connexion pour ouvrir

--- a/crates/ruscker-admin/assets/i18n/pt/landing.ftl
+++ b/crates/ruscker-admin/assets/i18n/pt/landing.ftl
@@ -246,6 +246,11 @@ spec-form-lifetime = Vida máx. (min)
 spec-form-lifetime-help = 360 = 6 horas
 spec-form-link-section = Link externo
 spec-form-link = URL de destino
+spec-form-accent = Cor de destaque
+spec-form-accent-help = Tinge a capa do card (quando não há cover definido).
+spec-form-monogram = Monograma
+spec-form-monogram-ph = AB
+spec-form-monogram-help = Mostrado na capa quando não há logo.
 spec-form-meta = Acesso & escala
 spec-form-restricted = Acesso restrito
 spec-form-restricted-hint = Exige login para abrir

--- a/crates/ruscker-admin/src/routes/admin/spec_form.rs
+++ b/crates/ruscker-admin/src/routes/admin/spec_form.rs
@@ -208,6 +208,15 @@ pub struct SpecForm {
     /// fail-softs), same policy as `landing_customization.header_bg`.
     #[serde(default)]
     pub cover: String,
+    /// Per-app accent colour (`template-properties.accent`). When set and
+    /// no explicit `cover`, the landing card cover is tinted from it
+    /// (#701). Empty ⇒ no accent.
+    #[serde(default)]
+    pub accent: String,
+    /// Short monogram (`template-properties.monogram`, 1–2 chars) shown on
+    /// the card cover when there's no logo; empty ⇒ the id is used.
+    #[serde(default)]
+    pub monogram: String,
     /// Updated date in DD/MM/YYYY. Empty ⇒ stamp with today.
     pub updated: String,
     /// External link target (for type=link/package).
@@ -326,6 +335,8 @@ impl SpecForm {
             featured: if spec.is_featured() { "on".into() } else { String::new() },
             logo: tp.get_str("logo").map(str::to_string).unwrap_or_default(),
             cover: tp.get_str("cover").map(str::to_string).unwrap_or_default(),
+            accent: tp.get_str("accent").map(str::to_string).unwrap_or_default(),
+            monogram: tp.get_str("monogram").map(str::to_string).unwrap_or_default(),
             updated: tp.get_str("updated").map(str::to_string).unwrap_or_default(),
             link: tp.get_str("link").map(str::to_string).unwrap_or_default(),
             seats_per_container: spec
@@ -482,6 +493,8 @@ impl SpecForm {
         set_or_remove(&mut tp_map, "subject", &self.subject);
         set_or_remove(&mut tp_map, "logo", &self.logo);
         set_or_remove(&mut tp_map, "cover", &self.cover);
+        set_or_remove(&mut tp_map, "accent", &self.accent);
+        set_or_remove(&mut tp_map, "monogram", &self.monogram);
         set_or_remove(&mut tp_map, "link", &self.link);
 
         let container_image = match dt {

--- a/crates/ruscker-admin/src/view_model.rs
+++ b/crates/ruscker-admin/src/view_model.rs
@@ -226,6 +226,10 @@ pub struct CardCtx<'a> {
     /// `landing_customization.header_bg`.) Any embedded
     /// `url(/assets/…)` is base-prefixed at construction (#294).
     pub cover: Option<String>,
+    /// Short fallback shown on the card cover when there's no logo
+    /// (`template-properties.monogram`, 1–2 chars). When unset the card
+    /// id is used, as before.
+    pub monogram: Option<&'a str>,
     pub updated_raw: Option<&'a str>,
     /// "DD/MM" — short form used in the meta row.
     pub updated_short: Option<String>,
@@ -256,12 +260,24 @@ impl<'a> CardCtx<'a> {
         let active = tp.is_active();
         let subject = tp.get_str("subject");
         let logo = tp.get_str("logo").map(|l| prefix_asset_url(l, base));
+        let monogram = tp.get_str("monogram").filter(|s| !s.trim().is_empty());
         // Empty string ⇒ treat as unset so the kind-tint fallback
         // kicks in rather than rendering `background: ;`.
+        // An explicit `cover` always wins; otherwise, when the operator
+        // set a per-app `accent` (#701), synthesize a soft tinted cover
+        // from it (`color-mix(accent 14%, surface)` — the same recipe the
+        // editor preview uses) so the accent shows on the card without a
+        // full cover. No accent ⇒ None ⇒ the per-kind tint class.
         let cover = tp
             .get_str("cover")
             .filter(|s| !s.trim().is_empty())
-            .map(|c| prefix_css_asset_urls(c, base));
+            .map(|c| prefix_css_asset_urls(c, base))
+            .or_else(|| {
+                tp.get_str("accent")
+                    .map(str::trim)
+                    .filter(|a| is_css_color(a))
+                    .map(|a| format!("color-mix(in srgb, {a} 14%, var(--surface))"))
+            });
         let updated_raw = tp.get_str("updated");
         let updated_date = updated_raw.and_then(parse_dmy);
         let updated_short = updated_date.map(|d| d.format("%d/%m").to_string());
@@ -283,6 +299,7 @@ impl<'a> CardCtx<'a> {
             featured: spec.is_featured(),
             logo,
             cover,
+            monogram,
             updated_raw,
             updated_short,
             status,
@@ -320,6 +337,19 @@ fn prefix_css_asset_urls(value: &str, base: &str) -> String {
         .replace("url(/assets/", &format!("url({base}/assets/"))
         .replace("url('/assets/", &format!("url('{base}/assets/"))
         .replace("url(\"/assets/", &format!("url(\"{base}/assets/"))
+}
+
+/// Accept a value only if it's plausibly a CSS colour and can't break
+/// out of the `color-mix(... {a} ...)` it's interpolated into — the
+/// `accent` is admin-authored (same trust as `cover`), but it lands
+/// inside a function call rather than a bare declaration, so a stray
+/// `)`/`;`/`<` would corrupt the cover. Hex, `rgb()/hsl()`, and bare
+/// colour keywords all pass.
+fn is_css_color(s: &str) -> bool {
+    !s.is_empty()
+        && s.chars().all(|c| {
+            c.is_ascii_alphanumeric() || matches!(c, '#' | '(' | ')' | ',' | '%' | '.' | ' ' | '-')
+        })
 }
 
 /// Parse the operator-authored `DD/MM/YYYY` form used in the SEPE
@@ -509,6 +539,32 @@ mod tests {
         let spec = spec_with_tp("  subject: Saúde\n");
         let card = CardCtx::from_spec(&spec, "");
         assert_eq!(card.cover, None);
+    }
+
+    #[test]
+    fn accent_synthesizes_a_tinted_cover_when_no_cover() {
+        // #701: a per-app accent (and no explicit cover) tints the card.
+        let spec = spec_with_tp("  accent: \"#2563eb\"\n");
+        let card = CardCtx::from_spec(&spec, "");
+        assert_eq!(
+            card.cover.as_deref(),
+            Some("color-mix(in srgb, #2563eb 14%, var(--surface))")
+        );
+        // An explicit cover still wins over the accent.
+        let spec2 = spec_with_tp("  accent: \"#2563eb\"\n  cover: \"#101010\"\n");
+        assert_eq!(CardCtx::from_spec(&spec2, "").cover.as_deref(), Some("#101010"));
+        // A junk accent that could break out of color-mix is ignored.
+        let spec3 = spec_with_tp("  accent: \"red); }\"\n");
+        assert_eq!(CardCtx::from_spec(&spec3, "").cover, None);
+    }
+
+    #[test]
+    fn monogram_read_from_template_properties() {
+        let spec = spec_with_tp("  monogram: \"PR\"\n");
+        assert_eq!(CardCtx::from_spec(&spec, "").monogram, Some("PR"));
+        // Blank ⇒ None (template falls back to the id).
+        let spec2 = spec_with_tp("  monogram: \"  \"\n");
+        assert_eq!(CardCtx::from_spec(&spec2, "").monogram, None);
     }
 
     #[test]

--- a/crates/ruscker-admin/templates/admin/spec_form.html
+++ b/crates/ruscker-admin/templates/admin/spec_form.html
@@ -191,6 +191,32 @@
         </details>
       </div>
 
+      {# ── Accent colour + monogram (#701) — accent tints the card cover
+         (when no explicit cover); monogram is the no-logo fallback. ── #}
+      <div class="grid grid-cols-2 gap-3">
+        <div class="spec-form-field">
+          <label class="spec-form-label">{{ self.t("spec-form-accent") }}</label>
+          <div class="brand-swatches">
+            {% for c in ["#0f6e56", "#2563eb", "#1e3a5f", "#10b981", "#ec4899", "#8b5cf6", "#d97706"] %}
+            <button type="button" class="brand-swatch" style="background:{{ c }};color:{{ c }}"
+                    :class="{ 'is-active': (form.accent || '').toLowerCase() === '{{ c }}' }"
+                    @click="form.accent = (form.accent === '{{ c }}' ? '' : '{{ c }}')"
+                    aria-label="{{ c }}"></button>
+            {% endfor %}
+          </div>
+          <input type="hidden" name="accent" :value="form.accent">
+          <div class="spec-form-help">{{ self.t("spec-form-accent-help") }}</div>
+        </div>
+        <div class="spec-form-field">
+          <label for="f-monogram" class="spec-form-label">{{ self.t("spec-form-monogram") }}</label>
+          <input id="f-monogram" type="text" name="monogram" maxlength="2"
+                 value="{{ form.monogram }}" x-model="form.monogram"
+                 placeholder="{{ self.t("spec-form-monogram-ph") }}"
+                 class="spec-form-input spec-form-input--mono" style="max-width:96px">
+          <div class="spec-form-help">{{ self.t("spec-form-monogram-help") }}</div>
+        </div>
+      </div>
+
       {# ── Card cover (#11) — Auto tint / Solid / Gradient ───── #}
       <div class="spec-form-field">
         <div class="spec-form-label-row">
@@ -941,7 +967,7 @@
       <div class="rcard" style="margin:0">
         <div class="rcover">
           <div class="rcover-bg"
-               :class="form.cover ? '' : 'tint-' + form.display_type"
+               :class="(form.cover || form.accent) ? '' : 'tint-' + form.display_type"
                :style="coverStyle()"></div>
           <template x-if="form.logo">
             {# Mirror the landing card's fit rule (#359): SVG logos get
@@ -952,7 +978,7 @@
                  :class="(form.logo || '').toLowerCase().endsWith('.svg') ? 'rcover-img rcover-img--contain' : 'rcover-img'">
           </template>
           <template x-if="!form.logo">
-            <span class="rcover-fallback" x-text="form.id || '—'"></span>
+            <span class="rcover-fallback" x-text="form.monogram || form.id || '—'"></span>
           </template>
           <div class="rbadges">
             <span class="rbadge" :class="'b-' + form.display_type" x-text="badgeText()"></span>
@@ -1198,7 +1224,13 @@ window.ruscker.specForm = (initial, logoImages, availableGroups) => ({
   // root-absolute asset URLs for *display only* (#270). The submitted
   // `form.cover` stays base-agnostic.
   coverStyle() {
-    if (!this.form.cover) return '';
+    // An explicit cover wins; otherwise an accent paints a soft tint
+    // (mirrors the server-side CardCtx synthesis in view_model.rs).
+    if (!this.form.cover) {
+      return this.form.accent
+        ? 'background: color-mix(in srgb, ' + this.form.accent + ' 14%, var(--surface));'
+        : '';
+    }
     const base = window.RUSCKER_BASE || '';
     const css = base
       ? this.form.cover.replace(/url\((['"]?)\/assets\//g, 'url($1' + base + '/assets/')

--- a/crates/ruscker-admin/templates/landing.html
+++ b/crates/ruscker-admin/templates/landing.html
@@ -131,7 +131,7 @@
               <img src="{{ logo }}" alt="" loading="lazy" onerror="this.style.display='none'"
                    class="rcover-img{% if logo.ends_with(".svg") %} rcover-img--contain{% endif %}">
             {% when None %}
-              <span class="rcover-fallback">{{ card.id }}</span>
+              <span class="rcover-fallback">{% if let Some(m) = card.monogram %}{{ m }}{% else %}{{ card.id }}{% endif %}</span>
             {% endmatch %}
             <div class="rbadges">
               <span class="rbadge b-{{ card.display_type.key() }}">{{ self.t(card.display_type.abbr_key()) }}</span>
@@ -315,7 +315,7 @@
                  onerror="this.style.display='none'"
                  class="rcover-img{% if logo.ends_with(".svg") %} rcover-img--contain{% endif %}">
           {% when None %}
-            <span class="rcover-fallback">{{ card.id }}</span>
+            <span class="rcover-fallback">{% if let Some(m) = card.monogram %}{{ m }}{% else %}{{ card.id }}{% endif %}</span>
           {% endmatch %}
 
           <div class="rbadges">


### PR DESCRIPTION
Final piece of the Apps-editor redesign. Two per-app appearance fields stored in `template-properties` (no migration), with real landing effect:

- **Accent** — when set (and no explicit cover), the card cover is tinted `color-mix(<accent> 14%, surface)`. Validated so it can't break out of the color-mix.
- **Monogram** (1–2 chars) — the no-logo cover fallback uses it instead of the spec id.

Editor: accent swatch row + monogram input in Appearance; live preview reacts. Round-trips via `set_or_remove`. Verified end-to-end (--no-docker): save → tinted cover + monogram on the landing card; preview reacts live. Unit tests added (accent→cover synthesis incl. junk rejection + explicit-cover precedence; monogram read).

🤖 Generated with [Claude Code](https://claude.com/claude-code)