### PR TITLE
fix: carousel hover stretch + stop/restart feedback repaint

### DIFF
--- a/crates/ruscker-admin/assets/tailwind/input.css
+++ b/crates/ruscker-admin/assets/tailwind/input.css
@@ -1196,6 +1196,10 @@ input[type="range"]::-moz-range-thumb {
 }
 .highlights-track {
   display: flex; gap: 14px;
+  /* Top-align so a card whose description expands on hover (#825/#828)
+     grows on its own — flex default `stretch` made every card in the
+     rail stretch to the hovered one's new height. */
+  align-items: flex-start;
   transition: transform 0.32s cubic-bezier(0.4, 0, 0.2, 1);
 }
 .highlights-track > .rcard { flex: 0 0 auto; }

--- a/crates/ruscker-admin/templates/admin/dashboard.html
+++ b/crates/ruscker-admin/templates/admin/dashboard.html
@@ -345,11 +345,24 @@
   // _layout, so a cancelled confirm (defaultPrevented) is a no-op.
   document.addEventListener('submit', function (e) {
     if (e.defaultPrevented) return;
-    var action = (e.target.getAttribute && e.target.getAttribute('action')) || '';
+    var f = e.target;
+    var action = (f.getAttribute && f.getAttribute('action')) || '';
     var m = action.match(/\/replicas\/([^/]+)\/(stop|restart)$/);
     if (!m) return;
-    applying.set(decodeURIComponent(m[1]), m[2]);
-    markBusy(e.target.closest('[data-replica-id]'), m[2]);
+    // Do the action over FETCH, not a navigating form POST (#828): a
+    // navigation makes the browser skip the repaint of the busy state we
+    // just applied — so the spinner/dim never showed and the page just
+    // looked frozen. With fetch the page stays put, the feedback paints
+    // and persists for the whole (slow) operation, and we reload once it
+    // resolves to pick up the new state. Same-origin POST ⇒ the
+    // Fetch-Metadata/Origin guard still passes.
+    e.preventDefault();
+    var rid = decodeURIComponent(m[1]);
+    applying.set(rid, m[2]);
+    markBusy(f.closest('[data-replica-id]'), m[2]);
+    fetch(action, { method: 'POST', headers: { 'X-Requested-With': 'fetch' } })
+      .then(function () { location.reload(); })
+      .catch(function () { location.reload(); });
   }, false);
 
   function apply(snap) {


### PR DESCRIPTION
Closes #828. (1) The featured rail's flexbox stretched every card to the hovered one's expanded height — `align-items: flex-start` like the grid. (2) The #827 busy feedback never painted because the navigating form POST made the browser skip the repaint — stop/restart now run over fetch (no navigation; reload on resolve), so the spinner/dim show for the whole operation. Both Playwright-verified.

🤖 Generated with [Claude Code](https://claude.com/claude-code)