### PR TITLE
fix(admin,ux): picker a11y, localized strings, search/flash/keyboard consistency (#746)

### DIFF
--- a/crates/ruscker-admin/assets/i18n/en/landing.ftl
+++ b/crates/ruscker-admin/assets/i18n/en/landing.ftl
@@ -261,6 +261,7 @@ spec-form-actions = Actions
 spec-form-delete = Delete app
 spec-form-delete-confirm = Are you sure? This cannot be undone.
 
+spec-form-env-key = KEY
 spec-form-error-id-required = ID is required.
 spec-form-error-id-shape = ID must start with a letter and contain only letters, digits, "_" and "-".
 spec-form-error-id-duplicate = An app with that ID already exists.
@@ -403,6 +404,7 @@ search-shortcut = ⌘ K
 
 filter-subject-label = Subject
 filter-subject-all = All subjects
+filter-status-label = Status
 filter-status-active = Active only
 filter-status-all = Active and inactive
 filter-status-inactive-only = Inactive only

--- a/crates/ruscker-admin/assets/i18n/es/landing.ftl
+++ b/crates/ruscker-admin/assets/i18n/es/landing.ftl
@@ -261,6 +261,7 @@ spec-form-actions = Acciones
 spec-form-delete = Eliminar aplicación
 spec-form-delete-confirm = ¿Está seguro? Esto no se puede deshacer.
 
+spec-form-env-key = CLAVE
 spec-form-error-id-required = El ID es obligatorio.
 spec-form-error-id-shape = El ID debe empezar con una letra y contener solo letras, números, "_" y "-".
 spec-form-error-id-duplicate = Ya existe una aplicación con ese ID.
@@ -403,6 +404,7 @@ search-shortcut = ⌘ K
 
 filter-subject-label = Asunto
 filter-subject-all = Todos los asuntos
+filter-status-label = Estado
 filter-status-active = Solo activos
 filter-status-all = Activos e inactivos
 filter-status-inactive-only = Solo inactivos

--- a/crates/ruscker-admin/assets/i18n/fr/landing.ftl
+++ b/crates/ruscker-admin/assets/i18n/fr/landing.ftl
@@ -261,6 +261,7 @@ spec-form-actions = Actions
 spec-form-delete = Supprimer l'application
 spec-form-delete-confirm = Êtes-vous sûr ? Cette action est irréversible.
 
+spec-form-env-key = CLÉ
 spec-form-error-id-required = L'ID est obligatoire.
 spec-form-error-id-shape = L'ID doit commencer par une lettre et contenir uniquement lettres, chiffres, "_" et "-".
 spec-form-error-id-duplicate = Une application avec cet ID existe déjà.
@@ -403,6 +404,7 @@ search-shortcut = ⌘ K
 
 filter-subject-label = Sujet
 filter-subject-all = Tous les sujets
+filter-status-label = Statut
 filter-status-active = Actifs uniquement
 filter-status-all = Actifs et inactifs
 filter-status-inactive-only = Inactifs uniquement

--- a/crates/ruscker-admin/assets/i18n/pt/landing.ftl
+++ b/crates/ruscker-admin/assets/i18n/pt/landing.ftl
@@ -265,6 +265,7 @@ spec-form-actions = Ações
 spec-form-delete = Excluir aplicação
 spec-form-delete-confirm = Tem certeza? Esta ação não pode ser desfeita.
 
+spec-form-env-key = CHAVE
 spec-form-error-id-required = ID é obrigatório.
 spec-form-error-id-shape = ID deve começar com letra e conter apenas letras, números, "_" e "-".
 spec-form-error-id-duplicate = Já existe uma aplicação com esse ID.
@@ -407,6 +408,7 @@ search-shortcut = ⌘ K
 
 filter-subject-label = Assunto
 filter-subject-all = Todos os assuntos
+filter-status-label = Situação
 filter-status-active = Apenas ativos
 filter-status-all = Ativos e inativos
 filter-status-inactive-only = Apenas inativos

--- a/crates/ruscker-admin/src/routes/admin/spec_form.rs
+++ b/crates/ruscker-admin/src/routes/admin/spec_form.rs
@@ -975,6 +975,11 @@ struct SpecFormPage<'a> {
     /// Filenames in the media library, for the logo picker. Empty
     /// when no DB is wired or the listing fails.
     logo_images: Vec<String>,
+    /// Distinct subjects already used across the catalog, for the
+    /// subject `<datalist>` (#746) — replaces a hardcoded pt-BR list
+    /// that shipped domain-specific suggestions to every deployment
+    /// and locale.
+    subject_suggestions: Vec<String>,
     /// Names of stored registry credentials, for the
     /// `docker-registry-credential` datalist (#351). Empty when no DB
     /// is wired or the listing fails — the field stays free-text.
@@ -1042,6 +1047,21 @@ impl<'a> SpecFormPage<'a> {
 
 /// Media-library filenames for the logo picker. Empty when no DB is
 /// wired or the query fails — the picker degrades to the text field.
+/// Distinct, sorted `template-properties.subject` values across the
+/// effective catalog (#746) — real data instead of a fixed list.
+async fn subject_suggestions(state: &AppState) -> Vec<String> {
+    let specs = crate::catalog::effective_specs(state.db.as_ref(), &state.config).await;
+    let mut subjects: Vec<String> = specs
+        .iter()
+        .filter_map(|sp| sp.template_properties.get_str("subject"))
+        .map(|t| t.trim().to_string())
+        .filter(|t| !t.is_empty())
+        .collect();
+    subjects.sort();
+    subjects.dedup();
+    subjects
+}
+
 async fn logo_filenames(state: &AppState) -> Vec<String> {
     match state.db.as_ref() {
         Some(pool) => db::images::list_all(pool)
@@ -1113,6 +1133,7 @@ async fn new_form(
         },
         errors: Vec::new(),
         logo_images: logo_filenames(&state).await,
+        subject_suggestions: subject_suggestions(&state).await,
         available_groups: group_names(&state).await,
         credential_names: credential_names(&state).await,
     };
@@ -1160,6 +1181,7 @@ async fn edit_form(
         },
         errors: Vec::new(),
         logo_images: logo_filenames(&state).await,
+        subject_suggestions: subject_suggestions(&state).await,
         available_groups: group_names(&state).await,
         credential_names: credential_names(&state).await,
     };
@@ -1227,6 +1249,7 @@ async fn duplicate_form(
         form,
         errors: Vec::new(),
         logo_images: logo_filenames(&state).await,
+        subject_suggestions: subject_suggestions(&state).await,
         available_groups: group_names(&state).await,
         credential_names: credential_names(&state).await,
     };
@@ -1437,6 +1460,7 @@ async fn render_form_with_errors(
         form,
         errors,
         logo_images: logo_filenames(state).await,
+        subject_suggestions: subject_suggestions(state).await,
         available_groups: group_names(state).await,
         credential_names: credential_names(state).await,
     };

--- a/crates/ruscker-admin/templates/admin/_layout.html
+++ b/crates/ruscker-admin/templates/admin/_layout.html
@@ -207,6 +207,19 @@ window.ruscker.imagePicker = (filenames) => ({
   picker: { open: false, q: '' },
   imgUploading: false,
   imgError: '',
+  // Dialog a11y shared by every picker modal (#746): the element that
+  // opened the modal (focus returns to it on close) and a Tab trap.
+  // Living on the mixin keeps the spec-form and landing copies from
+  // forking on a11y again (the #720 fixes only reached one of them).
+  _pickerTrigger: null,
+  trapPickerTab(e) {
+    const sel = 'a[href],button:not([disabled]),input:not([disabled]),[tabindex]:not([tabindex="-1"])';
+    const f = Array.from(e.currentTarget.querySelectorAll(sel)).filter((el) => el.offsetParent !== null);
+    if (!f.length) return;
+    const first = f[0], last = f[f.length - 1];
+    if (e.shiftKey && document.activeElement === first) { e.preventDefault(); last.focus(); }
+    else if (!e.shiftKey && document.activeElement === last) { e.preventDefault(); first.focus(); }
+  },
   // Set by openImagePicker: where a pick goes, and the current value (to
   // highlight its tile). Underscored so they don't collide with caller
   // state when spread.
@@ -382,50 +395,67 @@ window.ruscker.imagePicker = (filenames) => ({
       return c.dataset.sortValue !== undefined ? c.dataset.sortValue : c.textContent.trim();
     }
 
-    // search toolbar
-    var wrap = document.createElement('div');
-    wrap.className = 'admin-table-toolbar';
-    var input = document.createElement('input');
-    input.type = 'search';
-    input.className = 'admin-table-search';
-    input.setAttribute('aria-label', I18N.search);
-    input.placeholder = I18N.search;
-    wrap.appendChild(input);
-    table.parentNode.insertBefore(wrap, table);
+    // search toolbar — skipped when the page brings its own search
+    // (`data-no-search`): the Apps page's sticky toolbar pill and the
+    // injected input filtered the same rows through two different
+    // mechanisms with contradictory results (#746).
+    if (!table.hasAttribute('data-no-search')) {
+      var wrap = document.createElement('div');
+      wrap.className = 'admin-table-toolbar';
+      var input = document.createElement('input');
+      input.type = 'search';
+      input.className = 'admin-table-search';
+      input.setAttribute('aria-label', I18N.search);
+      input.placeholder = I18N.search;
+      wrap.appendChild(input);
+      table.parentNode.insertBefore(wrap, table);
 
-    // empty-state row
-    var emptyRow = document.createElement('tr');
-    emptyRow.dataset.tableEmpty = '1';
-    emptyRow.style.display = 'none';
-    var emptyCell = document.createElement('td');
-    emptyCell.colSpan = headRow.cells.length;
-    emptyCell.className = 'admin-table-empty';
-    emptyCell.textContent = I18N.noResults;
-    emptyRow.appendChild(emptyCell);
-    tbody.appendChild(emptyRow);
+      // empty-state row
+      var emptyRow = document.createElement('tr');
+      emptyRow.dataset.tableEmpty = '1';
+      emptyRow.style.display = 'none';
+      var emptyCell = document.createElement('td');
+      emptyCell.colSpan = headRow.cells.length;
+      emptyCell.className = 'admin-table-empty';
+      emptyCell.textContent = I18N.noResults;
+      emptyRow.appendChild(emptyCell);
+      tbody.appendChild(emptyRow);
 
-    function applyFilter() {
-      var q = input.value.trim().toLowerCase(), visible = 0;
-      dataRows().forEach(function (r) {
-        var match = !q || r.textContent.toLowerCase().indexOf(q) !== -1;
-        r.style.display = match ? '' : 'none';
-        if (match) visible++;
-      });
-      emptyRow.style.display = visible ? 'none' : '';
+      var applyFilter = function () {
+        var q = input.value.trim().toLowerCase(), visible = 0;
+        dataRows().forEach(function (r) {
+          var match = !q || r.textContent.toLowerCase().indexOf(q) !== -1;
+          r.style.display = match ? '' : 'none';
+          if (match) visible++;
+        });
+        emptyRow.style.display = visible ? 'none' : '';
+      };
+      input.addEventListener('input', applyFilter);
     }
-    input.addEventListener('input', applyFilter);
 
-    // sortable headers
+    // sortable headers — keyboard-reachable (#746): tabbable, Enter/
+    // Space sorts, and aria-sort announces the direction instead of
+    // the glyph-only cue.
     Array.prototype.forEach.call(headRow.cells, function (th, idx) {
       if (th.hasAttribute('data-nosort')) return;
       th.classList.add('admin-th-sort');
-      th.addEventListener('click', function () {
+      th.setAttribute('tabindex', '0');
+      th.setAttribute('role', 'columnheader');
+      var doSort = function () {
         var asc = th.dataset.sortDir !== 'asc';
-        Array.prototype.forEach.call(headRow.cells, function (h) { if (h !== th) delete h.dataset.sortDir; });
+        Array.prototype.forEach.call(headRow.cells, function (h) {
+          if (h !== th) { delete h.dataset.sortDir; h.removeAttribute('aria-sort'); }
+        });
         th.dataset.sortDir = asc ? 'asc' : 'desc';
+        th.setAttribute('aria-sort', asc ? 'ascending' : 'descending');
+        var anchor = tbody.querySelector('[data-table-empty]');
         dataRows()
           .sort(function (a, b) { return compare(cellVal(a, idx), cellVal(b, idx)) * (asc ? 1 : -1); })
-          .forEach(function (r) { tbody.insertBefore(r, emptyRow); });
+          .forEach(function (r) { anchor ? tbody.insertBefore(r, anchor) : tbody.appendChild(r); });
+      };
+      th.addEventListener('click', doSort);
+      th.addEventListener('keydown', function (e) {
+        if (e.key === 'Enter' || e.key === ' ') { e.preventDefault(); doSort(); }
       });
     });
   }

--- a/crates/ruscker-admin/templates/admin/audit.html
+++ b/crates/ruscker-admin/templates/admin/audit.html
@@ -83,7 +83,13 @@
       </thead>
       <tbody>
         {% for e in entries %}
-        <tr{% if e.diff.is_some() %} @click="toggle({{ e.id }})" style="cursor:pointer"{% endif %}>
+        {# Diff rows are toggleable — keyboard-reachable like the
+           dashboard group heads (#746): tabbable, Enter/Space toggles,
+           aria-expanded announces state. #}
+        <tr{% if e.diff.is_some() %} @click="toggle({{ e.id }})"
+            @keydown.enter.prevent="toggle({{ e.id }})" @keydown.space.prevent="toggle({{ e.id }})"
+            tabindex="0" role="button" :aria-expanded="open === {{ e.id }} ? 'true' : 'false'"
+            style="cursor:pointer"{% endif %}>
           <td class="dash-mono text-[color:var(--text-faint)]" style="white-space:nowrap">{{ e.occurred_at.format("%d/%m/%Y %H:%M:%S") }}</td>
           <td>
             <span class="user-cell">

--- a/crates/ruscker-admin/templates/admin/disk.html
+++ b/crates/ruscker-admin/templates/admin/disk.html
@@ -10,12 +10,20 @@
   </div>
 </div>
 
+{# Flash split (#746) — see groups/users: persistent role="alert"
+   errors, toastable role="status" successes; no colour-only state. #}
 {% if let Some(f) = flash %}
-  <div class="admin-login-error mb-3" role="status"
-       style="{% if flash_error %}{% else %}background:rgba(29,158,117,0.12);color:var(--text-primary){% endif %}">
-    <i class="ti ti-info-circle" aria-hidden="true"></i>
+  {% if flash_error %}
+  <div class="admin-login-error mb-3" role="alert">
+    <i class="ti ti-alert-circle" aria-hidden="true"></i>
     {{ self.t(f) }}
   </div>
+  {% else %}
+  <div class="admin-flash-ok mb-3" role="status">
+    <i class="ti ti-check" aria-hidden="true"></i>
+    {{ self.t(f) }}
+  </div>
+  {% endif %}
 {% endif %}
 
 {% if !available %}

--- a/crates/ruscker-admin/templates/admin/groups.html
+++ b/crates/ruscker-admin/templates/admin/groups.html
@@ -12,15 +12,26 @@
   <div class="text-xs text-[color:var(--text-faint)]">{{ groups.len() }}</div>
 </div>
 
+{# Flash split (#746): an error is a PERSISTENT inline banner with
+   role="alert" — the old single .admin-flash-ok class made the layout
+   promote even errors into a 4s auto-dismissing toast, announced only
+   politely. Successes keep the toastable class. Matches images/
+   credentials/landing. #}
 {% match flash %}{% when Some with (f) %}
-  <div class="admin-flash-ok mb-4" role="status" style="{% if f == "bad-input" %}background:rgba(239,68,68,0.12);color:var(--text-primary){% endif %}">
-    <i class="ti ti-{% if f == "bad-input" %}alert-circle{% else %}check{% endif %}" aria-hidden="true"></i>
+  {% if f == "bad-input" %}
+  <div class="admin-login-error mb-4" role="alert">
+    <i class="ti ti-alert-circle" aria-hidden="true"></i>
+    {{ self.t("admin-groups-flash-bad-input") }}
+  </div>
+  {% else %}
+  <div class="admin-flash-ok mb-4" role="status">
+    <i class="ti ti-check" aria-hidden="true"></i>
     {% if f == "renamed" %}{{ self.t("admin-groups-flash-renamed") }}
     {% else if f == "deleted" %}{{ self.t("admin-groups-flash-deleted") }}
     {% else if f == "member-added" %}{{ self.t("admin-groups-flash-member-added") }}
-    {% else if f == "member-removed" %}{{ self.t("admin-groups-flash-member-removed") }}
-    {% else %}{{ self.t("admin-groups-flash-bad-input") }}{% endif %}
+    {% else %}{{ self.t("admin-groups-flash-member-removed") }}{% endif %}
   </div>
+  {% endif %}
 {% when None %}{% endmatch %}
 
 {# Create a group: a group exists once a user belongs to it, so "create" =

--- a/crates/ruscker-admin/templates/admin/landing.html
+++ b/crates/ruscker-admin/templates/admin/landing.html
@@ -723,7 +723,8 @@
 
         <div class="landing-preview-body">
           <p class="landing-preview-intro"
-             x-text="previewIntro()"
+             x-text="previewIntro() || $el.dataset.placeholder"
+             data-placeholder="{{ self.t("admin-landing-preview-empty") }}"
              :class="!previewIntro() ? 'opacity-40 italic' : ''"></p>
           {# Search pill + filter chips honour the Visible-sections toggles. #}
           <div class="landing-preview-mockfilter" x-show="!!form.show_search" x-cloak><i class="ti ti-search" aria-hidden="true"></i><span class="lp-search-ph"></span></div>
@@ -800,15 +801,24 @@
      and without the teleport the modal renders centered in the (tall)
      page instead of the screen. #}
   <template x-teleport="body">
+  {# Same dialog a11y as the spec-form picker (#746): focus moves to the
+     search on open, returns to the trigger on close, Tab is trapped. #}
   <div x-show="picker.open" x-cloak class="image-picker-overlay"
+       x-init="$watch('picker.open', open => {
+                 if (open) { _pickerTrigger = document.activeElement;
+                   $nextTick(() => $refs.landingPickerSearch && $refs.landingPickerSearch.focus()); }
+                 else if (_pickerTrigger && _pickerTrigger.focus) { _pickerTrigger.focus(); } })"
        @keydown.escape.window="picker.open = false" @click.self="picker.open = false">
-    <div class="image-picker-modal">
+    <div class="image-picker-modal" role="dialog" aria-modal="true"
+         aria-labelledby="landing-picker-title" @keydown.tab="trapPickerTab($event)">
       <div class="image-picker-head">
-        <strong>{{ self.t("spec-form-choose-image") }}</strong>
-        <button type="button" class="admin-nav-link" @click="picker.open = false"><i class="ti ti-x" aria-hidden="true"></i></button>
+        <strong id="landing-picker-title">{{ self.t("spec-form-choose-image") }}</strong>
+        <button type="button" class="admin-nav-link" @click="picker.open = false"
+                aria-label="{{ self.t("admin-import-cancel") }}"><i class="ti ti-x" aria-hidden="true"></i></button>
       </div>
       <div class="image-picker-tools">
-        <input type="search" x-model="picker.q" placeholder="{{ self.t("admin-images-search") }}"
+        <input type="search" x-ref="landingPickerSearch" x-model="picker.q" placeholder="{{ self.t("admin-images-search") }}"
+               aria-label="{{ self.t("admin-images-search") }}"
                class="spec-form-input text-sm" style="max-width:16rem">
         <label class="admin-login-btn" style="cursor:pointer;padding:6px 12px;font-size:12px"
                :class="imgUploading ? 'opacity-50 pointer-events-none' : ''">
@@ -878,13 +888,17 @@ window.ruscker.landingForm = (initial, logoImages) => ({
       this.applyGrad();
     }
   },
-  // Switching to gradient mode seeds header_bg from the builder
-  // so the preview updates immediately; switching to solid clears
-  // the gradient string so the color picker drives a fresh value.
+  // Switching to gradient mode seeds header_bg from the builder so
+  // the preview updates immediately. 'solid' mirrors the v0.2.2 seed
+  // fix the cover builders got (#746): keep an existing solid hex,
+  // replace a gradient with a seeded colour — the old `header_bg = ''`
+  // both left the preview inert until the picker was dragged AND
+  // silently wiped a saved gradient the moment Solid was clicked.
   setBgMode(mode) {
     this.bgMode = mode;
-    if (mode === 'gradient') this.applyGrad();
-    else this.form.header_bg = '';
+    if (mode === 'gradient') { this.applyGrad(); return; }
+    const c = (this.form.header_bg || '').trim();
+    if (!c || /^(linear|radial)-gradient\(/.test(c)) this.form.header_bg = '#0f6e56';
   },
 
   // ── Default card-cover builder (#720) — a parallel solid/gradient
@@ -929,8 +943,10 @@ window.ruscker.landingForm = (initial, logoImages) => ({
   previewIntro() {
     const code = "{{ locale.code() }}";
     const per = { pt: this.form.intro_pt, en: this.form.intro_en, es: this.form.intro_es, fr: this.form.intro_fr };
-    return (per[code] || this.form.intro || "").trim()
-        || "{{ self.t("admin-landing-preview-empty") }}";
+    // Empty stays empty (#746): the template shows a dimmed placeholder
+    // for the no-intro case — baking the fallback text in here made the
+    // `:class` dimming dead code, so the placeholder read as real text.
+    return (per[code] || this.form.intro || "").trim();
   },
 
   // ── Live-preview resolvers (#701 follow-up) ───────────────────

--- a/crates/ruscker-admin/templates/admin/spec_form.html
+++ b/crates/ruscker-admin/templates/admin/spec_form.html
@@ -103,12 +103,13 @@
                  x-model="form.subject"
                  list="subject-suggestions"
                  class="spec-form-input">
+          {# Suggestions come from the catalog's existing subjects (#746)
+             — a fixed pt-BR list shipped domain-specific values to every
+             deployment and locale. #}
           <datalist id="subject-suggestions">
-            <option value="Gestão"></option>
-            <option value="Infraestrutura e Mobilidade"></option>
-            <option value="Políticas Públicas"></option>
-            <option value="Saúde Pública"></option>
-            <option value="Segurança Pública"></option>
+            {% for subj in subject_suggestions %}
+            <option value="{{ subj }}"></option>
+            {% endfor %}
           </datalist>
         </div>
       </section>
@@ -661,7 +662,7 @@
             <div style="display:flex;flex-direction:column;gap:7px">
               <template x-for="(row, i) in envRows" :key="i">
                 <div class="env-row">
-                  <input type="text" class="spec-form-input spec-form-input--mono" placeholder="CHAVE"
+                  <input type="text" class="spec-form-input spec-form-input--mono" placeholder="{{ self.t("spec-form-env-key") }}"
                          x-model="row.key" @input="row.key = row.key.toUpperCase().replace(/[^A-Z0-9_]/g, '_'); envSync()">
                   <span class="env-eq">=</span>
                   <input type="text" class="spec-form-input spec-form-input--mono" placeholder="{{ self.t("spec-form-env-value") }}"
@@ -1052,12 +1053,12 @@
   <template x-teleport="body">
   <div x-show="picker.open" x-cloak class="image-picker-overlay"
        x-init="$watch('picker.open', open => {
-                 if (open) { _logoTrigger = document.activeElement;
+                 if (open) { _pickerTrigger = document.activeElement;
                    $nextTick(() => $refs.logoSearch && $refs.logoSearch.focus()); }
-                 else if (_logoTrigger && _logoTrigger.focus) { _logoTrigger.focus(); } })"
+                 else if (_pickerTrigger && _pickerTrigger.focus) { _pickerTrigger.focus(); } })"
        @keydown.escape.window="picker.open = false" @click.self="picker.open = false">
     <div class="image-picker-modal" role="dialog" aria-modal="true"
-         aria-labelledby="logo-picker-title" @keydown.tab="trapLogoTab($event)">
+         aria-labelledby="logo-picker-title" @keydown.tab="trapPickerTab($event)">
       <div class="image-picker-head">
         <strong id="logo-picker-title">{{ self.t("spec-form-logo") }}</strong>
         <button type="button" class="admin-nav-link" @click="picker.open = false"
@@ -1240,16 +1241,8 @@ window.ruscker.specForm = (initial, logoImages, availableGroups) => ({
   // ── Logo modal accessibility (#720 P7) ───────────────────────────
   // Remembers what had focus before the dialog opened, so it can be
   // restored on close (set by the $watch in the modal's x-init).
-  _logoTrigger: null,
-  // Focus trap: keep Tab/Shift+Tab inside the dialog while it's open.
-  trapLogoTab(e) {
-    const sel = 'a[href],button:not([disabled]),input:not([disabled]),[tabindex]:not([tabindex="-1"])';
-    const f = Array.from(e.currentTarget.querySelectorAll(sel)).filter((el) => el.offsetParent !== null);
-    if (!f.length) return;
-    const first = f[0], last = f[f.length - 1];
-    if (e.shiftKey && document.activeElement === first) { e.preventDefault(); last.focus(); }
-    else if (!e.shiftKey && document.activeElement === last) { e.preventDefault(); first.focus(); }
-  },
+  // Focus trap + trigger tracking now live on the shared imagePicker
+  // mixin (#746) — both picker modals use the same dialog a11y.
   // Cover background for the preview. `form.cover` is a CSS value that
   // may embed `url('/assets/img/x')`; prefix the base path on those
   // root-absolute asset URLs for *display only* (#270). The submitted
@@ -1338,13 +1331,17 @@ window.ruscker.specForm = (initial, logoImages, availableGroups) => ({
     return this.form.display_type === 'api';
   },
   badgeText() {
+    // Localized type-*-abbr strings, same keys the real card uses (#746)
+    // — the preview previously hardcoded the pt-BR abbreviations.
     const map = {
-      // PT — matches type-*-abbr keys; localizing the preview is
-      // a polish item for the next batch.
-      app: 'APP', talk: 'APR', report: 'RLT',
-      package: 'PCT', api: 'API', link: 'LNK',
+      app: "{{ self.t("type-app-abbr") }}",
+      talk: "{{ self.t("type-talk-abbr") }}",
+      report: "{{ self.t("type-report-abbr") }}",
+      package: "{{ self.t("type-package-abbr") }}",
+      api: "{{ self.t("type-api-abbr") }}",
+      link: "{{ self.t("type-link-abbr") }}",
     };
-    return map[this.form.display_type] || 'APP';
+    return map[this.form.display_type] || map.app;
   },
 });
 </script>

--- a/crates/ruscker-admin/templates/admin/specs.html
+++ b/crates/ruscker-admin/templates/admin/specs.html
@@ -111,7 +111,9 @@
       </button>
     </div>
   </div>
-  <table class="admin-table" data-enhance>
+  {# data-no-search: the sticky toolbar's pill is THE search here —
+     the enhancer's injected input fought it over the same rows (#746). #}
+  <table class="admin-table" data-enhance data-no-search>
     <thead>
       <tr>
         <th>{{ self.t("admin-specs-col-id") }}</th>

--- a/crates/ruscker-admin/templates/admin/users.html
+++ b/crates/ruscker-admin/templates/admin/users.html
@@ -10,16 +10,22 @@
   </div>
 </div>
 
-{% if flash != "" %}
-  <div class="admin-login-error mb-3" role="status"
-       style="{% if flash == "last-admin" || flash == "bad-input" || flash == "exists" %}{% else %}background:rgba(29,158,117,0.12);color:var(--text-primary){% endif %}">
-    <i class="ti ti-info-circle" aria-hidden="true"></i>
-    {% if flash == "created" %}{{ self.t("admin-users-flash-created") }}
-    {% else if flash == "saved" %}{{ self.t("admin-users-flash-saved") }}
-    {% else if flash == "deleted" %}{{ self.t("admin-users-flash-deleted") }}
-    {% else if flash == "last-admin" %}{{ self.t("admin-users-flash-last-admin") }}
+{# Flash split (#746): error vs success used to share one class + icon,
+   distinguished only by an inline background colour — colour-only state,
+   and errors never got role="alert". #}
+{% if flash == "last-admin" || flash == "bad-input" || flash == "exists" %}
+  <div class="admin-login-error mb-3" role="alert">
+    <i class="ti ti-alert-circle" aria-hidden="true"></i>
+    {% if flash == "last-admin" %}{{ self.t("admin-users-flash-last-admin") }}
     {% else if flash == "exists" %}{{ self.t("admin-users-flash-exists") }}
     {% else %}{{ self.t("admin-users-flash-bad-input") }}{% endif %}
+  </div>
+{% else if flash != "" %}
+  <div class="admin-flash-ok mb-3" role="status">
+    <i class="ti ti-check" aria-hidden="true"></i>
+    {% if flash == "created" %}{{ self.t("admin-users-flash-created") }}
+    {% else if flash == "saved" %}{{ self.t("admin-users-flash-saved") }}
+    {% else %}{{ self.t("admin-users-flash-deleted") }}{% endif %}
   </div>
 {% endif %}
 

--- a/crates/ruscker-admin/templates/landing.html
+++ b/crates/ruscker-admin/templates/landing.html
@@ -120,8 +120,11 @@
         <div class="highlights-track" x-ref="track" :style="trackStyle()">
       {% for card in cards %}
         {% if card.featured %}
+        {# An inactive card is not a destination (#746): no href (placeholder
+           link — not a tab stop, not announced as a link), aria-disabled for
+           AT, and the old `href="#"` scroll-to-top click is gone. #}
         <a class="rcard {% if !card.active %}inactive{% endif %}"
-           href="{% if card.active %}{{ card.href }}{% else %}#{% endif %}">
+           {% if card.active %}href="{{ card.href }}"{% else %}aria-disabled="true"{% endif %}>
           <div class="rcover">
             {% match card.cover %}
               {% when Some with (cover) %}<div class="rcover-bg" style="background: {{ cover }};"></div>
@@ -202,7 +205,7 @@
     <div class="select-wrap" :class="status_ !== 'active' ? 'is-active' : ''">
       <select x-model="status_"
               class="theme-select"
-              aria-label="status">
+              aria-label="{{ self.t("filter-status-label") }}">
         <option value="active">{{ self.t("filter-status-active") }}</option>
         <option value="all">{{ self.t("filter-status-all") }}</option>
         <option value="inactive">{{ self.t("filter-status-inactive-only") }}</option>
@@ -285,7 +288,7 @@
       <div class="cards-grid stagger{% if catalog_layout == "list" %} is-list{% endif %}{% if catalog_density == "compact" %} is-compact{% endif %}">
         {% for card in sec.cards %}
       <a class="rcard {% if !card.active %}inactive{% endif %}"
-         href="{% if card.active %}{{ card.href }}{% else %}#{% endif %}"
+         {% if card.active %}href="{{ card.href }}"{% else %}aria-disabled="true"{% endif %}
          data-type="{{ card.display_type.key() }}"
          data-access="{% if card.access_open %}open{% else %}closed{% endif %}"
          data-active="{% if card.active %}active{% else %}inactive{% endif %}"
@@ -408,9 +411,12 @@ window.ruscker.landing = () => ({
     this.$watch('status_',() => this.recount());
     this.$nextTick(() => this.recount());
 
-    // ⌘K / Ctrl+K focuses the search box, matching the kbd-hint.
+    // ⌘K / Ctrl+K focuses the search box, matching the kbd-hint. The
+    // input only renders when the operator left the search section
+    // visible — without the guard the shortcut threw (and still ate
+    // the browser's own ⌘K) on portals with search hidden (#746).
     addEventListener('keydown', (e) => {
-      if ((e.metaKey || e.ctrlKey) && e.key.toLowerCase() === 'k') {
+      if ((e.metaKey || e.ctrlKey) && e.key.toLowerCase() === 'k' && this.$refs.search) {
         e.preventDefault();
         this.$refs.search.focus();
       }


### PR DESCRIPTION
Fixes #746 — all nine items of the UX/a11y/i18n batch. **Stacked on #756** (chain: #754 → #755 → #756 → this); same template files, linear history.

## Changes

1. **Landing picker modal a11y** — same treatment the spec-form copy got in #720: `role=dialog`, `aria-modal`, labelled title, focus to search on open / back to the trigger on close, Tab trap. The trap + trigger tracking now live on the **shared `imagePicker` mixin** (spec_form's local `trapLogoTab` deleted) so the copies can't fork on a11y again.
2. **i18n** — subject `<datalist>` derived from the catalog's existing subjects (replacing a fixed, domain-specific pt-BR list served to every locale/deployment); `spec-form-env-key` + `filter-status-label` added in 4 locales; the preview card's `badgeText()` uses the localized `type-*-abbr` keys the real card uses.
3. **Apps page double search** — the table opts out of the enhancer's injected input (`data-no-search`, new enhancer flag); the sticky toolbar pill is THE search. Header sort stays.
4. **Flash split (groups/users/disk)** — errors: persistent inline `.admin-login-error` + `role="alert"`; successes: toastable `.admin-flash-ok` + `role="status"`. Groups errors used to auto-dismiss in 4s; users/disk distinguished states by background colour alone.
5. **Keyboard access** — sortable headers: `tabindex=0`, Enter/Space, `aria-sort`; audit diff rows: `tabindex`, `role=button`, Enter/Space, `aria-expanded` (mirrors the dashboard group heads).
6. **⌘K guard** — no longer throws (nor eats the browser shortcut) on portals with the search section hidden.
7. **Inactive cards** — no `href="#"` (placeholder link: not a tab stop, not announced as a destination, no scroll-to-top click) + `aria-disabled`, in both the highlights track and the grid.
8. **Header-bg Solid seed** — mirrors the v0.2.2 cover fix: keeps an existing hex, seeds a colour over a gradient; used to clear the value (inert preview) and silently wipe a saved gradient on a single click.
9. **`previewIntro()` placeholder** — returns `''` when unset; the dimmed placeholder rides `data-*`, so the `:class` dimming finally applies and placeholder text stops reading as operator content.

Gate: `cargo test` (517 green incl. the #741 template lints), `clippy --all-targets -- -D warnings` clean, i18n ✓.

## Smoke (lab box, real browser per project convention)

- Landing editor → open the image picker with the keyboard: focus lands in search, Tab cycles inside, Esc returns focus to the button.
- Apps page: one search box only; type in the pill → rows filter; click a header → sorts.
- Groups: submit a bad rename → error banner stays put.
- Appearance → Header background: click Solid with a gradient saved → preview shows the seeded colour, gradient not wiped until Save.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
