### PR TITLE
fix(cover): seed a colour on Solid so the preview reflects it

### DIFF
--- a/crates/ruscker-admin/templates/admin/landing.html
+++ b/crates/ruscker-admin/templates/admin/landing.html
@@ -911,11 +911,13 @@ window.ruscker.landingForm = (initial, logoImages) => ({
     this.coverDefMode = mode;
     if (mode === 'auto') { this.form.card_cover_default = ''; return; }
     if (mode === 'gradient') { this.applyCoverDef(); return; }
-    // 'solid': drop a gradient string so the colour picker drives a fresh
-    // value (mirrors setBgMode / the spec form's cover builder).
-    if (/^(linear|radial)-gradient\(/.test((this.form.card_cover_default || '').trim())) {
-      this.form.card_cover_default = '';
-    }
+    // 'solid': seed a starting colour so the preview reflects the choice
+    // *immediately* (selecting the mode alone left the value empty, so the
+    // mock card didn't change until the picker was dragged — #720 follow-up).
+    // A gradient string is also replaced so the colour picker drives a fresh
+    // value; an existing solid hex is kept.
+    const c = (this.form.card_cover_default || '').trim();
+    if (!c || /^(linear|radial)-gradient\(/.test(c)) this.form.card_cover_default = '#0f6e56';
   },
   /// Resolve the intro shown in the preview given the admin's
   /// own locale: prefer the per-locale field, fall back to the

--- a/crates/ruscker-admin/templates/admin/spec_form.html
+++ b/crates/ruscker-admin/templates/admin/spec_form.html
@@ -1237,11 +1237,12 @@ window.ruscker.specForm = (initial, logoImages, availableGroups) => ({
     this.coverMode = mode;
     if (mode === 'auto') { this.form.cover = ''; return; }
     if (mode === 'gradient') { this.applyCoverGrad(); return; }
-    // 'solid' keeps the current value only if it isn't a gradient;
-    // otherwise clear it so the saved cover can't disagree with the
-    // chosen mode (#304). The operator then picks a colour.
+    // 'solid': seed a starting colour so the preview reflects the choice
+    // immediately (selecting the mode left `cover` empty, so the preview
+    // card didn't change until the picker was dragged — #720 follow-up).
+    // A gradient string is replaced too; an existing solid hex is kept.
     const c = (this.form.cover || '').trim();
-    if (mode === 'solid' && /^(linear|radial)-gradient\(/.test(c)) this.form.cover = '';
+    if (!c || /^(linear|radial)-gradient\(/.test(c)) this.form.cover = '#0f6e56';
   },
   // Image covers were retired (they rendered *under* the logo → two
   // overlapping pictures on one card). A legacy `url(...)` cover degrades


### PR DESCRIPTION
Follow-up to #721. Operator report: *"ajuste no card cover não reflete no preview."*

## Root cause (browser-verified, not guessed)
Drove the Appearance editor with Playwright + real Chrome and watched the Alpine state:
- Mutating `card_cover_default` directly **does** update the preview (reactivity is fine).
- But clicking **"Sólido"** set `coverDefMode='solid'` while leaving `card_cover_default` **empty** → the preview stayed on the accent tint until the colour picker was dragged.

So the mode-select alone reflected nothing — exactly the complaint.

## Fix
Selecting Solid now **seeds a starting brand colour** (`#0f6e56`) when the value is empty or a gradient (an existing solid hex is kept). The mock card updates immediately; the picker then edits it live. Applied to both:
- the Appearance default-cover builder (`setCoverDefMode`)
- the per-app cover builder in the spec form (`setCoverMode`)

## Verification (Playwright, real Chrome)
Before: click Solid → `card_cover_default=""`, preview unchanged.
After: click Solid → `card_cover_default="#0f6e56"`, preview `rgb(15,110,86)` immediately; setting `#ff0000` → preview red.

Template-only change; `cargo build` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)