### PR TITLE
fix(docker): Hub serveraddress normalization + auth-tagged pull errors + picker placement

### DIFF
--- a/crates/ruscker-admin/templates/admin/spec_form.html
+++ b/crates/ruscker-admin/templates/admin/spec_form.html
@@ -362,6 +362,60 @@
               <span x-text="pull.line" class="spec-form-input--mono" style="opacity:0.75"></span>
             </div>
           </div>
+
+          {# Registry — pulling private images. Lives right under the
+             image field (#820: that's where "does this image need a
+             login?" is asked — it used to hide in Advanced). Unified
+             on the credential
+             store (#351): pick a SAVED credential here; create/manage them
+             on the Credentials page (where the password can be a literal —
+             AES-encrypted — or a `${VAR}` env-ref). The inline
+             domain/username/password from imported ShinyProxy YAML are
+             preserved as hidden fields (back-compat, no data loss on save)
+             but no longer edited here — a named credential takes
+             precedence anyway. #}
+          <div class="spec-form-subsection">{{ self.t("spec-form-registry-section") }}</div>
+          <div class="spec-form-field">
+            <div class="spec-form-label-row">
+              <label for="f-reg-cred" class="spec-form-label">{{ self.t("spec-form-registry-credential") }}</label>
+              {% call help(self.t("spec-help-registry-credential")) %}{% endcall %}
+            </div>
+            {% if credential_names.is_empty() %}
+              {# No saved credentials — guide the operator instead of a mute
+                 field (#504). A hidden input preserves any existing value
+                 (e.g. a later-deleted credential) so a save doesn't drop it. #}
+              <div class="spec-form-empty-hint">
+                <i class="ti ti-info-circle" aria-hidden="true"></i>
+                {{ self.t("spec-form-registry-none") }}
+              </div>
+              <input type="hidden" name="docker_registry_credential" value="{{ form.docker_registry_credential }}">
+            {% else %}
+              <select id="f-reg-cred" name="docker_registry_credential" class="spec-form-input theme-select">
+                <option value=""{% if form.docker_registry_credential.is_empty() %} selected{% endif %}>{{ self.t("spec-form-registry-none-option") }}</option>
+                {% for name in credential_names %}
+                  <option value="{{ name }}"{% if self.cred_selected(name) %} selected{% endif %}>{{ name }}</option>
+                {% endfor %}
+                {# A set-but-unknown value (deleted / imported) stays selectable. #}
+                {% if !self.cred_known() %}
+                  <option value="{{ form.docker_registry_credential }}" selected>{{ form.docker_registry_credential }} ({{ self.t("spec-form-registry-missing") }})</option>
+                {% endif %}
+              </select>
+            {% endif %}
+            <div class="spec-form-help">
+              {{ self.t("spec-form-registry-help") }}
+              <a href="{{ base }}/admin/credentials" target="_blank" rel="noopener" class="hover:underline">
+                {{ self.t("admin-nav-credentials") }}
+                <i class="ti ti-external-link" aria-hidden="true" style="font-size:11px"></i>
+              </a>
+            </div>
+          </div>
+          {# Back-compat: keep inline registry creds from imported YAML so a
+             save doesn't drop them (domain/username preserved verbatim;
+             blank password keeps the stored one, #260). No longer editable
+             here — migrate to a saved credential above. #}
+          <input type="hidden" name="docker_registry_domain" value="{{ form.docker_registry_domain }}">
+          <input type="hidden" name="docker_registry_username" value="{{ form.docker_registry_username }}">
+          <input type="hidden" name="docker_registry_password" value="">
         </section>
       </template>
 
@@ -688,56 +742,6 @@
             <div class="spec-form-help">{{ self.t("spec-form-container-cmd-help") }}</div>
           </div>
 
-          {# Registry — pulling private images. Unified on the credential
-             store (#351): pick a SAVED credential here; create/manage them
-             on the Credentials page (where the password can be a literal —
-             AES-encrypted — or a `${VAR}` env-ref). The inline
-             domain/username/password from imported ShinyProxy YAML are
-             preserved as hidden fields (back-compat, no data loss on save)
-             but no longer edited here — a named credential takes
-             precedence anyway. #}
-          <div class="spec-form-subsection">{{ self.t("spec-form-registry-section") }}</div>
-          <div class="spec-form-field">
-            <div class="spec-form-label-row">
-              <label for="f-reg-cred" class="spec-form-label">{{ self.t("spec-form-registry-credential") }}</label>
-              {% call help(self.t("spec-help-registry-credential")) %}{% endcall %}
-            </div>
-            {% if credential_names.is_empty() %}
-              {# No saved credentials — guide the operator instead of a mute
-                 field (#504). A hidden input preserves any existing value
-                 (e.g. a later-deleted credential) so a save doesn't drop it. #}
-              <div class="spec-form-empty-hint">
-                <i class="ti ti-info-circle" aria-hidden="true"></i>
-                {{ self.t("spec-form-registry-none") }}
-              </div>
-              <input type="hidden" name="docker_registry_credential" value="{{ form.docker_registry_credential }}">
-            {% else %}
-              <select id="f-reg-cred" name="docker_registry_credential" class="spec-form-input theme-select">
-                <option value=""{% if form.docker_registry_credential.is_empty() %} selected{% endif %}>{{ self.t("spec-form-registry-none-option") }}</option>
-                {% for name in credential_names %}
-                  <option value="{{ name }}"{% if self.cred_selected(name) %} selected{% endif %}>{{ name }}</option>
-                {% endfor %}
-                {# A set-but-unknown value (deleted / imported) stays selectable. #}
-                {% if !self.cred_known() %}
-                  <option value="{{ form.docker_registry_credential }}" selected>{{ form.docker_registry_credential }} ({{ self.t("spec-form-registry-missing") }})</option>
-                {% endif %}
-              </select>
-            {% endif %}
-            <div class="spec-form-help">
-              {{ self.t("spec-form-registry-help") }}
-              <a href="{{ base }}/admin/credentials" target="_blank" rel="noopener" class="hover:underline">
-                {{ self.t("admin-nav-credentials") }}
-                <i class="ti ti-external-link" aria-hidden="true" style="font-size:11px"></i>
-              </a>
-            </div>
-          </div>
-          {# Back-compat: keep inline registry creds from imported YAML so a
-             save doesn't drop them (domain/username preserved verbatim;
-             blank password keeps the stored one, #260). No longer editable
-             here — migrate to a saved credential above. #}
-          <input type="hidden" name="docker_registry_domain" value="{{ form.docker_registry_domain }}">
-          <input type="hidden" name="docker_registry_username" value="{{ form.docker_registry_username }}">
-          <input type="hidden" name="docker_registry_password" value="">
           {% if !form.docker_registry_domain.is_empty() || !form.docker_registry_username.is_empty() %}
           <div class="spec-form-help" style="color:var(--color-lock)">{{ self.t("spec-form-registry-inline-note") }}</div>
           {% endif %}

--- a/crates/ruscker-docker/src/lib.rs
+++ b/crates/ruscker-docker/src/lib.rs
@@ -379,18 +379,17 @@ impl LocalDockerBackend {
         let bollard_creds = creds.map(|c| bollard::auth::DockerCredentials {
             username: Some(c.username.clone()),
             password: Some(c.password.clone()),
-            serveraddress: c.server_address.clone(),
+            serveraddress: canonical_server_address(c.server_address.as_deref()),
             ..Default::default()
         });
-        tracing::info!(
-            image,
-            with_creds = bollard_creds.is_some(),
-            registry = ?creds.and_then(|c| c.server_address.as_deref()),
-            "pulling image"
-        );
+        let auth = auth_desc(creds);
+        tracing::info!(image, auth = %auth, "pulling image");
         let mut stream = self.docker.create_image(Some(opts), None, bollard_creds);
         while let Some(event) = stream.next().await {
-            event.map_err(|e| backend_err("pull image", e))?;
+            // The auth context rides in the error: "pull access denied"
+            // with `anonymous` vs `authenticated as …` is the difference
+            // between a missing credential and a wrong one (#820).
+            event.map_err(|e| backend_err(&format!("pull image ({auth})"), e))?;
         }
         Ok(())
     }
@@ -820,7 +819,7 @@ impl ContainerBackend for LocalDockerBackend {
         let bollard_creds = creds.map(|c| bollard::auth::DockerCredentials {
             username: Some(c.username.clone()),
             password: Some(c.password.clone()),
-            serveraddress: c.server_address.clone(),
+            serveraddress: canonical_server_address(c.server_address.as_deref()),
             ..Default::default()
         });
         let stream = self
@@ -1194,6 +1193,56 @@ fn state_from_docker(s: Option<&str>) -> ReplicaState {
     }
 }
 
+
+/// The registry address the Docker daemon should see for a pull.
+///
+/// Docker Hub is special: `docker login` records it as
+/// `https://index.docker.io/v1/` and daemons match `X-Registry-Auth`
+/// against that exact string — a bare `docker.io` (what an operator
+/// naturally types in the credential's Registry field) can be treated
+/// as a *different* registry and the credential silently ignored,
+/// degrading the pull to anonymous: a private image then fails with
+/// "404: pull access denied" even though the credential is valid
+/// (#820). Map the Hub aliases (and the empty value, which the
+/// credential store documents as "Docker Hub") to the canonical
+/// address; any other registry passes through verbatim.
+fn canonical_server_address(addr: Option<&str>) -> Option<String> {
+    const HUB: &str = "https://index.docker.io/v1/";
+    let Some(a) = addr.map(str::trim).filter(|s| !s.is_empty()) else {
+        return Some(HUB.to_string());
+    };
+    let bare = a
+        .trim_start_matches("https://")
+        .trim_start_matches("http://")
+        .trim_end_matches('/')
+        .trim_end_matches("/v1")
+        .trim_end_matches('/');
+    if matches!(
+        bare,
+        "docker.io" | "index.docker.io" | "registry-1.docker.io"
+            | "hub.docker.com" | "registry.hub.docker.com"
+    ) {
+        Some(HUB.to_string())
+    } else {
+        Some(a.to_string())
+    }
+}
+
+/// Operator-facing description of how a pull authenticates — rides in
+/// the pull error so "credential ignored / not attached" is diagnosable
+/// from the splash message alone (#820).
+fn auth_desc(creds: Option<&ruscker_core::RegistryCredentials>) -> String {
+    match creds {
+        Some(c) => format!(
+            "authenticated as {} @ {}",
+            c.username,
+            canonical_server_address(c.server_address.as_deref())
+                .unwrap_or_else(|| "Docker Hub".into())
+        ),
+        None => "anonymous".to_string(),
+    }
+}
+
 fn backend_err(op: &str, e: bollard::errors::Error) -> CoreError {
     CoreError::Backend(format!("{op}: {e}"))
 }
@@ -1229,6 +1278,32 @@ fn apply_limits(host_config: &mut HostConfig, limits: &ruscker_core::ResourceLim
 #[cfg(test)]
 mod tests {
     use super::*;
+
+    #[test]
+    fn hub_aliases_normalize_to_the_v1_index(){
+        let hub = Some("https://index.docker.io/v1/".to_string());
+        for a in [None, Some(""), Some("  "), Some("docker.io"), Some("https://docker.io"),
+                  Some("index.docker.io"), Some("registry-1.docker.io/"),
+                  Some("hub.docker.com"), Some("https://index.docker.io/v1/")] {
+            assert_eq!(canonical_server_address(a), hub, "alias {a:?}");
+        }
+        assert_eq!(
+            canonical_server_address(Some("registry.example.com")),
+            Some("registry.example.com".to_string()),
+            "non-Hub registries pass through"
+        );
+    }
+
+    #[test]
+    fn auth_desc_names_user_and_registry() {
+        assert_eq!(auth_desc(None), "anonymous");
+        let c = ruscker_core::RegistryCredentials {
+            username: "milkway".into(),
+            password: "x".into(),
+            server_address: Some("docker.io".into()),
+        };
+        assert_eq!(auth_desc(Some(&c)), "authenticated as milkway @ https://index.docker.io/v1/");
+    }
 
     #[test]
     fn state_from_docker_maps_common_values() {


### PR DESCRIPTION
Closes #820. Maps Docker Hub aliases to `https://index.docker.io/v1/` at both pull boundaries (mismatched serveraddress made daemons drop the credential → anonymous pull → 404-denied for private repos); spawn pull errors now say `authenticated as <user> @ <registry>` or `anonymous`; the credential picker moves from Advanced to right under the image field. Unit tests for the normalization + auth description; browser smoke for placement and denial surfacing.

🤖 Generated with [Claude Code](https://claude.com/claude-code)