### PR TITLE
fix(admin): credential picker binds to Alpine (on-demand Pull works before saving)

### DIFF
--- a/crates/ruscker-admin/templates/admin/spec_form.html
+++ b/crates/ruscker-admin/templates/admin/spec_form.html
@@ -390,7 +390,12 @@
               </div>
               <input type="hidden" name="docker_registry_credential" value="{{ form.docker_registry_credential }}">
             {% else %}
-              <select id="f-reg-cred" name="docker_registry_credential" class="spec-form-input theme-select">
+              {# x-model so a freshly-picked credential reaches the
+                 on-demand Pull button immediately (#822): without it
+                 `form.docker_registry_credential` stayed at the loaded
+                 value, so a Pull before saving went anonymous → 404 on a
+                 private image, and only worked after a save+reload. #}
+              <select id="f-reg-cred" name="docker_registry_credential" x-model="form.docker_registry_credential" class="spec-form-input theme-select">
                 <option value=""{% if form.docker_registry_credential.is_empty() %} selected{% endif %}>{{ self.t("spec-form-registry-none-option") }}</option>
                 {% for name in credential_names %}
                   <option value="{{ name }}"{% if self.cred_selected(name) %} selected{% endif %}>{{ name }}</option>

--- a/crates/ruscker-docker/src/lib.rs
+++ b/crates/ruscker-docker/src/lib.rs
@@ -822,13 +822,18 @@ impl ContainerBackend for LocalDockerBackend {
             serveraddress: canonical_server_address(c.server_address.as_deref()),
             ..Default::default()
         });
+        // Ride the auth context on the streamed error line too (#822):
+        // the spawn pull already does, but the editor's Pull button
+        // (this path) didn't — "denied — anonymous" vs "— authenticated
+        // as …" tells a dropped credential from a rejected one.
+        let auth = auth_desc(creds);
         let stream = self
             .docker
             .create_image(Some(opts), None, bollard_creds)
-            .map(|ev| match ev {
+            .map(move |ev| match ev {
                 Ok(info) => {
                     if let Some(err) = info.error_detail {
-                        return format!("error: {}", err.message.unwrap_or_default());
+                        return format!("error: {} — {auth}", err.message.unwrap_or_default());
                     }
                     let id = info.id.unwrap_or_default();
                     let status = info.status.unwrap_or_default();


### PR DESCRIPTION
Closes #822. The registry-credential `<select>` gained `x-model` — without it a freshly-picked credential never reached the Pull button (it reads `form.docker_registry_credential`), so a private pull went anonymous → 404 and only worked after save+reload. Verified end-to-end with a real Hub PAT: the on-demand pull of a private `milkway/*` image streams 'Downloaded newer image'. The editor Pull's error line also gets the auth context, like the spawn path.

🤖 Generated with [Claude Code](https://claude.com/claude-code)