### PR TITLE
fix(proxy): identity encoding upstream when the HTML rewriter is on (#732)

### DIFF
--- a/crates/ruscker-admin/src/routes/proxy.rs
+++ b/crates/ruscker-admin/src/routes/proxy.rs
@@ -228,7 +228,7 @@ async fn forward(
     route_prefix: &'static str,
     spec_id: String,
     upstream_path: String,
-    req: Request,
+    mut req: Request,
 ) -> Response {
     // Capture the request scheme before `req` is consumed by the
     // forward — used to decide the `Secure` flag on the sticky
@@ -606,6 +606,21 @@ async fn forward(
     // to meter). Only API specs — interactive apps meter via sticky sessions.
     let inflight =
         (route_prefix == API_PREFIX).then(|| InflightGuard::new(replica.id.clone()));
+    // Whether 6b below will transform HTML bodies. Decided here because
+    // the *request* must match: when we transform, the upstream must not
+    // compress — nothing decompresses in between, so a gzip/br HTML body
+    // would reach the rewriter as opaque bytes: no `<base href>`, no
+    // runtime shim, and lol_html mutating compressed bytes corrupts the
+    // stream outright (#732). `identity` asks the app for plain bytes
+    // (ShinyProxy does the same). Non-transformed routes (the `/api/`
+    // family, `inject-base-href: false`) keep end-to-end compression.
+    let transform_html = route_prefix == APP_PREFIX && spec.effective_inject_base_href();
+    if transform_html {
+        req.headers_mut().insert(
+            header::ACCEPT_ENCODING,
+            HeaderValue::from_static("identity"),
+        );
+    }
     let resp = match do_forward(
         &replica,
         upstream_path,
@@ -637,7 +652,7 @@ async fn forward(
     //     return JSON / binary, not HTML. Operators can also disable
     //     the transform per spec (`inject-base-href: false`) once the
     //     app self-routes from the forwarded-prefix headers above.
-    let resp = if route_prefix == APP_PREFIX && spec.effective_inject_base_href() {
+    let resp = if transform_html {
         // Include the portal base path (#173) so the app's `<base href>`
         // is `/box/app/{spec}/` when Ruscker is mounted under `/box`.
         let base = format!("{}{route_prefix}{}/", state.base_path, spec.id);
@@ -2938,5 +2953,127 @@ docker-registry-password: hunter2
             }
             other => panic!("expected an HTTP 502 handshake rejection, got {other:?}"),
         }
+    }
+
+    /// Mock HTTP upstream that captures each connection's request head
+    /// and answers a minimal 200. Returns its address and the channel
+    /// the heads arrive on.
+    async fn capture_upstream() -> (
+        SocketAddr,
+        tokio::sync::mpsc::UnboundedReceiver<String>,
+    ) {
+        use tokio::io::{AsyncReadExt, AsyncWriteExt};
+        let listener = tokio::net::TcpListener::bind("127.0.0.1:0").await.unwrap();
+        let addr = listener.local_addr().unwrap();
+        let (tx, rx) = tokio::sync::mpsc::unbounded_channel();
+        tokio::spawn(async move {
+            loop {
+                let Ok((mut conn, _)) = listener.accept().await else {
+                    return;
+                };
+                let tx = tx.clone();
+                tokio::spawn(async move {
+                    let mut buf = Vec::new();
+                    let mut chunk = [0u8; 1024];
+                    while !buf.windows(4).any(|w| w == b"\r\n\r\n") {
+                        match conn.read(&mut chunk).await {
+                            Ok(0) | Err(_) => break,
+                            Ok(n) => buf.extend_from_slice(&chunk[..n]),
+                        }
+                    }
+                    let _ = tx.send(String::from_utf8_lossy(&buf).into_owned());
+                    let _ = conn
+                        .write_all(
+                            b"HTTP/1.1 200 OK\r\nContent-Length: 2\r\nConnection: close\r\n\r\nok",
+                        )
+                        .await;
+                });
+            }
+        });
+        (addr, rx)
+    }
+
+    // #732: when the response will be HTML-transformed (the `/app/`
+    // family with `inject-base-href` on — the default), the upstream
+    // request must carry `Accept-Encoding: identity`: a gzip/br HTML
+    // body would reach the rewriter as opaque bytes (no <base href>,
+    // possibly corrupted). With the transform disabled per spec, the
+    // client's Accept-Encoding must pass through untouched.
+    #[tokio::test]
+    async fn app_forward_asks_upstream_for_identity_encoding_iff_transforming() {
+        use tower::ServiceExt;
+
+        let (up_addr, mut heads) = capture_upstream().await;
+
+        let backend = StdArc::new(CountingBackend {
+            spawns: AtomicU32::new(0),
+            delay: StdDuration::ZERO,
+        });
+        let mut state = coalescer_state(backend as StdArc<dyn ContainerBackend>);
+        state.config = std::sync::Arc::new(
+            ruscker_config::Config::from_yaml(
+                "proxy:\n  specs:\n    - id: rewritten\n      container-image: t:1\n    - id: raw\n      container-image: t:1\n      inject-base-href: false\n",
+            )
+            .expect("config"),
+        );
+        for id in ["rewritten", "raw"] {
+            state.replicas.write().await.add(Replica {
+                id: ReplicaId(uuid::Uuid::new_v4()),
+                spec_id: id.into(),
+                container_id: "c".into(),
+                upstream: up_addr,
+                state: ReplicaState::Ready,
+                started_at: chrono::Utc::now(),
+                sessions_active: 0,
+                sessions_max: 10,
+                host: None,
+            });
+        }
+        let app = Router::new()
+            .merge(routes())
+            .layer(tower_cookies::CookieManagerLayer::new())
+            .with_state(state);
+
+        // Transformed spec: the client's gzip offer must NOT reach the app.
+        let resp = app
+            .clone()
+            .oneshot(
+                Request::builder()
+                    .uri("/app/rewritten/data.html")
+                    .header(header::ACCEPT_ENCODING, "gzip, br")
+                    .body(Body::empty())
+                    .unwrap(),
+            )
+            .await
+            .unwrap();
+        assert_eq!(resp.status(), StatusCode::OK);
+        let head = heads.recv().await.expect("upstream saw the request");
+        let head_lower = head.to_ascii_lowercase();
+        assert!(
+            head_lower.contains("accept-encoding: identity"),
+            "transforming forward must ask for identity, got:\n{head}"
+        );
+        assert!(
+            !head_lower.contains("gzip"),
+            "client's compressed offer leaked through:\n{head}"
+        );
+
+        // Transform disabled: end-to-end compression stays available.
+        let resp = app
+            .oneshot(
+                Request::builder()
+                    .uri("/app/raw/data.html")
+                    .header(header::ACCEPT_ENCODING, "gzip, br")
+                    .body(Body::empty())
+                    .unwrap(),
+            )
+            .await
+            .unwrap();
+        assert_eq!(resp.status(), StatusCode::OK);
+        let head = heads.recv().await.expect("upstream saw the request");
+        assert!(
+            head.to_ascii_lowercase().contains("accept-encoding: gzip, br"),
+            "non-transforming forward must pass the client's offer through, got:\n{head}"
+        );
     }
 }

--- a/crates/ruscker-admin/src/routes/rewrite.rs
+++ b/crates/ruscker-admin/src/routes/rewrite.rs
@@ -187,6 +187,20 @@ pub async fn inject_base_href(
         return Response::from_parts(parts, body);
     }
 
+    // Defense-in-depth (#732): the proxy asks the upstream for
+    // `Accept-Encoding: identity` whenever this transform is enabled,
+    // but a non-compliant server may compress anyway. A content-encoded
+    // body is opaque bytes — running the rewriter over it would corrupt
+    // the stream — so pass it through untouched instead.
+    let content_encoded = parts
+        .headers
+        .get(header::CONTENT_ENCODING)
+        .and_then(|v| v.to_str().ok())
+        .is_some_and(|s| !s.trim().eq_ignore_ascii_case("identity"));
+    if content_encoded {
+        return Response::from_parts(parts, body);
+    }
+
     // Decide *before* consuming the body. A declared Content-Length over
     // the transform cap streams the original through untouched — we
     // can't buffer-then-fail, because `to_bytes` would have already
@@ -1031,6 +1045,38 @@ mod tests {
         let out = inject_base_href(resp, "/app/foo/", "").await;
         let s = body_string(out).await;
         assert_eq!(s, "{\"a\":1}");
+    }
+
+    // #732: a content-encoded HTML body is opaque bytes — the rewriter
+    // must pass it through bit-identical (no <base href>, no shim)
+    // instead of corrupting the compressed stream.
+    #[tokio::test]
+    async fn inject_base_href_passes_compressed_html_through_untouched() {
+        // Not real gzip — just bytes that must come back identical.
+        let payload: &[u8] = b"\x1f\x8b\x08\x00<html><head></head></html>";
+        let resp = Response::builder()
+            .status(StatusCode::OK)
+            .header(header::CONTENT_TYPE, "text/html; charset=utf-8")
+            .header(header::CONTENT_ENCODING, "gzip")
+            .body(Body::from(payload))
+            .unwrap();
+        let out = inject_base_href(resp, "/app/foo/", "").await;
+        assert_eq!(
+            out.headers().get(header::CONTENT_ENCODING).unwrap(),
+            "gzip"
+        );
+        let bytes = out.into_body().collect().await.unwrap().to_bytes();
+        assert_eq!(bytes.as_ref(), payload, "compressed body must not be touched");
+    }
+
+    // `identity` means "not encoded" — the transform must still run.
+    #[tokio::test]
+    async fn inject_base_href_treats_identity_encoding_as_plain() {
+        let mut resp = html_response("<html><head></head><body></body></html>");
+        resp.headers_mut()
+            .insert(header::CONTENT_ENCODING, "identity".parse().unwrap());
+        let out = body_string(inject_base_href(resp, "/app/foo/", "").await).await;
+        assert!(out.contains("<base href=\"/app/foo/\">"), "got: {out}");
     }
 
     #[tokio::test]


### PR DESCRIPTION
Fixes #732.

## What

A gzipped `text/html` upstream body was buffered and pushed through the `/app/*` rewriter as **compressed bytes** — `strip_hop_headers` never touched `Accept-Encoding` (the browser's `gzip, br` reached the container) and `inject_base_href` gated only on `Content-Type`. Result: no `<base href>`, no runtime shim, app 404s on root-absolute assets; worst case lol_html corrupts the stream. Trigger: any Flask+flask-compress (Dash), nginx-fronted or Tornado-gzip app.

## How

1. **Request side** — `forward()` now computes `transform_html` (the same condition 6b uses: `/app/` family + `inject-base-href` on) and, when true, sets `Accept-Encoding: identity` on the upstream request (ShinyProxy's approach). `/api/` and `inject-base-href: false` specs keep end-to-end compression.
2. **Defense-in-depth** — `inject_base_href` passes any response with a non-identity `Content-Encoding` through bit-identical (a non-compliant server may compress anyway); `identity` itself still transforms.

Browser-side compression of `/app` HTML is unchanged by this (the proxy routes already sit outside Ruscker's own `CompressionLayer`).

## Tests

- `app_forward_asks_upstream_for_identity_encoding_iff_transforming` — through the real router with a head-capturing TCP upstream: `identity` forced on a transforming spec, client's `gzip, br` passes through with `inject-base-href: false`.
- `inject_base_href_passes_compressed_html_through_untouched` + `inject_base_href_treats_identity_encoding_as_plain`.

Gate: `cargo test` all green, `clippy --all-targets -- -D warnings` clean, i18n ✓.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
