### PR TITLE
fix(proxy): WS upgrade — query string, subprotocol echo, 502 on dead upstream (#730)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2884,6 +2884,7 @@ dependencies = [
  "sqlx",
  "thiserror",
  "tokio",
+ "tokio-tungstenite",
  "tower",
  "tower-cookies",
  "tower-http",

--- a/crates/ruscker-admin/Cargo.toml
+++ b/crates/ruscker-admin/Cargo.toml
@@ -91,3 +91,5 @@ pretty_assertions = { workspace = true }
 insta = { workspace = true }
 tower = { workspace = true, features = ["util"] }
 tokio = { workspace = true }
+# WS client + mock upstream for the proxy upgrade tests (#730)
+tokio-tungstenite = { workspace = true }

--- a/crates/ruscker-admin/src/routes/proxy.rs
+++ b/crates/ruscker-admin/src/routes/proxy.rs
@@ -515,7 +515,16 @@ async fn forward(
     //    can't be set on a 101). Issuing the sticky cookie on the
     //    preceding HTTP request is how WS-only apps stay sticky.
     if let MaybeWs(Some(upgrade)) = ws_upgrade {
-        let upstream_ws_url = format!("ws://{}{}", replica.upstream, upstream_path);
+        // The query string must ride along (#730): Jupyter kernel channels
+        // (`/api/kernels/<id>/channels?session_id=…`), SockJS cache-busters
+        // and any app keying WS reconnection on query params depend on it.
+        // Mirrors what `do_forward` does for the HTTP path.
+        let query = req
+            .uri()
+            .query()
+            .map(|q| format!("?{q}"))
+            .unwrap_or_default();
+        let upstream_ws_url = format!("ws://{}{}{}", replica.upstream, upstream_path, query);
         // Forward the client's *app* cookies and requested subprotocol
         // onto the upstream handshake so the app keeps its session — but
         // strip Ruscker's own cookies first (#258). The HTTP path strips
@@ -537,8 +546,38 @@ async fn forward(
             spec = %spec.id, replica = %replica.id, url = %upstream_ws_url,
             "ws upgrade"
         );
-        return upgrade
-            .on_upgrade(move |socket| ws::pump(socket, upstream_ws_url, cookie, subprotocols));
+        // Connect the upstream BEFORE answering the client's 101 (#730):
+        // a dead replica then gets the client a real 502 instead of an
+        // opaque post-upgrade 1006 drop, and the subprotocol the upstream
+        // selected can be echoed on our 101 — a browser that offered
+        // subprotocols and receives a 101 without one selected must fail
+        // the connection (RFC 6455 §4.1).
+        let handshake = match ws::connect(
+            &upstream_ws_url,
+            cookie.as_deref(),
+            subprotocols.as_deref(),
+        )
+        .await
+        {
+            Ok(h) => h,
+            Err(err) => {
+                tracing::error!(
+                    spec = %spec.id, replica = %replica.id, error = ?err,
+                    "upstream ws connect failed"
+                );
+                return with_cors(
+                    (StatusCode::BAD_GATEWAY, "upstream unavailable").into_response(),
+                    cors_on,
+                );
+            }
+        };
+        let upgrade = match handshake.selected_protocol.clone() {
+            // axum echoes a protocol only if the client offered it — which
+            // it did, since the upstream chose from the client's own list.
+            Some(proto) => upgrade.protocols([proto]),
+            None => upgrade,
+        };
+        return upgrade.on_upgrade(move |socket| ws::pump(socket, handshake.stream));
     }
 
     // 6. HTTP forward.
@@ -2744,5 +2783,160 @@ docker-registry-password: hunter2
             !sticky_replica_is_live(&starting, "rstudio", &owner),
             "a Starting (not-yet-Ready) replica is not a usable seat yet"
         );
+    }
+
+    // #730 end-to-end: the WS upgrade must (a) carry the query string to
+    // the upstream handshake, (b) echo the upstream-SELECTED subprotocol
+    // on the 101 to the client, and (c) pump frames both ways. The mock
+    // upstream picks the SECOND offered protocol, so a pass proves the
+    // echo is the upstream's choice, not the client's first offer.
+    #[tokio::test]
+    // tungstenite's accept_hdr callback returns its large ErrorResponse
+    // by value; fine for a test.
+    #[allow(clippy::result_large_err)]
+    async fn ws_upgrade_preserves_query_and_echoes_upstream_subprotocol() {
+        use futures_util::{SinkExt, StreamExt};
+        use tokio_tungstenite::tungstenite::client::IntoClientRequest;
+        use tokio_tungstenite::tungstenite::handshake::server::{
+            Request as WsRequest, Response as WsResponse,
+        };
+        use tokio_tungstenite::tungstenite::Message as TgMsg;
+
+        // Mock upstream: record the handshake URI, select a subprotocol,
+        // then echo one text frame.
+        let up_listener = tokio::net::TcpListener::bind("127.0.0.1:0").await.unwrap();
+        let up_addr = up_listener.local_addr().unwrap();
+        let upstream = tokio::spawn(async move {
+            let (tcp, _) = up_listener.accept().await.unwrap();
+            let mut seen_uri = String::new();
+            let mut ws = tokio_tungstenite::accept_hdr_async(
+                tcp,
+                |req: &WsRequest, mut resp: WsResponse| {
+                    seen_uri = req.uri().to_string();
+                    resp.headers_mut().insert(
+                        header::SEC_WEBSOCKET_PROTOCOL,
+                        HeaderValue::from_static("superchat"),
+                    );
+                    Ok(resp)
+                },
+            )
+            .await
+            .unwrap();
+            if let Some(Ok(msg)) = ws.next().await {
+                ws.send(msg).await.unwrap();
+            }
+            seen_uri
+        });
+
+        // Proxy state: one spec, one Ready replica pointing at the mock.
+        let backend = StdArc::new(CountingBackend {
+            spawns: AtomicU32::new(0),
+            delay: StdDuration::ZERO,
+        });
+        let mut state = coalescer_state(backend as StdArc<dyn ContainerBackend>);
+        state.config = std::sync::Arc::new(
+            ruscker_config::Config::from_yaml(
+                "proxy:\n  specs:\n    - id: wsapp\n      container-image: test:latest\n",
+            )
+            .expect("config"),
+        );
+        state.replicas.write().await.add(Replica {
+            id: ReplicaId(uuid::Uuid::new_v4()),
+            spec_id: "wsapp".into(),
+            container_id: "c".into(),
+            upstream: up_addr,
+            state: ReplicaState::Ready,
+            started_at: chrono::Utc::now(),
+            sessions_active: 0,
+            sessions_max: 10,
+            host: None,
+        });
+
+        let app = Router::new()
+            .merge(routes())
+            .layer(tower_cookies::CookieManagerLayer::new())
+            .with_state(state);
+        let listener = tokio::net::TcpListener::bind("127.0.0.1:0").await.unwrap();
+        let proxy_addr = listener.local_addr().unwrap();
+        tokio::spawn(async move { axum::serve(listener, app).await.unwrap() });
+
+        // WS client through the proxy, offering two subprotocols + a query.
+        let mut req = format!("ws://{proxy_addr}/app/wsapp/ws/echo?session_id=abc")
+            .into_client_request()
+            .expect("client request");
+        req.headers_mut().insert(
+            header::SEC_WEBSOCKET_PROTOCOL,
+            HeaderValue::from_static("chat, superchat"),
+        );
+        let (mut client, resp) = tokio_tungstenite::connect_async(req)
+            .await
+            .expect("ws handshake through the proxy");
+        assert_eq!(
+            resp.headers()
+                .get(header::SEC_WEBSOCKET_PROTOCOL)
+                .and_then(|v| v.to_str().ok()),
+            Some("superchat"),
+            "the proxy 101 must echo the subprotocol the upstream selected"
+        );
+
+        client.send(TgMsg::text("hello")).await.expect("send");
+        let echoed = client.next().await.expect("a frame").expect("ok frame");
+        assert_eq!(echoed.into_text().expect("text").as_str(), "hello");
+
+        assert_eq!(
+            upstream.await.unwrap(),
+            "/ws/echo?session_id=abc",
+            "query string must reach the upstream handshake"
+        );
+    }
+
+    // #730: a WS request whose replica is unreachable must get a real
+    // 502 — not a 101 followed by an opaque drop (the pre-#730 shape).
+    #[tokio::test]
+    async fn ws_upgrade_to_a_dead_replica_returns_502_not_101() {
+        use tokio_tungstenite::tungstenite::client::IntoClientRequest;
+        use tokio_tungstenite::tungstenite::Error as TgError;
+
+        let backend = StdArc::new(CountingBackend {
+            spawns: AtomicU32::new(0),
+            delay: StdDuration::ZERO,
+        });
+        let mut state = coalescer_state(backend as StdArc<dyn ContainerBackend>);
+        state.config = std::sync::Arc::new(
+            ruscker_config::Config::from_yaml(
+                "proxy:\n  specs:\n    - id: wsapp\n      container-image: test:latest\n",
+            )
+            .expect("config"),
+        );
+        // Ready replica whose upstream is a dead port.
+        state.replicas.write().await.add(Replica {
+            id: ReplicaId(uuid::Uuid::new_v4()),
+            spec_id: "wsapp".into(),
+            container_id: "c".into(),
+            upstream: "127.0.0.1:1".parse::<SocketAddr>().unwrap(),
+            state: ReplicaState::Ready,
+            started_at: chrono::Utc::now(),
+            sessions_active: 0,
+            sessions_max: 10,
+            host: None,
+        });
+
+        let app = Router::new()
+            .merge(routes())
+            .layer(tower_cookies::CookieManagerLayer::new())
+            .with_state(state);
+        let listener = tokio::net::TcpListener::bind("127.0.0.1:0").await.unwrap();
+        let proxy_addr = listener.local_addr().unwrap();
+        tokio::spawn(async move { axum::serve(listener, app).await.unwrap() });
+
+        let req = format!("ws://{proxy_addr}/app/wsapp/ws")
+            .into_client_request()
+            .expect("client request");
+        match tokio_tungstenite::connect_async(req).await {
+            Err(TgError::Http(resp)) => {
+                assert_eq!(resp.status(), StatusCode::BAD_GATEWAY);
+            }
+            other => panic!("expected an HTTP 502 handshake rejection, got {other:?}"),
+        }
     }
 }

