### PR TITLE
chore(release): bump workspace version 0.2.3 → 0.2.4

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2845,7 +2845,7 @@ dependencies = [
 
 [[package]]
 name = "ruscker-admin"
-version = "0.2.3"
+version = "0.2.4"
 dependencies = [
  "aes-gcm",
  "anyhow",
@@ -2895,7 +2895,7 @@ dependencies = [
 
 [[package]]
 name = "ruscker-cli"
-version = "0.2.3"
+version = "0.2.4"
 dependencies = [
  "anyhow",
  "clap",
@@ -2915,7 +2915,7 @@ dependencies = [
 
 [[package]]
 name = "ruscker-config"
-version = "0.2.3"
+version = "0.2.4"
 dependencies = [
  "chrono",
  "ordered-float",
@@ -2930,7 +2930,7 @@ dependencies = [
 
 [[package]]
 name = "ruscker-core"
-version = "0.2.3"
+version = "0.2.4"
 dependencies = [
  "async-trait",
  "chrono",
@@ -2943,7 +2943,7 @@ dependencies = [
 
 [[package]]
 name = "ruscker-docker"
-version = "0.2.3"
+version = "0.2.4"
 dependencies = [
  "anyhow",
  "async-stream",
@@ -2962,7 +2962,7 @@ dependencies = [
 
 [[package]]
 name = "ruscker-proxy"
-version = "0.2.3"
+version = "0.2.4"
 dependencies = [
  "anyhow",
  "axum",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -10,7 +10,7 @@ members = [
 ]
 
 [workspace.package]
-version = "0.2.3"
+version = "0.2.4"
 edition = "2021"
 rust-version = "1.85"
 license = "Apache-2.0"

--- a/book/src/news.md
+++ b/book/src/news.md
@@ -9,6 +9,19 @@ the [GitHub releases page](https://github.com/StrategicProjects/ruscker/releases
 
 ---
 
+## v0.2.4 — 2026-06-09
+
+**Logo picker is now a searchable modal.** The app form's inline logo
+thumbnail grid didn't scale — with a large media library the tiles
+overflowed and overlapped (an SVG with a big viewBox got no height from
+`aspect-ratio` and blew up its cell). It's now a compact control (current
+logo thumbnail + "Choose from library") that opens the shared image-picker
+modal with search, the full library, and inline upload. Tiles got a
+`min-height` fallback so a failed `aspect-ratio` can't overflow them, and
+logos render `contain` (no crop).
+
+---
+
 ## v0.2.3 — 2026-06-09
 
 **Gradient card-cover preview fix.** A gradient default card cover didn't


### PR DESCRIPTION
Release bump for the searchable logo-picker modal merged in #727.

- `[workspace.package] version` 0.2.3 → 0.2.4 + `Cargo.lock` refresh
- `book/src/news.md` v0.2.4 entry

Tagging `v0.2.4` after this merges triggers the release workflow.

🤖 Generated with [Claude Code](https://claude.com/claude-code)