### PR TITLE
fix(db): port migrations 0017–0021 to Postgres; guard against future drift (#758)

### DIFF
--- a/crates/ruscker-admin/migrations-pg/0017_landing_footer.sql
+++ b/crates/ruscker-admin/migrations-pg/0017_landing_footer.sql
@@ -1,0 +1,4 @@
+-- Postgres twin of migrations/0017. Editable public-portal footer text
+-- (appearance editor). NULL → the built-in version + "ruscker" lockup
+-- renders unchanged. Idempotent.
+ALTER TABLE landing_customization ADD COLUMN IF NOT EXISTS footer TEXT;

--- a/crates/ruscker-admin/migrations-pg/0018_landing_default_theme.sql
+++ b/crates/ruscker-admin/migrations-pg/0018_landing_default_theme.sql
@@ -1,0 +1,4 @@
+-- Postgres twin of migrations/0018. Default portal theme for a
+-- cookieless visitor: 'light' | 'dark' | 'auto'. NULL/'auto' → OS
+-- prefers-color-scheme. Idempotent.
+ALTER TABLE landing_customization ADD COLUMN IF NOT EXISTS default_theme TEXT;

--- a/crates/ruscker-admin/migrations-pg/0019_landing_appearance.sql
+++ b/crates/ruscker-admin/migrations-pg/0019_landing_appearance.sql
@@ -1,0 +1,14 @@
+-- Postgres twin of migrations/0019 (design handoff ruscker-06). All
+-- nullable; NULL → the built-in default for each. BOOLEAN where the
+-- sqlite twin used INTEGER-as-bool; BIGINT where the row struct reads
+-- i64. Idempotent.
+ALTER TABLE landing_customization ADD COLUMN IF NOT EXISTS show_search BOOLEAN;        -- default on
+ALTER TABLE landing_customization ADD COLUMN IF NOT EXISTS show_filters BOOLEAN;       -- default on
+ALTER TABLE landing_customization ADD COLUMN IF NOT EXISTS logo_mode TEXT;             -- mark | symbol | custom
+ALTER TABLE landing_customization ADD COLUMN IF NOT EXISTS logo_size BIGINT;           -- px, default 28
+ALTER TABLE landing_customization ADD COLUMN IF NOT EXISTS logo_margin BIGINT;         -- px, default 8
+ALTER TABLE landing_customization ADD COLUMN IF NOT EXISTS header_preset TEXT;         -- flat | soft | bold
+ALTER TABLE landing_customization ADD COLUMN IF NOT EXISTS card_cover TEXT;            -- tinted | gradient
+ALTER TABLE landing_customization ADD COLUMN IF NOT EXISTS catalog_layout TEXT;        -- grid | list | sections
+ALTER TABLE landing_customization ADD COLUMN IF NOT EXISTS catalog_density TEXT;       -- comfortable | compact
+ALTER TABLE landing_customization ADD COLUMN IF NOT EXISTS analytics_provider TEXT;    -- none | ga | plausible | matomo

--- a/crates/ruscker-admin/migrations-pg/0020_landing_analytics_key.sql
+++ b/crates/ruscker-admin/migrations-pg/0020_landing_analytics_key.sql
@@ -1,0 +1,4 @@
+-- Postgres twin of migrations/0020. Site key for the analytics provider
+-- picker: a GA4 measurement id, a Plausible domain, or a Matomo
+-- "url|siteId". NULL → no provider snippet. Idempotent.
+ALTER TABLE landing_customization ADD COLUMN IF NOT EXISTS analytics_key TEXT;

--- a/crates/ruscker-admin/migrations-pg/0021_landing_card_cover_default.sql
+++ b/crates/ruscker-admin/migrations-pg/0021_landing_card_cover_default.sql
@@ -1,0 +1,4 @@
+-- Postgres twin of migrations/0021 (#720). Default card-cover CSS value
+-- (solid colour or gradient) applied to every card without its own
+-- cover/accent. NULL → per-kind tint (the editor's "Auto"). Idempotent.
+ALTER TABLE landing_customization ADD COLUMN IF NOT EXISTS card_cover_default TEXT;

--- a/crates/ruscker-admin/src/db.rs
+++ b/crates/ruscker-admin/src/db.rs
@@ -169,6 +169,35 @@ pub mod spec_access;
 pub mod specs;
 pub mod users;
 
+#[cfg(test)]
+mod migration_parity {
+    // #758: `migrations-pg/` silently stopped at 0016 while `migrations/`
+    // reached 0021 — every Postgres-catalog deployment's landing fetch
+    // broke from v0.1.90 until the drift was found, because the only
+    // schema-parity test was gated behind `postgres-it` and hadn't run.
+    // Filename parity needs no database, so it runs in the default gate;
+    // the file *contents* may differ (dialects), the SET may not.
+    #[test]
+    fn sqlite_and_postgres_migration_sets_match() {
+        fn names(dir: &str) -> Vec<String> {
+            let root = std::path::Path::new(env!("CARGO_MANIFEST_DIR")).join(dir);
+            let mut v: Vec<String> = std::fs::read_dir(&root)
+                .unwrap_or_else(|e| panic!("read {root:?}: {e}"))
+                .map(|e| e.expect("dir entry").file_name().to_string_lossy().into_owned())
+                .filter(|n| n.ends_with(".sql"))
+                .collect();
+            v.sort();
+            v
+        }
+        assert_eq!(
+            names("migrations"),
+            names("migrations-pg"),
+            "migrations/ and migrations-pg/ must carry the same migration \
+             files — port the missing twin before shipping (#758)"
+        );
+    }
+}
+
 #[cfg(all(test, feature = "postgres-it"))]
 mod pg_tests {
     use super::*;


### PR DESCRIPTION
Fixes #758.

## What

`migrations-pg/` stopped at `0016_specs_featured.sql` while `migrations/` reached 0021. On an HA deployment with `--config-db-url`, `landing_customization` was missing every column added since v0.1.90 (footer, default_theme, the 10 appearance fields, analytics_key, card_cover_default). `db::landing::fetch` selects them all via a `FromRow` struct, so it failed outright — `column "footer" does not exist` — breaking the landing render path and the whole Appearance editor on Postgres. Shipped broken in v0.1.90 (2026-06-08); the schema-parity test that would have caught it is gated behind `postgres-it` and hadn't been run.

## How

- Five Postgres twins (0017–0021), following the existing dialect conventions: `ADD COLUMN IF NOT EXISTS`, `BOOLEAN` where the sqlite twin used INTEGER-as-bool, `BIGINT` where the row struct reads `i64` (`logo_size`/`logo_margin` — an int4 column would fail sqlx decode). sqlx tracks migrations by version, so existing HA deployments apply them on next start.
- **Drift guard in the default gate:** `sqlite_and_postgres_migration_sets_match` asserts the two directories carry the same filename set — no database needed, so it runs on every `cargo test`, not just postgres-it.

## Verification

Full `cargo test -p ruscker-admin --features postgres-it` against a fresh `postgres:16-alpine`: **all green** (333 lib + integration), including the 3 tests that fail on `main` (`db::landing::tests::{fetch,update_then_fetch}_against_real_postgres`, `db::specs::tests::import_all_against_real_postgres`).

Gate: `cargo test` all green, `clippy --all-targets -- -D warnings` clean, i18n ✓.

Follow-up worth considering (not in this PR): run postgres-it in CI with a service container so the suite can't go unexercised again.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
