### PR TITLE
fix(admin): filename captions on image-picker tiles

### DIFF
--- a/crates/ruscker-admin/assets/tailwind/input.css
+++ b/crates/ruscker-admin/assets/tailwind/input.css
@@ -1965,7 +1965,17 @@ textarea.spec-form-input { resize: vertical; min-height: 64px; }
 }
 .image-picker-tile:hover { border-color: var(--border-strong); }
 .image-picker-tile.is-sel { border-color: #0f6e56; }
+.image-picker-tile { position: relative; }
 .image-picker-tile img { width: 100%; height: 100%; object-fit: cover; display: block; }
+/* Filename caption over the tile's bottom edge (#818): with look-alike
+   logos the name is the only reliable differentiator. */
+.image-picker-name {
+  position: absolute; left: 0; right: 0; bottom: 0;
+  padding: 2px 5px; font-size: 9.5px; line-height: 1.3; text-align: center;
+  white-space: nowrap; overflow: hidden; text-overflow: ellipsis;
+  background: color-mix(in srgb, var(--surface) 82%, transparent);
+  color: var(--text-muted); pointer-events: none;
+}
 .image-picker-tile.is-builtin img { object-fit: contain; padding: 8px; }
 /* Logo galleries (spec form): logos have intentional whitespace, so fit
    them whole instead of cropping. */

--- a/crates/ruscker-admin/templates/admin/landing.html
+++ b/crates/ruscker-admin/templates/admin/landing.html
@@ -1119,6 +1119,10 @@
           <button type="button" :title="name" @click="pickImage('/assets/img/' + name)"
                   class="image-picker-tile" :class="pickerSelected('/assets/img/' + name) ? 'is-sel' : ''">
             <img :src="assetUrl('/assets/img/' + name) + '?thumb'" :alt="name" loading="lazy">
+            {# Visible filename (#818): with look-alike logos (logo.webp
+               vs logo-2.webp after a same-name upload) the hover title
+               wasn't enough to tell tiles apart. #}
+            <span class="image-picker-name" x-text="name"></span>
           </button>
         </template>
       </div>

--- a/crates/ruscker-admin/templates/admin/spec_form.html
+++ b/crates/ruscker-admin/templates/admin/spec_form.html
@@ -1081,6 +1081,10 @@
           <button type="button" :title="name" @click="pickImage('/assets/img/' + name)"
                   class="image-picker-tile" :class="pickerSelected('/assets/img/' + name) ? 'is-sel' : ''">
             <img :src="assetUrl('/assets/img/' + name) + '?thumb'" :alt="name" loading="lazy">
+            {# Visible filename (#818): with look-alike logos (logo.webp
+               vs logo-2.webp after a same-name upload) the hover title
+               wasn't enough to tell tiles apart. #}
+            <span class="image-picker-name" x-text="name"></span>
           </button>
         </template>
       </div>


### PR DESCRIPTION
Follow-up to #815 (keep-both semantics): picker tiles now show a truncated filename caption, so `logo.webp` vs `logo-2.webp` look-alikes are distinguishable when choosing manually. Auto-select flows were verified correct beforehand (inline upload picks the renamed file in both pickers). Screenshot-verified.

🤖 Generated with [Claude Code](https://claude.com/claude-code)