### PR TITLE
fix(admin): v0.2.4 audit — atomic image refs, safe image pull, env validation, header sanitization, a11y

### DIFF
--- a/crates/ruscker-admin/assets/i18n/en/landing.ftl
+++ b/crates/ruscker-admin/assets/i18n/en/landing.ftl
@@ -468,6 +468,7 @@ spec-form-cover = Card cover
 spec-form-choose-image = Choose image
 spec-form-cover-auto = Auto (type tint)
 spec-form-cover-auto-help = Uses the card type default tint. Pick Solid or Gradient to customize.
+spec-form-cover-legacy-help = This cover uses an image (a retired mode — the logo already sits on top of the cover). It's kept as-is; pick Auto, Solid or Gradient above to replace it.
 
 # ── Spec form: advanced section + per-field help (#2) ──────────────
 spec-form-advanced = Advanced
@@ -522,6 +523,7 @@ spec-form-inject-base-href = Rewrite app HTML for the sub-path
 spec-form-inject-base-href-help = On by default. Ruscker rewrites <base href> and root-relative URLs so an app that assumes it lives at the server root works under its /app/ sub-path. Turn off only if the app reads X-Forwarded-Prefix and builds its own paths.
 spec-help-inject-base-href = Ruscker always forwards X-Forwarded-Prefix / X-Script-Name (plus X-Forwarded-Proto/-Host). Frameworks like FastAPI (root_path), Dash, and Streamlit can self-route from these — then this HTML rewriting is redundant.
 spec-form-error-volume = Each volume must be /host:/container (optionally :ro).
+spec-form-error-env = Each environment variable must be NAME=value, with a valid NAME (letters, digits, _; starting with a letter or _). Fix or remove the invalid line.
 admin-nav-logs = Logs
 admin-proclog-title = Logs
 admin-proclog-subtitle = Event stream from the balancer and replicas

--- a/crates/ruscker-admin/assets/i18n/es/landing.ftl
+++ b/crates/ruscker-admin/assets/i18n/es/landing.ftl
@@ -468,6 +468,7 @@ spec-form-cover = Cover de la tarjeta
 spec-form-choose-image = Elegir imagen
 spec-form-cover-auto = Auto (color del tipo)
 spec-form-cover-auto-help = Usa el tono por defecto del tipo. Elija Sólido o Degradado para personalizar.
+spec-form-cover-legacy-help = Esta portada usa una imagen (modo descontinuado — el logo ya va encima de la portada). Se mantiene como está; elija Auto, Sólido o Degradado arriba para reemplazarla.
 
 # ── Formulario de spec: sección avanzada + ayuda por campo (#2) ────
 spec-form-advanced = Avanzado
@@ -522,6 +523,7 @@ spec-form-inject-base-href = Reescribir el HTML de la app para el sub-path
 spec-form-inject-base-href-help = Activado por defecto. Ruscker reescribe <base href> y las URL relativas a la raíz para que una app que asume estar en la raíz del servidor funcione bajo su sub-path /app/. Desactiva solo si la app lee X-Forwarded-Prefix y construye sus propias rutas.
 spec-help-inject-base-href = Ruscker siempre reenvía X-Forwarded-Prefix / X-Script-Name (y X-Forwarded-Proto/-Host). Frameworks como FastAPI (root_path), Dash y Streamlit pueden auto-enrutarse con ellos — entonces esta reescritura de HTML es redundante.
 spec-form-error-volume = Cada volumen debe ser /host:/contenedor (opcional :ro).
+spec-form-error-env = Cada variable de entorno debe ser NOMBRE=valor, con un NOMBRE válido (letras, números, _; empezando por letra o _). Corrige o elimina la línea inválida.
 admin-nav-logs = Registros
 admin-proclog-title = Registros
 admin-proclog-subtitle = Flujo de eventos del balanceador y las réplicas

--- a/crates/ruscker-admin/assets/i18n/fr/landing.ftl
+++ b/crates/ruscker-admin/assets/i18n/fr/landing.ftl
@@ -468,6 +468,7 @@ spec-form-cover = Couverture de la carte
 spec-form-choose-image = Choisir une image
 spec-form-cover-auto = Auto (teinte du type)
 spec-form-cover-auto-help = Utilise la teinte par défaut du type. Choisissez Uni ou Dégradé pour personnaliser.
+spec-form-cover-legacy-help = Cette couverture utilise une image (mode retiré — le logo est déjà au-dessus de la couverture). Elle est conservée telle quelle ; choisissez Auto, Uni ou Dégradé ci-dessus pour la remplacer.
 
 # ── Formulaire de spec : section avancée + aide par champ (#2) ─────
 spec-form-advanced = Avancé
@@ -522,6 +523,7 @@ spec-form-inject-base-href = Réécrire le HTML de l'app pour le sous-chemin
 spec-form-inject-base-href-help = Activé par défaut. Ruscker réécrit <base href> et les URL relatives à la racine pour qu'une app qui se croit à la racine du serveur fonctionne sous son sous-chemin /app/. Désactivez uniquement si l'app lit X-Forwarded-Prefix et construit ses propres chemins.
 spec-help-inject-base-href = Ruscker transmet toujours X-Forwarded-Prefix / X-Script-Name (et X-Forwarded-Proto/-Host). Des frameworks comme FastAPI (root_path), Dash et Streamlit peuvent s'auto-router avec — la réécriture HTML devient alors redondante.
 spec-form-error-volume = Chaque volume doit être /hôte:/conteneur (optionnel :ro).
+spec-form-error-env = Chaque variable d'environnement doit être NOM=valeur, avec un NOM valide (lettres, chiffres, _ ; commençant par une lettre ou _). Corrigez ou supprimez la ligne invalide.
 admin-nav-logs = Journaux
 admin-proclog-title = Journaux
 admin-proclog-subtitle = Flux d'événements de l'équilibreur et des répliques

--- a/crates/ruscker-admin/assets/i18n/pt/landing.ftl
+++ b/crates/ruscker-admin/assets/i18n/pt/landing.ftl
@@ -472,6 +472,7 @@ spec-form-cover = Cover do card
 spec-form-choose-image = Escolher imagem
 spec-form-cover-auto = Auto (cor do tipo)
 spec-form-cover-auto-help = Usa o tom padrão do tipo do card. Escolha Sólida ou Gradiente para personalizar.
+spec-form-cover-legacy-help = Esta capa usa uma imagem (modo descontinuado — o logo já fica por cima da capa). Ela é mantida como está; escolha Auto, Sólida ou Gradiente acima para substituí-la.
 
 # ── Formulário de spec: seção avançada + ajuda por campo (#2) ──────
 spec-form-advanced = Avançado
@@ -526,6 +527,7 @@ spec-form-inject-base-href = Reescrever o HTML do app para o sub-caminho
 spec-form-inject-base-href-help = Ligado por padrão. O Ruscker reescreve <base href> e URLs relativas à raiz para que um app que assume estar na raiz do servidor funcione sob o sub-caminho /app/. Desligue só se o app lê X-Forwarded-Prefix e monta os próprios caminhos.
 spec-help-inject-base-href = O Ruscker sempre encaminha X-Forwarded-Prefix / X-Script-Name (e X-Forwarded-Proto/-Host). Frameworks como FastAPI (root_path), Dash e Streamlit se auto-roteiam por eles — aí esta reescrita de HTML fica redundante.
 spec-form-error-volume = Cada volume deve ser /host:/container (opcional :ro).
+spec-form-error-env = Cada variável de ambiente deve ser NOME=valor, com NOME válido (letras, números, _; começando por letra ou _). Corrija ou remova a linha inválida.
 admin-nav-logs = Logs
 admin-proclog-title = Logs
 admin-proclog-subtitle = Fluxo de eventos do balanceador e das réplicas

