### PR TITLE
docs(readme): Markdown-enabled intros

### DIFF
--- a/README.md
+++ b/README.md
@@ -95,7 +95,8 @@ What's in the box:
   form, including API/scaling/resource/lifecycle settings, with inline
   help, plus one-click archive/restore from the list), image/media
   library, encrypted credentials store, a landing-page editor with a
-  live preview (per-theme light/dark styling, logos, intros, SEO,
+  live preview (per-theme light/dark styling, logos, Markdown-enabled
+  per-locale intros, SEO,
   social meta, analytics, custom HTML blocks), an audit log, **user
   accounts with Viewer / Editor / Admin roles**, and a live SSE
   dashboard (CPU/memory sparklines, live-follow logs, stop/restart).


### PR DESCRIPTION
Follow-up to #813: the README's admin-panel bullet mentions the Markdown-enabled per-locale intros. The guide, YAML_SCHEMA and field helps were already updated in the feature PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)