### PR TITLE
chore(release): bump workspace version 0.2.1 → 0.2.2

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2845,7 +2845,7 @@ dependencies = [
 
 [[package]]
 name = "ruscker-admin"
-version = "0.2.1"
+version = "0.2.2"
 dependencies = [
  "aes-gcm",
  "anyhow",
@@ -2895,7 +2895,7 @@ dependencies = [
 
 [[package]]
 name = "ruscker-cli"
-version = "0.2.1"
+version = "0.2.2"
 dependencies = [
  "anyhow",
  "clap",
@@ -2915,7 +2915,7 @@ dependencies = [
 
 [[package]]
 name = "ruscker-config"
-version = "0.2.1"
+version = "0.2.2"
 dependencies = [
  "chrono",
  "ordered-float",
@@ -2930,7 +2930,7 @@ dependencies = [
 
 [[package]]
 name = "ruscker-core"
-version = "0.2.1"
+version = "0.2.2"
 dependencies = [
  "async-trait",
  "chrono",
@@ -2943,7 +2943,7 @@ dependencies = [
 
 [[package]]
 name = "ruscker-docker"
-version = "0.2.1"
+version = "0.2.2"
 dependencies = [
  "anyhow",
  "async-stream",
@@ -2962,7 +2962,7 @@ dependencies = [
 
 [[package]]
 name = "ruscker-proxy"
-version = "0.2.1"
+version = "0.2.2"
 dependencies = [
  "anyhow",
  "axum",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -10,7 +10,7 @@ members = [
 ]
 
 [workspace.package]
-version = "0.2.1"
+version = "0.2.2"
 edition = "2021"
 rust-version = "1.85"
 license = "Apache-2.0"

--- a/book/src/news.md
+++ b/book/src/news.md
@@ -9,6 +9,18 @@ the [GitHub releases page](https://github.com/StrategicProjects/ruscker/releases
 
 ---
 
+## v0.2.2 — 2026-06-09
+
+**Card-cover preview fix.** Selecting the **Solid** card-cover mode only
+flipped the editing mode and left the value empty, so the live preview
+didn't change until the colour picker was dragged — it read as "the
+cover adjustment isn't reflecting". Switching to Solid now seeds a
+starting brand colour, so the mock card updates immediately and the
+picker edits it live. Applies to both the Appearance default-cover
+builder and the per-app cover builder in the spec form.
+
+---
+
 ## v0.2.1 — 2026-06-09
 
 **Apps editor + Appearance polish.** Four operator-reported fixes:


### PR DESCRIPTION
Release bump for the card-cover preview fix merged in #723.

- `[workspace.package] version` 0.2.1 → 0.2.2 + `Cargo.lock` refresh
- `book/src/news.md` v0.2.2 entry

Tagging `v0.2.2` after this merges triggers the release workflow.

🤖 Generated with [Claude Code](https://claude.com/claude-code)