### PR TITLE
feat(admin): Restore-defaults button on the Appearance editor

### DIFF
--- a/crates/ruscker-admin/assets/i18n/en/landing.ftl
+++ b/crates/ruscker-admin/assets/i18n/en/landing.ftl
@@ -329,6 +329,9 @@ admin-landing-subtitle = Configure how the public portal looks to visitors.
 admin-landing-scope-help = These options (colors, intro texts, SEO, custom blocks) apply to the public landing live — saved here, shown on the next view, no restart. It's a fixed set of settings, not an arbitrary-CSS editor.
 admin-landing-open-portal = Open portal
 admin-landing-save = Save
+admin-landing-reset = Restore defaults
+admin-landing-reset-help = Reset the portal appearance to the original defaults
+admin-landing-reset-confirm = Restore the default appearance? Colors, theme, header style, covers and layout go back to the original. Titles, logos, texts, SEO, custom CSS and HTML blocks are kept.
 admin-landing-saved = Settings saved. Reload the public portal to see them.
 admin-landing-header-bg = Custom background color
 admin-landing-bg-help = Empty = use the theme's default (light/dark).

--- a/crates/ruscker-admin/assets/i18n/es/landing.ftl
+++ b/crates/ruscker-admin/assets/i18n/es/landing.ftl
@@ -329,6 +329,9 @@ admin-landing-subtitle = Configure cómo se ve el portal público para los visit
 admin-landing-scope-help = Estas opciones (colores, textos de introducción, SEO, bloques personalizados) se aplican a la portada pública en vivo — guardadas aquí, mostradas en la próxima visita, sin reinicio. Es un conjunto fijo de ajustes, no un editor de CSS arbitrario.
 admin-landing-open-portal = Abrir portal
 admin-landing-save = Guardar
+admin-landing-reset = Restaurar predeterminado
+admin-landing-reset-help = Devuelve la apariencia del portal a los valores originales
+admin-landing-reset-confirm = ¿Restaurar la apariencia predeterminada? Colores, tema, estilo de cabecera, portadas y diseño vuelven al original. Títulos, logos, textos, SEO, CSS personalizado y bloques HTML se conservan.
 admin-landing-saved = Ajustes guardados. Recargue el portal para ver los cambios.
 admin-landing-header-bg = Color de fondo personalizado
 admin-landing-bg-help = Vacío = usa el color predeterminado del tema (claro/oscuro).

--- a/crates/ruscker-admin/assets/i18n/fr/landing.ftl
+++ b/crates/ruscker-admin/assets/i18n/fr/landing.ftl
@@ -329,6 +329,9 @@ admin-landing-subtitle = Configurez l'apparence du portail public pour les visit
 admin-landing-scope-help = Ces options (couleurs, textes d'intro, SEO, blocs personnalisés) s'appliquent à la page d'accueil publique en direct — enregistrées ici, affichées à la prochaine visite, sans redémarrage. C'est un ensemble fixe de réglages, pas un éditeur de CSS arbitraire.
 admin-landing-open-portal = Ouvrir le portail
 admin-landing-save = Enregistrer
+admin-landing-reset = Rétablir le défaut
+admin-landing-reset-help = Ramène l'apparence du portail aux valeurs d'origine
+admin-landing-reset-confirm = Rétablir l'apparence par défaut ? Couleurs, thème, style d'en-tête, couvertures et disposition reviennent à l'origine. Titres, logos, textes, SEO, CSS personnalisé et blocs HTML sont conservés.
 admin-landing-saved = Paramètres enregistrés. Rechargez le portail public pour voir.
 admin-landing-header-bg = Couleur de fond personnalisée
 admin-landing-bg-help = Vide = utilise la couleur par défaut du thème (clair/sombre).

--- a/crates/ruscker-admin/assets/i18n/pt/landing.ftl
+++ b/crates/ruscker-admin/assets/i18n/pt/landing.ftl
@@ -333,6 +333,9 @@ admin-landing-subtitle = Configure como o portal público aparece para os visita
 admin-landing-scope-help = Estas opções (cores, textos de introdução, SEO, blocos customizados) se aplicam à landing pública ao vivo — salvas aqui, exibidas na próxima visita, sem restart. É um conjunto fixo de configurações, não um editor de CSS arbitrário.
 admin-landing-open-portal = Abrir portal
 admin-landing-save = Salvar
+admin-landing-reset = Restaurar padrão
+admin-landing-reset-help = Volta a aparência do portal ao padrão original
+admin-landing-reset-confirm = Restaurar a aparência padrão? Cores, tema, estilo do cabeçalho, capas e layout voltam ao original. Títulos, logos, textos, SEO, CSS personalizado e blocos HTML são mantidos.
 admin-landing-saved = Configurações salvas. Recarregue o portal público para ver.
 admin-landing-header-bg = Cor de fundo personalizada
 admin-landing-bg-help = Vazio = usa a cor padrão do tema (claro/escuro).

--- a/crates/ruscker-admin/src/routes/admin/landing.rs
+++ b/crates/ruscker-admin/src/routes/admin/landing.rs
@@ -15,7 +15,7 @@ use axum::{
     extract::{Form, State},
     http::StatusCode,
     response::{IntoResponse, Response},
-    routing::get,
+    routing::{get, post},
     Router,
 };
 use ruscker_config::LandingCustomization;
@@ -31,7 +31,9 @@ use crate::theme::Theme;
 use crate::AppState;
 
 pub fn routes() -> Router<AppState> {
-    Router::new().route("/admin/landing", get(index).post(save))
+    Router::new()
+        .route("/admin/landing", get(index).post(save))
+        .route("/admin/landing/appearance/reset", post(reset_appearance))
 }
 
 #[derive(Template)]
@@ -332,6 +334,68 @@ async fn save(
             .await
         }
     }
