### PR TITLE
fix(proxy,sessions): XFF/XFP trust, at_capacity, hot-path write, sweep race, latent footguns (#744)

### DIFF
--- a/crates/ruscker-admin/src/auth.rs
+++ b/crates/ruscker-admin/src/auth.rs
@@ -393,14 +393,25 @@ impl Default for LoginRateLimiter {
 /// whether to set the `Secure` flag on cookies — we can't just
 /// always set it because the dev server runs plain HTTP and the
 /// browser would then drop the cookie.
-pub fn request_is_https(headers: &axum::http::HeaderMap) -> bool {
+pub fn request_is_https(headers: &axum::http::HeaderMap, forwarded_trusted: bool) -> bool {
+    // Same trust model as every other X-Forwarded-* read (#744): only
+    // honoured when the operator opted in (`server.useForwardHeaders`).
+    // Before this, ANY client could flip a cookie's `Secure` flag with
+    // a spoofed header. TLS-terminating deployments must set the flag
+    // — ShinyProxy-migrated configs already do.
+    if !forwarded_trusted {
+        return false;
+    }
     headers
         .get("x-forwarded-proto")
         .and_then(|v| v.to_str().ok())
-        // XFP can be a comma list ("https, http") when chained;
-        // the leftmost is the original client scheme.
+        // XFP can be a comma list ("https, http") when chained; take
+        // the RIGHTMOST entry — the one appended by the trusted proxy
+        // closest to us. The leftmost is client-controlled whenever a
+        // proxy appends instead of replacing (the spoof-unsafe slot,
+        // same rationale as `client_key`'s XFF handling).
         .map(|s| {
-            s.split(',')
+            s.rsplit(',')
                 .next()
                 .map(|p| p.trim().eq_ignore_ascii_case("https"))
                 .unwrap_or(false)
@@ -739,22 +750,36 @@ mod tests {
     }
 
     #[test]
-    fn request_is_https_reads_x_forwarded_proto() {
+    fn request_is_https_reads_x_forwarded_proto_when_trusted() {
         let mut h = HeaderMap::new();
-        assert!(!request_is_https(&h), "no header → not https");
+        assert!(!request_is_https(&h, true), "no header → not https");
         h.insert("x-forwarded-proto", "http".parse().unwrap());
-        assert!(!request_is_https(&h));
+        assert!(!request_is_https(&h, true));
         h.insert("x-forwarded-proto", "https".parse().unwrap());
-        assert!(request_is_https(&h));
+        assert!(request_is_https(&h, true));
+    }
+
+    // #744: XFP rides the same opt-in as every other forwarded header —
+    // without `server.useForwardHeaders`, a direct client could flip a
+    // cookie's `Secure` flag with a spoofed header.
+    #[test]
+    fn request_is_https_ignores_header_when_untrusted() {
+        let mut h = HeaderMap::new();
+        h.insert("x-forwarded-proto", "https".parse().unwrap());
+        assert!(!request_is_https(&h, false), "untrusted → header ignored");
     }
 
     #[test]
     fn request_is_https_handles_chained_proto_list() {
         let mut h = HeaderMap::new();
-        // Chained proxies: leftmost is the original client scheme.
+        // Chained proxies: the RIGHTMOST entry is the one the trusted
+        // proxy appended — the spoof-safe slot (#744). A client sending
+        // "https" through an appending plain-HTTP proxy must not win.
         h.insert("x-forwarded-proto", "https, http".parse().unwrap());
-        assert!(request_is_https(&h));
+        assert!(!request_is_https(&h, true), "client-spoofed leftmost loses");
+        h.insert("x-forwarded-proto", "http, https".parse().unwrap());
+        assert!(request_is_https(&h, true), "trusted rightmost wins");
         h.insert("x-forwarded-proto", "HTTPS".parse().unwrap());
-        assert!(request_is_https(&h), "case-insensitive");
+        assert!(request_is_https(&h, true), "case-insensitive");
     }
 }

--- a/crates/ruscker-admin/src/db/credentials.rs
+++ b/crates/ruscker-admin/src/db/credentials.rs
@@ -246,9 +246,14 @@ pub async fn resolve(
     }
 }
 
-/// Decrypt the password for a single credential. Used by the
-/// runtime when pulling an image; **not** exposed in the UI.
-/// Returns `None` if the name doesn't exist.
+/// Decrypt the password for a single credential. Returns `None` if the
+/// name doesn't exist. Handles BOTH storage forms the same way
+/// [`resolve`] does (#744): an empty nonce marks a `${VAR}` env-ref
+/// stored verbatim (resolved from the environment here), a non-empty
+/// nonce is AES-GCM ciphertext — this used to decrypt unconditionally
+/// and errored on every env-ref credential ("nonce must be 12 bytes,
+/// got 0"), a divergent copy of the storage contract waiting for its
+/// first production caller.
 pub async fn fetch_password(
     db: &ConfigDb,
     key: &MasterKey,
@@ -272,9 +277,16 @@ pub async fn fetch_password(
     match row {
         None => Ok(None),
         Some((enc, nonce)) => {
-            let pt = key.decrypt(&enc, &nonce)?;
-            let s = String::from_utf8(pt.to_vec())
-                .context("decrypted password is not valid UTF-8")?;
+            let s = if nonce.is_empty() {
+                let raw = String::from_utf8(enc)
+                    .context("stored credential reference is not valid UTF-8")?;
+                ruscker_config::env::interpolate_value(&raw)
+                    .with_context(|| format!("resolve ${{VAR}} in credential {name}"))?
+            } else {
+                let pt = key.decrypt(&enc, &nonce)?;
+                String::from_utf8(pt.to_vec())
+                    .context("decrypted password is not valid UTF-8")?
+            };
             Ok(Some(Zeroizing::new(s)))
         }
     }
@@ -471,6 +483,16 @@ mod tests {
             c2.password, "resolved-pw",
             "verbatim env-ref ignores the master key (not encrypted)"
         );
+
+        // #744: `fetch_password` must read BOTH storage forms like
+        // `resolve` does — it used to decrypt unconditionally and
+        // errored on every env-ref credential ("nonce must be 12
+        // bytes, got 0").
+        let pw = fetch_password(&db, &key, "envcred")
+            .await
+            .unwrap()
+            .expect("env-ref credential readable");
+        assert_eq!(&*pw, "resolved-pw");
     }
 
     #[tokio::test]

--- a/crates/ruscker-admin/src/db/images.rs
+++ b/crates/ruscker-admin/src/db/images.rs
@@ -257,130 +257,11 @@ pub async fn unique_filename(db: &ConfigDb, desired: &str) -> Result<String> {
     anyhow::bail!("no free filename for {desired} after 9999 tries")
 }
 
-/// Rename an image (filename only — the id and BLOB are untouched).
-/// The caller must ensure `new_filename` is free and fix up any
-/// references first. Writes an `image.rename` audit row.
-pub async fn rename(db: &ConfigDb, id: &str, new_filename: &str, actor: Option<&str>) -> Result<()> {
-    let now = Utc::now();
-    let target = format!("image:{id}");
-    let diff = serde_json::to_string(&serde_json::json!({ "filename": new_filename }))?;
-    match db {
-        ConfigDb::Sqlite(pool) => {
-            let mut tx = pool.begin().await.context("begin image rename tx")?;
-            sqlx::query("UPDATE images SET filename = ? WHERE id = ?")
-                .bind(new_filename)
-                .bind(id)
-                .execute(&mut *tx)
-                .await
-                .context("rename image (sqlite)")?;
-            sqlx::query(
-                "INSERT INTO audit_log (actor, action, target, diff_json, occurred_at)
-                 VALUES (?, 'image.rename', ?, ?, ?)",
-            )
-            .bind(actor)
-            .bind(&target)
-            .bind(&diff)
-            .bind(now)
-            .execute(&mut *tx)
-            .await
-            .context("audit image.rename (sqlite)")?;
-            tx.commit().await.context("commit image rename")?;
-        }
-        ConfigDb::Postgres(pool) => {
-            let mut tx = pool.begin().await.context("begin image rename tx")?;
-            sqlx::query("UPDATE images SET filename = $1 WHERE id = $2")
-                .bind(new_filename)
-                .bind(id)
-                .execute(&mut *tx)
-                .await
-                .context("rename image (postgres)")?;
-            sqlx::query(
-                "INSERT INTO audit_log (actor, action, target, diff_json, occurred_at)
-                 VALUES ($1, 'image.rename', $2, $3, $4)",
-            )
-            .bind(actor)
-            .bind(&target)
-            .bind(&diff)
-            .bind(now)
-            .execute(&mut *tx)
-            .await
-            .context("audit image.rename (postgres)")?;
-            tx.commit().await.context("commit image rename")?;
-        }
-    }
-    Ok(())
-}
-
-/// Delete an image by id. Returns the deleted row's filename (so the
-/// caller can invalidate caches keyed by it, #301), or `None` if no
-/// such image existed. Audit row is written when a row was removed.
-pub async fn delete_one(db: &ConfigDb, id: &str, actor: Option<&str>) -> Result<Option<String>> {
-    let now = Utc::now();
-    let target = format!("image:{id}");
-    match db {
-        ConfigDb::Sqlite(pool) => {
-            let mut tx = pool.begin().await.context("begin image delete tx")?;
-            // Capture filename for the audit diff before deletion.
-            let filename: Option<(String,)> =
-                sqlx::query_as("SELECT filename FROM images WHERE id = ?")
-                    .bind(id)
-                    .fetch_optional(&mut *tx)
-                    .await
-                    .context("lookup image for delete")?;
-            let rows = sqlx::query("DELETE FROM images WHERE id = ?")
-                .bind(id)
-                .execute(&mut *tx)
-                .await
-                .with_context(|| format!("delete image {id}"))?;
-            let removed = rows.rows_affected() > 0;
-            if removed {
-                sqlx::query(
-                    "INSERT INTO audit_log (actor, action, target, diff_json, occurred_at)
-                     VALUES (?, 'image.delete', ?, ?, ?)",
-                )
-                .bind(actor)
-                .bind(&target)
-                .bind(serde_json::to_string(&delete_diff(filename.as_ref()))?)
-                .bind(now)
-                .execute(&mut *tx)
-                .await
-                .context("audit image.delete")?;
-            }
-            tx.commit().await.context("commit image delete")?;
-            Ok(if removed { filename.map(|(f,)| f) } else { None })
-        }
-        ConfigDb::Postgres(pool) => {
-            let mut tx = pool.begin().await.context("begin image delete tx")?;
-            let filename: Option<(String,)> =
-                sqlx::query_as("SELECT filename FROM images WHERE id = $1")
-                    .bind(id)
-                    .fetch_optional(&mut *tx)
-                    .await
-                    .context("lookup image for delete")?;
-            let rows = sqlx::query("DELETE FROM images WHERE id = $1")
-                .bind(id)
-                .execute(&mut *tx)
-                .await
-                .with_context(|| format!("delete image {id}"))?;
-            let removed = rows.rows_affected() > 0;
-            if removed {
-                sqlx::query(
-                    "INSERT INTO audit_log (actor, action, target, diff_json, occurred_at)
-                     VALUES ($1, 'image.delete', $2, $3, $4)",
-                )
-                .bind(actor)
-                .bind(&target)
-                .bind(serde_json::to_string(&delete_diff(filename.as_ref()))?)
-                .bind(now)
-                .execute(&mut *tx)
-                .await
-                .context("audit image.delete")?;
-            }
-            tx.commit().await.context("commit image delete")?;
-            Ok(if removed { filename.map(|(f,)| f) } else { None })
-        }
-    }
-}
+// The pre-#729 single-row `rename` / `delete_one` were REMOVED (#744):
+// they mutated the image row without touching spec/landing references
+// (the dangling-ref TOCTOU the audit fixed) and survived only as a
+// footgun for the next call site. Use `rename_with_refs` /
+// `delete_with_refs` — one transaction covering the row AND its refs.
 
 /// Rename an image AND rewrite every reference to it (the given specs +
 /// landing) in **one transaction** (#720 audit P2). Before, the route
@@ -675,9 +556,13 @@ mod pg_tests {
         assert_eq!(metas[0].size_bytes, 4);
         assert_eq!(metas[0].width, Some(48));
 
-        // Returns the deleted filename now (#301).
+        // Returns the deleted filename now (#301); the atomic
+        // refs-aware delete is the only deletion path since #744.
         assert_eq!(
-            delete_one(&db, &id, Some("admin")).await.unwrap().as_deref(),
+            delete_with_refs(&db, &id, &[], None, Some("admin"))
+                .await
+                .unwrap()
+                .as_deref(),
             Some("logo.webp")
         );
         assert!(fetch_by_filename(&db, "logo.webp").await.unwrap().is_none());

--- a/crates/ruscker-admin/src/db/users.rs
+++ b/crates/ruscker-admin/src/db/users.rs
@@ -232,17 +232,24 @@ pub async fn verify_login(
     }
     .with_context(|| format!("login lookup {username}"))?;
 
+    // argon2id is ~tens of ms of pure CPU — run it on the blocking
+    // pool so it can't stall a tokio worker (and every proxied request
+    // sharing it) during a login burst (#744). The unknown-username
+    // branch spends the same verify time on a decoy hash so response
+    // timing doesn't reveal whether the account exists.
+    let pw = password.to_string();
+    let (hash_to_check, found) = match &row {
+        Some((.., hash)) => (hash.clone(), true),
+        None => (dummy_hash().to_string(), false),
+    };
+    let verified = tokio::task::spawn_blocking(move || verify_password(&pw, &hash_to_check))
+        .await
+        .context("password verify task")?;
     match row {
-        Some((id, u, r, m, g, c, by, hash)) if verify_password(password, &hash) => {
+        Some((id, u, r, m, g, c, by, _)) if found && verified => {
             Ok(Some(row_from(id, u, r, m, g, c, by)))
         }
-        Some(_) => Ok(None),
-        None => {
-            // Spend the same argon2 verify time on an unknown username
-            // so response timing doesn't reveal whether it exists.
-            let _ = verify_password(password, dummy_hash());
-            Ok(None)
-        }
+        _ => Ok(None),
     }
 }
 
@@ -266,7 +273,14 @@ pub async fn create(
     actor: Option<&str>,
 ) -> Result<()> {
     let username = normalize_username(username);
-    let hash = hash_password(password)?;
+    // argon2id hashing is CPU-bound — blocking pool, not a tokio
+    // worker (#744).
+    let hash = {
+        let pw = password.to_string();
+        tokio::task::spawn_blocking(move || hash_password(&pw))
+            .await
+            .context("password hash task")??
+    };
     let groups = join_groups(groups);
     let now = Utc::now();
     let id = uuid::Uuid::new_v4().to_string();
@@ -331,7 +345,12 @@ pub async fn set_password(
     actor: Option<&str>,
 ) -> Result<()> {
     let username = normalize_username(username);
-    let hash = hash_password(new_password)?;
+    let hash = {
+        let pw = new_password.to_string();
+        tokio::task::spawn_blocking(move || hash_password(&pw))
+            .await
+            .context("password hash task")??
+    };
     let now = Utc::now();
     let target = format!("user:{username}");
 

--- a/crates/ruscker-admin/src/routes/admin.rs
+++ b/crates/ruscker-admin/src/routes/admin.rs
@@ -140,14 +140,19 @@ async fn redirect_to_dashboard(_: AdminSession) -> Redirect {
 }
 
 /// Issue the admin session cookie. 24h lifetime; `Secure` only under
-/// TLS (signalled by `X-Forwarded-Proto`) so the plain-HTTP dev server
-/// doesn't make the browser drop it. The value is an opaque session id.
-fn issue_session_cookie(cookies: &Cookies, headers: &HeaderMap, session_id: String) {
+/// TLS (signalled by `X-Forwarded-Proto`, honoured only when the
+/// operator trusts forwarded headers — #744) so the plain-HTTP dev
+/// server doesn't make the browser drop it. The value is an opaque
+/// session id.
+fn issue_session_cookie(state: &AppState, cookies: &Cookies, headers: &HeaderMap, session_id: String) {
     let mut c = Cookie::new(COOKIE_NAME, session_id);
     c.set_path("/");
     c.set_http_only(true);
     c.set_same_site(tower_cookies::cookie::SameSite::Strict);
-    c.set_secure(crate::auth::request_is_https(headers));
+    c.set_secure(crate::auth::request_is_https(
+        headers,
+        crate::routes::proxy::forward_headers_trusted(&state.config.server),
+    ));
     c.set_max_age(Duration::hours(24));
     cookies.add(c);
 }
@@ -281,7 +286,7 @@ async fn login_submit(
         .admin_sessions
         .create(user.role, Some(user.username.clone()))
         .await;
-    issue_session_cookie(&cookies, &headers, session_id);
+    issue_session_cookie(&state, &cookies, &headers, session_id);
 
     // First login with an admin-assigned password ⇒ ask whether to
     // change it.
@@ -384,7 +389,7 @@ async fn token_login(
 
     state.login_limiter.record_success();
     let session_id = state.admin_sessions.create(Role::Admin, None).await;
-    issue_session_cookie(&cookies, &headers, session_id);
+    issue_session_cookie(&state, &cookies, &headers, session_id);
 
     // No admin account yet (and a DB to create one in) ⇒ run setup.
     let need_setup = match state.db.as_ref() {
@@ -504,7 +509,7 @@ async fn setup_submit(
         .admin_sessions
         .create(Role::Admin, Some(username))
         .await;
-    issue_session_cookie(&cookies, &headers, session_id);
+    issue_session_cookie(&state, &cookies, &headers, session_id);
     Redirect::to("/admin/dashboard").into_response()
 }
 
@@ -628,7 +633,7 @@ async fn password_submit(
         .admin_sessions
         .create(session.role, Some(actor.clone()))
         .await;
-    issue_session_cookie(&cookies, &headers, session_id);
+    issue_session_cookie(&state, &cookies, &headers, session_id);
     Redirect::to("/admin/dashboard").into_response()
 }
 

--- a/crates/ruscker-admin/src/routes/proxy.rs
+++ b/crates/ruscker-admin/src/routes/proxy.rs
@@ -230,10 +230,16 @@ async fn forward(
     upstream_path: String,
     mut req: Request,
 ) -> Response {
+    // Whether the operator opted into trusting X-Forwarded-* (#328);
+    // gates both the scheme below and the X-Forwarded-For handling in
+    // the forward (#744).
+    let xfwd_trusted = forward_headers_trusted(&state.config.server);
     // Capture the request scheme before `req` is consumed by the
     // forward — used to decide the `Secure` flag on the sticky
-    // cookie we may set at the end.
-    let is_https = crate::auth::request_is_https(req.headers());
+    // cookie we may set at the end. Same trust gate as every other
+    // forwarded header (#744): without the opt-in, a direct client
+    // could flip the cookie's `Secure` flag with a spoofed header.
+    let is_https = crate::auth::request_is_https(req.headers(), xfwd_trusted);
 
     // Signed-in username (if any), captured before the access-guard below
     // consumes `session.0`. Used to index the session for `stop-on-logout`
@@ -621,6 +627,37 @@ async fn forward(
             HeaderValue::from_static("identity"),
         );
     }
+    // X-Forwarded-For (#744): apps behind a proxy expect the standard
+    // chain, and before this the client's header passed through
+    // VERBATIM with the real peer never appended — upstream apps that
+    // log or trust XFF saw spoofable data and never the true client.
+    // Trusted mode (server.useForwardHeaders) appends the peer to the
+    // inbound chain; untrusted mode replaces the (spoofable) inbound
+    // value with just the peer.
+    {
+        let peer_ip = peer.map(|p| p.ip().to_string());
+        let existing = req
+            .headers()
+            .get("x-forwarded-for")
+            .and_then(|v| v.to_str().ok())
+            .map(String::from);
+        let new_xff = match (peer_ip, existing) {
+            (Some(ip), Some(chain)) if xfwd_trusted => Some(format!("{chain}, {ip}")),
+            (Some(ip), _) => Some(ip),
+            // No peer (Router::oneshot tests): keep a trusted chain,
+            // drop an untrusted one.
+            (None, Some(chain)) if xfwd_trusted => Some(chain),
+            (None, _) => None,
+        };
+        match new_xff.and_then(|v| HeaderValue::from_str(&v).ok()) {
+            Some(v) => {
+                req.headers_mut().insert("x-forwarded-for", v);
+            }
+            None => {
+                req.headers_mut().remove("x-forwarded-for");
+            }
+        }
+    }
     let resp = match do_forward(
         &replica,
         upstream_path,
@@ -692,9 +729,14 @@ async fn forward(
     }
 
     // API specs aren't sticky, so count each forwarded call here (#549
-    // follow-up). One per request — for an API, each call *is* the access.
+    // follow-up). One per request — for an API, each call *is* the
+    // access. Spawned, not awaited (#744): the write is best-effort by
+    // contract, and awaiting it inline added a DB round-trip to every
+    // API response (serializing on SQLite's single writer under load).
     if spec.kind() == SpecKind::Api {
-        record_access(&state, &spec.id).await;
+        let st = state.clone();
+        let id = spec.id.clone();
+        tokio::spawn(async move { record_access(&st, &id).await });
     }
 
     let resp = with_cors(resp, cors_on);
@@ -1113,7 +1155,21 @@ async fn has_sticky_seat(state: &AppState, spec: &Spec, cookies: &Cookies) -> bo
 async fn at_capacity(state: &AppState, spec: &Spec) -> bool {
     let max = spec.effective_max_replicas() as usize;
     let reg = state.replicas.read().await;
-    reg.replicas_of(&spec.id).len() >= max
+    // Count only replicas a spawn would actually compete with —
+    // mirroring `spawn_one`'s notion of "live" (#744). Counting
+    // Failed/Stopped leftovers made the splash say "full — waiting for
+    // a slot" and skip the background spawn while `pick_or_spawn`'s own
+    // capped branch would happily have spawned over them.
+    reg.replicas_of(&spec.id)
+        .iter()
+        .filter(|r| {
+            matches!(
+                r.state,
+                ReplicaState::Starting | ReplicaState::Ready | ReplicaState::Draining
+            )
+        })
+        .count()
+        >= max
 }
 
 /// The post-decode core of [`has_sticky_seat`]: does this sticky session
@@ -2981,6 +3037,116 @@ docker-registry-password: hunter2
                 assert_eq!(resp.status(), StatusCode::BAD_GATEWAY);
             }
             other => panic!("expected an HTTP 502 handshake rejection, got {other:?}"),
+        }
+    }
+
+    // #744: `at_capacity` must count only replicas a spawn would compete
+    // with (Starting/Ready/Draining) — a registry still holding a crashed
+    // replica made the splash claim "full — waiting for a slot" and skip
+    // the background spawn, while pick_or_spawn would happily have
+    // spawned over the corpse.
+    #[tokio::test]
+    async fn at_capacity_ignores_failed_and_stopped_replicas() {
+        let backend = StdArc::new(CountingBackend {
+            spawns: AtomicU32::new(0),
+            delay: StdDuration::from_millis(1),
+        });
+        let state = coalescer_state(backend as StdArc<dyn ContainerBackend>);
+        let spec: Spec = serde_yaml_ng::from_str(
+            "id: capp
+container-image: t:1
+max-replicas: 1",
+        )
+        .unwrap();
+
+        let mk = |st: ReplicaState| Replica {
+            id: ReplicaId(uuid::Uuid::new_v4()),
+            spec_id: "capp".into(),
+            container_id: "c".into(),
+            upstream: "127.0.0.1:1".parse::<SocketAddr>().unwrap(),
+            state: st,
+            started_at: chrono::Utc::now(),
+            sessions_active: 0,
+            sessions_max: 1,
+            host: None,
+        };
+
+        state.replicas.write().await.add(mk(ReplicaState::Failed));
+        assert!(
+            !at_capacity(&state, &spec).await,
+            "a Failed leftover must not count toward the ceiling"
+        );
+        state.replicas.write().await.add(mk(ReplicaState::Ready));
+        assert!(
+            at_capacity(&state, &spec).await,
+            "a live replica does count (max-replicas: 1)"
+        );
+    }
+
+    // #744: X-Forwarded-For handling on the forward. Untrusted (the
+    // default): a client-supplied chain is spoofable and must be
+    // dropped/replaced. Trusted (server.useForwardHeaders): the inbound
+    // chain is preserved (the peer is appended when one exists — under
+    // Router::oneshot there is no TCP peer, so the chain passes as-is).
+    #[tokio::test]
+    async fn xff_dropped_when_untrusted_and_kept_when_trusted() {
+        use tower::ServiceExt;
+
+        for (trusted, expect_xff) in [(false, false), (true, true)] {
+            let (up_addr, mut heads) = capture_upstream().await;
+            let backend = StdArc::new(CountingBackend {
+                spawns: AtomicU32::new(0),
+                delay: StdDuration::from_millis(1),
+            });
+            let mut state = coalescer_state(backend as StdArc<dyn ContainerBackend>);
+            let yaml = if trusted {
+                "server:
+  useForwardHeaders: true
+proxy:
+  specs:
+    - id: x
+      container-image: t:1
+"
+            } else {
+                "proxy:
+  specs:
+    - id: x
+      container-image: t:1
+"
+            };
+            state.config = std::sync::Arc::new(ruscker_config::Config::from_yaml(yaml).unwrap());
+            state.replicas.write().await.add(Replica {
+                id: ReplicaId(uuid::Uuid::new_v4()),
+                spec_id: "x".into(),
+                container_id: "c".into(),
+                upstream: up_addr,
+                state: ReplicaState::Ready,
+                started_at: chrono::Utc::now(),
+                sessions_active: 0,
+                sessions_max: 10,
+                host: None,
+            });
+            let app = Router::new()
+                .merge(routes())
+                .layer(tower_cookies::CookieManagerLayer::new())
+                .with_state(state);
+            let resp = app
+                .oneshot(
+                    Request::builder()
+                        .uri("/app/x/data")
+                        .header("x-forwarded-for", "6.6.6.6")
+                        .body(Body::empty())
+                        .unwrap(),
+                )
+                .await
+                .unwrap();
+            assert_eq!(resp.status(), StatusCode::OK);
+            let head = heads.recv().await.expect("upstream saw the request").to_ascii_lowercase();
+            assert_eq!(
+                head.contains("x-forwarded-for: 6.6.6.6"),
+                expect_xff,
+                "trusted={trusted}: spoofable XFF must only survive when the operator opted in\n{head}"
+            );
         }
     }
 

--- a/crates/ruscker-admin/src/sessions.rs
+++ b/crates/ruscker-admin/src/sessions.rs
@@ -264,15 +264,22 @@ impl SessionStore for InMemorySessionStore {
         if victims.is_empty() {
             return 0;
         }
-        let n = victims.len();
+        let mut evicted = 0;
         {
             let mut reg = registry.write().await;
             for (sid, rid) in &victims {
-                reg.dec_sessions(rid);
-                self.sessions.remove(sid);
+                // Remove first; decrement only when WE removed it. A
+                // concurrent `end_session` (stop-on-logout #337) may have
+                // already evicted this sid and decremented — a second
+                // decrement undercounts the replica's seats and re-opens
+                // the over-admission class #582 closed (#744).
+                if self.sessions.remove(sid).is_some() {
+                    reg.dec_sessions(rid);
+                    evicted += 1;
+                }
             }
         }
-        n
+        evicted
     }
 
     /// Purge every session entry pointing at `replica_id`. Collects the


### PR DESCRIPTION
Fixes #744 — all seven items of the proxy/sessions P3 batch.

## Changes

1. **X-Forwarded-For handled on the forward.** Trusted (`server.useForwardHeaders`): the real peer IP is appended to the inbound chain. Untrusted (default): the spoofable client value is replaced with the peer (or dropped when there's no peer, e.g. under `Router::oneshot`). Upstream apps stop seeing forged chains and finally see the true client.
2. **X-Forwarded-Proto rides the same trust gate** and reads the **rightmost** (trusted-proxy-appended) entry — previously any direct client could flip the sticky/admin cookie's `Secure` flag, and the leftmost slot is client-controlled whenever a proxy appends. `request_is_https(headers, trusted)`; `issue_session_cookie` resolves the flag from state.
3. **`at_capacity` counts only `Starting|Ready|Draining`** — mirrors `spawn_one`'s "live"; a crashed leftover no longer makes the splash claim "full — waiting" while skipping the spawn.
4. **API hot-path `record_access` is spawned**, not awaited — best-effort by contract; inline it added a DB round-trip to every API response and serialized on SQLite's single writer.
5. **Sweep double-decrement race**: `sweep` removes the entry first and decrements only on `Some` — a racing `end_session` (stop-on-logout #337) could decrement the same session twice, re-opening the #582 over-admission class. Returns the actually-evicted count. (The race window itself isn't deterministically testable without injection hooks; the ordering change is the fix.)
6. **`fetch_password` reads env-ref credentials** (empty-nonce form) like `resolve()` instead of erroring `nonce must be 12 bytes, got 0` — was a divergent copy of the storage contract waiting for its first caller.
7. **Legacy non-atomic `images::rename`/`delete_one` deleted** — the `_with_refs` transactions from #729 are the only paths now; a tombstone comment explains why.
8. **argon2id verify/hash on `spawn_blocking`** — a login burst can't stall tokio workers serving proxied traffic; the unknown-username decoy verify keeps its timing-equalizing behaviour.

## Tests

`xff_dropped_when_untrusted_and_kept_when_trusted` (router-level with a head-capturing upstream), `at_capacity_ignores_failed_and_stopped_replicas`, `request_is_https_*` (untrusted-ignored + rightmost-wins + spoofed-leftmost-loses), `fetch_password` env-ref read added to the #351 test.

Gate: `cargo test` (516 green), `clippy --all-targets -- -D warnings` clean, i18n ✓.

## Compat / merge notes

- **Deployments terminating TLS in front of Ruscker must set `server.useForwardHeaders: true`** for cookies to carry `Secure` (ShinyProxy-migrated configs already do — the example config does). Worth one line in the deploy guide at release time.
- Trivial conflict with **#753** (both touch `issue_session_cookie`'s call sites — this PR adds a `state` param, #753 adds a call site). Whichever merges second needs a one-line fixup; I'll rebase.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