--- a/crates/ruscker-admin/src/db/images.rs
+++ b/crates/ruscker-admin/src/db/images.rs
@@ -10,8 +10,9 @@
 //! install crosses ~1 GB of images or someone wants to share a
 //! gallery across multiple Ruscker instances.
 
-use anyhow::{Context, Result};
+use anyhow::{Context, Result, bail};
 use chrono::{DateTime, Utc};
+use ruscker_config::{LandingCustomization, Spec};
 use uuid::Uuid;
 
 use crate::db::ConfigDb;
@@ -381,6 +382,252 @@ pub async fn delete_one(db: &ConfigDb, id: &str, actor: Option<&str>) -> Result<
     }
 }
 
+/// Rename an image AND rewrite every reference to it (the given specs +
+/// landing) in **one transaction** (#720 audit P2). Before, the route
+/// rewrote specs/landing in separate transactions and renamed the image
+/// last — a failure there left cards pointing at a filename that no
+/// longer existed. Here all writes commit together or not at all.
+///
+/// `specs` are the already-rewritten specs to upsert; `landing` is the
+/// rewritten customization, or `None` when it held no reference. The
+/// target filename is re-checked *inside* the tx (authoritative over the
+/// route's advisory pre-check), so a colliding name rolls the batch back.
+pub(crate) async fn rename_with_refs(
+    db: &ConfigDb,
+    id: &str,
+    new_filename: &str,
+    specs: &[Spec],
+    landing: Option<&LandingCustomization>,
+    actor: Option<&str>,
+) -> Result<()> {
+    let now = Utc::now();
+    let target = format!("image:{id}");
+    let diff = serde_json::to_string(&serde_json::json!({ "filename": new_filename }))?;
+    match db {
+        ConfigDb::Sqlite(pool) => {
+            let mut tx = pool.begin().await.context("begin image rename tx")?;
+            let taken: (i64,) =
+                sqlx::query_as("SELECT count(*) FROM images WHERE filename = ? AND id != ?")
+                    .bind(new_filename)
+                    .bind(id)
+                    .fetch_one(&mut *tx)
+                    .await
+                    .context("rename collision check (sqlite)")?;
+            if taken.0 > 0 {
+                bail!("filename '{new_filename}' is already taken");
+            }
+            sqlx::query("UPDATE images SET filename = ? WHERE id = ?")
+                .bind(new_filename)
+                .bind(id)
+                .execute(&mut *tx)
+                .await
+                .context("rename image (sqlite)")?;
+            audit_sqlite(&mut tx, actor, "image.rename", &target, Some(&diff), now).await?;
+            for spec in specs {
+                crate::db::specs::upsert_in_tx(&mut tx, spec, now).await?;
+                let t = format!("spec:{}", spec.id);
+                audit_sqlite(&mut tx, actor, "spec.update", &t, None, now).await?;
+            }
+            if let Some(lc) = landing {
+                crate::db::landing::update_in_tx(&mut tx, lc, now).await?;
+                audit_sqlite(
+                    &mut tx,
+                    actor,
+                    "landing.update",
+                    "landing:customization",
+                    None,
+                    now,
+                )
+                .await?;
+            }
+            tx.commit().await.context("commit image rename")?;
+        }
+        ConfigDb::Postgres(pool) => {
+            let mut tx = pool.begin().await.context("begin image rename tx")?;
+            let taken: (i64,) =
+                sqlx::query_as("SELECT count(*) FROM images WHERE filename = $1 AND id != $2")
+                    .bind(new_filename)
+                    .bind(id)
+                    .fetch_one(&mut *tx)
+                    .await
+                    .context("rename collision check (postgres)")?;
+            if taken.0 > 0 {
+                bail!("filename '{new_filename}' is already taken");
+            }
+            sqlx::query("UPDATE images SET filename = $1 WHERE id = $2")
+                .bind(new_filename)
+                .bind(id)
+                .execute(&mut *tx)
+                .await
+                .context("rename image (postgres)")?;
+            audit_pg(&mut tx, actor, "image.rename", &target, Some(&diff), now).await?;
+            for spec in specs {
+                crate::db::specs::upsert_in_tx_pg(&mut tx, spec, now).await?;
+                let t = format!("spec:{}", spec.id);
+                audit_pg(&mut tx, actor, "spec.update", &t, None, now).await?;
+            }
+            if let Some(lc) = landing {
+                crate::db::landing::update_in_tx_pg(&mut tx, lc, now).await?;
+                audit_pg(
+                    &mut tx,
+                    actor,
+                    "landing.update",
+                    "landing:customization",
+                    None,
+                    now,
+                )
+                .await?;
+            }
+            tx.commit().await.context("commit image rename")?;
+        }
+    }
+    Ok(())
+}
+
+/// Delete an image AND reset every reference to it (the given specs +
+/// landing) in **one transaction** (#720 audit P2). `specs` are the
+/// already-reset specs to upsert (logo → default mark, cover removed);
+/// `landing` is the reset customization, or `None`. Returns the deleted
+/// row's filename (for cache invalidation), or `None` if it was already
+/// gone — in which case nothing is written.
+pub(crate) async fn delete_with_refs(
+    db: &ConfigDb,
+    id: &str,
+    specs: &[Spec],
+    landing: Option<&LandingCustomization>,
+    actor: Option<&str>,
+) -> Result<Option<String>> {
+    let now = Utc::now();
+    let target = format!("image:{id}");
+    match db {
+        ConfigDb::Sqlite(pool) => {
+            let mut tx = pool.begin().await.context("begin image delete tx")?;
+            let filename: Option<(String,)> =
+                sqlx::query_as("SELECT filename FROM images WHERE id = ?")
+                    .bind(id)
+                    .fetch_optional(&mut *tx)
+                    .await
+                    .context("lookup image for delete")?;
+            if filename.is_none() {
+                return Ok(None); // already gone — tx drops, nothing written
+            }
+            sqlx::query("DELETE FROM images WHERE id = ?")
+                .bind(id)
+                .execute(&mut *tx)
+                .await
+                .with_context(|| format!("delete image {id}"))?;
+            let diff = serde_json::to_string(&delete_diff(filename.as_ref()))?;
+            audit_sqlite(&mut tx, actor, "image.delete", &target, Some(&diff), now).await?;
+            for spec in specs {
+                crate::db::specs::upsert_in_tx(&mut tx, spec, now).await?;
+                let t = format!("spec:{}", spec.id);
+                audit_sqlite(&mut tx, actor, "spec.update", &t, None, now).await?;
+            }
+            if let Some(lc) = landing {
+                crate::db::landing::update_in_tx(&mut tx, lc, now).await?;
+                audit_sqlite(
+                    &mut tx,
+                    actor,
+                    "landing.update",
+                    "landing:customization",
+                    None,
+                    now,
+                )
+                .await?;
+            }
+            tx.commit().await.context("commit image delete")?;
+            Ok(filename.map(|(f,)| f))
+        }
+        ConfigDb::Postgres(pool) => {
+            let mut tx = pool.begin().await.context("begin image delete tx")?;
+            let filename: Option<(String,)> =
+                sqlx::query_as("SELECT filename FROM images WHERE id = $1")
+                    .bind(id)
+                    .fetch_optional(&mut *tx)
+                    .await
+                    .context("lookup image for delete")?;
+            if filename.is_none() {
+                return Ok(None);
+            }
+            sqlx::query("DELETE FROM images WHERE id = $1")
+                .bind(id)
+                .execute(&mut *tx)
+                .await
+                .with_context(|| format!("delete image {id}"))?;
+            let diff = serde_json::to_string(&delete_diff(filename.as_ref()))?;
+            audit_pg(&mut tx, actor, "image.delete", &target, Some(&diff), now).await?;
+            for spec in specs {
+                crate::db::specs::upsert_in_tx_pg(&mut tx, spec, now).await?;
+                let t = format!("spec:{}", spec.id);
+                audit_pg(&mut tx, actor, "spec.update", &t, None, now).await?;
+            }
+            if let Some(lc) = landing {
+                crate::db::landing::update_in_tx_pg(&mut tx, lc, now).await?;
+                audit_pg(
+                    &mut tx,
+                    actor,
+                    "landing.update",
+                    "landing:customization",
+                    None,
+                    now,
+                )
+                .await?;
+            }
+            tx.commit().await.context("commit image delete")?;
+            Ok(filename.map(|(f,)| f))
+        }
+    }
+}
+
+/// Append one audit row inside a SQLite transaction (shared by the atomic
+/// image ops above). `diff` is the JSON diff, or `None` for no diff.
+async fn audit_sqlite(
+    tx: &mut sqlx::Transaction<'_, sqlx::Sqlite>,
+    actor: Option<&str>,
+    action: &str,
+    target: &str,
+    diff: Option<&str>,
+    now: DateTime<Utc>,
+) -> Result<()> {
+    sqlx::query(
+        "INSERT INTO audit_log (actor, action, target, diff_json, occurred_at)
+         VALUES (?, ?, ?, ?, ?)",
+    )
+    .bind(actor)
+    .bind(action)
+    .bind(target)
+    .bind(diff)
+    .bind(now)
+    .execute(&mut **tx)
+    .await
+    .with_context(|| format!("audit {action}"))?;
+    Ok(())
+}
+
+/// Postgres twin of [`audit_sqlite`].
+async fn audit_pg(
+    tx: &mut sqlx::Transaction<'_, sqlx::Postgres>,
+    actor: Option<&str>,
+    action: &str,
+    target: &str,
+    diff: Option<&str>,
+    now: DateTime<Utc>,
+) -> Result<()> {
+    sqlx::query(
+        "INSERT INTO audit_log (actor, action, target, diff_json, occurred_at)
+         VALUES ($1, $2, $3, $4, $5)",
+    )
+    .bind(actor)
+    .bind(action)
+    .bind(target)
+    .bind(diff)
+    .bind(now)
+    .execute(&mut **tx)
+    .await
+    .with_context(|| format!("audit {action}"))?;
+    Ok(())
+}
+
 /// Audit diff for a delete — the filename if we captured one, else
 /// an empty object.
 fn delete_diff(filename: Option<&(String,)>) -> serde_json::Value {
@@ -434,5 +681,126 @@ mod pg_tests {
             Some("logo.webp")
         );
         assert!(fetch_by_filename(&db, "logo.webp").await.unwrap().is_none());
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::db::open_memory;
+    use ruscker_config::Config;
+
+    async fn insert_image(db: &ConfigDb, id: &str, filename: &str) {
+        let ConfigDb::Sqlite(pool) = db else {
+            return;
+        };
+        sqlx::query(
+            "INSERT INTO images (id, filename, mime_type, size_bytes, blob, uploaded_at)
+             VALUES (?, ?, 'image/png', 3, ?, ?)",
+        )
+        .bind(id)
+        .bind(filename)
+        .bind(vec![1u8, 2, 3])
+        .bind(Utc::now())
+        .execute(pool)
+        .await
+        .unwrap();
+    }
+
+    fn spec_with_logo(id: &str, logo: &str) -> Spec {
+        std::env::set_var("DOCKER_REGISTRY_PASSWORD", "test");
+        let yaml = format!(
+            "proxy:\n  specs:\n    - id: {id}\n      container-image: img\n      template-properties:\n        logo: \"{logo}\"\n"
+        );
+        Config::from_yaml(&yaml)
+            .unwrap()
+            .proxy
+            .specs
+            .into_iter()
+            .next()
+            .unwrap()
+    }
+
+    async fn logo_of(db: &ConfigDb, id: &str) -> Option<String> {
+        crate::db::specs::fetch_one(db, id)
+            .await
+            .unwrap()
+            .unwrap()
+            .template_properties
+            .get_str("logo")
+            .map(str::to_string)
+    }
+
+    // Happy path: the image rename and the spec rewrite commit together.
+    #[tokio::test]
+    async fn rename_with_refs_commits_image_and_spec_together() {
+        let db = ConfigDb::Sqlite(open_memory().await.unwrap());
+        insert_image(&db, "img1", "old.png").await;
+        let mut spec = spec_with_logo("app", "/assets/img/old.png");
+        crate::db::specs::upsert_one(&db, &spec, None).await.unwrap();
+
+        spec.template_properties
+            .set_str("logo", "/assets/img/new.png");
+        rename_with_refs(&db, "img1", "new.png", std::slice::from_ref(&spec), None, None)
+            .await
+            .unwrap();
+
+        assert_eq!(filename_for(&db, "img1").await.unwrap().as_deref(), Some("new.png"));
+        assert_eq!(logo_of(&db, "app").await.as_deref(), Some("/assets/img/new.png"));
+    }
+
+    // Conflict: renaming onto a name another image already holds must roll
+    // the WHOLE batch back — the spec ref stays pointing at the old name,
+    // and the image keeps its old name (no half-applied state).
+    #[tokio::test]
+    async fn rename_with_refs_rolls_back_on_name_conflict() {
+        let db = ConfigDb::Sqlite(open_memory().await.unwrap());
+        insert_image(&db, "img1", "old.png").await;
+        insert_image(&db, "img2", "taken.png").await;
+        let spec = spec_with_logo("app", "/assets/img/old.png");
+        crate::db::specs::upsert_one(&db, &spec, None).await.unwrap();
+
+        let mut rewritten = spec.clone();
+        rewritten
+            .template_properties
+            .set_str("logo", "/assets/img/taken.png");
+        let res =
+            rename_with_refs(&db, "img1", "taken.png", std::slice::from_ref(&rewritten), None, None)
+                .await;
+
+        assert!(res.is_err(), "rename onto a taken name must fail");
+        assert_eq!(
+            filename_for(&db, "img1").await.unwrap().as_deref(),
+            Some("old.png"),
+            "image name rolled back"
+        );
+        assert_eq!(
+            logo_of(&db, "app").await.as_deref(),
+            Some("/assets/img/old.png"),
+            "spec ref rolled back — not left pointing at the failed rename"
+        );
+    }
+
+    // Delete + reference reset commit together: image gone, spec reset.
+    #[tokio::test]
+    async fn delete_with_refs_removes_image_and_resets_specs_together() {
+        let db = ConfigDb::Sqlite(open_memory().await.unwrap());
+        insert_image(&db, "img1", "gone.png").await;
+        let mut spec = spec_with_logo("app", "/assets/img/gone.png");
+        crate::db::specs::upsert_one(&db, &spec, None).await.unwrap();
+
+        spec.template_properties
+            .set_str("logo", "/assets/img/ruscker-mark.svg");
+        let removed = delete_with_refs(&db, "img1", std::slice::from_ref(&spec), None, None)
+            .await
+            .unwrap();
+
+        assert_eq!(removed.as_deref(), Some("gone.png"));
+        assert!(filename_for(&db, "img1").await.unwrap().is_none(), "image deleted");
+        assert_eq!(
+            logo_of(&db, "app").await.as_deref(),
+            Some("/assets/img/ruscker-mark.svg"),
+            "spec logo reset to the default mark"
+        );
     }
 }

