### PR TITLE
chore(release): bump workspace version 0.1.99 → 0.2.0

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2845,7 +2845,7 @@ dependencies = [
 
 [[package]]
 name = "ruscker-admin"
-version = "0.1.99"
+version = "0.2.0"
 dependencies = [
  "aes-gcm",
  "anyhow",
@@ -2895,7 +2895,7 @@ dependencies = [
 
 [[package]]
 name = "ruscker-cli"
-version = "0.1.99"
+version = "0.2.0"
 dependencies = [
  "anyhow",
  "clap",
@@ -2915,7 +2915,7 @@ dependencies = [
 
 [[package]]
 name = "ruscker-config"
-version = "0.1.99"
+version = "0.2.0"
 dependencies = [
  "chrono",
  "ordered-float",
@@ -2930,7 +2930,7 @@ dependencies = [
 
 [[package]]
 name = "ruscker-core"
-version = "0.1.99"
+version = "0.2.0"
 dependencies = [
  "async-trait",
  "chrono",
@@ -2943,7 +2943,7 @@ dependencies = [
 
 [[package]]
 name = "ruscker-docker"
-version = "0.1.99"
+version = "0.2.0"
 dependencies = [
  "anyhow",
  "async-stream",
@@ -2962,7 +2962,7 @@ dependencies = [
 
 [[package]]
 name = "ruscker-proxy"
-version = "0.1.99"
+version = "0.2.0"
 dependencies = [
  "anyhow",
  "axum",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -10,7 +10,7 @@ members = [
 ]
 
 [workspace.package]
-version = "0.1.99"
+version = "0.2.0"
 edition = "2021"
 rust-version = "1.85"
 license = "Apache-2.0"

--- a/book/src/news.md
+++ b/book/src/news.md
@@ -9,6 +9,20 @@ the [GitHub releases page](https://github.com/StrategicProjects/ruscker/releases
 
 ---
 
+## v0.2.0 — 2026-06-09
+
+**Apps editor redesign complete + per-app accent & monogram.** The
+final piece of the editor rework: each app can now set an **accent
+colour** (tints the card cover when no cover is set) and a **monogram**
+(1–2 chars shown on the cover when there's no logo) — both stored in
+`template-properties`, no migration. The editor's Appearance section
+gains a swatch row and a monogram field, and the live preview reflects
+them. This closes the editor redesign that also brought the handoff
+section structure, the inline logo gallery, and the Access & scale
+section (v0.1.98–0.1.99).
+
+---
+
 ## v0.1.99 — 2026-06-08
 
 **Apps editor — Access & scale.** The old "Metadata" section is now


### PR DESCRIPTION
Release **v0.2.0** — Apps editor redesign complete: per-app accent colour + monogram (#719). Tag pushed after merge.

🤖 Generated with [Claude Code](https://claude.com/claude-code)