### PR TITLE
fix(landing): mobile portal cards — full-width + full description (#843)

### DIFF
--- a/crates/ruscker-admin/assets/tailwind/input.css
+++ b/crates/ruscker-admin/assets/tailwind/input.css
@@ -1033,7 +1033,10 @@ input[type="range"]::-moz-range-thumb {
      a no-op until a hover. */
   align-items: start;
 }
-@media (max-width: 320px) {
+/* Phones: let cards fill the width instead of a fixed 256px column
+   centred with dead space either side (#843). Two 256px cards need
+   ~526px, so below that one card per row reads better full-width. */
+@media (max-width: 512px) {
   :root { --card-w: 100%; }
 }
 
@@ -1263,6 +1266,17 @@ input[type="range"]::-moz-range-thumb {
   -webkit-line-clamp: unset; line-clamp: unset;
   max-height: 40em; /* fallback; the script overrides with the exact px */
   transition-delay: 0.08s; /* a quick pass-through doesn't fire it */
+}
+/* Touch devices can't hover, so the reveal never fires — show the whole
+   description up-front instead of a permanently-clamped 2 lines (#843).
+   `hover: none` targets touch devices regardless of width; the width
+   fallback covers narrow screens (and is what's testable in a headless
+   browser, where `hover` isn't reliably emulated). */
+@media (hover: none), (max-width: 640px) {
+  .rdesc {
+    -webkit-line-clamp: unset; line-clamp: unset;
+    max-height: none; overflow: visible;
+  }
 }
 .rmeta {
   display: flex; align-items: center; justify-content: space-between;


### PR DESCRIPTION
Closes #843.

## O que muda (mobile)

- **Cards full-width:** `--card-w: 100%` agora a partir de **≤512px** (era ≤320px) — antes o card ficava fixo em 256px centralizado, estreito e com espaço morto, parecendo "uma coluna por cima da outra".
- **Descrição completa sem hover:** `@media (hover: none), (max-width: 640px)` remove o clamp de 2 linhas do `.rdesc` — touch/tela estreita mostram o texto inteiro (em desktop o clamp + hover-expand seguem iguais).

## Verificação (Playwright, real)

390px touch-emulado: card **342px** (full-width), `.rdesc` line-clamp **none** (texto completo), overflow horizontal **+0px**. Desktop inalterado.

🤖 Generated with [Claude Code](https://claude.com/claude-code)