--- a/crates/ruscker-admin/src/db/specs.rs
+++ b/crates/ruscker-admin/src/db/specs.rs
@@ -404,7 +404,7 @@ pub async fn delete_one(db: &ConfigDb, id: &str, actor: Option<&str>) -> Result<
     }
 }
 
-async fn upsert_in_tx(
+pub(crate) async fn upsert_in_tx(
     tx: &mut sqlx::Transaction<'_, sqlx::Sqlite>,
     spec: &Spec,
     now: DateTime<Utc>,
@@ -504,7 +504,7 @@ async fn upsert_in_tx(
 /// Postgres twin of [`upsert_in_tx`] — identical logic, `$n`
 /// placeholders. Used by the Postgres arms of [`upsert_one`] and
 /// [`import_all`] (each dispatches on the `ConfigDb` dialect).
-async fn upsert_in_tx_pg(
+pub(crate) async fn upsert_in_tx_pg(
     tx: &mut sqlx::Transaction<'_, sqlx::Postgres>,
     spec: &Spec,
     now: DateTime<Utc>,

--- a/crates/ruscker-admin/src/routes/admin/images.rs
+++ b/crates/ruscker-admin/src/routes/admin/images.rs
@@ -19,6 +19,7 @@ use axum::{
     routing::{get, post},
     Form, Json, Router,
 };
+use ruscker_config::Spec;
 use serde::Deserialize;
 
 use crate::auth::{RequireEditor, Role};
@@ -469,64 +470,84 @@ async fn rename(
         }
     }
 
-    // Rewrite spec logo/cover references old → new.
-    if let Ok(specs) = db::specs::list_all(pool).await {
-        for spec in specs {
-            let logo_hit = spec
-                .template_properties
-                .get_str("logo")
-                .is_some_and(|v| references_image(v, &old));
-            let cover_hit = spec
-                .template_properties
-                .get_str("cover")
-                .is_some_and(|v| references_image(v, &old));
-            if !logo_hit && !cover_hit {
-                continue;
-            }
-            let mut spec = spec;
-            if logo_hit {
-                if let Some(v) = spec.template_properties.get_str("logo") {
+    // Compute the rewritten spec + landing references in memory, then
+    // commit the image rename together with EVERY reference in a single
+    // transaction (#720 audit P2). Previously each rewrite was its own
+    // transaction and the image rename came last, so a failure there left
+    // cards pointing at a filename that no longer existed.
+    let specs_to_update: Vec<Spec> = match db::specs::list_all(pool).await {
+        Ok(specs) => specs
+            .into_iter()
+            .filter_map(|mut spec| {
+                let logo_hit = spec
+                    .template_properties
+                    .get_str("logo")
+                    .is_some_and(|v| references_image(v, &old));
+                let cover_hit = spec
+                    .template_properties
+                    .get_str("cover")
+                    .is_some_and(|v| references_image(v, &old));
+                if !logo_hit && !cover_hit {
+                    return None;
+                }
+                if let Some(v) = spec.template_properties.get_str("logo").filter(|_| logo_hit) {
                     let nv = rewrite_reference(v, &old, &new);
                     spec.template_properties.set_str("logo", &nv);
                 }
-            }
-            if cover_hit {
-                if let Some(v) = spec.template_properties.get_str("cover") {
+                if let Some(v) = spec.template_properties.get_str("cover").filter(|_| cover_hit) {
                     let nv = rewrite_reference(v, &old, &new);
                     spec.template_properties.set_str("cover", &nv);
                 }
-            }
-            if let Err(e) = db::specs::upsert_one(pool, &spec, Some(editor.actor())).await {
-                tracing::warn!(spec = %spec.id, error = ?e, "rewrite spec image on rename failed");
-            }
+                Some(spec)
+            })
+            .collect(),
+        Err(err) => {
+            tracing::error!(error = ?err, "list specs for rename failed");
+            return (StatusCode::INTERNAL_SERVER_ERROR, "rename failed").into_response();
         }
-    }
+    };
+    let landing = match db::landing::fetch(pool).await {
+        Ok(mut lc) => {
+            let mut touched = false;
+            for logo in &mut lc.logos {
+                if references_image(&logo.url, &old) {
+                    logo.url = rewrite_reference(&logo.url, &old, &new);
+                    touched = true;
+                }
+            }
+            touched.then_some(lc)
+        }
+        Err(err) => {
+            tracing::error!(error = ?err, "fetch landing for rename failed");
+            return (StatusCode::INTERNAL_SERVER_ERROR, "rename failed").into_response();
+        }
+    };
 
-    // Rewrite landing header/footer logo URLs old → new.
-    if let Ok(mut lc) = db::landing::fetch(pool).await {
-        let mut touched = false;
-        for logo in &mut lc.logos {
-            if references_image(&logo.url, &old) {
-                logo.url = rewrite_reference(&logo.url, &old, &new);
-                touched = true;
-            }
-        }
-        if touched {
-            if let Err(e) = db::landing::update(pool, &lc, Some(editor.actor())).await {
-                tracing::warn!(error = ?e, "rewrite landing logos on rename failed");
-            }
-        }
-    }
-
-    match db::images::rename(pool, &id, &new, Some(editor.actor())).await {
+    match db::images::rename_with_refs(
+        pool,
+        &id,
+        &new,
+        &specs_to_update,
+        landing.as_ref(),
+        Some(editor.actor()),
+    )
+    .await
+    {
         Ok(()) => {
             crate::routes::assets::invalidate_thumb(&old);
             crate::routes::assets::invalidate_thumb(&new);
-            tracing::info!(id, %old, %new, "image renamed; references rewritten");
+            tracing::info!(id, %old, %new, specs = specs_to_update.len(),
+                "image renamed atomically; references rewritten");
             Redirect::to("/admin/media").into_response()
         }
+        // The in-tx collision re-check rolled the whole batch back: the
+        // target name was taken between the pre-check and the commit.
+        Err(err) if err.to_string().contains("taken") => {
+            tracing::warn!(error = ?err, id, "image rename rolled back (name taken)");
+            Redirect::to("/admin/media?error=taken").into_response()
+        }
         Err(err) => {
-            tracing::error!(error = ?err, id, "image rename failed");
+            tracing::error!(error = ?err, id, "image rename failed (rolled back)");
             (StatusCode::INTERNAL_SERVER_ERROR, "rename failed").into_response()
         }
     }
@@ -552,48 +573,72 @@ async fn delete(
         }
     };
 
-    // Reset every spec that used the image: a referencing `logo` falls back
-    // to the Ruscker mark; a referencing `cover` is cleared (kind tint).
-    let mut reset = 0usize;
-    if let Ok(specs) = db::specs::list_all(pool).await {
-        for spec in specs {
-            let logo_hit = spec
-                .template_properties
-                .get_str("logo")
-                .is_some_and(|v| references_image(v, &filename));
-            let cover_hit = spec
-                .template_properties
-                .get_str("cover")
-                .is_some_and(|v| references_image(v, &filename));
-            if !logo_hit && !cover_hit {
-                continue;
-            }
-            let mut spec = spec;
-            if logo_hit {
-                spec.template_properties
-                    .set_str("logo", RUSCKER_DEFAULT_LOGO);
-            }
-            if cover_hit {
-                spec.template_properties.remove("cover");
-            }
-            if let Err(e) = db::specs::upsert_one(pool, &spec, Some(editor.actor())).await {
-                tracing::warn!(spec = %spec.id, error = ?e, "reset spec image on delete failed");
-            } else {
-                reset += 1;
+    // Reset every reference in memory, then delete the image AND commit
+    // the resets in a single transaction (#720 audit P2) — a referencing
+    // spec `logo` falls back to the Ruscker mark, a `cover` is cleared
+    // (kind tint), and a landing logo url is cleared. Doing it atomically
+    // means a failure can't leave a card pointing at a gone image (or
+    // remove the image while a card still references it).
+    let mut reset_specs: Vec<Spec> = Vec::new();
+    match db::specs::list_all(pool).await {
+        Ok(specs) => {
+            for mut spec in specs {
+                let logo_hit = spec
+                    .template_properties
+                    .get_str("logo")
+                    .is_some_and(|v| references_image(v, &filename));
+                let cover_hit = spec
+                    .template_properties
+                    .get_str("cover")
+                    .is_some_and(|v| references_image(v, &filename));
+                if !logo_hit && !cover_hit {
+                    continue;
+                }
+                if logo_hit {
+                    spec.template_properties
+                        .set_str("logo", RUSCKER_DEFAULT_LOGO);
+                }
+                if cover_hit {
+                    spec.template_properties.remove("cover");
+                }
+                reset_specs.push(spec);
             }
         }
+        Err(err) => {
+            tracing::error!(error = ?err, "list specs for delete failed");
+            return (StatusCode::INTERNAL_SERVER_ERROR, "delete failed").into_response();
+        }
     }
+    let landing = match db::landing::fetch(pool).await {
+        Ok(mut lc) => {
+            let mut touched = false;
+            for logo in &mut lc.logos {
+                if references_image(&logo.url, &filename) {
+                    logo.url = String::new();
+                    touched = true;
+                }
+            }
+            touched.then_some(lc)
+        }
+        Err(err) => {
+            tracing::error!(error = ?err, "fetch landing for delete failed");
+            return (StatusCode::INTERNAL_SERVER_ERROR, "delete failed").into_response();
+        }
+    };
 
-    match db::images::delete_one(pool, &id, Some(editor.actor())).await {
+    match db::images::delete_with_refs(pool, &id, &reset_specs, landing.as_ref(), Some(editor.actor()))
+        .await
+    {
         Ok(name) => {
             if let Some(n) = name {
                 crate::routes::assets::invalidate_thumb(&n);
             }
-            tracing::info!(id, %filename, reset, "image deleted; apps reset to default logo");
+            tracing::info!(id, %filename, reset = reset_specs.len(),
+                "image deleted atomically; references reset");
             Redirect::to("/admin/media").into_response()
         }
         Err(err) => {
-            tracing::error!(error = ?err, id, "image delete failed");
+            tracing::error!(error = ?err, id, "image delete failed (rolled back)");
             (StatusCode::INTERNAL_SERVER_ERROR, "delete failed").into_response()
         }
     }

--- a/crates/ruscker-admin/src/routes/admin/spec_form.rs
+++ b/crates/ruscker-admin/src/routes/admin/spec_form.rs
@@ -44,7 +44,10 @@ pub fn routes() -> Router<AppState> {
         )
         .route("/admin/specs/{id}/duplicate", get(duplicate_form))
         .route("/admin/specs/image-check", get(image_check))
-        .route("/admin/specs/image-pull", get(image_pull))
+        // POST starts the pull (a side effect → CSRF-guarded); the GET
+        // only follows the resulting progress stream (#720 audit P2).
+        .route("/admin/specs/image-pull", post(image_pull_start))
+        .route("/admin/specs/image-pull/events", get(image_pull_events))
         .route("/admin/specs/{id}", post(update))
         .route("/admin/specs/{id}/delete", post(delete))
 }
@@ -108,19 +111,42 @@ struct ImagePullQuery {
     credential: String,
 }
 
-/// `GET /admin/specs/image-pull?image=…&credential=…` — pull an absent
-/// image now, streaming the daemon's progress over SSE so the editor's
-/// Pull button (#498, slice B) can show it. Reuses the same pull path as
-/// a spawn. A terminal `done` event lets the client close the stream and
-/// re-check presence (success ⇒ present, failure ⇒ still absent + the
-/// `error: …` line). Editor-gated.
-async fn image_pull(
+/// One progress message from a running pull job.
+enum PullEvent {
+    Line(String),
+    Done,
+}
+
+/// A started-but-not-yet-followed image pull. The progress stream is
+/// parked here under a one-shot token; the follower GET takes the
+/// receiver exactly once.
+struct PullJob {
+    rx: tokio::sync::Mutex<Option<tokio::sync::mpsc::UnboundedReceiver<PullEvent>>>,
+}
+
+/// In-flight pull jobs keyed by one-shot token (#720 audit P2). A pull is
+/// a side effect, so it's *started* by a CSRF-guarded POST and *followed*
+/// by a side-effect-free GET/SSE — instead of a GET that pulled. A module
+/// static (same pattern as the thumbnail caches in `routes::assets`), so
+/// it needs no `AppState` field; an unfollowed job is swept after a grace
+/// period so a started-but-never-watched pull can't leak its entry.
+static PULL_JOBS: std::sync::LazyLock<
+    dashmap::DashMap<String, std::sync::Arc<PullJob>>,
+> = std::sync::LazyLock::new(dashmap::DashMap::new);
+
+const PULL_JOB_TTL_SECS: u64 = 300;
+
+/// `POST /admin/specs/image-pull` (form: `image`, `credential`) — START
+/// pulling an absent image (#498 slice B; #720 P2 moved the side effect
+/// off GET). Validates, kicks off the daemon pull, parks the progress
+/// stream under a random token, and returns `{ "job": "<token>" }`. The
+/// editor then opens an EventSource on `…/image-pull/events?job=<token>`.
+/// Editor-gated; the POST inherits the chrome CSRF (Fetch-Metadata) guard.
+async fn image_pull_start(
     _: RequireEditor,
     State(state): State<AppState>,
-    Query(q): Query<ImagePullQuery>,
+    Form(q): Form<ImagePullQuery>,
 ) -> Response {
-    use axum::http::header::{HeaderName, CACHE_CONTROL};
-    use axum::response::sse::{Event, KeepAlive, Sse};
     use futures_util::StreamExt;
 
     let image = q.image.trim().to_string();
@@ -135,20 +161,78 @@ async fn image_pull(
         return (StatusCode::SERVICE_UNAVAILABLE, "Docker backend not connected").into_response();
     };
     let creds = resolve_pull_creds(&state, &q.credential).await;
-    let line_stream = match backend.pull_image(&image, creds.as_ref(), None).await {
+    let mut line_stream = match backend.pull_image(&image, creds.as_ref(), None).await {
         Ok(s) => s,
         Err(e) => {
             tracing::warn!(image, error = ?e, "image pull start failed");
             return (StatusCode::BAD_GATEWAY, format!("pull failed: {e}")).into_response();
         }
     };
-    // Progress lines as default events, then one terminal `done` event so
-    // the client closes the EventSource (no auto-reconnect → re-pull).
-    let progress = line_stream.map(|line| Ok::<_, std::convert::Infallible>(Event::default().data(line)));
-    let done = futures_util::stream::once(async {
-        Ok::<_, std::convert::Infallible>(Event::default().event("done").data(""))
+    // Drive the pull on a task, forwarding lines into the channel; the
+    // follower GET drains them. A terminal `Done` lets the follower close.
+    let (tx, rx) = tokio::sync::mpsc::unbounded_channel::<PullEvent>();
+    tokio::spawn(async move {
+        while let Some(line) = line_stream.next().await {
+            if tx.send(PullEvent::Line(line)).is_err() {
+                return; // follower disconnected
+            }
+        }
+        let _ = tx.send(PullEvent::Done);
     });
-    let sse = Sse::new(progress.chain(done))
+    let token = uuid::Uuid::new_v4().to_string();
+    PULL_JOBS.insert(
+        token.clone(),
+        std::sync::Arc::new(PullJob {
+            rx: tokio::sync::Mutex::new(Some(rx)),
+        }),
+    );
+    // Sweep an unfollowed job after a grace period (no follower ever
+    // connected) so the registry can't grow without bound.
+    let sweep = token.clone();
+    tokio::spawn(async move {
+        tokio::time::sleep(std::time::Duration::from_secs(PULL_JOB_TTL_SECS)).await;
+        PULL_JOBS.remove(&sweep);
+    });
+    tracing::info!(image, job = %token, "image pull started; awaiting follower");
+    Json(serde_json::json!({ "job": token })).into_response()
+}
+
+#[derive(Deserialize)]
+struct PullEventsQuery {
+    job: String,
+}
+
+/// `GET /admin/specs/image-pull/events?job=<token>` — FOLLOW a pull job
+/// started by [`image_pull_start`]. Side-effect-free: it only streams the
+/// already-running pull's progress over SSE (default events = lines, then
+/// one terminal `done` event), then drops the job. An unknown or
+/// already-followed token ⇒ 404. Editor-gated (RBAC preserved).
+async fn image_pull_events(_: RequireEditor, Query(q): Query<PullEventsQuery>) -> Response {
+    use axum::http::header::{HeaderName, CACHE_CONTROL};
+    use axum::response::sse::{Event, KeepAlive, Sse};
+
+    // Take the job out of the registry (so a token can't be replayed and
+    // nothing leaks), then take its receiver exactly once.
+    let Some((_, job)) = PULL_JOBS.remove(&q.job) else {
+        return (StatusCode::NOT_FOUND, "unknown or already-followed pull job").into_response();
+    };
+    let Some(mut rx) = job.rx.lock().await.take() else {
+        return (StatusCode::NOT_FOUND, "pull job already followed").into_response();
+    };
+    let stream = async_stream::stream! {
+        while let Some(ev) = rx.recv().await {
+            match ev {
+                PullEvent::Line(l) => {
+                    yield Ok::<_, std::convert::Infallible>(Event::default().data(l));
+                }
+                PullEvent::Done => {
+                    yield Ok(Event::default().event("done").data(""));
+                    break;
+                }
+            }
+        }
+    };
+    let sse = Sse::new(stream)
         .keep_alive(KeepAlive::new().interval(std::time::Duration::from_secs(15)));
     // `X-Accel-Buffering: no` so nginx streams the pull instead of buffering.
     (
@@ -699,8 +783,36 @@ impl SpecForm {
             errs.push("spec-form-error-volume");
         }
 
+        // container-env: every non-blank line must be `NAME=value` with a
+        // valid NAME. A typo'd line (missing `=`, or a key with spaces /
+        // bad chars) used to be silently dropped by `parse_env` — turning
+        // a mistake into lost config. Block the save instead (#720 P4).
+        if self
+            .container_env
+            .lines()
+            .map(str::trim)
+            .filter(|l| !l.is_empty())
+            .any(|l| match l.split_once('=') {
+                None => true,
+                Some((k, _)) => !is_valid_env_key(k.trim()),
+            })
+        {
+            errs.push("spec-form-error-env");
+        }
+
         errs
     }
+}
+
+/// A valid environment-variable name: a letter or `_`, then letters,
+/// digits or `_` (the POSIX-ish shape Docker accepts). Empty is invalid.
+fn is_valid_env_key(k: &str) -> bool {
+    let mut chars = k.chars();
+    match chars.next() {
+        Some(c) if c.is_ascii_alphabetic() || c == '_' => {}
+        _ => return false,
+    }
+    chars.all(|c| c.is_ascii_alphanumeric() || c == '_')
 }
 
 fn empty_to_none(s: &str) -> Option<String> {
@@ -1636,5 +1748,30 @@ proxy:
         f.max_body_size = "10m".into();
         f.container_cpu_request = "0.25".into();
         assert!(f.validate(FormMode::New).is_empty());
+    }
+
+    // #720 P4: an invalid container-env line is a config error, not a
+    // silent drop. A missing `=` or a bad key blocks the save.
+    #[test]
+    fn validate_rejects_bad_container_env() {
+        let mut f = valid_form();
+        f.container_env = "JUST_A_KEY".into(); // no `=`
+        assert!(f.validate(FormMode::New).contains(&"spec-form-error-env"));
+
+        let mut f = valid_form();
+        f.container_env = "BAD KEY=value".into(); // space in key
+        assert!(f.validate(FormMode::New).contains(&"spec-form-error-env"));
+
+        let mut f = valid_form();
+        f.container_env = "1ABC=value".into(); // key starts with a digit
+        assert!(f.validate(FormMode::New).contains(&"spec-form-error-env"));
+    }
+
+    #[test]
+    fn validate_accepts_good_container_env() {
+        let mut f = valid_form();
+        // blank lines ok; values may contain `=` and `${VAR}`.
+        f.container_env = "\nDATABASE_URL=postgres://x\n_LOG=info\nTOKEN=${API_TOKEN}\n".into();
+        assert!(!f.validate(FormMode::New).contains(&"spec-form-error-env"));
     }
 }

--- a/crates/ruscker-admin/src/routes/landing.rs
+++ b/crates/ruscker-admin/src/routes/landing.rs
@@ -337,10 +337,18 @@ async fn index(
         }
     }
 
-    let header_style = match (&lc.header_bg, &lc.header_fg) {
-        (Some(bg), Some(fg)) => format!("background: {}; color: {};", bg, fg),
-        (Some(bg), None) => format!("background: {};", bg),
-        (None, Some(fg)) => format!("color: {};", fg),
+    // Sanitize the header colours through the same charset guard as the
+    // per-theme palette (#720 audit P5): the editor is Admin-only, but a
+    // stray `;`/`}`/`<` in `header-bg`/`header-fg` would corrupt the
+    // inline `style`. The charset still passes `linear-gradient(...)`
+    // (alphanumerics + `(),%.- `), so the gradient builder keeps working;
+    // it only drops values that could break out of the declaration.
+    let header_bg = sanitize_css_color(&lc.header_bg);
+    let header_fg = sanitize_css_color(&lc.header_fg);
+    let header_style = match (&header_bg, &header_fg) {
+        (Some(bg), Some(fg)) => format!("background: {bg}; color: {fg};"),
+        (Some(bg), None) => format!("background: {bg};"),
+        (None, Some(fg)) => format!("color: {fg};"),
         (None, None) => String::new(),
     };
     let intro = lc
@@ -619,9 +627,14 @@ fn analytics_provider_snippet(provider: &str, key: &str) -> Option<(String, Stri
     }
 }
 
-/// Accept a CSS color value only if it's plausibly a color and can't
-/// break out of a `{ }` declaration block — even though the editor is
-/// Admin-only, a stray `}`/`;`/`<` would corrupt the whole `<style>`.
+/// Accept a CSS colour (or gradient) value only if it can't break out of
+/// the declaration / inline `style` it lands in — even though the editor
+/// is Admin-only, a stray `}`/`;`/`<`/`:`/quote would corrupt the
+/// surrounding `<style>` or `style="…"`. Charset-based: alphanumerics
+/// plus `# ( ) , % . - space`, which passes `#rrggbb`, `rgb()/hsl()`,
+/// bare keywords AND `linear-/radial-gradient(...)`, while rejecting
+/// anything that could escape the value (used for per-theme palette
+/// colours and the header background/foreground, #720 P5).
 fn sanitize_css_color(s: &Option<String>) -> Option<String> {
     let t = s.as_deref().map(str::trim).filter(|t| !t.is_empty())?;
     let ok = t
@@ -698,5 +711,31 @@ mod analytics_tests {
         assert!(analytics_provider_snippet("ga", "").is_none());
         assert!(analytics_provider_snippet("ga", "G-X\"><script>").is_none());
         assert!(analytics_provider_snippet("none", "x").is_none());
+    }
+}
+
+#[cfg(test)]
+mod sanitize_tests {
+    use super::sanitize_css_color;
+
+    fn san(s: &str) -> Option<String> {
+        sanitize_css_color(&Some(s.to_string()))
+    }
+
+    #[test]
+    fn passes_colours_and_gradients() {
+        assert_eq!(san("#0f6e56").as_deref(), Some("#0f6e56"));
+        assert_eq!(san("rgb(15, 110, 86)").as_deref(), Some("rgb(15, 110, 86)"));
+        assert!(san("linear-gradient(135deg, #ff0000 0%, #0000ff 100%)").is_some());
+        assert!(san("radial-gradient(circle, #fff 0%, #000 100%)").is_some());
+    }
+
+    #[test]
+    fn rejects_declaration_breakouts() {
+        // `;`/`}`/`<`/`:`/quotes can't escape the inline style — all dropped.
+        assert!(san("red; } body { display:none").is_none());
+        assert!(san("#fff\"></style><script>alert(1)</script>").is_none());
+        assert!(san("url('/x.png')").is_none()); // `/` + `:` + quote rejected
+        assert!(san("expression(alert(1))").is_some()); // harmless: no breakout chars, and `expression()` is dead in modern browsers
     }
 }

--- a/crates/ruscker-admin/templates/admin/spec_form.html
+++ b/crates/ruscker-admin/templates/admin/spec_form.html
@@ -159,7 +159,7 @@
         <div class="logo-pick">
           <button type="button" class="logo-pick__thumb" @click="openLogoPicker()"
                   :title="form.logo || '{{ self.t("spec-form-logo-none") }}'">
-            <img x-show="form.logo" x-cloak :src="assetUrl(form.logo) + '?thumb'" alt="">
+            <img x-show="form.logo" x-cloak :src="thumbUrl(form.logo)" alt="">
             <i class="ti ti-photo" x-show="!form.logo" aria-hidden="true"></i>
           </button>
           <div class="logo-pick__body">
@@ -217,8 +217,10 @@
          Image covers were retired: a logo sits *on top* of the cover, so
          a cover image + a logo rendered two overlapping pictures on one
          card. The cover is now a tint/colour/gradient only; the logo is
-         the single image. `coverInit()` drops any legacy `url(...)`. #}
-      <div class="spec-form-field" x-init="coverInit()">
+         the single image. A spec saved with a legacy image cover (`url(…)`)
+         keeps it — shown in the read-only "legacy" notice below — until the
+         operator picks another mode; it is never dropped silently (#720 P3). #}
+      <div class="spec-form-field">
         <div class="spec-form-label-row">
           <label class="spec-form-label">{{ self.t("spec-form-cover") }}</label>
           {% call help(self.t("spec-help-cover")) %}{% endcall %}
@@ -278,6 +280,18 @@
           <input type="text" name="cover" x-model="form.cover" readonly
                  :disabled="coverMode !== 'gradient'"
                  class="spec-form-input spec-form-input--mono grad-output">
+        </div>
+
+        {# LEGACY image cover (#720 P3) — a `url(…)` cover saved before
+           image covers were retired. Kept as-is (the hidden field submits
+           it while in this mode) until the operator picks Auto/Solid/
+           Gradient to replace it, instead of being wiped on open. #}
+        <div x-show="coverMode === 'legacy'" x-cloak>
+          <div class="info-box" style="margin-top:6px">
+            <i class="ti ti-info-circle" aria-hidden="true"></i>
+            <span>{{ self.t("spec-form-cover-legacy-help") }}</span>
+          </div>
+          <input type="hidden" name="cover" :value="form.cover" :disabled="coverMode !== 'legacy'">
         </div>
       </div>
 
@@ -1034,14 +1048,21 @@
      fixed descendants). The `is-logos` grid keeps logos uncropped. #}
   <template x-teleport="body">
   <div x-show="picker.open" x-cloak class="image-picker-overlay"
+       x-init="$watch('picker.open', open => {
+                 if (open) { _logoTrigger = document.activeElement;
+                   $nextTick(() => $refs.logoSearch && $refs.logoSearch.focus()); }
+                 else if (_logoTrigger && _logoTrigger.focus) { _logoTrigger.focus(); } })"
        @keydown.escape.window="picker.open = false" @click.self="picker.open = false">
-    <div class="image-picker-modal">
+    <div class="image-picker-modal" role="dialog" aria-modal="true"
+         aria-labelledby="logo-picker-title" @keydown.tab="trapLogoTab($event)">
       <div class="image-picker-head">
-        <strong>{{ self.t("spec-form-logo") }}</strong>
-        <button type="button" class="admin-nav-link" @click="picker.open = false"><i class="ti ti-x" aria-hidden="true"></i></button>
+        <strong id="logo-picker-title">{{ self.t("spec-form-logo") }}</strong>
+        <button type="button" class="admin-nav-link" @click="picker.open = false"
+                aria-label="{{ self.t("admin-import-cancel") }}"><i class="ti ti-x" aria-hidden="true"></i></button>
       </div>
       <div class="image-picker-tools">
-        <input type="search" x-model="picker.q" placeholder="{{ self.t("admin-images-search") }}"
+        <input type="search" x-ref="logoSearch" x-model="picker.q" placeholder="{{ self.t("admin-images-search") }}"
+               aria-label="{{ self.t("admin-images-search") }}"
                class="spec-form-input text-sm" style="max-width:16rem">
         <label class="admin-login-btn" style="cursor:pointer;padding:6px 12px;font-size:12px"
                :class="imgUploading ? 'opacity-50 pointer-events-none' : ''">
@@ -1165,25 +1186,39 @@ window.ruscker.specForm = (initial, logoImages, availableGroups) => ({
   // re-check presence so the badge reflects success (present) or failure
   // (still absent + the last `error:` line).
   pull: { running: false, line: '' },
-  pullImage() {
+  async pullImage() {
     const image = (this.form.container_image || '').trim();
     if (!image || this.pull.running) return;
     this.pull = { running: true, line: '' };
     const base = window.RUSCKER_BASE || '';
-    const cred = encodeURIComponent(this.form.docker_registry_credential || '');
-    const url = base + '/admin/specs/image-pull?image=' + encodeURIComponent(image) + '&credential=' + cred;
-    const es = new EventSource(url);
+    const cred = this.form.docker_registry_credential || '';
     let finished = false;
     const finish = () => {
       if (finished) return;
       finished = true;
-      es.close();
       this.pull.running = false;
       this.checkImage();
     };
-    es.onmessage = (e) => { if (e.data) this.pull.line = e.data; };
-    es.addEventListener('done', finish);
-    es.onerror = finish;  // stream closed / network / 4xx — re-check tells us
+    try {
+      // POST starts the pull (a side effect → same-origin/CSRF-guarded)
+      // and returns a one-shot job token; the GET below only FOLLOWS it.
+      const resp = await fetch(base + '/admin/specs/image-pull', {
+        method: 'POST',
+        headers: { 'content-type': 'application/x-www-form-urlencoded' },
+        body: 'image=' + encodeURIComponent(image) + '&credential=' + encodeURIComponent(cred),
+      });
+      if (!resp.ok) { this.pull.line = 'pull failed (' + resp.status + ')'; finish(); return; }
+      const data = await resp.json().catch(() => ({}));
+      if (!data.job) { finish(); return; }
+      const es = new EventSource(base + '/admin/specs/image-pull/events?job=' + encodeURIComponent(data.job));
+      const close = () => { es.close(); finish(); };
+      es.onmessage = (e) => { if (e.data) this.pull.line = e.data; };
+      es.addEventListener('done', close);
+      es.onerror = close;  // stream closed / network / 4xx — re-check tells us
+    } catch (e) {
+      this.pull.line = String(e);
+      finish();
+    }
   },
   // Open the shared library modal for the logo; the pick writes the
   // chosen asset path into `form.logo`, with the current value
@@ -1191,6 +1226,26 @@ window.ruscker.specForm = (initial, logoImages, availableGroups) => ({
   // imagePicker mixin spread above.)
   openLogoPicker() {
     this.openImagePicker((v) => { this.form.logo = v; }, this.form.logo);
+  },
+  // `?thumb` only for local media (`/assets/img/…`): an external or
+  // advanced URL (CDN, signed link) must pass through untouched — a
+  // stray `?thumb` would break the signature / hit a 404 (#720 P6).
+  thumbUrl(p) {
+    const local = (p || '').indexOf('/assets/img/') === 0;
+    return this.assetUrl(p) + (local ? '?thumb' : '');
+  },
+  // ── Logo modal accessibility (#720 P7) ───────────────────────────
+  // Remembers what had focus before the dialog opened, so it can be
+  // restored on close (set by the $watch in the modal's x-init).
+  _logoTrigger: null,
+  // Focus trap: keep Tab/Shift+Tab inside the dialog while it's open.
+  trapLogoTab(e) {
+    const sel = 'a[href],button:not([disabled]),input:not([disabled]),[tabindex]:not([tabindex="-1"])';
+    const f = Array.from(e.currentTarget.querySelectorAll(sel)).filter((el) => el.offsetParent !== null);
+    if (!f.length) return;
+    const first = f[0], last = f[f.length - 1];
+    if (e.shiftKey && document.activeElement === first) { e.preventDefault(); last.focus(); }
+    else if (!e.shiftKey && document.activeElement === last) { e.preventDefault(); first.focus(); }
   },
   // Cover background for the preview. `form.cover` is a CSS value that
   // may embed `url('/assets/img/x')`; prefix the base path on those
@@ -1229,13 +1284,13 @@ window.ruscker.specForm = (initial, logoImages, availableGroups) => ({
   // set. Off ⇒ the ceiling + thresholds are cleared (run at the floor).
   autoscaling: (parseInt(initial.max_replicas, 10) || 0) > 1,
   // Card-cover editing mode: 'auto' (kind tint, empty cover),
-  // 'solid' (color), 'gradient' (builder). Seeded from any existing
-  // `cover` value; a legacy image cover (`url(...)`) opens as 'auto'
-  // since image covers were retired (see `coverInit`).
+  // 'solid' (color), 'gradient' (builder), or 'legacy' for a saved
+  // image cover (`url(...)`) from before image covers were retired —
+  // preserved (not wiped) until the operator picks another mode (#720 P3).
   coverMode: !((initial.cover || '').trim())
     ? 'auto'
     : ((initial.cover || '').trim().indexOf('url(') === 0
-        ? 'auto'
+        ? 'legacy'
         : window.ruscker.bgMode(initial.cover)),
   // Seed from the saved gradient so editing it modifies it in place
   // instead of resetting to the default palette (#720 follow-up).
@@ -1264,13 +1319,9 @@ window.ruscker.specForm = (initial, logoImages, availableGroups) => ({
     // card didn't change until the picker was dragged — #720 follow-up).
     // A gradient string is replaced too; an existing solid hex is kept.
     const c = (this.form.cover || '').trim();
-    if (!c || /^(linear|radial)-gradient\(/.test(c)) this.form.cover = '#0f6e56';
-  },
-  // Image covers were retired (they rendered *under* the logo → two
-  // overlapping pictures on one card). A legacy `url(...)` cover degrades
-  // to the kind-tint / accent fallback and is dropped on the next save.
-  coverInit() {
-    if ((this.form.cover || '').trim().indexOf('url(') === 0) this.form.cover = '';
+    if (!c || /^(linear|radial)-gradient\(/.test(c) || c.indexOf('url(') === 0) {
+      this.form.cover = '#0f6e56';
+    }
   },
   // (uploadImage comes from the imagePicker mixin — its inline upload
   // auto-selects the result via the active openImagePicker callback.)

--- a/crates/ruscker-admin/tests/rbac.rs
+++ b/crates/ruscker-admin/tests/rbac.rs
@@ -236,3 +236,46 @@ async fn inline_upload_is_editor_gated() {
         "anon upload ⇒ redirect to login, got {status}"
     );
 }
+
+// ── Image pull: side effect on POST, follow-only GET (#720 P2) ──────
+
+#[tokio::test]
+async fn image_pull_start_is_post_only() {
+    // The old side-effecting `GET /admin/specs/image-pull` is gone: the
+    // path now only accepts POST, so a GET is 405 (no pull on GET).
+    assert_eq!(
+        send(state(), "GET", "/admin/specs/image-pull", None).await,
+        StatusCode::METHOD_NOT_ALLOWED,
+        "pull must not be startable via GET"
+    );
+}
+
+#[tokio::test]
+async fn image_pull_is_editor_gated() {
+    // Viewer is forbidden on both the start (POST) and the follow (GET).
+    let st = state();
+    let c = cookie_for(&st, Role::Viewer).await;
+    assert_eq!(
+        send(st, "POST", "/admin/specs/image-pull", Some(&c)).await,
+        StatusCode::FORBIDDEN,
+    );
+    let st = state();
+    let c = cookie_for(&st, Role::Viewer).await;
+    assert_eq!(
+        send(st, "GET", "/admin/specs/image-pull/events?job=bogus", Some(&c)).await,
+        StatusCode::FORBIDDEN,
+    );
+}
+
+#[tokio::test]
+async fn following_an_unknown_pull_job_is_404_for_editor() {
+    // Editor passes the guard; the follow GET is side-effect-free and
+    // returns 404 for a token that was never issued (or already drained).
+    let st = state();
+    let c = cookie_for(&st, Role::Editor).await;
+    assert_eq!(
+        send(st, "GET", "/admin/specs/image-pull/events?job=bogus", Some(&c)).await,
+        StatusCode::NOT_FOUND,
+        "unknown pull token ⇒ 404, never a side effect"
+    );
+}


### PR DESCRIPTION
Addresses the seven audit findings on the v0.2.4 apps-editor / appearance work. Each fix has tests; the three mandatory gates pass. No crate-wide `cargo fmt`, no `cargo fmt --check` added to the gate — only touched regions were hand-formatted.

## Findings & fixes

**P2 — image rename/delete now atomic.** `db::images::rename_with_refs` / `delete_with_refs` commit the image row + every spec reference + landing in **one transaction** (reusing `upsert_in_tx`/`update_in_tx`). The rename re-checks the target filename **inside the tx** (closes the TOCTOU race with the route's advisory pre-check) and rolls the whole batch back on conflict — so specs/landing can never end up pointing at a filename that no longer exists. Routes compute the rewrites in memory, then commit atomically.
_Tests:_ rollback-on-conflict + joint-commit for both rename and delete.

**P3 — image pull off GET.** A pull is a side effect, so `POST /admin/specs/image-pull` now starts it (inherits the chrome CSRF/Fetch-Metadata guard) and returns a one-shot job token; `GET /admin/specs/image-pull/events?job=<token>` only **follows** the SSE stream (side-effect-free). Job registry is a module static (same pattern as the thumbnail caches) with a TTL sweep for unfollowed jobs. RBAC preserved on both.
_Tests:_ GET on the old path → 405; viewer → 403; unknown token → 404.

**P3 — legacy `url(...)` cover preserved.** Opening a spec saved with an image cover no longer wipes it. A new read-only **"legacy"** mode shows a notice and keeps the value (hidden field submits it) until the operator picks Auto/Solid/Gradient to replace it.

**P3 — `container-env` validated server-side.** A line without `=`, or with an invalid key, now **blocks the save** with a clear message (`spec-form-error-env`, all 4 locales) instead of being silently dropped by `parse_env`.
_Tests:_ rejects missing-`=`/bad-key, accepts good env (incl. blank lines, `=` in values, `${VAR}`).

**P3 — `header_bg`/`header_fg` sanitized.** Both now pass through the existing charset guard (`sanitize_css_color`), which accepts colours **and** gradients while rejecting `;`/`}`/`<`/`:`/quotes — so a stray char can't break out of the inline `style`. Standardizes with the per-theme palette sanitization.
_Tests:_ gradient passes, declaration-breakout rejected.

**P3 — logo preview `?thumb` only for local assets.** `thumbUrl()` appends `?thumb` only for `/assets/img/…`; an external/CDN/signed URL (advanced field) passes through untouched, so a signed URL isn't broken.

**P3 — logo picker modal accessibility.** `role="dialog"`, `aria-modal="true"`, `aria-labelledby`, initial focus on the search box, focus return to the trigger on close, and a Tab focus-trap.

## Verification
- `DOCKER_REGISTRY_PASSWORD=test cargo test` — green (310 admin-lib + integration suites)
- `cargo clippy --all-targets -- -D warnings` — clean
- `./scripts/i18n-check.sh` — parity OK
- Frontend findings (legacy cover, `thumbUrl`, modal a11y) additionally verified in a real browser (Playwright + Chrome).
- Optional `cargo test -p ruscker-docker --features docker-it` **not run** — no Docker daemon available in this environment.

🤖 Generated with [Claude Code](https://claude.com/claude-code)