+}
+
+/// `POST /admin/landing/appearance/reset` — restore the portal's
+/// default look (#783). Resets the STYLE knobs only: header preset/
+/// background/text colour, per-theme palettes, default theme, card
+/// cover style + default cover, catalog layout/density, and the logo
+/// mode/size/margin. Content and identity survive: title/subtitle/
+/// footer, the logos list, intro texts, SEO/analytics, custom CSS and
+/// HTML blocks are untouched. Confirmed client-side via `data-confirm`;
+/// audited as `landing.appearance_reset` on top of the update's own row.
+async fn reset_appearance(
+    admin: RequireAdmin,
+    State(state): State<AppState>,
+    loc: Locale,
+    theme: Theme,
+) -> Response {
+    let Some(pool) = state.db.as_ref() else {
+        return (StatusCode::SERVICE_UNAVAILABLE, "no db").into_response();
+    };
+    let mut lc = match db::landing::fetch(pool).await {
+        Ok(lc) => lc,
+        Err(err) => {
+            tracing::error!(error = ?err, "landing fetch for reset failed");
+            return (StatusCode::INTERNAL_SERVER_ERROR, "db error").into_response();
+        }
+    };
+    lc.header_preset = None;
+    lc.header_bg = None;
+    lc.header_fg = None;
+    lc.theme_colors = Default::default();
+    lc.default_theme = None;
+    lc.card_cover = None;
+    lc.card_cover_default = None;
+    lc.catalog_layout = None;
+    lc.catalog_density = None;
+    lc.logo_mode = None;
+    lc.logo_size = None;
+    lc.logo_margin = None;
+    if let Err(err) = db::landing::update(pool, &lc, Some(admin.actor())).await {
+        tracing::error!(error = ?err, "appearance reset failed");
+        return render(
+            &state,
+            loc,
+            theme,
+            Some(LandingForm::from_customization(&lc)),
+            false,
+            Some(err.to_string()),
+        )
+        .await;
+    }
+    if let Err(err) = db::audit::record(
+        pool,
+        admin.actor(),
+        "landing.appearance_reset",
+        "landing",
+        None,
+    )
+    .await
+    {
+        tracing::warn!(error = ?err, "audit appearance reset failed");
+    }
+    render(&state, loc, theme, None, true, None).await
 }
 
 async fn render(

--- a/crates/ruscker-admin/templates/admin/landing.html
+++ b/crates/ruscker-admin/templates/admin/landing.html
@@ -29,6 +29,16 @@
       <p class="text-xs text-[color:var(--text-muted)] mt-1">{{ self.t("admin-landing-subtitle") }}</p>
     </div>
     <div class="flex items-center gap-2">
+      {# Reset to the default look (#783): style knobs only — content,
+         logos, SEO, CSS and HTML blocks survive (the confirm says so).
+         data-confirm rides the global capture-phase submit listener. #}
+      <form method="post" action="{{ base }}/admin/landing/appearance/reset" style="display:inline"
+            data-confirm="{{ self.t("admin-landing-reset-confirm") }}">
+        <button type="submit" class="admin-nav-link" title="{{ self.t("admin-landing-reset-help") }}">
+          <i class="ti ti-restore" aria-hidden="true"></i>
+          {{ self.t("admin-landing-reset") }}
+        </button>
+      </form>
       <a href="{{ base }}/" target="_blank" class="admin-nav-link" title="{{ self.t("admin-landing-open-portal") }}">
         <i class="ti ti-external-link" aria-hidden="true"></i>
         {{ self.t("admin-landing-open-portal") }}


### PR DESCRIPTION
Closes #783. Style-only reset (header preset/bg/fg, palettes, default theme, covers, layout/density, logo mode/size/margin) behind a `data-confirm`; content/identity (titles, logos, intros, SEO, custom CSS, blocks) survive. Audited as `landing.appearance_reset`. Gate green; Playwright smoke: cancel keeps the look, accept resets style and keeps the title, portal header back to the default tint.

🤖 Generated with [Claude Code](https://claude.com/claude-code)