### PR TITLE
feat(admin): public-app chips with type-colour tint on the Groups page

### DIFF
--- a/crates/ruscker-admin/assets/tailwind/input.css
+++ b/crates/ruscker-admin/assets/tailwind/input.css
@@ -2272,6 +2272,28 @@ input[type="color"].cover-swatch::-webkit-color-swatch { border: 0; border-radiu
 }
 .group-pill:hover { border-color: var(--color-teal-600); background: var(--surface); }
 .group-pill .ti { font-size: 13px; color: var(--text-muted); }
+
+/* Public-app chips on the Groups page (#809): logo thumb on the
+   catalog's per-type tint (the colour cue), name, green globe. */
+.app-chips { display: flex; flex-wrap: wrap; gap: 10px; }
+.app-chip {
+  display: inline-flex; align-items: center; gap: 9px;
+  padding: 7px 12px 7px 8px;
+  background: var(--surface); border: 1px solid var(--border);
+  border-radius: 12px; text-decoration: none;
+  font-size: 13.5px; color: var(--text);
+  transition: border-color 0.12s, box-shadow 0.12s;
+}
+.app-chip:hover { border-color: var(--color-teal-600); box-shadow: var(--shadow-sm); }
+.app-chip__thumb {
+  width: 30px; height: 30px; min-height: 30px; flex: none;
+  border-radius: 8px; border: 0.5px solid var(--border);
+  display: flex; align-items: center; justify-content: center;
+  overflow: hidden;
+}
+.app-chip__thumb img { width: 22px; height: 22px; object-fit: contain; }
+.app-chip__thumb .ti { font-size: 15px; color: var(--text-muted); }
+.app-chip__globe { font-size: 15px; color: var(--color-teal-600); }
 .group-empty { font-size: 12px; color: var(--text-faint); font-style: italic; }
 
 /* Featured-star toggle in the Apps table (#521). */

--- a/crates/ruscker-admin/src/routes/admin/groups.rs
+++ b/crates/ruscker-admin/src/routes/admin/groups.rs
@@ -33,10 +33,25 @@ pub fn routes() -> Router<AppState> {
         .route("/admin/groups/members/remove", post(remove_member))
 }
 
-/// One app reference inside a group (id + display name).
+/// One app reference inside a group — id, display name, plus the card
+/// logo and display-type key so the chips can carry the catalog's
+/// per-type tint (#809).
 struct AppRef {
     id: String,
     name: String,
+    logo: Option<String>,
+    kind: &'static str,
+}
+
+impl AppRef {
+    fn from_spec(s: &ruscker_config::Spec) -> Self {
+        Self {
+            id: s.id.clone(),
+            name: s.display_name.clone().unwrap_or_else(|| s.id.clone()),
+            logo: s.template_properties.get_str("logo").map(str::to_string),
+            kind: crate::view_model::DisplayType::from_spec(s).key(),
+        }
+    }
 }
 
 /// A derived group with its members and the apps it gates.
@@ -130,7 +145,14 @@ async fn index(
             members: members.into_iter().collect(),
             apps: apps
                 .into_iter()
-                .map(|(id, name)| AppRef { id, name })
+                .map(|(id, name)| {
+                    // Resolve back to the spec for logo + type (#809);
+                    // admin page, the linear scan is fine.
+                    match specs.iter().find(|s| s.id == id) {
+                        Some(s) => AppRef::from_spec(s),
+                        None => AppRef { id, name, logo: None, kind: "app" },
+                    }
+                })
                 .collect(),
         })
         .collect();
@@ -140,10 +162,7 @@ async fn index(
     let mut public_apps: Vec<AppRef> = specs
         .iter()
         .filter(|s| s.is_open())
-        .map(|s| AppRef {
-            id: s.id.clone(),
-            name: s.display_name.clone().unwrap_or_else(|| s.id.clone()),
-        })
+        .map(AppRef::from_spec)
         .collect();
     public_apps.sort_by(|a, b| a.name.cmp(&b.name));
 

--- a/crates/ruscker-admin/templates/admin/groups.html
+++ b/crates/ruscker-admin/templates/admin/groups.html
@@ -133,8 +133,21 @@
   <span class="text-xs text-[color:var(--text-faint)] font-normal">· {{ public_apps.len() }}</span>
 </div>
 <p class="text-xs text-[color:var(--text-faint)] mb-2">{{ self.t("admin-groups-public-help") }}</p>
-<div class="group-pills">
-  {% for a in public_apps %}<a href="{{ base }}/admin/specs/{{ a.id }}/edit" class="group-pill"><i class="ti ti-app-window" aria-hidden="true"></i> {{ a.name }}</a>{% endfor %}
+{# Logo chips with the catalog's per-type tint behind the thumb (#809):
+   the tint colour IS the type cue — same palette as the portal cards. #}
+<div class="app-chips">
+  {% for a in public_apps %}
+  <a href="{{ base }}/admin/specs/{{ a.id }}/edit" class="app-chip" title="{{ a.name }}">
+    <span class="app-chip__thumb tint-{{ a.kind }}">
+      {% match a.logo %}
+        {% when Some with (l) %}<img src="{% if l.starts_with("http") %}{{ l }}{% else %}{{ base }}{{ l }}{% endif %}" alt="" loading="lazy" onerror="this.style.display='none'">
+        {% when None %}<i class="ti ti-app-window" aria-hidden="true"></i>
+      {% endmatch %}
+    </span>
+    <span class="app-chip__name">{{ a.name }}</span>
+    <i class="ti ti-world app-chip__globe" aria-hidden="true"></i>
+  </a>
+  {% endfor %}
 </div>
 {% endif %}
 


### PR DESCRIPTION
Closes #809. 'Public apps' renders as logo chips per the mockup: logo thumb on the catalog's per-type tint (the colour cue), name, green globe, edit link. AppRef carries logo + display-type; group app lists share the constructor for a future pass. Browser-verified (21 chips, 5 tints).

🤖 Generated with [Claude Code](https://claude.com/claude-code)