### PR TITLE
fix(admin): archive toggle keeps scroll position (in-place fetch)

### DIFF
--- a/crates/ruscker-admin/src/routes/admin/specs.rs
+++ b/crates/ruscker-admin/src/routes/admin/specs.rs
@@ -77,14 +77,21 @@ async fn toggle_featured(
     .into_response()
 }
 
+/// JSON returned by the archive toggle (#787) — the new state, so the
+/// row's pill + button repaint in place.
+#[derive(serde::Serialize)]
+struct StateToggleResult {
+    state: &'static str,
+}
+
 /// `POST /admin/specs/{id}/state/toggle` — archive/unarchive a spec from
 /// the Apps table (#775): flips `template-properties.state` between
 /// `active` and `inactive`. An inactive app keeps its config, history and
 /// audit trail, but its card leaves the public portal (the landing hides
 /// inactive cards behind the status filter and makes them non-clickable).
-/// Editor-gated; a plain form POST + redirect, so the reloaded page
-/// repaints the state pill — archiving is rare enough that the
-/// optimistic-fetch machinery the featured star needs would be overkill.
+/// Editor-gated; returns the new state as JSON for the in-place fetch
+/// toggle (#787 — the original form POST + redirect reloaded the page
+/// and threw the scroll back to the top).
 async fn toggle_state(
     editor: RequireEditor,
     State(state): State<AppState>,
@@ -111,7 +118,10 @@ async fn toggle_state(
         tracing::error!(id, error = ?e, "save state toggle failed");
         return (StatusCode::INTERNAL_SERVER_ERROR, "save failed").into_response();
     }
-    Redirect::to("/admin/specs").into_response()
+    Json(StateToggleResult {
+        state: if next_active { "active" } else { "inactive" },
+    })
+    .into_response()
 }
 
 /// One row out of the `specs` table, picked for the list view.

--- a/crates/ruscker-admin/templates/admin/specs.html
+++ b/crates/ruscker-admin/templates/admin/specs.html
@@ -222,18 +222,33 @@
             {# Archive toggle (#775): active ⇄ inactive without opening the
                editor. An inactive app keeps everything (config, history,
                containers can be restarted later) but its card leaves the
-               public portal — the landing hides inactive cards by default. #}
-            <form method="post" action="{{ base }}/admin/specs/{{ spec.id }}/state/toggle" style="display:inline">
-              {% if spec.state == "active" %}
-              <button type="submit" class="admin-nav-link" title="{{ self.t("admin-specs-archive") }}">
-                <i class="ti ti-archive" aria-hidden="true"></i>
-              </button>
-              {% else %}
-              <button type="submit" class="admin-nav-link" title="{{ self.t("admin-specs-unarchive") }}">
-                <i class="ti ti-archive-off" aria-hidden="true"></i>
-              </button>
-              {% endif %}
-            </form>
+               public portal — the landing hides inactive cards by default.
+               In-place fetch like the featured star (#787): the original
+               form POST + redirect reloaded the page and threw the scroll
+               to the top. The response repaints the row's state pill and
+               this button's icon/tooltip; titles ride data-* (never
+               localized strings inside the JS handler — template_lint). #}
+            <button type="button" class="admin-nav-link" x-data="{ busy: false }"
+                    data-toggle-url="{{ base }}/admin/specs/{{ spec.id }}/state/toggle"
+                    data-title-archive="{{ self.t("admin-specs-archive") }}"
+                    data-title-unarchive="{{ self.t("admin-specs-unarchive") }}"
+                    :disabled="busy"
+                    title="{% if spec.state == "active" %}{{ self.t("admin-specs-archive") }}{% else %}{{ self.t("admin-specs-unarchive") }}{% endif %}"
+                    @click="busy = true;
+                            fetch($el.dataset.toggleUrl, { method: 'POST' })
+                              .then(r => r.ok ? r.json() : Promise.reject())
+                              .then(d => {
+                                const pill = $el.closest('tr').querySelector('[class*=pill-state-]');
+                                if (pill) { pill.className = 'pill pill-state-' + d.state; pill.textContent = d.state; }
+                                $el.querySelector('i').className =
+                                  d.state === 'active' ? 'ti ti-archive' : 'ti ti-archive-off';
+                                $el.title = d.state === 'active'
+                                  ? $el.dataset.titleArchive : $el.dataset.titleUnarchive;
+                              })
+                              .catch(() => {})
+                              .finally(() => { busy = false })">
+              <i class="ti {% if spec.state == "active" %}ti-archive{% else %}ti-archive-off{% endif %}" aria-hidden="true"></i>
+            </button>
             {# Delete (#775): same handler the edit form uses (stops the
                app's containers, audits). The confirm rides `data-confirm`
                + the global capture-phase submit listener in _layout.html —


### PR DESCRIPTION
Closes #787. The archive toggle becomes an optimistic fetch (like the featured star): the route returns `{state}` JSON; the button repaints the row's pill + its icon/tooltip in place — no navigation, no scroll jump. Verified with Playwright: scrollY identical before/after, no framenavigated, state persists across reload, both directions.

🤖 Generated with [Claude Code](https://claude.com/claude-code)