### PR TITLE
feat(admin): archive + delete actions on the Apps list

### DIFF
--- a/crates/ruscker-admin/assets/i18n/en/landing.ftl
+++ b/crates/ruscker-admin/assets/i18n/en/landing.ftl
@@ -198,6 +198,9 @@ admin-specs-duplicate = Duplicate
 admin-specs-config-badge = config
 admin-specs-config-defined = Defined in the YAML config — read-only here; edit the file
 admin-specs-delete = Delete
+admin-specs-archive = Archive — hide the card from the portal
+admin-specs-unarchive = Unarchive — show the card on the portal again
+admin-specs-delete-confirm = Delete this application? Its containers will be stopped and the configuration removed. This cannot be undone.
 
 # Spec form (new / edit)
 spec-form-title-new = New app

--- a/crates/ruscker-admin/assets/i18n/es/landing.ftl
+++ b/crates/ruscker-admin/assets/i18n/es/landing.ftl
@@ -198,6 +198,9 @@ admin-specs-duplicate = Duplicar
 admin-specs-config-badge = config
 admin-specs-config-defined = Definido en el YAML — solo lectura aquí; edita el archivo
 admin-specs-delete = Borrar
+admin-specs-archive = Archivar — ocultar la tarjeta del portal
+admin-specs-unarchive = Reactivar — volver a mostrar la tarjeta en el portal
+admin-specs-delete-confirm = ¿Borrar esta aplicación? Sus contenedores se detendrán y la configuración se eliminará. Esta acción no se puede deshacer.
 
 # Spec form (new / edit)
 spec-form-title-new = Nueva aplicación

--- a/crates/ruscker-admin/assets/i18n/fr/landing.ftl
+++ b/crates/ruscker-admin/assets/i18n/fr/landing.ftl
@@ -198,6 +198,9 @@ admin-specs-duplicate = Dupliquer
 admin-specs-config-badge = config
 admin-specs-config-defined = Défini dans le YAML — lecture seule ici; modifiez le fichier
 admin-specs-delete = Supprimer
+admin-specs-archive = Archiver — masquer la carte du portail
+admin-specs-unarchive = Réactiver — réafficher la carte sur le portail
+admin-specs-delete-confirm = Supprimer cette application ? Ses conteneurs seront arrêtés et la configuration supprimée. Cette action est irréversible.
 
 # Spec form (new / edit)
 spec-form-title-new = Nouvelle application

--- a/crates/ruscker-admin/assets/i18n/pt/landing.ftl
+++ b/crates/ruscker-admin/assets/i18n/pt/landing.ftl
@@ -202,6 +202,9 @@ admin-specs-duplicate = Duplicar
 admin-specs-config-badge = config
 admin-specs-config-defined = Definido no YAML — somente leitura aqui; edite o arquivo
 admin-specs-delete = Apagar
+admin-specs-archive = Arquivar — ocultar o card do portal
+admin-specs-unarchive = Reativar — voltar a exibir o card no portal
+admin-specs-delete-confirm = Excluir esta aplicação? Os contêineres serão parados e a configuração removida. Esta ação não pode ser desfeita.
 
 # Spec form (new / edit)
 spec-form-title-new = Nova aplicação

--- a/crates/ruscker-admin/src/db/specs.rs
+++ b/crates/ruscker-admin/src/db/specs.rs
@@ -836,6 +836,40 @@ container-image: a:1").unwrap();
         assert!(v2 > v1, "a save must bump the version ({v1} → {v2})");
     }
 
+    // #775: the Apps-list archive toggle flips `template-properties.state`
+    // and saves through `upsert_one` — both readers must agree afterwards:
+    // the list view reads the `state` COLUMN, the landing reads
+    // `is_active()` off the deserialized spec.
+    #[tokio::test]
+    async fn state_flip_updates_column_and_roundtrips() {
+        let pool = open_memory().await.unwrap();
+        let db = ConfigDb::Sqlite(pool.clone());
+        let mut spec: Spec =
+            serde_yaml_ng::from_str("id: app
+container-image: a:1").unwrap();
+        insert_new(&db, &spec, None).await.unwrap();
+
+        spec.template_properties.set_str("state", "inactive");
+        upsert_one(&db, &spec, Some("admin")).await.unwrap();
+
+        let (col,): (String,) = sqlx::query_as("SELECT state FROM specs WHERE id = 'app'")
+            .fetch_one(&pool)
+            .await
+            .unwrap();
+        assert_eq!(col, "inactive", "list view reads the column");
+        let back = fetch_one(&db, "app").await.unwrap().expect("still there");
+        assert!(!back.template_properties.is_active(), "landing reads the spec");
+
+        // …and back to active.
+        spec.template_properties.set_str("state", "active");
+        upsert_one(&db, &spec, Some("admin")).await.unwrap();
+        let (col,): (String,) = sqlx::query_as("SELECT state FROM specs WHERE id = 'app'")
+            .fetch_one(&pool)
+            .await
+            .unwrap();
+        assert_eq!(col, "active");
+    }
+
     fn fixture_yaml() -> String {
         std::env::set_var("DOCKER_REGISTRY_PASSWORD", "test");
         std::fs::read_to_string("../../examples/application.yml").unwrap()

--- a/crates/ruscker-admin/src/routes/admin/specs.rs
+++ b/crates/ruscker-admin/src/routes/admin/specs.rs
@@ -36,6 +36,7 @@ pub fn routes() -> Router<AppState> {
             "/admin/specs/{id}/featured/toggle",
             post(toggle_featured),
         )
+        .route("/admin/specs/{id}/state/toggle", post(toggle_state))
         .layer(DefaultBodyLimit::max(IMPORT_BODY_LIMIT))
 }
 
@@ -74,6 +75,45 @@ async fn toggle_featured(
         featured: now_featured,
     })
     .into_response()
