### PR TITLE
fix(admin): cover sanitization, create/edit races, replica audit, import id gate (#745)

### DIFF
--- a/crates/ruscker-admin/assets/i18n/en/landing.ftl
+++ b/crates/ruscker-admin/assets/i18n/en/landing.ftl
@@ -269,6 +269,7 @@ spec-form-error-number = A numeric field has a non-numeric value.
 spec-form-error-cpu = CPU limit must be a positive number (e.g. 0.5).
 spec-form-error-memory = Memory limit must be a size like 512m or 1.5g.
 spec-form-error-replica-range = Max replicas must be greater than or equal to min replicas.
+spec-form-error-stale = Someone else saved this app while you were editing. Review the current values below and submit again.
 
 # Admin image library
 admin-images-title = Media library

--- a/crates/ruscker-admin/assets/i18n/es/landing.ftl
+++ b/crates/ruscker-admin/assets/i18n/es/landing.ftl
@@ -269,6 +269,7 @@ spec-form-error-number = Un campo numérico tiene un valor no numérico.
 spec-form-error-cpu = El límite de CPU debe ser un número positivo (ej.: 0.5).
 spec-form-error-memory = El límite de memoria debe ser un tamaño como 512m o 1.5g.
 spec-form-error-replica-range = Réplicas máx. debe ser mayor o igual que réplicas mín.
+spec-form-error-stale = Otra persona guardó esta app mientras editabas. Revisa los valores actuales abajo y envía de nuevo.
 
 # Admin image library
 admin-images-title = Biblioteca multimedia

--- a/crates/ruscker-admin/assets/i18n/fr/landing.ftl
+++ b/crates/ruscker-admin/assets/i18n/fr/landing.ftl
@@ -269,6 +269,7 @@ spec-form-error-number = Un champ numérique a une valeur non numérique.
 spec-form-error-cpu = La limite CPU doit être un nombre positif (ex. 0.5).
 spec-form-error-memory = La limite mémoire doit être une taille comme 512m ou 1.5g.
 spec-form-error-replica-range = Le max de réplicas doit être supérieur ou égal au min.
+spec-form-error-stale = Une autre personne a enregistré cette app pendant votre édition. Vérifiez les valeurs actuelles ci-dessous et soumettez à nouveau.
 
 # Admin image library
 admin-images-title = Bibliothèque de médias

--- a/crates/ruscker-admin/assets/i18n/pt/landing.ftl
+++ b/crates/ruscker-admin/assets/i18n/pt/landing.ftl
@@ -273,6 +273,7 @@ spec-form-error-number = Um campo numérico tem valor não numérico.
 spec-form-error-cpu = O limite de CPU deve ser um número positivo (ex.: 0.5).
 spec-form-error-memory = O limite de memória deve ser um tamanho como 512m ou 1.5g.
 spec-form-error-replica-range = Réplicas máx. deve ser maior ou igual a réplicas mín.
+spec-form-error-stale = Outra pessoa salvou este app enquanto você editava. Revise os valores atuais abaixo e envie novamente.
 
 # Admin image library
 admin-images-title = Biblioteca de mídia

--- a/crates/ruscker-admin/src/db/audit.rs
+++ b/crates/ruscker-admin/src/db/audit.rs
@@ -127,6 +127,50 @@ const LIST_SELECT: &str =
 /// `query_as` family takes `&'static str` only). All values are
 /// bound through `push_bind`; no string interpolation, no SQL
 /// injection.
+/// Write one standalone audit row — for operational actions that don't
+/// ride a config-mutation transaction (replica stop/restart, #745).
+/// Config mutations keep writing their rows inside their own txs.
+pub async fn record(
+    db: &ConfigDb,
+    actor: &str,
+    action: &str,
+    target: &str,
+    diff_json: Option<&str>,
+) -> Result<()> {
+    let now = Utc::now();
+    match db {
+        ConfigDb::Sqlite(pool) => {
+            sqlx::query(
+                "INSERT INTO audit_log (actor, action, target, diff_json, occurred_at)
+                 VALUES (?, ?, ?, ?, ?)",
+            )
+            .bind(actor)
+            .bind(action)
+            .bind(target)
+            .bind(diff_json)
+            .bind(now)
+            .execute(pool)
+            .await
+            .context("audit record (sqlite)")?;
+        }
+        ConfigDb::Postgres(pool) => {
+            sqlx::query(
+                "INSERT INTO audit_log (actor, action, target, diff_json, occurred_at)
+                 VALUES ($1, $2, $3, $4, $5)",
+            )
+            .bind(actor)
+            .bind(action)
+            .bind(target)
+            .bind(diff_json)
+            .bind(now)
+            .execute(pool)
+            .await
+            .context("audit record (postgres)")?;
+        }
+    }
+    Ok(())
+}
+
 pub async fn list(db: &ConfigDb, filter: &AuditFilter) -> Result<Vec<AuditEntry>> {
     let rows: Vec<ListRow> = match db {
         ConfigDb::Sqlite(pool) => {

--- a/crates/ruscker-admin/src/db/specs.rs
+++ b/crates/ruscker-admin/src/db/specs.rs
@@ -269,6 +269,100 @@ fn upsert_audit_action(outcome: &UpsertOutcome) -> Option<&'static str> {
 /// differ per backend, so the body forks per arm — but each arm reuses
 /// the dialect's `upsert_in_tx*` helper and the shared
 /// [`upsert_audit_action`].
+/// The spec's current `version` counter, or `None` when absent. Powers
+/// the edit form's optimistic-concurrency check (#745).
+pub async fn fetch_version(db: &ConfigDb, id: &str) -> Result<Option<i64>> {
+    let row: Option<(i64,)> = match db {
+        ConfigDb::Sqlite(pool) => sqlx::query_as("SELECT version FROM specs WHERE id = ?")
+            .bind(id)
+            .fetch_optional(pool)
+            .await,
+        ConfigDb::Postgres(pool) => sqlx::query_as("SELECT version FROM specs WHERE id = $1")
+            .bind(id)
+            .fetch_optional(pool)
+            .await,
+    }
+    .with_context(|| format!("fetch version of {id}"))?;
+    Ok(row.map(|(v,)| v))
+}
+
+/// Insert a NEW spec, failing closed when the id already exists (#745).
+/// The create form's pre-check + `upsert_one` was a TOCTOU: two
+/// concurrent creates of the same id both passed the check and the
+/// second silently overwrote the first. The existence check here runs
+/// inside the write transaction, and a racing insert that still slips
+/// past it dies on the primary-key constraint instead of clobbering.
+/// Returns `Ok(false)` when the id is already taken.
+pub async fn insert_new(db: &ConfigDb, spec: &Spec, actor: Option<&str>) -> Result<bool> {
+    let now = Utc::now();
+    let target = format!("spec:{}", spec.id);
+    let is_unique_violation = |e: &anyhow::Error| {
+        e.downcast_ref::<sqlx::Error>()
+            .and_then(|se| se.as_database_error())
+            .is_some_and(|de| de.is_unique_violation())
+    };
+    match db {
+        ConfigDb::Sqlite(pool) => {
+            let mut tx = pool.begin().await.context("begin insert_new tx")?;
+            let exists: Option<(i64,)> =
+                sqlx::query_as("SELECT 1 FROM specs WHERE id = ?")
+                    .bind(&spec.id)
+                    .fetch_optional(&mut *tx)
+                    .await
+                    .context("insert_new existence check")?;
+            if exists.is_some() {
+                return Ok(false);
+            }
+            match upsert_in_tx(&mut tx, spec, now).await {
+                Ok(_) => {}
+                Err(e) if is_unique_violation(&e) => return Ok(false),
+                Err(e) => return Err(e),
+            }
+            sqlx::query(
+                "INSERT INTO audit_log (actor, action, target, diff_json, occurred_at)
+                 VALUES (?, 'spec.create', ?, NULL, ?)",
+            )
+            .bind(actor)
+            .bind(&target)
+            .bind(now)
+            .execute(&mut *tx)
+            .await
+            .context("audit insert_new")?;
+            tx.commit().await.context("commit insert_new tx")?;
+            Ok(true)
+        }
+        ConfigDb::Postgres(pool) => {
+            let mut tx = pool.begin().await.context("begin insert_new tx")?;
+            let exists: Option<(i64,)> =
+                sqlx::query_as("SELECT 1 FROM specs WHERE id = $1")
+                    .bind(&spec.id)
+                    .fetch_optional(&mut *tx)
+                    .await
+                    .context("insert_new existence check")?;
+            if exists.is_some() {
+                return Ok(false);
+            }
+            match upsert_in_tx_pg(&mut tx, spec, now).await {
+                Ok(_) => {}
+                Err(e) if is_unique_violation(&e) => return Ok(false),
+                Err(e) => return Err(e),
+            }
+            sqlx::query(
+                "INSERT INTO audit_log (actor, action, target, diff_json, occurred_at)
+                 VALUES ($1, 'spec.create', $2, NULL, $3)",
+            )
+            .bind(actor)
+            .bind(&target)
+            .bind(now)
+            .execute(&mut *tx)
+            .await
+            .context("audit insert_new")?;
+            tx.commit().await.context("commit insert_new tx")?;
+            Ok(true)
+        }
+    }
+}
+
 pub async fn upsert_one(
     db: &ConfigDb,
     spec: &Spec,
@@ -694,6 +788,53 @@ fn kind_str(spec: &Spec) -> &'static str {
 mod tests {
     use super::*;
     use crate::db::open_memory;
+
+    // #745: the create path must fail CLOSED on an existing id — the old
+    // pre-check + upsert let a concurrent create silently overwrite.
+    #[tokio::test]
+    async fn insert_new_refuses_an_existing_id_without_clobbering() {
+        let db = ConfigDb::Sqlite(open_memory().await.unwrap());
+        let first: Spec =
+            serde_yaml_ng::from_str("id: app
+display-name: Original
+container-image: a:1")
+                .unwrap();
+        assert!(insert_new(&db, &first, Some("alice")).await.unwrap());
+
+        let second: Spec =
+            serde_yaml_ng::from_str("id: app
+display-name: Usurper
+container-image: b:2")
+                .unwrap();
+        assert!(
+            !insert_new(&db, &second, Some("bob")).await.unwrap(),
+            "existing id must be refused"
+        );
+        let kept = fetch_one(&db, "app").await.unwrap().expect("still there");
+        assert_eq!(
+            kept.display_name.as_deref(),
+            Some("Original"),
+            "the loser must not overwrite the original"
+        );
+    }
+
+    // #745: `fetch_version` tracks the per-save counter the edit form's
+    // optimistic-concurrency check compares against.
+    #[tokio::test]
+    async fn fetch_version_follows_saves() {
+        let db = ConfigDb::Sqlite(open_memory().await.unwrap());
+        assert_eq!(fetch_version(&db, "ghost").await.unwrap(), None);
+        let mut spec: Spec =
+            serde_yaml_ng::from_str("id: app
+display-name: V1
+container-image: a:1").unwrap();
+        insert_new(&db, &spec, None).await.unwrap();
+        let v1 = fetch_version(&db, "app").await.unwrap().expect("versioned");
+        spec.display_name = Some("V2".into());
+        upsert_one(&db, &spec, None).await.unwrap();
+        let v2 = fetch_version(&db, "app").await.unwrap().expect("versioned");
+        assert!(v2 > v1, "a save must bump the version ({v1} → {v2})");
+    }
 
     fn fixture_yaml() -> String {
         std::env::set_var("DOCKER_REGISTRY_PASSWORD", "test");

--- a/crates/ruscker-admin/src/routes/admin/dashboard.rs
+++ b/crates/ruscker-admin/src/routes/admin/dashboard.rs
@@ -719,7 +719,7 @@ fn parse_replica_id(s: &str) -> Result<ReplicaId, Box<Response>> {
 /// Redirects back to the dashboard so the browser lands on a
 /// fresh render.
 async fn stop_replica(
-    _: RequireEditor,
+    editor: RequireEditor,
     State(state): State<AppState>,
     Path(replica_id): Path<String>,
 ) -> Response {
@@ -741,8 +741,22 @@ async fn stop_replica(
     // Drop the replica's sessions too, or `len()` stays inflated until
     // the idle sweep (forever under `heartbeat-timeout: -1`) (#324).
     state.sessions.drop_replica(&rid).await;
+    // Destructive operational action → audit row (#745); config
+    // mutations were audited, replica stop/restart only hit the log.
+    record_replica_action(&state, editor.actor(), "replica.stop", &replica_id).await;
     tracing::info!(replica = %replica_id, "replica stopped via dashboard");
     Redirect::to("/admin/dashboard").into_response()
+}
+
+/// Best-effort audit row for a dashboard replica action (#745) — a
+/// missing DB or a write error must not fail the action itself.
+async fn record_replica_action(state: &AppState, actor: &str, action: &str, replica_id: &str) {
+    let Some(db) = state.db.as_ref() else { return };
+    if let Err(e) =
+        crate::db::audit::record(db, actor, action, &format!("replica:{replica_id}"), None).await
+    {
+        tracing::warn!(error = ?e, action, replica = %replica_id, "audit write failed");
+    }
 }
 
 /// POST `/admin/dashboard/replicas/{id}/restart` — stop the
@@ -751,7 +765,7 @@ async fn stop_replica(
 /// respawn ~one tick later), restart brings capacity back
 /// right away.
 async fn restart_replica(
-    _: RequireEditor,
+    editor: RequireEditor,
     State(state): State<AppState>,
     Path(replica_id): Path<String>,
 ) -> Response {
@@ -800,6 +814,7 @@ async fn restart_replica(
         )
             .into_response();
     }
+    record_replica_action(&state, editor.actor(), "replica.restart", &replica_id).await;
     tracing::info!(replica = %replica_id, spec = %spec.id, "replica restarted via dashboard");
     Redirect::to("/admin/dashboard").into_response()
 }

--- a/crates/ruscker-admin/src/routes/admin/spec_form.rs
+++ b/crates/ruscker-admin/src/routes/admin/spec_form.rs
@@ -274,6 +274,12 @@ async fn resolve_pull_creds(
 #[serde(default)]
 pub struct SpecForm {
     pub id: String,
+    /// The spec `version` the edit form was rendered against (#745) —
+    /// optimistic concurrency: a submit whose base is stale (someone
+    /// else saved meanwhile) is rejected instead of last-write-wins.
+    /// Empty on the create form and on pre-#745 tabs (check skipped).
+    #[serde(default)]
+    pub base_version: String,
     pub display_name: String,
     pub description: String,
     /// "app" | "talk" | "report" | "package" | "api" | "link"
@@ -406,6 +412,7 @@ impl SpecForm {
         let dt = DisplayType::from_spec(spec);
         Self {
             id: spec.id.clone(),
+            base_version: String::new(),
             display_name: spec.display_name.clone().unwrap_or_default(),
             description: spec.description.clone().unwrap_or_default(),
             display_type: dt.key().to_string(),
@@ -924,7 +931,7 @@ fn placement_to_key(p: Placement) -> String {
     }
     .into()
 }
-fn is_kebab_id(s: &str) -> bool {
+pub(crate) fn is_kebab_id(s: &str) -> bool {
     !s.is_empty()
         && s.chars().all(|c| c.is_ascii_alphanumeric() || c == '_' || c == '-')
         && s.chars()
@@ -1139,7 +1146,18 @@ async fn edit_form(
         nav_section: "specs",
         role: editor.role,
         mode: FormMode::Edit,
-        form: SpecForm::from_spec(&spec),
+        form: {
+            let mut f = SpecForm::from_spec(&spec);
+            // Optimistic-concurrency token (#745): the template emits it
+            // as a hidden field; `update` rejects a stale submit.
+            f.base_version = db::specs::fetch_version(pool, &id)
+                .await
+                .ok()
+                .flatten()
+                .map(|v| v.to_string())
+                .unwrap_or_default();
+            f
+        },
         errors: Vec::new(),
         logo_images: logo_filenames(&state).await,
         available_groups: group_names(&state).await,
@@ -1262,8 +1280,23 @@ async fn create(
         }
     };
 
-    match db::specs::upsert_one(pool, &spec, Some(editor.actor())).await {
-        Ok(_) => Redirect::to(&format!("/admin/specs/{}/edit", id)).into_response(),
+    // insert_new fails CLOSED on an existing id (#745) — the friendly
+    // pre-check above is just UX; this is the race-proof gate (the old
+    // upsert silently overwrote the loser of a concurrent create).
+    match db::specs::insert_new(pool, &spec, Some(editor.actor())).await {
+        Ok(true) => Redirect::to(&format!("/admin/specs/{}/edit", id)).into_response(),
+        Ok(false) => {
+            render_form_with_errors(
+                &state,
+                loc,
+                theme,
+                editor.role,
+                FormMode::New,
+                SpecForm::from_spec(&spec),
+                vec!["spec-form-error-id-duplicate"],
+            )
+            .await
+        }
         Err(e) => {
             tracing::error!(error = ?e, "save failed");
             (StatusCode::INTERNAL_SERVER_ERROR, "save failed").into_response()
@@ -1318,6 +1351,29 @@ async fn update(
     // since-deleted spec). #261
     if base.is_none() {
         return (StatusCode::NOT_FOUND, format!("spec `{id}` not found")).into_response();
+    }
+
+    // Optimistic concurrency (#745): the form carries the version it
+    // was rendered against; if someone saved meanwhile, re-render with
+    // a conflict error instead of silently last-write-winning over
+    // their changes. An empty token (create form / pre-#745 tab) skips
+    // the check.
+    if let Ok(submitted) = form.base_version.trim().parse::<i64>() {
+        let current = db::specs::fetch_version(pool, &id).await.ok().flatten();
+        if current.is_some_and(|v| v != submitted) {
+            let mut stale = form;
+            stale.base_version = current.map(|v| v.to_string()).unwrap_or_default();
+            return render_form_with_errors(
+                &state,
+                loc,
+                theme,
+                editor.role,
+                FormMode::Edit,
+                stale,
+                vec!["spec-form-error-stale"],
+            )
+            .await;
+        }
     }
 
     let spec = match form.into_spec(base.as_ref(), editor.role) {

--- a/crates/ruscker-admin/src/routes/admin/specs.rs
+++ b/crates/ruscker-admin/src/routes/admin/specs.rs
@@ -632,6 +632,15 @@ async fn import_confirm(
         return Redirect::to("/admin/specs?import=ok&created=0&updated=0&unchanged=0&warnings=0")
             .into_response();
     }
+    // #745: the interactive form enforces the id shape; the import path
+    // persisted whatever ids the YAML carried (they flow into /app/{id}
+    // routes, admin links and docker labels). Same gate on both
+    // creation paths, fail closed.
+    if let Some(bad) = ids.iter().find(|id| !super::spec_form::is_kebab_id(id)) {
+        return redirect_err(&format!(
+            "invalid spec id `{bad}` — ids must start with a letter and use only letters, digits, '_' and '-'"
+        ));
+    }
     let mut config = match ruscker_config::Config::from_yaml(&raw) {
         Ok(c) => c,
         Err(e) => return redirect_err(&format!("YAML parse failed: {e}")),

--- a/crates/ruscker-admin/src/view_model.rs
+++ b/crates/ruscker-admin/src/view_model.rs
@@ -271,6 +271,13 @@ impl<'a> CardCtx<'a> {
         let cover = tp
             .get_str("cover")
             .filter(|s| !s.trim().is_empty())
+            // #745: `accent` below is gated by `is_css_color`, but an
+            // explicit cover was rendered verbatim into the card's
+            // inline `style` — same-element CSS injection for an
+            // Editor. Covers are looser than plain colours (gradients,
+            // legacy `url(...)` paths), so this is a blocklist of the
+            // breakout chars rather than `is_css_color`.
+            .filter(|s| is_safe_cover_value(s))
             .map(|c| prefix_css_asset_urls(c, base))
             .or_else(|| {
                 tp.get_str("accent")
@@ -362,6 +369,21 @@ fn prefix_css_asset_urls(value: &str, base: &str) -> String {
 /// inside a function call rather than a bare declaration, so a stray
 /// `)`/`;`/`<` would corrupt the cover. Hex, `rgb()/hsl()`, and bare
 /// colour keywords all pass.
+/// A card-cover CSS value that cannot break out of its inline
+/// `background:` declaration — no `;` (extra properties), `{}`/`<>`
+/// (style/markup contexts) or backslash (CSS escapes). Looser than
+/// [`is_css_color`] on purpose: covers legitimately carry `/`, `:`
+/// and quotes (gradients with positions, legacy
+/// `url('/assets/img/…')`). Quotes are fine here — Askama
+/// entity-escapes them in the attribute, and inside CSS they can
+/// only open a string, never terminate the declaration.
+fn is_safe_cover_value(s: &str) -> bool {
+    !s.trim().is_empty()
+        && !s
+            .chars()
+            .any(|c| matches!(c, ';' | '{' | '}' | '<' | '>' | '\\'))
+}
+
 fn is_css_color(s: &str) -> bool {
     !s.is_empty()
         && s.chars().all(|c| {
@@ -648,6 +670,28 @@ mod tests {
         assert!(
             !CardCtx::from_spec(&restricted, "").access_open,
             "access-groups present ⇒ restricted"
+        );
+    }
+
+    // #745: an explicit cover is sanitized — `accent` already was, but
+    // a cover went verbatim into the card's inline style (same-element
+    // CSS injection for an Editor). Legit shapes survive.
+    #[test]
+    fn cover_blocklist_rejects_declaration_breakout_keeps_legit_values() {
+        let inj = spec_with_tp("  cover: \"red; background-image: url(//evil)\"\n");
+        assert_eq!(
+            CardCtx::from_spec(&inj, "").cover,
+            None,
+            "a `;` smuggling extra declarations must be dropped"
+        );
+        let grad = spec_with_tp(
+            "  cover: \"linear-gradient(135deg, #0f6e56 0%, #5dcaa5 100%)\"\n",
+        );
+        assert!(CardCtx::from_spec(&grad, "").cover.is_some(), "gradients pass");
+        let legacy = spec_with_tp("  cover: \"url('/assets/img/c.png')\"\n");
+        assert!(
+            CardCtx::from_spec(&legacy, "").cover.is_some(),
+            "legacy quoted url() covers pass"
         );
     }
 

--- a/crates/ruscker-admin/templates/admin/spec_form.html
+++ b/crates/ruscker-admin/templates/admin/spec_form.html
@@ -58,6 +58,9 @@
           action="{{ base }}{% if mode.is_new() %}/admin/specs{% else %}/admin/specs/{{ form.id }}{% endif %}"
           class="spec-form-fields"
           autocomplete="off">
+      {# Optimistic-concurrency token (#745) — `update` rejects a submit
+         whose base version is stale (someone saved meanwhile). #}
+      <input type="hidden" name="base_version" value="{{ form.base_version }}">
 
       {# ── Card: Identity — id + name + subject ───────────────── #}
       <section class="editor-card">


### PR DESCRIPTION
Fixes #745 — all five items of the admin-routes P3 batch.

## Changes

1. **`template-properties.cover` sanitized** (`view_model.rs`): a blocklist of the declaration-breakout chars (`; { } < > \`) before the value lands in the card's inline `style`. Deliberately looser than `is_css_color` (which gates `accent`): covers legitimately carry `/`, `:` and quoted `url()` paths — gradients and the #729-preserved legacy covers keep working (test covers all three shapes).
2. **Spec create fails closed** — new `db::specs::insert_new`: existence check inside the write transaction, and a racing insert that still slips past dies on the PK constraint and is reported as "duplicate" instead of silently overwriting (the old pre-check + `upsert_one` was a TOCTOU). The friendly pre-check stays as UX.
3. **Spec edit optimistic concurrency** — the form carries a hidden `base_version` (threaded by `edit_form` via the new `fetch_version`); `update` rejects a stale submit with a localized `spec-form-error-stale` banner (en/pt/es/fr) re-rendering the user's input, instead of last-write-wins wiping the other editor's changes. An empty token (open pre-deploy tabs) skips the check gracefully.
4. **Replica stop/restart audited** — new standalone `db::audit::record` (both dialects); `replica.stop` / `replica.restart` rows carry the session actor. Best-effort: an audit write failure never fails the action.
5. **Import id gate** — `import_confirm` enforces `is_kebab_id` on every selected id, matching the form path (ids flow into `/app/{id}` routing, admin links and docker labels).

## Tests

`insert_new_refuses_an_existing_id_without_clobbering` (the loser must not overwrite), `fetch_version_follows_saves`, `cover_blocklist_rejects_declaration_breakout_keeps_legit_values` (injection dropped; gradient + legacy quoted `url()` pass).

Gate: `cargo test` all green, `clippy --all-targets -- -D warnings` clean, i18n ✓ (new key in all four locales).

## Smoke

Two-tab edit on the lab box: open the same app's form in two tabs, save in one, save in the other → the second gets the conflict banner with its input intact.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
