### PR TITLE
fix(admin): Featured-carousel toggle moves into Visible sections

### DIFF
--- a/crates/ruscker-admin/templates/admin/landing.html
+++ b/crates/ruscker-admin/templates/admin/landing.html
@@ -98,19 +98,6 @@
                placeholder="v{{ crate::APP_VERSION }} · Ruscker" class="spec-form-input">
         <div class="spec-form-help">{{ self.t("admin-landing-footer-help") }}</div>
       </div>
-      {# "Featured" carousel toggle (#506) — plain checkbox; the carousel
-         only shows when this is on AND at least one app is featured. #}
-      <div class="spec-form-field">
-        <label class="spec-form-check" style="cursor:pointer;gap:10px">
-          <span class="switch">
-            <input type="checkbox" name="show_highlights" value="on" {% if !form.show_highlights.is_empty() %}checked{% endif %}>
-            <span class="switch__track"><span class="switch__dot"></span></span>
-          </span>
-          <span>{{ self.t("admin-landing-show-highlights") }}</span>
-        </label>
-        <div class="spec-form-help">{{ self.t("admin-landing-show-highlights-help") }}</div>
-      </div>
-
       </section>
 
       {# ── Card: Logos — the header brand + the extra per-slot logos,
@@ -762,6 +749,20 @@
             </span>
             <span>{{ self.t("admin-landing-show-filters") }}</span>
           </label>
+        </div>
+        {# "Featured" carousel toggle (#506), moved here from the Header
+           card (#803) — it is a visible portal section like search and
+           filters. The carousel only shows when this is on AND at least
+           one app is featured. #}
+        <div class="spec-form-field">
+          <label class="spec-form-check" style="cursor:pointer;gap:10px">
+            <span class="switch">
+              <input type="checkbox" name="show_highlights" value="on" {% if !form.show_highlights.is_empty() %}checked{% endif %}>
+              <span class="switch__track"><span class="switch__dot"></span></span>
+            </span>
+            <span>{{ self.t("admin-landing-show-highlights") }}</span>
+          </label>
+          <div class="spec-form-help">{{ self.t("admin-landing-show-highlights-help") }}</div>
         </div>
       </section>
 


### PR DESCRIPTION
Operator request: the highlights toggle is a visible portal section like search/filters — moved from the Header card into Visible sections (template-only, same field). Browser-checked: 3 switches in the card, gone from Header.

🤖 Generated with [Claude Code](https://claude.com/claude-code)