### PR TITLE
fix(specs): centre the post-create dialog on screen (#835)

### DIFF
--- a/crates/ruscker-admin/templates/admin/spec_form.html
+++ b/crates/ruscker-admin/templates/admin/spec_form.html
@@ -25,25 +25,34 @@
    boolean (no localized string inside a JS handler — that's the #765 trap),
    and the list action is a plain link. #}
 {% if just_created %}
-<div x-data="{ open: true }" x-show="open" x-cloak
-     class="spec-created-overlay" role="dialog" aria-modal="true"
-     aria-labelledby="spec-created-title"
-     @keydown.escape.window="open = false">
-  <div class="spec-created-modal" @click.outside="open = false">
-    <div class="spec-created-icon" aria-hidden="true"><i class="ti ti-circle-check"></i></div>
-    <h2 id="spec-created-title" class="spec-created-title">{{ self.t("spec-form-created-title") }}</h2>
-    <p class="spec-created-body">{{ self.t("spec-form-created-body") }}</p>
-    <div class="spec-created-actions">
-      <button type="button" class="admin-nav-link" @click="open = false">
-        <i class="ti ti-pencil" aria-hidden="true"></i>
-        {{ self.t("spec-form-created-stay") }}
-      </button>
-      <a href="{{ base }}/admin/specs" class="admin-login-btn" style="padding:6px 12px;font-size:12px">
-        <i class="ti ti-list" aria-hidden="true"></i>
-        {{ self.t("spec-form-created-list") }}
-      </a>
+<div x-data="{ open: true }">
+  {# Teleported to <body> so the overlay's `position: fixed` resolves
+     against the viewport, not the admin shell's animated
+     `<main class="fade-in">` — its transform is a containing block for
+     fixed descendants, which otherwise centred the dialog inside the long
+     form and pushed it off-screen (same fix as the image picker). #}
+  <template x-teleport="body">
+    <div x-show="open" x-cloak
+         class="spec-created-overlay" role="dialog" aria-modal="true"
+         aria-labelledby="spec-created-title"
+         @keydown.escape.window="open = false" @click.self="open = false">
+      <div class="spec-created-modal">
+        <div class="spec-created-icon" aria-hidden="true"><i class="ti ti-circle-check"></i></div>
+        <h2 id="spec-created-title" class="spec-created-title">{{ self.t("spec-form-created-title") }}</h2>
+        <p class="spec-created-body">{{ self.t("spec-form-created-body") }}</p>
+        <div class="spec-created-actions">
+          <button type="button" class="admin-nav-link" @click="open = false">
+            <i class="ti ti-pencil" aria-hidden="true"></i>
+            {{ self.t("spec-form-created-stay") }}
+          </button>
+          <a href="{{ base }}/admin/specs" class="admin-login-btn" style="padding:6px 12px;font-size:12px">
+            <i class="ti ti-list" aria-hidden="true"></i>
+            {{ self.t("spec-form-created-list") }}
+          </a>
+        </div>
+      </div>
     </div>
-  </div>
+  </template>
 </div>
 {% endif %}
 


### PR DESCRIPTION
Follow-up to #836 / v0.2.24.

## Problema

O diálogo de confirmação pós-criação aparecia **muito embaixo na tela, meio escondido**. O overlay é `position: fixed`, mas o `<main class="fade-in">` do shell admin tem um `transform` de animação — e um ancestral com `transform` vira o *containing block* de descendentes `fixed`. Resultado: o diálogo centralizava dentro do formulário (longo), não da viewport.

## Correção

Teleportar o overlay para `<body>` via `<template x-teleport="body">` — a mesma correção já usada no image-picker — para que `position: fixed` volte a resolver contra a viewport.

## Smoke (Playwright + servidor real)

- `overlay.parentElement.tagName` → **BODY** (teleportado).
- `.spec-created-modal` centraliza em **y≈454** numa viewport de 900px, totalmente dentro dela.
- Screenshot confere: diálogo centralizado, backdrop escurecendo o form.

🤖 Generated with [Claude Code](https://claude.com/claude-code)