--- a/crates/ruscker-proxy/src/ws.rs
+++ b/crates/ruscker-proxy/src/ws.rs
@@ -57,50 +57,58 @@ const IDLE_CHECK: Duration = Duration::from_secs(30);
 /// frames (the close handshake, a last burst) before forced teardown.
 const DRAIN_GRACE: Duration = Duration::from_secs(5);
 
-type UpstreamStream = WebSocketStream<MaybeTlsStream<TcpStream>>;
+/// An established upstream WebSocket connection.
+pub type UpstreamStream = WebSocketStream<MaybeTlsStream<TcpStream>>;
 
-/// Connect to `upstream_ws_url` and pump frames between `client` and the
-/// upstream in both directions until either closes (or the connection
-/// goes idle). `cookie` / `subprotocols` are forwarded onto the upstream
-/// handshake so the app sees the client's session and negotiated
-/// protocol.
-pub async fn pump(
-    client: WebSocket,
-    upstream_ws_url: String,
-    cookie: Option<String>,
-    subprotocols: Option<String>,
-) {
-    let mut request = match upstream_ws_url.as_str().into_client_request() {
-        Ok(r) => r,
-        Err(err) => {
-            tracing::error!(error = ?err, url = %upstream_ws_url, "build upstream ws request failed");
-            return;
-        }
-    };
+/// Result of a successful upstream handshake: the stream plus the
+/// subprotocol the upstream selected on its 101 (if any). The caller
+/// must echo that selection on its own 101 to the client — a browser
+/// that offered subprotocols and receives a 101 without one selected
+/// is required by RFC 6455 §4.1 to fail the connection (#730).
+pub struct UpstreamHandshake {
+    pub stream: UpstreamStream,
+    pub selected_protocol: Option<String>,
+}
+
+/// Open the WebSocket handshake to `upstream_ws_url`, forwarding the
+/// client's `cookie` and offered `subprotocols` so the app sees the
+/// client's session and can negotiate a protocol.
+///
+/// This runs *before* the client's own upgrade is answered: on failure
+/// the caller still holds a plain HTTP request and can return a real
+/// 502 instead of an opaque post-101 drop (#730).
+pub async fn connect(
+    upstream_ws_url: &str,
+    cookie: Option<&str>,
+    subprotocols: Option<&str>,
+) -> Result<UpstreamHandshake, tokio_tungstenite::tungstenite::Error> {
+    let mut request = upstream_ws_url.into_client_request()?;
     // Forward the client's session cookie and requested subprotocol.
-    if let Some(v) = cookie
-        .as_deref()
-        .and_then(|s| HeaderValue::from_str(s).ok())
-    {
+    if let Some(v) = cookie.and_then(|s| HeaderValue::from_str(s).ok()) {
         request.headers_mut().insert(header::COOKIE, v);
     }
-    if let Some(v) = subprotocols
-        .as_deref()
-        .and_then(|s| HeaderValue::from_str(s).ok())
-    {
+    if let Some(v) = subprotocols.and_then(|s| HeaderValue::from_str(s).ok()) {
         request
             .headers_mut()
             .insert(header::SEC_WEBSOCKET_PROTOCOL, v);
     }
 
-    let upstream = match tokio_tungstenite::connect_async(request).await {
-        Ok((s, _resp)) => s,
-        Err(err) => {
-            tracing::error!(error = ?err, url = %upstream_ws_url, "upstream ws connect failed");
-            return;
-        }
-    };
+    let (stream, resp) = tokio_tungstenite::connect_async(request).await?;
+    let selected_protocol = resp
+        .headers()
+        .get(header::SEC_WEBSOCKET_PROTOCOL)
+        .and_then(|v| v.to_str().ok())
+        .map(String::from);
+    Ok(UpstreamHandshake {
+        stream,
+        selected_protocol,
+    })
+}
 
+/// Pump frames between `client` and the already-connected `upstream`
+/// in both directions until either closes (or the connection goes
+/// idle). Open the upstream with [`connect`] first.
+pub async fn pump(client: WebSocket, upstream: UpstreamStream) {
     let (cli_tx, cli_rx) = client.split();
     let (up_tx, up_rx) = upstream.split();
 
@@ -245,5 +253,53 @@ mod tests {
     fn close_frame_translation_passes_none_through() {
         assert!(ax_close_to_tg(None).is_none());
         assert!(tg_close_to_ax(None).is_none());
+    }
+
+    // #730: the upstream handshake must carry the full URL (Jupyter
+    // kernel channels key on `?session_id=`) and report back which
+    // subprotocol the upstream selected, so the proxy can echo it on
+    // its own 101 to the client.
+    #[tokio::test]
+    // tungstenite's accept_hdr callback returns its large ErrorResponse
+    // by value; fine for a test.
+    #[allow(clippy::result_large_err)]
+    async fn connect_preserves_query_and_reports_upstream_selected_subprotocol() {
+        use tokio_tungstenite::tungstenite::handshake::server::{Request, Response};
+
+        let listener = tokio::net::TcpListener::bind("127.0.0.1:0").await.unwrap();
+        let addr = listener.local_addr().unwrap();
+        let server = tokio::spawn(async move {
+            let (tcp, _) = listener.accept().await.unwrap();
+            let mut seen_uri = String::new();
+            let ws = tokio_tungstenite::accept_hdr_async(
+                tcp,
+                |req: &Request, mut resp: Response| {
+                    seen_uri = req.uri().to_string();
+                    // The app picks the SECOND offered protocol — proves the
+                    // reported selection is the upstream's choice, not an
+                    // echo of the client's first offer.
+                    resp.headers_mut().insert(
+                        header::SEC_WEBSOCKET_PROTOCOL,
+                        HeaderValue::from_static("superchat"),
+                    );
+                    Ok(resp)
+                },
+            )
+            .await
+            .unwrap();
+            drop(ws);
+            seen_uri
+        });
+
+        let url = format!("ws://{addr}/api/kernels/k1/channels?session_id=abc");
+        let hs = connect(&url, None, Some("chat, superchat"))
+            .await
+            .expect("upstream handshake");
+        assert_eq!(hs.selected_protocol.as_deref(), Some("superchat"));
+        assert_eq!(
+            server.await.unwrap(),
+            "/api/kernels/k1/channels?session_id=abc",
+            "query string must reach the upstream handshake"
+        );
     }
 }

--- a/crates/ruscker-proxy/tests/ws_pump.rs
+++ b/crates/ruscker-proxy/tests/ws_pump.rs
@@ -37,14 +37,19 @@ async fn spawn_echo_upstream() -> String {
     format!("ws://{addr}/")
 }
 
-/// Spawn the axum proxy app (one `/ws` route → `ws::pump`). Returns its
-/// bound address.
+/// Spawn the axum proxy app (one `/ws` route → `ws::connect` +
+/// `ws::pump`, the #730 two-step shape). Returns its bound address.
 async fn spawn_proxy(upstream_url: String) -> std::net::SocketAddr {
     let app = Router::new().route(
         "/ws",
         any(move |ws: WebSocketUpgrade| {
             let url = upstream_url.clone();
-            async move { ws.on_upgrade(move |sock| ruscker_proxy::ws::pump(sock, url, None, None)) }
+            async move {
+                let handshake = ruscker_proxy::ws::connect(&url, None, None)
+                    .await
+                    .expect("upstream handshake");
+                ws.on_upgrade(move |sock| ruscker_proxy::ws::pump(sock, handshake.stream))
+            }
         }),
     );
     let listener = TcpListener::bind("127.0.0.1:0").await.unwrap();


### PR DESCRIPTION
Fixes #730.

## What

Three correctness fixes to the WebSocket upgrade path in `routes/proxy.rs` + `ruscker-proxy::ws`:

1. **Query string preserved.** The upstream WS URL was built from the `Path` extractor only — `?session_id=` (Jupyter kernel channels), SockJS cache-busters etc. never reached the upstream. Now mirrors `do_forward`.
2. **Upstream connects before the 101** (`ws::connect` / `ws::pump` split). Two wins:
   - a dead replica now gets the client a real **502** instead of a 101 followed by an opaque 1006 drop;
   - the subprotocol the **upstream selected** is echoed on our 101 via `upgrade.protocols()`. Per RFC 6455 §4.1 a browser that offered subprotocols and receives a 101 without one selected must fail the connection (breaks newer jupyter-server's `v1.kernel.websocket.jupyter.org`, SockJS/STOMP stacks).
3. The old in-pump connect-failure path (silent return) is gone with the split.

## Tests

- `ws::connect` unit test: query reaches the upstream handshake; the **upstream-selected** protocol is reported back (mock picks the *second* offered one, so a pass proves it isn't just echoing the client's first offer).
- Two end-to-end tests through the real axum router over TCP: full frame roundtrip with subprotocol negotiation, and the dead-replica 502.
- Existing `ws_pump.rs` integration test adapted to the two-step shape.

Gate: `cargo test` (all green), `cargo clippy --all-targets -- -D warnings`, `./scripts/i18n-check.sh` ✓.

## Smoke

The e2e tests exercise real sockets through the real router. A live Jupyter-under-proxy smoke (kernel WS with `?session_id=`) is worth doing on the lab box before release — the fix removes the silent query-drop that the runtime shim was masking for some apps.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
