### PR TITLE
fix(cover): gradient default cover not reflecting in the Appearance preview

### DIFF
--- a/crates/ruscker-admin/templates/admin/_layout.html
+++ b/crates/ruscker-admin/templates/admin/_layout.html
@@ -159,6 +159,41 @@ window.ruscker.gradientDefault = () => ({
 window.ruscker.bgMode = (value) =>
   (typeof value === 'string' && /^(linear|radial)-gradient\(/.test(value.trim()))
     ? 'gradient' : 'solid';
+// Parse a gradient CSS string back into builder state {type, angle, stops}
+// — the inverse of gradientCss — so reopening the editor seeds the builder
+// from the SAVED gradient instead of the default. Without this, the first
+// edit of a saved gradient rebuilt from the default palette and silently
+// wiped the saved one (#720 follow-up). Returns null when the value isn't a
+// gradient we can round-trip; callers fall back to gradientDefault().
+window.ruscker.gradientParse = (value) => {
+  const v = (value || '').trim();
+  const m = /^(linear|radial)-gradient\((.*)\)$/i.exec(v);
+  if (!m) return null;
+  const type = m[1].toLowerCase();
+  // Split on top-level commas only, so a color like `rgb(1, 2, 3)` stays whole.
+  const parts = [];
+  let depth = 0, cur = '';
+  for (const ch of m[2]) {
+    if (ch === '(') depth++;
+    else if (ch === ')') depth--;
+    if (ch === ',' && depth === 0) { parts.push(cur.trim()); cur = ''; }
+    else cur += ch;
+  }
+  if (cur.trim()) parts.push(cur.trim());
+  let angle = 135;
+  let rest = parts;
+  if (type === 'linear' && /^-?\d+(?:\.\d+)?deg$/i.test(parts[0] || '')) {
+    angle = parseInt(parts[0], 10) || 0;
+    rest = parts.slice(1);
+  } else if (type === 'radial' && /^(circle|ellipse)\b/i.test(parts[0] || '')) {
+    rest = parts.slice(1);  // drop the shape keyword gradientCss emits
+  }
+  const stops = rest.map((p) => {
+    const mm = /^(.*?)(?:\s+(\d+(?:\.\d+)?)%)?$/.exec(p.trim());
+    return { color: (mm[1] || '').trim(), pos: mm[2] != null ? Number(mm[2]) : '' };
+  }).filter((s) => s.color);
+  return stops.length >= 2 ? { type, angle, stops } : null;
+};
 
 // Shared image-picker mixin (#451) — the gallery modal reused by the
 // spec form's logo/cover and the landing logos editor. Spread it into an

--- a/crates/ruscker-admin/templates/admin/landing.html
+++ b/crates/ruscker-admin/templates/admin/landing.html
@@ -858,7 +858,9 @@ window.ruscker.landingForm = (initial, logoImages) => ({
   })(),
   // Header-background editing mode + gradient builder sub-state.
   bgMode: window.ruscker.bgMode(initial.header_bg || ''),
-  grad: window.ruscker.gradientDefault(),
+  // Seed the builder from the saved gradient (not the default) so editing
+  // a saved gradient modifies it in place instead of wiping it (#720).
+  grad: window.ruscker.gradientParse(initial.header_bg) || window.ruscker.gradientDefault(),
   // Recompute header_bg from the gradient builder. Called on any
   // builder control change while in gradient mode.
   applyGrad() {
@@ -891,7 +893,9 @@ window.ruscker.landingForm = (initial, logoImages) => ({
   coverDefMode: !((initial.card_cover_default || '').trim())
     ? 'auto'
     : window.ruscker.bgMode(initial.card_cover_default),
-  coverDefGrad: window.ruscker.gradientDefault(),
+  // Seed from the saved gradient so editing it modifies it in place
+  // instead of resetting to the default palette (#720 follow-up).
+  coverDefGrad: window.ruscker.gradientParse(initial.card_cover_default) || window.ruscker.gradientDefault(),
   applyCoverDef() {
     this.form.card_cover_default = window.ruscker.gradientCss(this.coverDefGrad);
   },
@@ -988,11 +992,17 @@ window.ruscker.landingForm = (initial, logoImages) => ({
   // (mirrors the public landing: inline `background` + .cover-gradient
   // .rcover-bg's `background-image`).
   pvCoverStyle() {
+    // An explicit default cover wins and is shown as-is — mirroring the
+    // public landing, where the inline `background` overrides the
+    // `.cover-gradient` overlay. (Appending the overlay here would be a
+    // second `background-image` that clobbers the colour gradient, leaving
+    // a grey wash — the bug this fixes.)
     const def = (this.form.card_cover_default || '').trim();
-    const base = def
-      ? `background: ${def};`
-      : `background-color: color-mix(in srgb, ${this.pvAccent()} 14%, var(--surface));`;
-    return base
+    if (def) return `background: ${def};`;
+    // No explicit cover: the accent tint, plus the subtle gradient overlay
+    // when card-cover is `gradient` (these are separate properties —
+    // background-color + background-image — so they layer cleanly).
+    return `background-color: color-mix(in srgb, ${this.pvAccent()} 14%, var(--surface));`
       + (this.form.card_cover === 'gradient'
         ? 'background-image: linear-gradient(135deg, rgba(255,255,255,0.10), rgba(0,0,0,0.16));'
         : '');

--- a/crates/ruscker-admin/templates/admin/spec_form.html
+++ b/crates/ruscker-admin/templates/admin/spec_form.html
@@ -1217,7 +1217,9 @@ window.ruscker.specForm = (initial, logoImages, availableGroups) => ({
     : ((initial.cover || '').trim().indexOf('url(') === 0
         ? 'auto'
         : window.ruscker.bgMode(initial.cover)),
-  grad: window.ruscker.gradientDefault(),
+  // Seed from the saved gradient so editing it modifies it in place
+  // instead of resetting to the default palette (#720 follow-up).
+  grad: window.ruscker.gradientParse(initial.cover) || window.ruscker.gradientDefault(),
   applyCoverGrad() {
     this.form.cover = window.ruscker.gradientCss(this.grad);
   },


### PR DESCRIPTION
Operator report (with screenshot): a **gradient** default card cover doesn't show in the Portal Preview — the mock cards stay grey — when **Card covers: Gradient** is selected.

## Root cause (reproduced in a real browser)
With the `card_cover` toggle on **Gradient**, `pvCoverStyle()` produced:
```
background: linear-gradient(135deg, #c4bc00 0%, #5dcaa5 100%);
background-image: linear-gradient(135deg, rgba(255,255,255,.10), rgba(0,0,0,.16));
```
Two `background-image` declarations in one inline style → the subtle overlay **clobbers** the colour gradient, leaving a translucent grey wash. (My earlier tests missed it because the toggle wasn't on Gradient.) The public landing is unaffected — there the inline `background` overrides the `.cover-gradient` overlay *class*.

## Fixes
1. **`pvCoverStyle`**: when an explicit default cover is set, show it as-is (no overlay), mirroring the public landing. The overlay only layers over the accent-tint fallback (separate `background-color` + `background-image`, so no collision).
2. **Builder seeding** (`gradientParse`): the gradient builders seeded from `gradientDefault()`, never the saved value — so reopening showed the default palette and the first edit silently **wiped the saved gradient**. Added `window.ruscker.gradientParse()` (inverse of `gradientCss`) and seed all three builders (Appearance default cover, header bg, per-app cover) from the saved value.

## Verification (Playwright, real Chrome)
- Gradient default cover + toggle Gradient → preview shows `rgb(196,188,0)→rgb(93,202,165)` (the colour gradient), not grey.
- Reopen a saved `#ff0000→#0000ff` gradient → builder shows those stops; editing modifies them in place.
- `cargo test` green, i18n parity OK. Template-only change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)