### PR TITLE
feat(landing): inline Markdown (bold/italic/links) in the intro

### DIFF
--- a/book/src/admin.md
+++ b/book/src/admin.md
@@ -200,7 +200,10 @@ blocks:
 - **Visible sections** — toggles for the search box, the filter chips
   and the *Featured* carousel.
 - **Content** — a per-locale intro paragraph (rendered full-width and
-  justified on the portal) and the footer text.
+  justified on the portal) and the footer text. The intro understands
+  an inline slice of Markdown — `**bold**`, `*italic*` and
+  `[links](https://…)` — never raw HTML; the preview renders it the
+  same way.
 - **SEO & sharing** — page title, meta description, `og:image`, with a
   live Google-style **search-result preview** that updates as you type.
   The landing `<head>` emits `description` + `og:*` + `twitter:card`.

--- a/crates/ruscker-admin/assets/i18n/en/landing.ftl
+++ b/crates/ruscker-admin/assets/i18n/en/landing.ftl
@@ -345,7 +345,7 @@ admin-landing-clear = Clear
 admin-landing-intro = Intro text (default)
 admin-landing-intro-default = Default (fallback for all languages)
 admin-landing-intro-default-placeholder = Welcome to the portal…
-admin-landing-intro-help = Rendered between the header and the filters. Empty = no text.
+admin-landing-intro-help = Shown above the catalog. Accepts **bold**, *italic* and [links](https://…) — no HTML.
 admin-landing-intro-locales = Intro text per language
 admin-landing-intro-pt = Portuguese
 admin-landing-intro-en = English

--- a/crates/ruscker-admin/assets/i18n/es/landing.ftl
+++ b/crates/ruscker-admin/assets/i18n/es/landing.ftl
@@ -345,7 +345,7 @@ admin-landing-clear = Limpiar
 admin-landing-intro = Texto de introducción (predeterminado)
 admin-landing-intro-default = Predeterminado (fallback para todos los idiomas)
 admin-landing-intro-default-placeholder = Bienvenido al portal…
-admin-landing-intro-help = Se muestra entre el encabezado y los filtros. Vacío = sin texto.
+admin-landing-intro-help = Se muestra sobre el catálogo. Acepta **negrita**, *cursiva* y [enlaces](https://…) — sin HTML.
 admin-landing-intro-locales = Texto de introducción por idioma
 admin-landing-intro-pt = Portugués
 admin-landing-intro-en = Inglés

--- a/crates/ruscker-admin/assets/i18n/fr/landing.ftl
+++ b/crates/ruscker-admin/assets/i18n/fr/landing.ftl
@@ -345,7 +345,7 @@ admin-landing-clear = Effacer
 admin-landing-intro = Texte d'introduction (par défaut)
 admin-landing-intro-default = Par défaut (fallback pour toutes les langues)
 admin-landing-intro-default-placeholder = Bienvenue sur le portail…
-admin-landing-intro-help = Affiché entre l'en-tête et les filtres. Vide = pas de texte.
+admin-landing-intro-help = Affiché au-dessus du catalogue. Accepte **gras**, *italique* et des [liens](https://…) — pas de HTML.
 admin-landing-intro-locales = Texte d'introduction par langue
 admin-landing-intro-pt = Portugais
 admin-landing-intro-en = Anglais

--- a/crates/ruscker-admin/assets/i18n/pt/landing.ftl
+++ b/crates/ruscker-admin/assets/i18n/pt/landing.ftl
@@ -349,7 +349,7 @@ admin-landing-clear = Limpar
 admin-landing-intro = Texto introdutório (padrão)
 admin-landing-intro-default = Padrão (fallback para todos os idiomas)
 admin-landing-intro-default-placeholder = Bem-vindo ao portal…
-admin-landing-intro-help = Texto exibido entre o cabeçalho e os filtros. Vazio = sem texto.
+admin-landing-intro-help = Mostrado acima do catálogo. Aceita **negrito**, *itálico* e [links](https://…) — sem HTML.
 admin-landing-intro-locales = Texto introdutório por idioma
 admin-landing-intro-pt = Português
 admin-landing-intro-en = Inglês

--- a/crates/ruscker-admin/assets/tailwind/input.css
+++ b/crates/ruscker-admin/assets/tailwind/input.css
@@ -2203,6 +2203,8 @@ input[type="color"].cover-swatch::-webkit-color-swatch { border: 0; border-radiu
   color: var(--text-muted);
   text-align: justify; hyphens: auto; overflow-wrap: break-word;
 }
+.landing-intro a { color: var(--color-teal-600); text-decoration: underline; }
+.landing-intro a:hover { color: var(--color-teal-400); }
 
 /* ── Landing editor: modern section-card layout (#482 polish) ────── */
 /* Sticky action bar so Save / Open portal stay reachable on a long form. */

--- a/crates/ruscker-admin/src/lib.rs
+++ b/crates/ruscker-admin/src/lib.rs
@@ -31,6 +31,7 @@ pub mod i18n;
 pub mod images;
 pub mod leader;
 pub mod logbuf;
+pub mod markdown;
 pub mod metrics_cache;
 pub mod ratelimit;
 pub mod routes;

--- a/crates/ruscker-admin/src/markdown.rs
+++ b/crates/ruscker-admin/src/markdown.rs
@@ -1,0 +1,136 @@
+//! Inline-Markdown rendering for the landing intro (#812).
+//!
+//! A deliberately tiny subset — `**bold**`, `*italic*` and
+//! `[label](https://url)` — NOT a CommonMark engine. The input is
+//! HTML-escaped *first*, then the three constructs are rewritten, so
+//! raw HTML can never pass through: the intro renders on the public
+//! landing. Anything that doesn't match a construct stays literal
+//! (a lone `*` is just an asterisk), which keeps every existing
+//! plain-text intro rendering byte-for-byte as before.
+//!
+//! Lives in its own module (not `routes::landing`) because the admin
+//! preview mirrors the same subset client-side — keeping the server
+//! half small and visible makes it practical to keep the two in sync.
+
+use regex::Regex;
+use std::sync::OnceLock;
+
+fn link_re() -> &'static Regex {
+    static RE: OnceLock<Regex> = OnceLock::new();
+    // Label without `]`, URL restricted to http(s) and stopped at
+    // whitespace/`)` — the escape pass already neutralized quotes, so
+    // the URL can't break out of the href attribute.
+    RE.get_or_init(|| Regex::new(r"\[([^\]]+)\]\((https?://[^\s)]+)\)").unwrap())
+}
+
+fn bold_re() -> &'static Regex {
+    static RE: OnceLock<Regex> = OnceLock::new();
+    RE.get_or_init(|| Regex::new(r"\*\*([^*]+)\*\*").unwrap())
+}
+
+fn italic_re() -> &'static Regex {
+    static RE: OnceLock<Regex> = OnceLock::new();
+    RE.get_or_init(|| Regex::new(r"\*([^*]+)\*").unwrap())
+}
+
+fn escape_html(src: &str) -> String {
+    src.replace('&', "&amp;")
+        .replace('<', "&lt;")
+        .replace('>', "&gt;")
+        .replace('"', "&quot;")
+}
+
+/// Render the inline subset to HTML. Escape-first: the output is safe
+/// to emit with `|safe` into the landing template.
+pub fn render_inline(src: &str) -> String {
+    let escaped = escape_html(src);
+    // Links first (so a `*` inside a URL can't be eaten by emphasis),
+    // then bold before italic (`**` would otherwise read as two `*`).
+    let s = link_re().replace_all(
+        &escaped,
+        "<a href=\"$2\" target=\"_blank\" rel=\"noopener\">$1</a>",
+    );
+    let s = bold_re().replace_all(&s, "<strong>$1</strong>");
+    let s = italic_re().replace_all(&s, "<em>$1</em>");
+    s.into_owned()
+}
+
+/// The plain-text reading of the same subset — markers dropped, link
+/// labels kept. Used where the intro feeds plain-text contexts (the
+/// meta-description fallback), so `**` never leaks into a `<meta>`.
+pub fn strip_inline(src: &str) -> String {
+    let s = link_re().replace_all(src, "$1");
+    let s = bold_re().replace_all(&s, "$1");
+    let s = italic_re().replace_all(&s, "$1");
+    s.into_owned()
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn plain_text_is_untouched_but_escaped() {
+        assert_eq!(render_inline("hello world"), "hello world");
+        assert_eq!(
+            render_inline("a <script>alert(1)</script> & \"quote\""),
+            "a &lt;script&gt;alert(1)&lt;/script&gt; &amp; &quot;quote&quot;"
+        );
+    }
+
+    #[test]
+    fn bold_italic_and_nesting() {
+        assert_eq!(render_inline("**b**"), "<strong>b</strong>");
+        assert_eq!(render_inline("*i*"), "<em>i</em>");
+        assert_eq!(
+            render_inline("***both***"),
+            "<em><strong>both</strong></em>"
+        );
+        assert_eq!(
+            render_inline("mix **b** and *i*."),
+            "mix <strong>b</strong> and <em>i</em>."
+        );
+    }
+
+    #[test]
+    fn lone_or_unpaired_markers_stay_literal() {
+        assert_eq!(render_inline("2 * 3 = 6"), "2 * 3 = 6");
+        assert_eq!(render_inline("a ** b"), "a ** b");
+        assert_eq!(render_inline("*open"), "*open");
+    }
+
+    #[test]
+    fn links_are_scheme_restricted_and_attribute_safe() {
+        assert_eq!(
+            render_inline("[docs](https://example.com/a?b=1&c=2)"),
+            "<a href=\"https://example.com/a?b=1&amp;c=2\" target=\"_blank\" rel=\"noopener\">docs</a>"
+        );
+        // Non-http(s) schemes don't linkify.
+        assert_eq!(
+            render_inline("[x](javascript:alert(1))"),
+            "[x](javascript:alert(1))"
+        );
+        // A quote can't escape the href — it was escaped first.
+        assert_eq!(
+            render_inline("[x](https://e.com/\"onmouseover=1)"),
+            "<a href=\"https://e.com/&quot;onmouseover=1\" target=\"_blank\" rel=\"noopener\">x</a>"
+        );
+    }
+
+    #[test]
+    fn emphasis_inside_link_labels() {
+        assert_eq!(
+            render_inline("[**bold** label](https://e.com)"),
+            "<a href=\"https://e.com\" target=\"_blank\" rel=\"noopener\"><strong>bold</strong> label</a>"
+        );
+    }
+
+    #[test]
+    fn strip_drops_markers_and_keeps_labels() {
+        assert_eq!(
+            strip_inline("**Welcome** to *the* [portal](https://e.com)."),
+            "Welcome to the portal."
+        );
+        assert_eq!(strip_inline("2 * 3"), "2 * 3");
+    }
+}

--- a/crates/ruscker-admin/src/routes/landing.rs
+++ b/crates/ruscker-admin/src/routes/landing.rs
@@ -42,8 +42,10 @@ struct LandingPage<'a> {
     /// the `<select>` filter at the top of the landing.
     subjects: Vec<&'a str>,
     counts: CardCounts,
-    /// Resolved per-locale intro text, or empty string when no
-    /// `landing-customization.intro` is configured.
+    /// Resolved per-locale intro, rendered through the inline-Markdown
+    /// subset (#812: **bold**, *italic*, [links] — escape-first, see
+    /// `crate::markdown`). Empty string when no intro is configured;
+    /// emitted with `|safe`.
     intro: String,
     /// Header title — `landing-customization.title` override, else
     /// `proxy.title`, else the localized `landing-title` (#468).
@@ -364,7 +366,10 @@ async fn index(
     };
     let page_title =
         not_blank(&lc.seo_title).unwrap_or_else(|| state.locales.t(loc, "landing-title", None));
-    let seo_description = not_blank(&lc.seo_description).unwrap_or_else(|| intro.clone());
+    // The meta-description fallback wants PLAIN text — strip the
+    // Markdown markers instead of leaking `**` into the tag (#812).
+    let seo_description = not_blank(&lc.seo_description)
+        .unwrap_or_else(|| crate::markdown::strip_inline(&intro));
     // Social-share image with an auto-default chain: the explicit
     // `og-image` wins; otherwise the operator's header-left brand logo
     // (the one that replaces the Ruscker mark) is reused so a shared link
@@ -515,7 +520,7 @@ async fn index(
         type_chips,
         subjects,
         counts,
-        intro,
+        intro: crate::markdown::render_inline(&intro),
         header_title,
         header_subtitle,
         // Footer override (blank ⇒ the default version+wordmark lockup).

--- a/crates/ruscker-admin/templates/admin/landing.html
+++ b/crates/ruscker-admin/templates/admin/landing.html
@@ -1004,8 +1004,12 @@
         </div>
 
         <div class="landing-preview-body">
+          {# x-html, fed by pvIntroHtml() — the client mirror of the
+             server's inline-Markdown subset (#812); it escapes the raw
+             text before the three rewrites, so typed HTML shows as
+             text here exactly like on the portal. #}
           <p class="landing-preview-intro"
-             x-text="previewIntro() || $el.dataset.placeholder"
+             x-html="pvIntroHtml() || $el.dataset.placeholder"
              data-placeholder="{{ self.t("admin-landing-preview-empty") }}"
              :class="!previewIntro() ? 'opacity-40 italic' : ''"></p>
           {# Search pill + filter chips honour the Visible-sections toggles. #}
@@ -1385,6 +1389,19 @@ window.ruscker.landingForm = (initial, logoImages) => ({
   /// Resolve the intro shown in the preview given the admin's
   /// own locale: prefer the per-locale field, fall back to the
   /// default. Mirrors the server-side resolution in routes/landing.rs.
+  // Client mirror of crate::markdown::render_inline (#812): escape
+  // first, then links → bold → italic. Keep the two in sync.
+  mdInline(t) {
+    const esc = (t || '')
+      .replace(/&/g, '&amp;').replace(/</g, '&lt;')
+      .replace(/>/g, '&gt;').replace(/"/g, '&quot;');
+    return esc
+      .replace(/\[([^\]]+)\]\((https?:\/\/[^\s)]+)\)/g,
+        '<a href="$2" target="_blank" rel="noopener">$1</a>')
+      .replace(/\*\*([^*]+)\*\*/g, '<strong>$1</strong>')
+      .replace(/\*([^*]+)\*/g, '<em>$1</em>');
+  },
+  pvIntroHtml() { return this.mdInline(this.previewIntro()); },
   previewIntro() {
     const code = "{{ locale.code() }}";
     const per = { pt: this.form.intro_pt, en: this.form.intro_en, es: this.form.intro_es, fr: this.form.intro_fr };

--- a/crates/ruscker-admin/templates/landing.html
+++ b/crates/ruscker-admin/templates/landing.html
@@ -101,8 +101,10 @@
        width, justified with per-language hyphenation — it used to cap
        at max-w-3xl and rag right, wasting the row. The class is also
        the operator's CSS hook. #}
+    {# Pre-rendered by the inline-Markdown subset (#812) — escape-first
+       in crate::markdown, so |safe never sees raw operator HTML. #}
     <p class="landing-intro">
-      {{ intro }}
+      {{ intro|safe }}
     </p>
   {% endif %}
 

--- a/docs/YAML_SCHEMA.md
+++ b/docs/YAML_SCHEMA.md
@@ -226,8 +226,8 @@ Field reference:
 | `header-fg-dark` | CSS color | none | Dark-theme header text. Unset inherits `header-fg`. |
 | `card-cover-default` | CSS value | none | Default cover (solid/gradient) painted behind catalog cards that have no per-app `cover`/`accent`. Unset keeps the per-kind tint. |
 | `card-cover-default-dark` | CSS value | none | Dark-theme default card cover. Unset inherits `card-cover-default`. |
-| `intro` | string | none | Plain text (no HTML); single-language fallback. |
-| `intro-locales` | map | `{}` | Locale code → intro string. Wins over `intro` for matching locales. |
+| `intro` | string | none | Single-language fallback. Inline Markdown only — `**bold**`, `*italic*`, `[links](https://…)`; no HTML. |
+| `intro-locales` | map | `{}` | Locale code → intro string (same inline Markdown). Wins over `intro` for matching locales. |
 | `seo-title` | string | `proxy.title` | Override for `<title>`. |
 | `seo-description` | string | resolved intro | `<meta name="description">` + `og:description`. |
 | `og-image` | path / URL | none | `og:image` for social-share. |


### PR DESCRIPTION
Closes #812 — the evaluated direction, implemented for the intro only.

- New `crate::markdown`: escape-first inline renderer (`**bold**`, `*italic*`, `[label](https://…)`) + a `strip_inline` plain-text reading for the meta-description fallback. No CommonMark dependency; unmatched markers stay literal so existing plain-text intros are byte-identical; links are http(s)-only and attribute-safe (quotes escaped before the rewrite).
- Landing renders the intro via the subset (`|safe` only ever sees our own output); intro links get the brand colour.
- The Appearance preview mirrors the subset client-side (escape-first `x-html`), with comments pinning the two implementations together.
- Help texts ×4 locales, YAML_SCHEMA + admin guide updated.

Tests: 6 unit cases (escaping, nesting, lone `*`, `javascript:` refused, quote-in-URL safe, emphasis in labels) + Playwright smoke (preview == portal, HTML-as-text, marker-free meta). Full gate green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)