### PR TITLE
docs: cover the private-image + deploy-robustness + UX releases (v0.2.13–v0.2.19)

### DIFF
--- a/README.md
+++ b/README.md
@@ -75,7 +75,9 @@ went through a systematic bug / security / UX audit in June 2026
 (shipped as v0.2.5 with every finding fixed), followed by an
 operator-driven design sprint that brought the entire admin — the
 Appearance editor in particular — to the product's design handoff,
-with per-theme (light/dark) portal styling throughout. Releases are
+with per-theme (light/dark) portal styling throughout, plus a round of
+private-image and deploy-robustness fixes from real production use.
+Releases are
 multi-arch (amd64 + arm64) and [cosign-signed]; the
 [releases page](https://github.com/StrategicProjects/ruscker/releases)
 has the current version. Built for efficiency, Ruscker's idle footprint

--- a/book/src/admin.md
+++ b/book/src/admin.md
@@ -59,7 +59,10 @@ worst replica state, and aggregate sessions / CPU / memory with little
 meters — and expands to the per-replica detail (state, container id,
 uptime, sessions, CPU, memory) with stop / restart / logs actions.
 A toolbar offers an **expand/collapse-all** control. Shows a banner when
-started without `--docker`.
+started without `--docker`. Stop and restart take a few seconds (drain,
+signal, and a respawn for restart), so while one runs the replica row
+dims, its buttons disable to prevent a double-fire, and the clicked
+action shows a spinner.
 
 ![Monitoring dashboard: aggregate cards (containers, apps with replicas, active sessions, memory) above a per-replica table with live CPU sparklines and memory, and per-row stop/restart/logs actions.](images/admin-dashboard.png)
 
@@ -98,6 +101,19 @@ Two editors can have the same app open without trampling each other:
 the form carries the version it was loaded against, and a stale save is
 rejected with a conflict banner (your input intact) instead of silently
 overwriting the other person's changes.
+
+**Private images.** Right under the Docker-image field, a **Check**
+button reports whether the image is already on the host, and a
+**Pull** / **Update image** button fetches (or re-fetches) it on
+demand with live progress — handy after re-publishing the same tag
+(new build, or a corrected CPU architecture). A **credential picker**
+sits next to the image field: pick a saved registry credential and
+Ruscker pulls private images with it. Docker Hub credentials are
+normalised to the canonical registry address so they apply reliably,
+and a pull failure names how it authenticated (anonymous vs. the
+user/registry). If a container crashes on startup, the dashboard and
+logs show the container's own error output and exit code — not a
+generic "no port binding".
 
 Under the collapsible **Advanced** band, every remaining spec option is
 editable too — so an app can be configured end-to-end from the web UI,

--- a/book/src/introduction.md
+++ b/book/src/introduction.md
@@ -18,7 +18,7 @@ startup**, Ruscker comes fully equipped with an **admin panel**,
 YAML schema, so migration is smooth and configuration is effortless.
 
 <p align="center">
-  <img src="images/landing.png" alt="The Ruscker landing page: a portal of app cards with a Featured carousel at the top, plus search and type/access filters — all served by a single binary." width="860">
+  <img src="images/landing.png" alt="The Ruscker landing page: a portal of app cards with a Featured carousel at the top, plus search and type/access filters — hovering a card reveals its full description — all served by a single binary." width="860">
 </p>
 
 ## How it works

--- a/book/src/roadmap.md
+++ b/book/src/roadmap.md
@@ -172,6 +172,15 @@ what real operation surfaced, in days:
   renamed and announced), and picker tiles show filename captions so
   look-alikes can't be confused.
 
+**Private-image & deploy robustness (v0.2.14 – v0.2.19).** Driven by an
+operator bringing a private Plumber2 app online: Docker Hub credentials
+are normalised so they apply reliably, the credential picker moved
+beside the image field, a force **re-pull** ("Update image") handles a
+re-published tag, and a boot crash now surfaces the container's own
+error + exit code instead of a generic "no port binding". Plus catalog
+cards expand their description on hover, and the dashboard's
+stop/restart actions show in-progress feedback.
+
 ## Planned (optional)
 
 Demand-driven — Ruscker is complete and useful without it.


### PR DESCRIPTION
Guide/README/roadmap catch-up for the releases since the last docs refresh: the Apps form's private-image flow (Check/Pull/Update-image, credential picker placement, Hub normalisation, auth-tagged errors, crash diagnosis), the dashboard's stop/restart progress feedback, and the card hover-expand. No new version strings outside news.md; mdbook clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)