### PR TITLE
fix(admin): blocks card width + anchored redirects

### DIFF
--- a/crates/ruscker-admin/src/routes/admin/blocks.rs
+++ b/crates/ruscker-admin/src/routes/admin/blocks.rs
@@ -56,7 +56,7 @@ pub(crate) fn grouped_blocks(blocks: &[LandingBlock]) -> Vec<SlotGroup> {
 /// The standalone blocks list page was folded into the Portal page
 /// (#242); the route stays so old links/bookmarks still resolve.
 async fn index(_: RequireAdmin) -> Response {
-    Redirect::to("/admin/landing").into_response()
+    Redirect::to("/admin/landing#blocks").into_response()
 }
 
 // ── Form (new / edit) ────────────────────────────────────────────
@@ -197,7 +197,7 @@ async fn create(
         return no_db();
     };
     match landing_blocks::insert(pool, &form.into_input(), Some(admin.actor())).await {
-        Ok(_) => Redirect::to("/admin/landing").into_response(),
+        Ok(_) => Redirect::to("/admin/landing#blocks").into_response(),
         Err(e) => {
             tracing::error!(error = ?e, "create block failed");
             (StatusCode::INTERNAL_SERVER_ERROR, "db error").into_response()
@@ -215,7 +215,7 @@ async fn update(
         return no_db();
     };
     match landing_blocks::update(pool, &id, &form.into_input(), Some(admin.actor())).await {
-        Ok(true) => Redirect::to("/admin/landing").into_response(),
+        Ok(true) => Redirect::to("/admin/landing#blocks").into_response(),
         Ok(false) => (StatusCode::NOT_FOUND, "block not found").into_response(),
         Err(e) => {
             tracing::error!(error = ?e, id, "update block failed");
@@ -233,7 +233,7 @@ async fn delete(
         return no_db();
     };
     match landing_blocks::delete(pool, &id, Some(admin.actor())).await {
-        Ok(_) => Redirect::to("/admin/landing").into_response(),
+        Ok(_) => Redirect::to("/admin/landing#blocks").into_response(),
         Err(e) => {
             tracing::error!(error = ?e, id, "delete block failed");
             (StatusCode::INTERNAL_SERVER_ERROR, "db error").into_response()
@@ -255,7 +255,7 @@ async fn move_block(
         _ => return (StatusCode::BAD_REQUEST, "dir must be up|down").into_response(),
     };
     match landing_blocks::move_block(pool, &id, up, Some(admin.actor())).await {
-        Ok(_) => Redirect::to("/admin/landing").into_response(),
+        Ok(_) => Redirect::to("/admin/landing#blocks").into_response(),
         Err(e) => {
             tracing::error!(error = ?e, id, "move block failed");
             (StatusCode::INTERNAL_SERVER_ERROR, "db error").into_response()

--- a/crates/ruscker-admin/templates/admin/_blocks_editor.html
+++ b/crates/ruscker-admin/templates/admin/_blocks_editor.html
@@ -6,7 +6,7 @@
    POST routes are unchanged (create/update/delete/move/reorder all
    redirect back to /admin/landing). Own Alpine root — it sits outside
    the landing form's x-data. #}
-<section class="editor-card mt-6" x-data="{ editing: null, creating: false }">
+<section class="editor-card mt-6" id="blocks" x-data="{ editing: null, creating: false }">
   <div class="flex items-start justify-between gap-4 mb-1">
     <div>
       <div class="form-section__title" style="margin-bottom:4px"><i class="ti ti-code" style="margin-right:6px;vertical-align:-2px" aria-hidden="true"></i>{{ self.t("admin-blocks-title") }}</div>

--- a/crates/ruscker-admin/templates/admin/landing.html
+++ b/crates/ruscker-admin/templates/admin/landing.html
@@ -66,9 +66,13 @@
 
   <div class="spec-form-layout">
 
-    {# ── LEFT: form ────────────────────────────────────────── #}
+    {# ── LEFT: form + the blocks editor below it. The blocks card has
+       its own <form>s, so it can't live INSIDE the landing form — the
+       wrapper div keeps both in the same grid column at the same width
+       (#808). #}
+    <div class="spec-form-fields">
     <form id="landing-form" method="post" action="{{ base }}/admin/landing"
-          class="spec-form-fields" autocomplete="off">
+          autocomplete="off">
 
       {# Scope note (#350): everything here is applied to the public
          landing live (saved to the DB, rendered on the next view) — no
@@ -921,6 +925,11 @@
 
     </form>
 
+    {# Custom HTML blocks editor, folded in from the old standalone tab
+       (#242) — same column/width as the form cards (#808). #}
+    {% include "admin/_blocks_editor.html" %}
+    </div>
+
     {# ── RIGHT: live preview ──────────────────────────────── #}
     <aside class="spec-form-preview" style="top:96px">
       <div class="editor-card editor-card--preview">
@@ -1115,8 +1124,6 @@
   </template>
 </div>
 
-{# Custom HTML blocks editor, folded in from the old standalone tab (#242). #}
-{% include "admin/_blocks_editor.html" %}
 
 {# Syntax highlighting for the CSS / analytics-HTML editors (#623). #}
 {% include "admin/_code_editor.html" %}


### PR DESCRIPTION
Follow-ups to #806: the blocks card now lives in the form column (wrapper div — its own forms can't nest in the landing form), matching the other cards' width exactly; the five block-action redirects target `/admin/landing#blocks` so the page returns to the section instead of the top. Playwright-verified.

🤖 Generated with [Claude Code](https://claude.com/claude-code)