### PR TITLE
chore(release): bump workspace version 0.2.0 → 0.2.1

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2845,7 +2845,7 @@ dependencies = [
 
 [[package]]
 name = "ruscker-admin"
-version = "0.2.0"
+version = "0.2.1"
 dependencies = [
  "aes-gcm",
  "anyhow",
@@ -2895,7 +2895,7 @@ dependencies = [
 
 [[package]]
 name = "ruscker-cli"
-version = "0.2.0"
+version = "0.2.1"
 dependencies = [
  "anyhow",
  "clap",
@@ -2915,7 +2915,7 @@ dependencies = [
 
 [[package]]
 name = "ruscker-config"
-version = "0.2.0"
+version = "0.2.1"
 dependencies = [
  "chrono",
  "ordered-float",
@@ -2930,7 +2930,7 @@ dependencies = [
 
 [[package]]
 name = "ruscker-core"
-version = "0.2.0"
+version = "0.2.1"
 dependencies = [
  "async-trait",
  "chrono",
@@ -2943,7 +2943,7 @@ dependencies = [
 
 [[package]]
 name = "ruscker-docker"
-version = "0.2.0"
+version = "0.2.1"
 dependencies = [
  "anyhow",
  "async-stream",
@@ -2962,7 +2962,7 @@ dependencies = [
 
 [[package]]
 name = "ruscker-proxy"
-version = "0.2.0"
+version = "0.2.1"
 dependencies = [
  "anyhow",
  "axum",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -10,7 +10,7 @@ members = [
 ]
 
 [workspace.package]
-version = "0.2.0"
+version = "0.2.1"
 edition = "2021"
 rust-version = "1.85"
 license = "Apache-2.0"

--- a/book/src/news.md
+++ b/book/src/news.md
@@ -9,6 +9,26 @@ the [GitHub releases page](https://github.com/StrategicProjects/ruscker/releases
 
 ---
 
+## v0.2.1 — 2026-06-09
+
+**Apps editor + Appearance polish.** Four operator-reported fixes:
+
+- **Current logo reads as selected** in the inline logo gallery. The
+  match was an exact path compare, which missed a stored value carrying
+  a base-path prefix (`/box/assets/img/…`); it now compares by filename.
+- **Card cover drops the "Image" mode.** A logo renders *on top* of the
+  cover, so an image cover + a logo painted two overlapping pictures on
+  one card. Cover is now tint / colour / gradient only; a legacy image
+  cover degrades to the kind-tint/accent fallback.
+- **Environment-variable rows** are laid out one clean line each
+  (`KEY · = · value · ✕`) instead of the inputs stacking full-width.
+- **Default card cover in Appearance.** A new Auto / Solid / Gradient
+  builder in the Background section sets one catalog-wide default cover
+  for cards without their own `cover`/`accent` (which still win), so the
+  default is no longer editable only per app (migration 0021).
+
+---
+
 ## v0.2.0 — 2026-06-09
 
 **Apps editor redesign complete + per-app accent & monogram.** The


### PR DESCRIPTION
Release bump for the apps-editor + Appearance polish merged in #721.

- `[workspace.package] version` 0.2.0 → 0.2.1 + `Cargo.lock` refresh
- `book/src/news.md` v0.2.1 entry

Tagging `v0.2.1` after this merges triggers the release workflow (.deb + musl tarballs + cosign-signed ghcr image + Homebrew formula).

🤖 Generated with [Claude Code](https://claude.com/claude-code)