### PR TITLE
fix(dashboard): stop/restart confirm via data-confirm + delegated listener (#740)

### DIFF
--- a/crates/ruscker-admin/src/routes/admin/dashboard.rs
+++ b/crates/ruscker-admin/src/routes/admin/dashboard.rs
@@ -1085,6 +1085,40 @@ mod tests {
         assert!(html.contains("3</span>") || html.contains(">3<"));
     }
 
+    // #740: the stop/restart confirmation must ride a `data-confirm`
+    // attribute consumed by the delegated submit listener — NEVER an
+    // inline onsubmit handler. An inline handler interpolating a
+    // localized message breaks at the message's own quotes (the
+    // JSON.stringify-in-double-quoted-attribute variant shipped with NO
+    // confirmation at all), so the rendered page must not contain
+    // `onsubmit` anywhere — including inside the SSE row-builder script.
+    #[test]
+    fn replica_actions_use_data_confirm_not_inline_onsubmit() {
+        let html = render_with(
+            vec![fake_row("alpha", "Alpha App", ReplicaState::Ready, 1, 1)],
+            true,
+        );
+        assert!(
+            html.contains("data-confirm="),
+            "action forms must carry the confirm message via data-confirm"
+        );
+        assert!(
+            html.contains("addEventListener('submit'"),
+            "the delegated confirm listener must be wired on the container"
+        );
+        // Every <form …> opening tag on the page — server-rendered AND the
+        // ones built as string literals inside the SSE row script — must be
+        // free of inline onsubmit. (A page-wide substring check would trip
+        // on the _perceived_speed.html comment that *mentions* onsubmit.)
+        for chunk in html.split("<form").skip(1) {
+            let tag = &chunk[..chunk.find('>').unwrap_or(chunk.len())];
+            assert!(
+                !tag.contains("onsubmit"),
+                "a form still carries an inline onsubmit handler: <form{tag}>"
+            );
+        }
+    }
+
     #[test]
     fn renders_replicas_grouped_by_app_in_accordion_cards() {
         // #623 redesign: each app is one expandable `.app-group` card with

--- a/crates/ruscker-admin/templates/admin/dashboard.html
+++ b/crates/ruscker-admin/templates/admin/dashboard.html
@@ -149,10 +149,14 @@
         <span class="replica-actions">
           {% if role.can_manage() %}
           <a href="{{ base }}/admin/dashboard/logs/{{ row.replica_id }}" title="{{ self.t("admin-logs-title") }}"><i class="ti ti-file-text" aria-hidden="true"></i></a>
-          <form method="post" action="{{ base }}/admin/dashboard/replicas/{{ row.replica_id }}/restart" style="display:inline" onsubmit="return confirm('{{ self.t("admin-dashboard-confirm-restart") }}')">
+          {# data-confirm + the delegated submit listener below — never an
+             inline onsubmit: a localized message inside an inline handler
+             breaks the handler when it carries quotes/apostrophes (#740,
+             same class as #532/#741). #}
+          <form method="post" action="{{ base }}/admin/dashboard/replicas/{{ row.replica_id }}/restart" style="display:inline" data-confirm="{{ self.t("admin-dashboard-confirm-restart") }}">
             <button type="submit" title="{{ self.t("admin-dashboard-action-restart") }}"><i class="ti ti-refresh" aria-hidden="true"></i></button>
           </form>
-          <form method="post" action="{{ base }}/admin/dashboard/replicas/{{ row.replica_id }}/stop" style="display:inline" onsubmit="return confirm('{{ self.t("admin-dashboard-confirm-stop") }}')">
+          <form method="post" action="{{ base }}/admin/dashboard/replicas/{{ row.replica_id }}/stop" style="display:inline" data-confirm="{{ self.t("admin-dashboard-confirm-stop") }}">
             <button type="submit" class="is-danger" title="{{ self.t("admin-dashboard-action-stop") }}"><i class="ti ti-player-stop" aria-hidden="true"></i></button>
           </form>
           {% endif %}
@@ -172,6 +176,20 @@
 (function () {
   var container = document.getElementById('dash-groups');
   var emptyEl = document.getElementById('dash-empty');
+  // Confirm guard for the stop/restart forms (#740). Delegated — NOT an
+  // inline onsubmit per form: the old generated rows interpolated the
+  // localized message into a double-quoted onsubmit attribute, the
+  // message's own quotes terminated the attribute, the handler never
+  // compiled, and destructive actions fired with NO confirmation. One
+  // listener on the container survives every SSE innerHTML rebuild and
+  // covers the server-rendered rows too (submit events bubble).
+  if (container) {
+    container.addEventListener('submit', function (e) {
+      var form = e.target;
+      var msg = form && form.getAttribute && form.getAttribute('data-confirm');
+      if (msg && !window.confirm(msg)) e.preventDefault();
+    });
+  }
   var ds = (container && container.dataset) || {};
   var pendingLabel = ds.pendingLabel || 'awaiting first reading';
   var logsTitle = ds.logsTitle || 'Logs';
@@ -216,11 +234,11 @@
       + '<a href="' + base + '/admin/dashboard/logs/' + rid + '" title="' + escapeHtml(logsTitle)
         + '"><i class="ti ti-file-text"></i></a>'
       + '<form method="post" action="' + base + '/admin/dashboard/replicas/' + rid
-        + '/restart" style="display:inline" onsubmit="return confirm(' + JSON.stringify(confirmRestart) + ')">'
+        + '/restart" style="display:inline" data-confirm="' + escapeHtml(confirmRestart) + '">'
         + '<button type="submit" title="' + escapeHtml(restartLabel) + '"><i class="ti ti-refresh"></i></button>'
       + '</form>'
       + '<form method="post" action="' + base + '/admin/dashboard/replicas/' + rid
-        + '/stop" style="display:inline" onsubmit="return confirm(' + JSON.stringify(confirmStop) + ')">'
+        + '/stop" style="display:inline" data-confirm="' + escapeHtml(confirmStop) + '">'
         + '<button type="submit" class="is-danger" title="' + escapeHtml(stopLabel) + '"><i class="ti ti-player-stop"></i></button>'
       + '</form>';
   }


### PR DESCRIPTION
Fixes #740.

## What

`actionsHtml()` built rows with `onsubmit="return confirm(' + JSON.stringify(label) + ')"`. `JSON.stringify` emits **double quotes inside a double-quoted attribute** — the attribute value terminated at the inner quote, the handler body became unparseable, and the browser silently dropped it. Because `apply(initial)` replaces the server-rendered rows at page load, every visible stop/restart button fired **with no confirmation at all**.

## How

- Both the server-rendered and the JS-built action forms now carry the localized message in a **`data-confirm`** attribute (HTML-escaped — the established #521 `data-*` pattern).
- One **delegated submit listener** on `#dash-groups` performs the confirm. It survives every SSE `innerHTML` rebuild (the container element itself is never replaced), covers the server-rendered rows too (submit bubbles), and is structurally immune to quotes/apostrophes in localized messages — the same failure class as #532/#741.

## Tests

`replica_actions_use_data_confirm_not_inline_onsubmit` — renders the dashboard with a manageable row and walks **every `<form` opening tag** (server markup *and* the script's string literals) asserting none carries inline `onsubmit`, plus `data-confirm` and the listener are present.

Gate: `cargo test` all green, `clippy --all-targets -- -D warnings` clean, i18n ✓.

## Smoke

Worth one click-through on the lab box dashboard (stop a replica → confirm dialog appears, Cancel actually cancels) — the new path is 5 lines of vanilla JS but it guards a destructive action.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
