### PR TITLE
fix(auth): self-service password change revokes the user's other sessions (#739)

### DIFF
--- a/crates/ruscker-admin/src/routes/admin.rs
+++ b/crates/ruscker-admin/src/routes/admin.rs
@@ -554,6 +554,8 @@ async fn password_submit(
     State(state): State<AppState>,
     loc: Locale,
     theme: Theme,
+    cookies: Cookies,
+    headers: HeaderMap,
     Form(form): Form<PasswordForm>,
 ) -> Response {
     let Some(actor) = session.actor.clone() else {
@@ -612,6 +614,21 @@ async fn password_submit(
         tracing::error!(error = ?e, "password change failed");
         return (StatusCode::INTERNAL_SERVER_ERROR, "save failed").into_response();
     }
+
+    // A self-service password change must invalidate every OTHER live
+    // session for this account (#739) — changing the password is the
+    // natural response to a suspected session compromise, and there is
+    // no separate "log out everywhere" control. The admin-reset path
+    // already does this (#544); this path was the gap. `revoke_by_actor`
+    // also kills the session making this request, so mint a fresh one
+    // and re-issue the cookie: every other session dies, the user
+    // stays signed in.
+    state.admin_sessions.revoke_by_actor(&actor).await;
+    let session_id = state
+        .admin_sessions
+        .create(session.role, Some(actor.clone()))
+        .await;
+    issue_session_cookie(&cookies, &headers, session_id);
     Redirect::to("/admin/dashboard").into_response()
 }
 
@@ -693,6 +710,130 @@ mod tests {
     use crate::i18n::{Locale, Locales};
     use crate::theme::Theme;
     use askama::Template;
+
+    /// Minimal AppState over an in-memory SQLite DB with admin auth
+    /// configured — just enough for account-route tests.
+    async fn state_with_db() -> crate::AppState {
+        use std::sync::Arc;
+        let pool = crate::db::ConfigDb::Sqlite(crate::db::open_memory().await.expect("memory db"));
+        crate::AppState {
+            config: Arc::new(ruscker_config::Config::from_yaml("proxy:\n  specs: []").expect("config")),
+            base_path: Arc::from(""),
+            locales: Arc::new(Locales::load().expect("load locales")),
+            admin_auth: crate::auth::AdminAuth::with_token("break-glass-token"),
+            admin_sessions: Arc::new(crate::auth::InMemoryAdminSessionStore::default()),
+            log_buffer: None,
+            login_limiter: Arc::new(crate::auth::LoginRateLimiter::default_policy()),
+            api_limiter: Arc::new(crate::ratelimit::ApiRateLimiter::new()),
+            db: Some(pool),
+            images_dir: None,
+            master_key: Default::default(),
+            backend: None,
+            replicas: Arc::new(tokio::sync::RwLock::new(ruscker_core::ReplicaRegistry::new())),
+            cookie_key: ruscker_proxy::sticky::CookieKey::random(),
+            spawn_locks: Arc::new(dashmap::DashMap::new()),
+            sessions: Arc::new(crate::sessions::InMemorySessionStore::new()),
+            logout_index: Arc::new(dashmap::DashMap::new()),
+            leader: Arc::new(crate::leader::AlwaysLeader),
+            metrics: crate::metrics_cache::MetricsCache::new(),
+            draining: Arc::new(std::sync::atomic::AtomicBool::new(false)),
+            spec_cache: Arc::new(dashmap::DashMap::new()),
+        }
+    }
+
+    // #739: a self-service password change must revoke every OTHER live
+    // session for the account (an attacker's stolen session must die),
+    // while the user making the change stays signed in on a freshly
+    // minted session.
+    #[tokio::test]
+    async fn self_password_change_revokes_other_sessions_but_keeps_the_user_in() {
+        use axum::body::Body;
+        use axum::http::{header, Request, StatusCode};
+        use tower::ServiceExt;
+
+        let state = state_with_db().await;
+        let pool = state.db.as_ref().unwrap();
+        crate::db::users::create(
+            pool,
+            "alice",
+            "old-password-1",
+            crate::auth::Role::Editor,
+            false,
+            &[],
+            None,
+        )
+        .await
+        .expect("create user");
+
+        // Two live sessions: the requester's and a second device's
+        // (the one a compromise would ride).
+        let mine = state
+            .admin_sessions
+            .create(crate::auth::Role::Editor, Some("alice".into()))
+            .await;
+        let other = state
+            .admin_sessions
+            .create(crate::auth::Role::Editor, Some("alice".into()))
+            .await;
+
+        let app = axum::Router::new()
+            .route(
+                "/admin/account/password",
+                axum::routing::post(super::password_submit),
+            )
+            .layer(tower_cookies::CookieManagerLayer::new())
+            .with_state(state.clone());
+        let resp = app
+            .oneshot(
+                Request::builder()
+                    .method("POST")
+                    .uri("/admin/account/password")
+                    .header(header::COOKIE, format!("{}={}", crate::auth::COOKIE_NAME, mine))
+                    .header(header::CONTENT_TYPE, "application/x-www-form-urlencoded")
+                    .body(Body::from(
+                        "current=old-password-1&new_password=new-password-2&confirm=new-password-2",
+                    ))
+                    .unwrap(),
+            )
+            .await
+            .unwrap();
+        assert_eq!(resp.status(), StatusCode::SEE_OTHER, "change accepted");
+
+        // The other device's session is dead; so is the requester's old id.
+        assert!(
+            state.admin_sessions.validate(&other).await.is_none(),
+            "the second session must be revoked by the password change"
+        );
+        assert!(
+            state.admin_sessions.validate(&mine).await.is_none(),
+            "the old session id must not survive either"
+        );
+
+        // The response re-issues a fresh, VALID session cookie — the
+        // user who changed the password stays signed in.
+        let set = resp
+            .headers()
+            .get(header::SET_COOKIE)
+            .and_then(|v| v.to_str().ok())
+            .expect("a session cookie is re-issued");
+        let new_sid = set
+            .split(';')
+            .next()
+            .and_then(|kv| kv.strip_prefix(&format!("{}=", crate::auth::COOKIE_NAME)))
+            .expect("cookie carries the new session id");
+        let info = state
+            .admin_sessions
+            .validate(new_sid)
+            .await
+            .expect("the fresh session is live");
+        assert_eq!(info.actor.as_deref(), Some("alice"));
+
+        // And the new password is the one that verifies.
+        assert!(crate::db::users::verify_login(pool, "alice", "new-password-2")
+            .await
+            .expect("verify")
+            .is_some());
+    }
 
     #[test]
     fn strip_base_prefix_root_is_noop() {

--- a/crates/ruscker-admin/tests/user_accounts.rs
+++ b/crates/ruscker-admin/tests/user_accounts.rs
@@ -329,18 +329,46 @@ async fn changing_password_lifts_the_guard() {
         .await;
     let cookie = format!("{COOKIE_NAME}={sid}");
 
-    let (status, loc) = post(
-        state.clone(),
-        "/admin/account/password",
-        "current=bobpass12&new_password=bobpass-new9&confirm=bobpass-new9",
-        Some(&cookie),
-    )
-    .await;
-    assert_eq!(status, StatusCode::SEE_OTHER);
-    assert_eq!(loc, "/admin/dashboard");
+    // Do the POST by hand (not via the `post` helper) because we need
+    // the response's Set-Cookie: since #739 a password change revokes
+    // every session of the account — including the one making the
+    // request — and re-issues a fresh cookie on the response.
+    let app = router(state.clone());
+    let resp = app
+        .oneshot(
+            Request::builder()
+                .method("POST")
+                .uri("/admin/account/password")
+                .header("content-type", "application/x-www-form-urlencoded")
+                .header("cookie", &cookie)
+                .body(Body::from(
+                    "current=bobpass12&new_password=bobpass-new9&confirm=bobpass-new9",
+                ))
+                .unwrap(),
+        )
+        .await
+        .unwrap();
+    assert_eq!(resp.status(), StatusCode::SEE_OTHER);
+    assert_eq!(
+        resp.headers().get("location").and_then(|v| v.to_str().ok()),
+        Some("/admin/dashboard")
+    );
+    let fresh_cookie = resp
+        .headers()
+        .get("set-cookie")
+        .and_then(|v| v.to_str().ok())
+        .and_then(|c| c.split(';').next())
+        .expect("the change re-issues a session cookie (#739)")
+        .to_string();
 
-    // The guard no longer fires — the dashboard renders.
-    let (dash_status, _) = get(state, "/admin/dashboard", Some(&cookie)).await;
+    // The old session died with the change (#739)…
+    let (old_status, old_loc) = get(state.clone(), "/admin/dashboard", Some(&cookie)).await;
+    assert_eq!(old_status, StatusCode::SEE_OTHER);
+    assert_eq!(old_loc, "/admin/login");
+
+    // …and on the fresh session the guard no longer fires — the
+    // dashboard renders.
+    let (dash_status, _) = get(state, "/admin/dashboard", Some(&fresh_cookie)).await;
     assert_eq!(dash_status, StatusCode::OK);
 }
 


### PR DESCRIPTION
Fixes #739.

## What

The admin-initiated reset path honors the #544 invariant ("a password reset must invalidate existing sessions") via `revoke_by_actor`, but the **self-service** path (`password_submit`) only called `set_password` and redirected. A user changing their own password — the natural reaction to a suspected session compromise, with no "log out everywhere" UI available — left every other live session (including an attacker's) valid for up to the 24h session TTL.

## How

After a successful self-change, `password_submit` now:
1. `revoke_by_actor(actor)` — kills **all** of the account's sessions (including the requester's current one);
2. mints a fresh session with the same role and re-issues the cookie via the existing `issue_session_cookie` — so other sessions die and the user stays signed in without a re-login bounce.

Works for both session stores (in-memory and the HA Postgres store — `revoke_by_actor` is a trait method both implement).

## Tests

`self_password_change_revokes_other_sessions_but_keeps_the_user_in` — route-level over in-memory SQLite: two live sessions for `alice`, POST the change → the second session and the old id no longer validate, the re-issued cookie validates as `alice`, and only the new password verifies.

Gate: `cargo test` all green, `clippy --all-targets -- -D warnings` clean, i18n ✓.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
