### PR TITLE
fix(dashboard): SSE rebuild keeps keyboard focus; skip identical snapshots (#742)

### DIFF
--- a/crates/ruscker-admin/src/routes/admin/dashboard.rs
+++ b/crates/ruscker-admin/src/routes/admin/dashboard.rs
@@ -1119,6 +1119,22 @@ mod tests {
         }
     }
 
+    // #742: the SSE apply must (a) skip the innerHTML rebuild when the
+    // markup is unchanged and (b) restore keyboard focus to the
+    // equivalent element after a real rebuild — otherwise focus was
+    // thrown back to <body> every tick, making the replica actions
+    // unreachable by keyboard. Structural guard on the wiring.
+    #[test]
+    fn sse_apply_carries_the_focus_preservation_wiring() {
+        let html = render_with(
+            vec![fake_row("alpha", "Alpha App", ReplicaState::Ready, 1, 1)],
+            true,
+        );
+        assert!(html.contains("lastGroupsHtml"), "identical-snapshot skip missing");
+        assert!(html.contains("function focusKey"), "focus capture missing");
+        assert!(html.contains("function refocus"), "focus restore missing");
+    }
+
     #[test]
     fn renders_replicas_grouped_by_app_in_accordion_cards() {
         // #623 redesign: each app is one expandable `.app-group` card with

--- a/crates/ruscker-admin/templates/admin/dashboard.html
+++ b/crates/ruscker-admin/templates/admin/dashboard.html
@@ -326,19 +326,64 @@
     if (rows.length === 0) {
       container.style.display = 'none';
       container.innerHTML = '';
+      lastGroupsHtml = null; // a later identical snapshot must rebuild
       if (emptyEl) emptyEl.style.display = '';
       return;
     }
     if (emptyEl) emptyEl.style.display = 'none';
     container.style.display = '';
 
-    // Rebuild the whole grouped container each tick. Far simpler than a
-    // per-row diff and cheap at this scale (a handful of apps, ~1 tick/s);
-    // the open/closed state lives in `closed`, not the DOM, so it survives.
-    container.innerHTML = groupRows(rows).map(function (g) {
+    // Rebuild the whole grouped container. Far simpler than a per-row
+    // diff and cheap at this scale (a handful of apps, ~1 tick/s); the
+    // open/closed state lives in `closed`, not the DOM, so it survives.
+    // But innerHTML destroys keyboard focus and text selection (#742) —
+    // a keyboard user was thrown back to <body> every tick, making the
+    // stop/restart buttons unreachable. So: skip the rebuild entirely
+    // when the markup is unchanged (the common idle tick), and
+    // otherwise restore focus to the equivalent element afterwards.
+    var html = groupRows(rows).map(function (g) {
       return groupHtml(g, !closed[g.spec_id]);
     }).join('');
+    if (html === lastGroupsHtml) return;
+    lastGroupsHtml = html;
+    var key = null;
+    if (document.activeElement && container.contains(document.activeElement)) {
+      key = focusKey(document.activeElement);
+    }
+    container.innerHTML = html;
+    refocus(key);
   }
+
+  // Identify a focused element structurally — by its replica row (or
+  // group head) plus its index among the focusables inside it — so the
+  // equivalent element can be re-focused in the rebuilt DOM (#742).
+  function focusKey(el) {
+    var row = el.closest && el.closest('[data-replica-id]');
+    var head = el.closest && el.closest('.app-group__head');
+    var scope = row || head;
+    if (!scope) return null;
+    var focusables = scope.querySelectorAll('a, button, [tabindex]');
+    return {
+      row: row ? row.getAttribute('data-replica-id') : null,
+      spec: !row && head ? head.parentElement.getAttribute('data-spec-id') : null,
+      idx: Array.prototype.indexOf.call(focusables, el),
+      self: scope === el,
+    };
+  }
+  function refocus(key) {
+    if (!key) return;
+    var scope = key.row
+      ? container.querySelector('[data-replica-id="' + CSS.escape(key.row) + '"]')
+      : key.spec
+        ? container.querySelector('.app-group[data-spec-id="' + CSS.escape(key.spec) + '"] .app-group__head')
+        : null;
+    if (!scope) return;   // the replica/group is gone — nothing to restore
+    if (key.self) { scope.focus(); return; }
+    var focusables = scope.querySelectorAll('a, button, [tabindex]');
+    var el = key.idx >= 0 ? focusables[key.idx] : null;
+    (el || scope).focus();
+  }
+  var lastGroupsHtml = null;
 
   // Expand/collapse a group on head click or Enter/Space. Delegated on the
   // container so it keeps working after every innerHTML rebuild. Action


### PR DESCRIPTION
Fixes #742. **Stacked on #755** (which stacks on #754) — merge order: #754 → #755 → this. All three touch `dashboard.html`'s script.

## What

`es.onmessage` rebuilt the whole `#dash-groups` container via `innerHTML` on **every** SSE message (~1/s). Anything focused inside — the tabbable group heads, logs links, stop/restart buttons — was destroyed each tick: keyboard focus fell back to `<body>` every second, making the replica actions effectively unreachable by keyboard. Text selection died the same way.

## How

Inside `apply()`:
1. **Identical-snapshot skip** — the grouped HTML string is compared to the previous tick's; unchanged markup (the common idle tick) skips the rebuild entirely, so focus/selection are simply untouched.
2. **Focus restore** — before a real rebuild, the focused element is keyed structurally (`data-replica-id` row / group head's `data-spec-id` + index among the focusables inside it); after `innerHTML`, the equivalent element is re-focused. A replica that disappeared restores nothing (correct — its controls are gone).

The zero-rows path resets the cache so "5 rows → 0 → same 5 rows" still rebuilds.

## Tests

Structural render guard (`sse_apply_carries_the_focus_preservation_wiring`). The behavior itself is DOM-side — see smoke below.

Gate: `cargo test` all green, `clippy --all-targets -- -D warnings` clean, i18n ✓.

## Smoke

On the lab box dashboard with ≥1 replica: Tab to a stop/restart button and wait a few SSE ticks — focus must stay put (or to the same button after a metrics change); with CPU numbers fluctuating, confirm the rebuild path also keeps focus.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
