### PR TITLE
fix(landing): hover reveals the full description at any length

### DIFF
--- a/crates/ruscker-admin/assets/tailwind/input.css
+++ b/crates/ruscker-admin/assets/tailwind/input.css
@@ -1248,23 +1248,21 @@ input[type="range"]::-moz-range-thumb {
   -webkit-box-orient: vertical;
   overflow: hidden;
   min-height: calc(1.5em * 2);
-  /* Hold the clamped height, then let it grow on hover (#825). The
-     max-height animates; the clamp is dropped so the full text shows.
-     Collapse uses this (no delay) so leaving feels responsive. */
+  /* Hold the clamped height, then grow on hover (#825). The max-height
+     animates; the clamp is dropped so the full text shows. The eased
+     curve + slow-in/out makes the reveal feel smooth (#831). On hover
+     the script sets the EXACT content height inline (#832) so the
+     animation neither snaps (a huge target) nor clips long text (a
+     small one); the 40em rule below is the no-JS fallback. Collapse
+     drops back here with no delay, so leaving feels responsive. */
   max-height: calc(1.5em * 2);
-  transition: max-height 0.28s ease;
+  transition: max-height 0.4s cubic-bezier(0.4, 0, 0.2, 1);
   margin-bottom: 12px;
 }
 .rcard:hover .rdesc {
   -webkit-line-clamp: unset; line-clamp: unset;
-  /* A REALISTIC target (≈9 lines), not 40em (#831): with a huge target
-     the 0.25s duration was spent racing toward 40em, so the real text
-     height was reached in a few ms — the reveal felt like a snap. A
-     close target makes the eased duration the actual reveal time;
-     gentle ease-out + a small open delay so a quick pass-through
-     doesn't fire it. */
-  max-height: 11em;
-  transition: max-height 0.4s cubic-bezier(0.4, 0, 0.2, 1) 0.08s;
+  max-height: 40em; /* fallback; the script overrides with the exact px */
+  transition-delay: 0.08s; /* a quick pass-through doesn't fire it */
 }
 .rmeta {
   display: flex; align-items: center; justify-content: space-between;

--- a/crates/ruscker-admin/templates/landing.html
+++ b/crates/ruscker-admin/templates/landing.html
@@ -547,6 +547,46 @@ window.ruscker.highlights = () => ({
     return 'transform: translateX(' + (-this.page * this.perPage * this.step) + 'px)';
   },
 });
+
+// Hover-reveal a card's full description by animating .rdesc to its
+// EXACT content height (#832). A fixed max-height either snapped (a
+// huge target) or clipped long text (a small one); measuring the real
+// height makes the eased animation land exactly on the full text, any
+// length. Delegated, so it covers the grid, the per-type sections and
+// the featured rail; the CSS `:hover { max-height: 40em }` rule is the
+// no-JS fallback (shows everything, just not to the exact pixel).
+(function () {
+  function fullHeight(desc) {
+    // scrollHeight under -webkit-line-clamp can report the clamped
+    // height, so measure with the clamp lifted, then restore.
+    var prevClamp = desc.style.webkitLineClamp;
+    var prevMax = desc.style.maxHeight;
+    desc.style.webkitLineClamp = 'unset';
+    desc.style.maxHeight = 'none';
+    var h = desc.scrollHeight;
+    desc.style.webkitLineClamp = prevClamp;
+    desc.style.maxHeight = prevMax;
+    return h;
+  }
+  document.addEventListener('mouseover', function (e) {
+    var card = e.target.closest && e.target.closest('.rcard');
+    if (!card || card.classList.contains('inactive')) return;
+    var desc = card.querySelector('.rdesc');
+    if (!desc || desc.dataset.open) return;
+    desc.dataset.open = '1';
+    desc.style.maxHeight = fullHeight(desc) + 'px';
+  });
+  document.addEventListener('mouseout', function (e) {
+    var card = e.target.closest && e.target.closest('.rcard');
+    if (!card) return;
+    // ignore moves that stay inside the same card
+    if (e.relatedTarget && card.contains(e.relatedTarget)) return;
+    var desc = card.querySelector('.rdesc');
+    if (!desc) return;
+    delete desc.dataset.open;
+    desc.style.maxHeight = ''; // back to the CSS clamp height
+  });
+})();
 </script>
 
 {% endblock %}


### PR DESCRIPTION
Closes #832. The #831 smoothing used a fixed ~11em target that clipped long descriptions. The card now animates to the description's measured content height (delegated mouseover/mouseout, line-clamp briefly lifted to read the true height), so the eased reveal lands exactly on the full text — any length, no clip, no empty space. CSS :hover 40em stays as the no-JS fallback. Smoke: a 224px description opens fully (zero clipping).

🤖 Generated with [Claude Code](https://claude.com/claude-code)