+}
+
+/// `POST /admin/specs/{id}/state/toggle` — archive/unarchive a spec from
+/// the Apps table (#775): flips `template-properties.state` between
+/// `active` and `inactive`. An inactive app keeps its config, history and
+/// audit trail, but its card leaves the public portal (the landing hides
+/// inactive cards behind the status filter and makes them non-clickable).
+/// Editor-gated; a plain form POST + redirect, so the reloaded page
+/// repaints the state pill — archiving is rare enough that the
+/// optimistic-fetch machinery the featured star needs would be overkill.
+async fn toggle_state(
+    editor: RequireEditor,
+    State(state): State<AppState>,
+    Path(id): Path<String>,
+) -> Response {
+    let Some(db) = state.db.as_ref() else {
+        return (StatusCode::SERVICE_UNAVAILABLE, "no db").into_response();
+    };
+    let mut spec = match crate::db::specs::fetch_one(db, &id).await {
+        Ok(Some(s)) => s,
+        Ok(None) => return (StatusCode::NOT_FOUND, "spec not found").into_response(),
+        Err(e) => {
+            tracing::error!(id, error = ?e, "fetch spec for state toggle failed");
+            return (StatusCode::INTERNAL_SERVER_ERROR, "db error").into_response();
+        }
+    };
+    let next = if spec.template_properties.is_active() {
+        "inactive"
+    } else {
+        "active"
+    };
+    spec.template_properties.set_str("state", next);
+    // `upsert_one` derives the `state` column from `template-properties`
+    // and writes the audit row with the actor, same as the spec form.
+    if let Err(e) = crate::db::specs::upsert_one(db, &spec, Some(editor.actor())).await {
+        tracing::error!(id, error = ?e, "save state toggle failed");
+        return (StatusCode::INTERNAL_SERVER_ERROR, "save failed").into_response();
+    }
+    Redirect::to("/admin/specs").into_response()
 }
 
 /// One row out of the `specs` table, picked for the list view.

--- a/crates/ruscker-admin/templates/admin/specs.html
+++ b/crates/ruscker-admin/templates/admin/specs.html
@@ -219,6 +219,31 @@
                title="{{ self.t("admin-specs-duplicate") }}">
               <i class="ti ti-copy" aria-hidden="true"></i>
             </a>
+            {# Archive toggle (#775): active ⇄ inactive without opening the
+               editor. An inactive app keeps everything (config, history,
+               containers can be restarted later) but its card leaves the
+               public portal — the landing hides inactive cards by default. #}
+            <form method="post" action="{{ base }}/admin/specs/{{ spec.id }}/state/toggle" style="display:inline">
+              {% if spec.state == "active" %}
+              <button type="submit" class="admin-nav-link" title="{{ self.t("admin-specs-archive") }}">
+                <i class="ti ti-archive" aria-hidden="true"></i>
+              </button>
+              {% else %}
+              <button type="submit" class="admin-nav-link" title="{{ self.t("admin-specs-unarchive") }}">
+                <i class="ti ti-archive-off" aria-hidden="true"></i>
+              </button>
+              {% endif %}
+            </form>
+            {# Delete (#775): same handler the edit form uses (stops the
+               app's containers, audits). The confirm rides `data-confirm`
+               + the global capture-phase submit listener in _layout.html —
+               never an inline JS handler (tests/template_lint.rs). #}
+            <form method="post" action="{{ base }}/admin/specs/{{ spec.id }}/delete" style="display:inline"
+                  data-confirm="{{ self.t("admin-specs-delete-confirm") }}">
+              <button type="submit" class="dash-action dash-action--danger" title="{{ self.t("admin-specs-delete") }}">
+                <i class="ti ti-trash" aria-hidden="true"></i>
+              </button>
+            </form>
           </td>
           {% endif %}
         </tr>


### PR DESCRIPTION
Closes #775.

## What

Two new actions per DB spec on `/admin/specs`:

- **Archive / unarchive** (`ti-archive` / `ti-archive-off`): new `POST /admin/specs/{id}/state/toggle` flips `template-properties.state` between `active`/`inactive` via `upsert_one` (audit row + version bump included). An inactive app keeps everything but its card leaves the public portal — the landing already hides inactive cards by default and renders them non-clickable (#746), so no landing changes were needed.
- **Delete** (`ti-trash`): the existing delete handler (container reap + audit), now reachable from the list through an inline form with `data-confirm` (global capture-phase listener — no inline JS, `template_lint` clean).

Config-only YAML specs remain read-only (no new buttons). Deleting a DB spec whose id also exists in the YAML `--config` resurfaces it as a read-only config row — expected (the file is its source).

## Tests & smoke

- New DB test `state_flip_updates_column_and_roundtrips` (column + deserialized spec agree after a flip, both directions).
- Full gate green: `cargo test` (workspace) + `clippy --all-targets -D warnings` + `i18n-check.sh`.
- Playwright + installed Chrome against a local `serve`: archive flips pill+icon both ways; inactive card is absent from the portal landing; delete confirm **cancel keeps** the row, **accept deletes** it (and the YAML twin resurfaces read-only).

## i18n

`admin-specs-archive`, `admin-specs-unarchive`, `admin-specs-delete-confirm` ×4 locales (pt/en/es/fr).

🤖 Generated with [Claude Code](https://claude.com/claude-code)