### PR TITLE
docs: roadmap refresh (v0.2.x polish loop + concrete Next-up list)

### DIFF
--- a/README.md
+++ b/README.md
@@ -71,8 +71,11 @@ tool" cases) is in
 ## Status
 
 **Production-ready and running in production.** The whole codebase
-went through a systematic bug / security / UX audit in June 2026,
-shipped as v0.2.5 with every finding fixed. Releases are
+went through a systematic bug / security / UX audit in June 2026
+(shipped as v0.2.5 with every finding fixed), followed by an
+operator-driven design sprint that brought the entire admin — the
+Appearance editor in particular — to the product's design handoff,
+with per-theme (light/dark) portal styling throughout. Releases are
 multi-arch (amd64 + arm64) and [cosign-signed]; the
 [releases page](https://github.com/StrategicProjects/ruscker/releases)
 has the current version. Built for efficiency, Ruscker's idle footprint

--- a/book/src/admin.md
+++ b/book/src/admin.md
@@ -147,10 +147,18 @@ Every image can be **deleted** from the gallery; if it is referenced by any
 spec logo/cover or landing logo, the entry shows an **"in use" badge** so
 you know before deleting.
 
+Uploading a file whose name already exists **keeps both images**: the
+new one is stored under a free name (`logo.webp` → `logo-2.webp`) and
+the flash tells you the stored name — nothing that references the
+original changes. The gallery sorts newest-first, so the renamed upload
+is the first tile.
+
 When editing a spec you can open a **modal picker** (search, browse, drag
 and drop, or upload inline without leaving the form) to select a logo or
 cover. A "Choose image" button auto-uploads on file select for a one-click
-flow.
+flow; inline uploads auto-select the stored (possibly renamed) file, and
+every picker tile shows a **filename caption**, so look-alike images are
+easy to tell apart.
 
 ![Media library: a gallery of images with built-in framework logos seeded alongside uploads, each tile showing its filename, size and type.](images/admin-media.png)
 

--- a/book/src/images/roadmap.svg
+++ b/book/src/images/roadmap.svg
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 720 520" width="720" height="520" font-family="Jost, Inter, system-ui, -apple-system, sans-serif" role="img" aria-label="Roadmap timeline. Phases 0 through 7 are done. Phases 0 to 5 shipped in v0.1.0 (scaffolding, landing page, persistence and admin CRUD, proxy and Docker backend, monitoring dashboard, production polish); phase 6 (multi-host scheduling, app visibility, sub-path mounting) shipped across v0.1.1 and v0.1.2; phase 7 (HA / multi-instance) shipped in v0.1.1. After phase 7, the v0.1.x–v0.2.x point releases added the admin redesign and, in v0.2.5, a full bug, security and UX audit across the shipped phases. Phase 8 (external auth) is planned and optional.">
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 720 520" width="720" height="520" font-family="Jost, Inter, system-ui, -apple-system, sans-serif" role="img" aria-label="Roadmap timeline. Phases 0 through 7 are done. Phases 0 to 5 shipped in v0.1.0 (scaffolding, landing page, persistence and admin CRUD, proxy and Docker backend, monitoring dashboard, production polish); phase 6 (multi-host scheduling, app visibility, sub-path mounting) shipped across v0.1.1 and v0.1.2; phase 7 (HA / multi-instance) shipped in v0.1.1. After phase 7, the v0.1.x–v0.2.x point releases added the admin redesign, a full bug, security and UX audit (v0.2.5), and an operator-driven design-handoff sprint across the Appearance editor, Apps list and Media flows. Phase 8 (external auth) is planned and optional.">
   <title>Ruscker — roadmap</title>
 
   <!-- rail: solid teal through the done phases (0–7) and the latest-release
@@ -69,7 +69,7 @@
        phase. Sits at the solid→dashed transition. -->
   <path d="M60,439 l7,7 l-7,7 l-7,-7 z" fill="#1D9E75" stroke="#FFFFFF" stroke-width="1.5"/>
   <text x="86" y="450" font-size="12.5">
-    <tspan font-weight="700" fill="#085041">v0.2.5</tspan><tspan fill="#5B6B66"> · latest — admin redesign + full bug/security/UX audit (across phases 1–7)</tspan>
+    <tspan font-weight="700" fill="#085041">v0.2.x</tspan><tspan fill="#5B6B66"> · latest — full audit (v0.2.5) + the admin design-handoff sprint (Appearance, Apps, Media)</tspan>
   </text>
 
   <!-- planned phase -->

--- a/book/src/roadmap.md
+++ b/book/src/roadmap.md
@@ -1,10 +1,12 @@
 # Roadmap
 
-Ruscker is at **v0.2.5** — Phases 0 through 7 are done, the proxy is
-production-ready and horizontally scalable, and a full bug / security /
-UX audit of the codebase shipped as v0.2.5 (every finding fixed). Phase
-8 (external auth) is the main optional, demand-driven work left. For
-what changed in each release, see the [release notes](./news.md).
+Phases 0 through 7 are done: the proxy is production-ready and
+horizontally scalable, a full bug / security / UX audit shipped as
+v0.2.5 (every finding fixed), and the v0.2.x series since then has been
+an **operator-driven polish loop** — short releases, each validated
+live on a real deployment before the next. Phase 8 (external auth) is
+the main optional, demand-driven work left. For what changed in each
+release, see the [release notes](./news.md).
 
 ![Roadmap timeline: phases 0–7 are done — 0 to 5 shipped in v0.1.0 (scaffolding, landing page, persistence + admin CRUD, proxy + Docker backend, monitoring dashboard, production polish); phase 6 (multi-host scheduling, app visibility, sub-path mounting) across v0.1.1–v0.1.2; phase 7 (HA / multi-instance) in v0.1.1. Post-1.0 point releases add demo forks, URL-rewrite modernization, unified credentials, the media library, portal logos, admin UX polish, and security + perf fixes. Phase 8 (external auth) is planned and optional.](images/roadmap.svg)
 
@@ -148,9 +150,51 @@ chrome. The social-share **`og:image` auto-defaults** to the header logo
 dashboard streams through reverse proxies** (`X-Accel-Buffering: no`), so
 new containers appear in real time even behind nginx on a subpath mount.
 
+**The design-handoff sprint (v0.2.6 – v0.2.13).** A rapid, live-tested
+series that brought the whole admin to the design handoff and fixed
+what real operation surfaced, in days:
+
+- **Apps list** — archive / restore an app in place (the card leaves
+  the public portal, nothing is lost) and delete with confirmation,
+  right from the table; toggles update the row without a reload or a
+  scroll jump.
+- **Appearance, end to end** — one Logos section with an inline
+  main-logo picker; the header background as an explicit
+  Preset / Solid / Gradient choice; **per-theme (light / dark) values**
+  for the header, the default card covers and the palettes — with a
+  draggable angle dial, Inherited ⇄ Own pills, layout tiles, a
+  light/dark switch on the live preview, and a confirmed
+  "Restore defaults". The HTML-blocks editor gained inline editing.
+- **Landing content** — the intro paragraph fills the row (justified,
+  hyphenated per locale) and understands **inline Markdown** (bold,
+  italic, links — escape-first, never raw HTML).
+- **Media** — same-name uploads keep both images (the new one is
+  renamed and announced), and picker tiles show filename captions so
+  look-alikes can't be confused.
+
 ## Planned (optional)
 
 Demand-driven — Ruscker is complete and useful without it.
+
+### Next up (small, operator-driven)
+Tracked in the GitHub issues; picked up as real usage asks for them:
+
+- **"System" tab** in the admin — a read-only diagnostic view of the
+  effective server configuration (issue #766, decision pending).
+- **Personal highlights** — let each visitor pin their own favourite
+  apps (cookie for anonymous visitors, DB for signed-in ones,
+  issue #519).
+- **Markdown in app descriptions** — the intro already supports the
+  inline subset; extending it to card descriptions is deferred until
+  there's a concrete need (issue #812).
+- **First-party demo images** — fork the remaining showcase demos
+  (Shiny, Shiny for Python, Streamlit, Voilà, R Markdown) into
+  `milkway/ruscker-*-demo` images that serve at the root
+  (issues #389–#397).
+- **Hardening follow-ups** — live end-to-end validation of the
+  WebSocket arc on Shiny/Streamlit (validated against Jupyter today),
+  and a post-drop cooldown for scale-down to finish off the
+  seats=1 long-session flap.
 
 ### Phase 8 — External auth
 OIDC (Keycloak / Auth0 / Google), SAML, and LDAP, plus per-app access

--- a/docs/ROADMAP.md
+++ b/docs/ROADMAP.md
@@ -1,9 +1,10 @@
 # Roadmap
 
-> **Status: Phases 0–5 shipped — `v0.1.0` is out and production-ready.**
-> Phases 6–8 below are optional and demand-driven. For the narrative,
-> up-to-date version with a timeline diagram, see the
-> [Roadmap chapter](https://strategicprojects.github.io/ruscker/roadmap.html)
+> **Status: Phases 0–7 shipped and running in production**, followed by
+> the v0.2.x polish series (the v0.2.5 audit release and the
+> admin design-handoff sprint). Phase 8 is optional and demand-driven.
+> For the narrative, up-to-date version with a timeline diagram, see
+> the [Roadmap chapter](https://strategicprojects.github.io/ruscker/roadmap.html)
 > on the docs site. The phase checklists below are the original
 > planning detail (they predate v0.1.0; treat the per-item boxes as
 > historical scope, not live status).


### PR DESCRIPTION
Roadmap (book + internal + timeline SVG) updated for the post-audit era: the v0.2.6–v0.2.13 design-handoff sprint as a shipped section, an issue-sourced **Next up** list (#766, #519, #812, #389–#397, WS-arc validation, scale-down cooldown) before Phase 8, and a no-stale-version header. README status mentions the sprint; admin guide documents Media's keep-both + picker captions. mdbook builds clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)