### PR TITLE
chore(release): bump workspace version 0.2.2 → 0.2.3

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2845,7 +2845,7 @@ dependencies = [
 
 [[package]]
 name = "ruscker-admin"
-version = "0.2.2"
+version = "0.2.3"
 dependencies = [
  "aes-gcm",
  "anyhow",
@@ -2895,7 +2895,7 @@ dependencies = [
 
 [[package]]
 name = "ruscker-cli"
-version = "0.2.2"
+version = "0.2.3"
 dependencies = [
  "anyhow",
  "clap",
@@ -2915,7 +2915,7 @@ dependencies = [
 
 [[package]]
 name = "ruscker-config"
-version = "0.2.2"
+version = "0.2.3"
 dependencies = [
  "chrono",
  "ordered-float",
@@ -2930,7 +2930,7 @@ dependencies = [
 
 [[package]]
 name = "ruscker-core"
-version = "0.2.2"
+version = "0.2.3"
 dependencies = [
  "async-trait",
  "chrono",
@@ -2943,7 +2943,7 @@ dependencies = [
 
 [[package]]
 name = "ruscker-docker"
-version = "0.2.2"
+version = "0.2.3"
 dependencies = [
  "anyhow",
  "async-stream",
@@ -2962,7 +2962,7 @@ dependencies = [
 
 [[package]]
 name = "ruscker-proxy"
-version = "0.2.2"
+version = "0.2.3"
 dependencies = [
  "anyhow",
  "axum",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -10,7 +10,7 @@ members = [
 ]
 
 [workspace.package]
-version = "0.2.2"
+version = "0.2.3"
 edition = "2021"
 rust-version = "1.85"
 license = "Apache-2.0"

--- a/book/src/news.md
+++ b/book/src/news.md
@@ -9,6 +9,20 @@ the [GitHub releases page](https://github.com/StrategicProjects/ruscker/releases
 
 ---
 
+## v0.2.3 — 2026-06-09
+
+**Gradient card-cover preview fix.** A gradient default card cover didn't
+show in the Appearance preview (the mock cards stayed grey) when the
+**Card covers: Gradient** toggle was on — the preview emitted two
+`background-image` declarations, so the subtle overlay clobbered the
+colour gradient. The preview now shows an explicit cover as-is, mirroring
+the public landing. Also: the gradient builders now seed from the saved
+value (`gradientParse`), so reopening shows the saved stops and editing a
+saved gradient modifies it in place instead of silently resetting it to
+the default palette.
+
+---
+
 ## v0.2.2 — 2026-06-09
 
 **Card-cover preview fix.** Selecting the **Solid** card-cover mode only


### PR DESCRIPTION
Release bump for the gradient card-cover preview fix merged in #725.

- `[workspace.package] version` 0.2.2 → 0.2.3 + `Cargo.lock` refresh
- `book/src/news.md` v0.2.3 entry

Tagging `v0.2.3` after this merges triggers the release workflow.

🤖 Generated with [Claude Code](https://claude.com/claude-code)