### PR TITLE
fix(landing): intro fills the row, justified + hyphenated

### DIFF
--- a/crates/ruscker-admin/assets/tailwind/input.css
+++ b/crates/ruscker-admin/assets/tailwind/input.css
@@ -2155,6 +2155,16 @@ input[type="color"].cover-swatch::-webkit-color-swatch { border: 0; border-radiu
 .palette-input { display: flex; align-items: center; gap: 10px; }
 .palette-input .spec-form-input { flex: 1; min-width: 0; background: var(--surface); }
 
+/* Operator intro paragraph on the public landing (#805): full
+   container width, justified with hyphenation — <html lang> picks the
+   dictionary, so each locale breaks words correctly. Also the stable
+   hook for operator custom CSS. */
+.landing-intro {
+  font-size: 0.875rem; line-height: 1.625; margin-bottom: 20px;
+  color: var(--text-muted);
+  text-align: justify; hyphens: auto; overflow-wrap: break-word;
+}
+
 /* ── Landing editor: modern section-card layout (#482 polish) ────── */
 /* Sticky action bar so Save / Open portal stay reachable on a long form. */
 .editor-topbar {

--- a/crates/ruscker-admin/templates/landing.html
+++ b/crates/ruscker-admin/templates/landing.html
@@ -96,8 +96,12 @@
       x-data="ruscker.landing()" x-cloak>
 
   {% if !intro.is_empty() %}
-    {# Operator-authored intro (per landing-customization.intro). #}
-    <p class="text-sm text-[color:var(--text-muted)] leading-relaxed mb-5 max-w-3xl">
+    {# Operator-authored intro (per landing-customization.intro). A
+       stable class (#805) instead of utility soup: full container
+       width, justified with per-language hyphenation — it used to cap
+       at max-w-3xl and rag right, wasting the row. The class is also
+       the operator's CSS hook. #}
+    <p class="landing-intro">
       {{ intro }}
     </p>
   {% endif %}


### PR DESCRIPTION
Operator report: the intro capped at max-w-3xl and ragged right. Now full container width, `text-align: justify` + `hyphens: auto` (per-locale via `<html lang>`), under a stable `.landing-intro` class (also the custom-CSS hook). Measured: paragraph width == main inner width; justify + hyphens confirmed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)