### PR TITLE
fix(admin): localized strings out of inline JS — data-confirm everywhere + template lint (#741)

### DIFF
--- a/crates/ruscker-admin/templates/_perceived_speed.html
+++ b/crates/ruscker-admin/templates/_perceived_speed.html
@@ -68,7 +68,8 @@
   });
 
   // A form submit that navigates. Bubble phase so a cancelled
-  // `onsubmit="return confirm(...)"` (defaultPrevented) is skipped. Opt out
+  // `data-confirm` guard (defaultPrevented by the layout's capture-phase
+  // listener, #741) is skipped. Opt out
   // with data-no-progress for an Alpine/fetch-hijacked form that stays put.
   document.addEventListener("submit", function (e) {
     if (e.defaultPrevented) return;

--- a/crates/ruscker-admin/templates/admin/_blocks_editor.html
+++ b/crates/ruscker-admin/templates/admin/_blocks_editor.html
@@ -52,7 +52,7 @@
             </form>
             <a href="{{ base }}/admin/blocks/{{ b.id }}" class="text-[color:var(--text-muted)] hover:text-[color:var(--text)] mr-3">{{ self.t("admin-blocks-edit") }}</a>
             <form method="post" action="{{ base }}/admin/blocks/{{ b.id }}/delete" class="inline"
-                  onsubmit="return confirm('{{ self.t("admin-blocks-delete-confirm") }}')">
+                  data-confirm="{{ self.t("admin-blocks-delete-confirm") }}">
               <button type="submit" class="text-[color:var(--text-faint)] hover:text-red-500">{{ self.t("admin-blocks-delete") }}</button>
             </form>
           </span>

--- a/crates/ruscker-admin/templates/admin/_layout.html
+++ b/crates/ruscker-admin/templates/admin/_layout.html
@@ -433,6 +433,21 @@ window.ruscker.imagePicker = (filenames) => ({
   document.addEventListener('DOMContentLoaded', function () {
     document.querySelectorAll('table[data-enhance]').forEach(enhance);
   });
+
+  // Global confirm guard for destructive forms (#741): the form carries
+  // its localized message in `data-confirm="…"` instead of an inline
+  // `onsubmit` handler — Askama entity-escapes the message, but the
+  // browser DECODES entities in attribute values before compiling
+  // inline JS, so any quote/apostrophe in a translation (FR
+  // "d'exécution") silently broke the handler and the destructive
+  // action fired unconfirmed. Capture phase so a cancel marks
+  // `defaultPrevented` before the perceived-speed bubble listener
+  // would start the progress bar.
+  document.addEventListener('submit', function (e) {
+    var f = e.target;
+    var msg = f && f.getAttribute && f.getAttribute('data-confirm');
+    if (msg && !window.confirm(msg)) e.preventDefault();
+  }, true);
 })();
 </script>
 

--- a/crates/ruscker-admin/templates/admin/credentials.html
+++ b/crates/ruscker-admin/templates/admin/credentials.html
@@ -110,7 +110,7 @@
           <td class="text-[color:var(--text-muted)]">{{ c.created_at.format("%d/%m/%Y") }}</td>
           <td class="actions-cell">
             <form method="post" action="{{ base }}/admin/credentials/{{ c.name }}/delete"
-                  onsubmit="return confirm('{{ self.t("admin-creds-delete-confirm") }}');"
+                  data-confirm="{{ self.t("admin-creds-delete-confirm") }}"
                   class="inline">
               <button type="submit" class="admin-nav-link" style="color:var(--color-lock)"
                       title="{{ self.t("admin-creds-delete") }}">

--- a/crates/ruscker-admin/templates/admin/dashboard.html
+++ b/crates/ruscker-admin/templates/admin/dashboard.html
@@ -176,20 +176,9 @@
 (function () {
   var container = document.getElementById('dash-groups');
   var emptyEl = document.getElementById('dash-empty');
-  // Confirm guard for the stop/restart forms (#740). Delegated — NOT an
-  // inline onsubmit per form: the old generated rows interpolated the
-  // localized message into a double-quoted onsubmit attribute, the
-  // message's own quotes terminated the attribute, the handler never
-  // compiled, and destructive actions fired with NO confirmation. One
-  // listener on the container survives every SSE innerHTML rebuild and
-  // covers the server-rendered rows too (submit events bubble).
-  if (container) {
-    container.addEventListener('submit', function (e) {
-      var form = e.target;
-      var msg = form && form.getAttribute && form.getAttribute('data-confirm');
-      if (msg && !window.confirm(msg)) e.preventDefault();
-    });
-  }
+  // The stop/restart forms carry `data-confirm` (#740) — the confirm
+  // itself is the layout's global document-level guard (#741), which
+  // survives every SSE innerHTML rebuild here.
   var ds = (container && container.dataset) || {};
   var pendingLabel = ds.pendingLabel || 'awaiting first reading';
   var logsTitle = ds.logsTitle || 'Logs';

--- a/crates/ruscker-admin/templates/admin/disk.html
+++ b/crates/ruscker-admin/templates/admin/disk.html
@@ -69,7 +69,7 @@
         </div>
         {% if unused_images_count > 0 %}
         <form method="post" action="{{ base }}/admin/disk/images/prune" class="disk-prune-form"
-              onsubmit="return confirm('{{ self.t("admin-disk-prune-images-confirm") }}')">
+              data-confirm="{{ self.t("admin-disk-prune-images-confirm") }}">
           <button type="submit" class="admin-login-btn admin-login-btn--danger"
                   style="padding:7px 12px;font-size:12px"
                   data-busy="{{ self.t("admin-disk-cleaning") }}">
@@ -110,7 +110,7 @@
                 </span>
               {% else %}
                 <form method="post" action="{{ base }}/admin/disk/images/remove" style="display:inline"
-                      onsubmit="return confirm('{{ self.t("admin-disk-remove-image-confirm") }}')">
+                      data-confirm="{{ self.t("admin-disk-remove-image-confirm") }}">
                   <input type="hidden" name="id" value="{{ img.id }}">
                   <button type="submit" class="dash-action dash-action--danger" title="{{ self.t("admin-disk-remove") }}">
                     <i class="ti ti-trash"></i>
@@ -141,7 +141,7 @@
         </div>
         {% if stopped_count > 0 %}
         <form method="post" action="{{ base }}/admin/disk/containers/prune" class="disk-prune-form"
-              onsubmit="return confirm('{{ self.t("admin-disk-prune-confirm") }}')">
+              data-confirm="{{ self.t("admin-disk-prune-confirm") }}">
           <button type="submit" class="admin-login-btn admin-login-btn--danger"
                   style="padding:7px 12px;font-size:12px"
                   data-busy="{{ self.t("admin-disk-cleaning") }}">
@@ -177,7 +177,7 @@
             </td>
             <td style="text-align:right;white-space:nowrap">
               <form method="post" action="{{ base }}/admin/disk/containers/remove" style="display:inline"
-                    onsubmit="return confirm('{% if c.running %}{{ self.t("admin-disk-remove-running-confirm") }}{% else %}{{ self.t("admin-disk-remove-confirm") }}{% endif %}')">
+                    data-confirm="{% if c.running %}{{ self.t("admin-disk-remove-running-confirm") }}{% else %}{{ self.t("admin-disk-remove-confirm") }}{% endif %}">
                 <input type="hidden" name="id" value="{{ c.id }}">
                 <button type="submit" class="dash-action dash-action--danger" title="{{ self.t("admin-disk-remove") }}">
                   <i class="ti ti-trash"></i>

--- a/crates/ruscker-admin/templates/admin/groups.html
+++ b/crates/ruscker-admin/templates/admin/groups.html
@@ -56,13 +56,14 @@
         {# Rename: prompt for a new name (read the old one from the DOM, not
            interpolated into JS, so a name with a quote can't break it). #}
         <form method="post" action="{{ base }}/admin/groups/rename" style="display:inline"
-              onsubmit="var i=this.querySelector('input[name=new]'); var n=prompt('{{ self.t("admin-groups-rename-prompt") }}', this.querySelector('input[name=old]').value); if(n===null||!n.trim()||n.indexOf(',')>=0){return false;} i.value=n.trim();">
+              data-rename-prompt="{{ self.t("admin-groups-rename-prompt") }}"
+              onsubmit="var i=this.querySelector('input[name=new]'); var n=prompt(this.dataset.renamePrompt, this.querySelector('input[name=old]').value); if(n===null||!n.trim()||n.indexOf(',')>=0){return false;} i.value=n.trim();">
           <input type="hidden" name="old" value="{{ g.name }}">
           <input type="hidden" name="new">
           <button type="submit" class="group-action" title="{{ self.t("admin-groups-rename") }}"><i class="ti ti-pencil" aria-hidden="true"></i></button>
         </form>
         <form method="post" action="{{ base }}/admin/groups/delete" style="display:inline"
-              onsubmit="return confirm('{{ self.t("admin-groups-delete-confirm") }}');">
+              data-confirm="{{ self.t("admin-groups-delete-confirm") }}">
           <input type="hidden" name="name" value="{{ g.name }}">
           <button type="submit" class="group-action group-action-del" title="{{ self.t("admin-groups-delete") }}"><i class="ti ti-trash" aria-hidden="true"></i></button>
         </form>
@@ -77,7 +78,7 @@
             <span class="group-pill">
               <i class="ti ti-user" aria-hidden="true"></i> {{ m }}
               <form method="post" action="{{ base }}/admin/groups/members/remove" style="display:inline"
-                    onsubmit="return confirm('{{ self.t("admin-groups-remove-member-confirm") }}');">
+                    data-confirm="{{ self.t("admin-groups-remove-member-confirm") }}">
                 <input type="hidden" name="group" value="{{ g.name }}">
                 <input type="hidden" name="username" value="{{ m }}">
                 <button type="submit" class="group-pill-x" title="{{ self.t("admin-groups-remove-member") }}">×</button>

--- a/crates/ruscker-admin/templates/admin/images.html
+++ b/crates/ruscker-admin/templates/admin/images.html
@@ -116,11 +116,13 @@
           </div>
           {# Rename: prompt for a new name (extension is kept server-side),
              then submit. References on cards/landing follow the rename. The
-             prompt text must carry no apostrophe — Askama escapes it and the
-             browser would break the single-quoted JS string (cf. #532). #}
+             prompt text rides data-* + dataset (#741) — interpolated into the
+             attribute expression, an apostrophe in a translation broke the
+             handler (the #532 comment-only policy regressed elsewhere). #}
           <form method="post" :action="assetUrl('/admin/media/' + img.id + '/rename')"
+                data-rename-prompt="{{ self.t("admin-images-rename-prompt") }}"
                 @submit="
-                  let nn = prompt('{{ self.t("admin-images-rename-prompt") }}', img.filename);
+                  let nn = prompt($el.dataset.renamePrompt, img.filename);
                   if (!nn || !nn.trim() || nn.trim() === img.filename) { $event.preventDefault(); return; }
                   $el.querySelector('input[name=newname]').value = nn.trim();
                 ">
@@ -129,8 +131,13 @@
               <i class="ti ti-pencil" aria-hidden="true"></i>
             </button>
           </form>
+          {# Conditional message → stays an Alpine handler (the global
+             data-confirm guard is unconditional), but the strings ride
+             data-* so translations can't break the expression (#741). #}
           <form method="post" :action="assetUrl('/admin/media/' + img.id + '/delete')"
-                @submit="if (!confirm(img.in_use ? '{{ self.t("admin-images-delete-confirm-inuse") }}' : '{{ self.t("admin-images-delete-confirm") }}')) $event.preventDefault()">
+                data-msg-inuse="{{ self.t("admin-images-delete-confirm-inuse") }}"
+                data-msg-plain="{{ self.t("admin-images-delete-confirm") }}"
+                @submit="if (!confirm(img.in_use ? $el.dataset.msgInuse : $el.dataset.msgPlain)) $event.preventDefault()">
             <button type="submit" class="image-tile-delete" title="{{ self.t("admin-images-delete") }}">
               <i class="ti ti-trash" aria-hidden="true"></i>
             </button>

--- a/crates/ruscker-admin/templates/admin/spec_form.html
+++ b/crates/ruscker-admin/templates/admin/spec_form.html
@@ -161,7 +161,7 @@
            (`openImagePicker` from the shared mixin). #}
         <div class="logo-pick">
           <button type="button" class="logo-pick__thumb" @click="openLogoPicker()"
-                  :title="form.logo || '{{ self.t("spec-form-logo-none") }}'">
+                  :title="form.logo || $el.dataset.noLogo" data-no-logo="{{ self.t("spec-form-logo-none") }}">
             <img x-show="form.logo" x-cloak :src="thumbUrl(form.logo)" alt="">
             <i class="ti ti-photo" x-show="!form.logo" aria-hidden="true"></i>
           </button>
@@ -1029,7 +1029,7 @@
         <div class="spec-form-actions-box">
           <div class="spec-form-actions-title">{{ self.t("spec-form-actions") }}</div>
           <form method="post" action="{{ base }}/admin/specs/{{ form.id }}/delete"
-                onsubmit="return confirm('{{ self.t("spec-form-delete-confirm") }}');">
+                data-confirm="{{ self.t("spec-form-delete-confirm") }}">
             <button type="submit" class="spec-form-delete">
               <i class="ti ti-trash" aria-hidden="true"></i>
               {{ self.t("spec-form-delete") }}

--- a/crates/ruscker-admin/templates/admin/users.html
+++ b/crates/ruscker-admin/templates/admin/users.html
@@ -134,7 +134,7 @@
             <button type="submit" class="dash-action" title="{{ self.t("admin-users-reset-password") }}"><i class="ti ti-key"></i></button>
           </form>
           <form method="post" action="{{ base }}/admin/users/{{ u.username }}/delete" style="display:inline"
-                onsubmit="return confirm('{{ self.t("admin-users-confirm-delete") }}')">
+                data-confirm="{{ self.t("admin-users-confirm-delete") }}">
             <button type="submit" class="dash-action dash-action--danger" title="{{ self.t("admin-users-delete") }}"><i class="ti ti-trash"></i></button>
           </form>
         </td>

--- a/crates/ruscker-admin/tests/template_lint.rs
+++ b/crates/ruscker-admin/tests/template_lint.rs
@@ -1,0 +1,95 @@
+//! Template lints for the inline-JS i18n trap (#741, #740, #532).
+//!
+//! Askama entity-escapes interpolated text, but the browser DECODES
+//! entities in attribute values BEFORE compiling an inline event
+//! handler — so a localized message interpolated into an inline JS
+//! string breaks the handler at the message's first quote/apostrophe
+//! (FR "d'exécution" shipped a confirm-less destructive action). The
+//! sanctioned patterns are `data-confirm="…"` (consumed by the
+//! layout's global submit guard) or routing the string through
+//! `data-*` + `dataset`; comments in `images.html` used to be the only
+//! enforcement, and it regressed. These lints are the teeth.
+
+use std::path::{Path, PathBuf};
+
+fn template_files() -> Vec<PathBuf> {
+    fn walk(dir: &Path, out: &mut Vec<PathBuf>) {
+        for entry in std::fs::read_dir(dir).expect("read templates dir") {
+            let path = entry.expect("dir entry").path();
+            if path.is_dir() {
+                walk(&path, out);
+            } else if path.extension().is_some_and(|e| e == "html") {
+                out.push(path);
+            }
+        }
+    }
+    let root = Path::new(env!("CARGO_MANIFEST_DIR")).join("templates");
+    let mut files = Vec::new();
+    walk(&root, &mut files);
+    assert!(!files.is_empty(), "no templates found under {root:?}");
+    files
+}
+
+/// No Askama interpolation inside an inline `confirm('…')` /
+/// `prompt('…')` string — that's the exact shape that breaks on a
+/// translated apostrophe. (A *static* inline handler reading from
+/// `this.dataset` is fine.)
+#[test]
+fn no_interpolation_inside_inline_confirm_or_prompt() {
+    let offenders: Vec<String> = template_files()
+        .iter()
+        .flat_map(|path| {
+            let body = std::fs::read_to_string(path).expect("read template");
+            body.lines()
+                .enumerate()
+                .filter(|(_, line)| {
+                    // Direct interpolation into a confirm/prompt string…
+                    let direct = ["confirm('{", "confirm(\"{", "prompt('{", "prompt(\"{"]
+                        .iter()
+                        .any(|pat| line.contains(pat));
+                    // …or a LOCALIZED string anywhere inside an event-handler
+                    // attribute's single-quoted JS (e.g. `@submit="… ?
+                    // '{{ self.t(...) }}' : …"`). Non-localized interpolations
+                    // (hex colours, enum keys) are server-controlled and can't
+                    // grow an apostrophe, so they pass.
+                    let handler = ["@submit", "@click", "onsubmit=", "onclick="]
+                        .iter()
+                        .any(|pat| line.contains(pat))
+                        && line.contains("'{{ self.t(");
+                    direct || handler
+                })
+                .map(|(n, line)| format!("{}:{}: {}", path.display(), n + 1, line.trim()))
+                .collect::<Vec<_>>()
+        })
+        .collect();
+    assert!(
+        offenders.is_empty(),
+        "localized text interpolated into an inline JS string — use \
+         data-confirm / data-* + dataset instead (#741):\n{}",
+        offenders.join("\n")
+    );
+}
+
+/// The `onsubmit="return confirm(…)"` idiom is retired wholesale in
+/// favour of `data-confirm` + the layout's global capture-phase guard —
+/// even a today-safe message regresses the moment a translator adds an
+/// apostrophe.
+#[test]
+fn no_inline_onsubmit_confirm_handlers() {
+    let offenders: Vec<String> = template_files()
+        .iter()
+        .flat_map(|path| {
+            let body = std::fs::read_to_string(path).expect("read template");
+            body.lines()
+                .enumerate()
+                .filter(|(_, line)| line.contains("onsubmit=\"return confirm"))
+                .map(|(n, line)| format!("{}:{}: {}", path.display(), n + 1, line.trim()))
+                .collect::<Vec<_>>()
+        })
+        .collect();
+    assert!(
+        offenders.is_empty(),
+        "inline onsubmit confirm — use data-confirm + the layout guard (#741):\n{}",
+        offenders.join("\n")
+    );
+}


### PR DESCRIPTION
Fixes #741. **Stacked on #754** (base branch `fix/740-dashboard-confirm`) — merge #754 first; this PR moves the confirm guard from the dashboard-local listener to the layout so the two don't double-fire.

## What

Askama escapes `'` to an entity, but the browser **decodes entities in attribute values before compiling inline JS** — a translated apostrophe broke handlers silently. Live today in French:
- Disk panel, removing a **running** container: `admin-disk-remove-running-confirm` ("…d'exécution. L'arrêter…") → handler invalid → **no confirmation**.
- Spec form logo tooltip: `spec-form-logo-none` ("Pas d'image — …") inside `:title="form.logo || '…'"` → Alpine expression throws.

`images.html` documented this trap as a comment-only policy (#532); nothing enforced it, so it regressed.

## How

- **One global capture-phase submit listener** in `_layout.html` consumes `data-confirm="…"` on any form, on every admin page. Capture phase so a cancel marks `defaultPrevented` before the perceived-speed bubble listener starts the progress bar.
- All 10 inline `onsubmit="return confirm('…')"` sites (disk ×4, credentials, groups ×2, users, spec_form, _blocks_editor) → `data-confirm`. The dashboard's #740 local listener is removed in favour of the global one.
- Prompt flows (groups rename, images rename) and the conditional images delete-confirm route messages via `data-*` + `dataset` — handler text stays static.
- `spec_form` `:title` fallback reads `$el.dataset.noLogo`.

## Enforcement

New `tests/template_lint.rs` walks every template and fails on:
1. interpolation inside `confirm('…')`/`prompt('…')` strings,
2. `'{{ self.t(` inside `@submit`/`@click`/`onsubmit=`/`onclick=` attributes (server-controlled non-localized interpolations like hex colours pass),
3. any `onsubmit="return confirm"` at all.

The lint immediately caught the two `images.html` cases beyond the ones in the issue.

Gate: `cargo test` all green, `clippy --all-targets -- -D warnings` clean, i18n ✓.

## Smoke

On the lab box in **French**: Disk → remove a running container → the confirm dialog must appear; spec form → hover the logo thumb with no logo set → tooltip shows "Pas d'image…" without console errors.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
