### PR TITLE
feat(admin): Catalog-layout card as handoff option tiles

### DIFF
--- a/crates/ruscker-admin/assets/tailwind/input.css
+++ b/crates/ruscker-admin/assets/tailwind/input.css
@@ -1997,6 +1997,35 @@ textarea.spec-form-input { resize: vertical; min-height: 64px; }
 .seg-control button + button { border-left: 0.5px solid var(--border, rgba(120,120,120,0.25)); }
 .seg-control button.is-active { background: var(--color-teal-600); color: #fff; }
 .seg-control .ti { font-size: 16px; }
+/* Full-width segmented bar (the catalog-density control, #794): two
+   equal halves; the active one flips to high-contrast (text-on-bg, so
+   it reads in both themes — the handoff shows black-on-white). */
+.seg-control--full { display: flex; width: 100%; }
+.seg-control--full button { flex: 1; }
+.seg-control--contrast button.is-active { background: var(--text); color: var(--bg); }
+
+/* Catalog-layout option tiles (#794, design handoff): big icon-over-
+   label choices; the active one reads as a card outlined in the brand
+   teal on the plain surface. */
+.layout-tiles { display: grid; grid-template-columns: repeat(3, 1fr); gap: 12px; }
+.layout-tile {
+  display: flex; flex-direction: column; align-items: center; gap: 8px;
+  padding: 18px 12px; cursor: pointer;
+  background: var(--surface-soft); color: var(--text-muted);
+  border: 1px solid var(--border); border-radius: 10px;
+  font-family: inherit; font-size: 13.5px; line-height: 1.2;
+  transition: border-color 0.12s, background 0.12s, color 0.12s;
+}
+.layout-tile .ti { font-size: 22px; }
+.layout-tile:hover { color: var(--text); border-color: var(--border-strong); }
+.layout-tile.is-active {
+  background: var(--surface); color: var(--text);
+  /* border-color + an inset ring instead of a thicker border, so the
+     tile doesn't grow a pixel and shift its neighbours when selected. */
+  border-color: var(--color-teal-600);
+  box-shadow: inset 0 0 0 1px var(--color-teal-600);
+}
+.layout-tile.is-active .ti { color: var(--color-teal-600); }
 
 /* ── Landing editor: modern section-card layout (#482 polish) ────── */
 /* Sticky action bar so Save / Open portal stay reachable on a long form. */

--- a/crates/ruscker-admin/templates/admin/landing.html
+++ b/crates/ruscker-admin/templates/admin/landing.html
@@ -646,20 +646,31 @@
 
       </section>
 
-      {# ── Card: Catalog layout — grid/list + density. #}
+      {# ── Card: Catalog layout — grid/list/sections as the handoff's
+         big option tiles (icon over label, active outlined in teal) with
+         the density bar full-width below (#794). #}
       <section class="editor-card">
         <div class="form-section__title">{{ self.t("admin-landing-catalog-layout") }}</div>
         <input type="hidden" name="catalog_layout" :value="form.catalog_layout">
         <input type="hidden" name="catalog_density" :value="form.catalog_density">
         <div class="spec-form-field">
-          <div class="seg-control" role="group">
-            <button type="button" :class="{ 'is-active': (form.catalog_layout || 'grid') === 'grid' }" @click="form.catalog_layout = 'grid'">{{ self.t("admin-landing-layout-grid") }}</button>
-            <button type="button" :class="{ 'is-active': form.catalog_layout === 'list' }" @click="form.catalog_layout = 'list'">{{ self.t("admin-landing-layout-list") }}</button>
-            <button type="button" :class="{ 'is-active': form.catalog_layout === 'sections' }" @click="form.catalog_layout = 'sections'">{{ self.t("admin-landing-layout-sections") }}</button>
+          <div class="layout-tiles" role="group">
+            <button type="button" class="layout-tile" :class="{ 'is-active': (form.catalog_layout || 'grid') === 'grid' }" @click="form.catalog_layout = 'grid'">
+              <i class="ti ti-layout-grid" aria-hidden="true"></i>
+              <span>{{ self.t("admin-landing-layout-grid") }}</span>
+            </button>
+            <button type="button" class="layout-tile" :class="{ 'is-active': form.catalog_layout === 'list' }" @click="form.catalog_layout = 'list'">
+              <i class="ti ti-list" aria-hidden="true"></i>
+              <span>{{ self.t("admin-landing-layout-list") }}</span>
+            </button>
+            <button type="button" class="layout-tile" :class="{ 'is-active': form.catalog_layout === 'sections' }" @click="form.catalog_layout = 'sections'">
+              <i class="ti ti-layout-rows" aria-hidden="true"></i>
+              <span>{{ self.t("admin-landing-layout-sections") }}</span>
+            </button>
           </div>
         </div>
         <div class="spec-form-field">
-          <div class="seg-control" role="group">
+          <div class="seg-control seg-control--full seg-control--contrast" role="group">
             <button type="button" :class="{ 'is-active': (form.catalog_density || 'comfortable') === 'comfortable' }" @click="form.catalog_density = 'comfortable'">{{ self.t("admin-landing-density-comfortable") }}</button>
             <button type="button" :class="{ 'is-active': form.catalog_density === 'compact' }" @click="form.catalog_density = 'compact'">{{ self.t("admin-landing-density-compact") }}</button>
           </div>


### PR DESCRIPTION
Closes #794. Grid/List/Sections as icon-over-label tiles (active = teal outline via inset ring, no layout shift) + the density bar full-width with a high-contrast active half (text-on-bg, theme-safe). Template+CSS only; bindings unchanged; Playwright check confirms the tiles drive the preview. Screenshot matches the handoff mockup.

🤖 Generated with [Claude Code](https://claude.com/claude-code)