### PR TITLE
fix(admin): icon-only landing header + table column overlap on mobile (#845)

### DIFF
--- a/crates/ruscker-admin/assets/tailwind/input.css
+++ b/crates/ruscker-admin/assets/tailwind/input.css
@@ -1610,6 +1610,10 @@ input[type="range"]::-moz-range-thumb {
 .admin-login-footer a:hover { color: var(--text); }
 
 /* ─── Admin apps table ───────────────────────────────────────── */
+/* The admin shell JS wraps every table in this box (#845). It's inert on
+   desktop (the table fits) and scrolls horizontally on mobile, where the
+   table keeps its natural width — so columns never collapse/overlap. */
+.admin-table-scroll { overflow-x: auto; -webkit-overflow-scrolling: touch; }
 .admin-table {
   width: 100%;
   border-collapse: collapse;
@@ -2810,16 +2814,26 @@ input[type="color"].cover-swatch::-webkit-color-swatch { border: 0; border-radiu
      wrap the breadcrumb + buttons instead of crushing them. */
   .editor-topbar { flex-wrap: wrap; align-items: center; gap: 10px; }
 
-  /* Data tables (apps/audit/users/disk/credentials): a wide table would
-     blow out the page sideways. `display:block` turns the table into its
-     own horizontal scroll container — an anonymous table box keeps the
-     columns aligned — so it scrolls inside its card instead of widening
-     the viewport. */
-  .admin-table {
-    display: block;
-    overflow-x: auto;
-    -webkit-overflow-scrolling: touch;
+  /* Landing header "Sign in" pill → icon only (matches the other chrome
+     icons), so the public header doesn't show a text label on a phone
+     (#845). Label kept for screen readers; position:relative contains the
+     absolute sr-only span. */
+  .chrome-signin span {
+    position: absolute; width: 1px; height: 1px;
+    padding: 0; margin: -1px; overflow: hidden;
+    clip: rect(0, 0, 0, 0); white-space: nowrap; border: 0;
   }
+  .chrome-signin {
+    width: 32px; padding: 0; gap: 0;
+    justify-content: center; position: relative;
+  }
+
+  /* Data tables: keep their natural column widths and let the wrapper
+     (.admin-table-scroll, added by the admin shell JS) do the scrolling.
+     `width:100%` alone would squeeze the columns until they overlap on a
+     phone — the bug behind "the first column sits over the second" (#845).
+     The table stays display:table so its columns always line up. */
+  .admin-table { min-width: max-content; }
 
   /* Dashboard replica grid: its fixed-width columns are wider than a
      phone. Scroll the header + all app groups together as one unit

--- a/crates/ruscker-admin/templates/admin/_layout.html
+++ b/crates/ruscker-admin/templates/admin/_layout.html
@@ -408,7 +408,10 @@ window.ruscker.imagePicker = (filenames) => ({
       input.setAttribute('aria-label', I18N.search);
       input.placeholder = I18N.search;
       wrap.appendChild(input);
-      table.parentNode.insertBefore(wrap, table);
+      // Place the search toolbar ABOVE the scroll box (not inside it), so
+      // it doesn't slide away when the table is scrolled sideways.
+      var anchor = table.closest('.admin-table-scroll') || table;
+      anchor.parentNode.insertBefore(wrap, anchor);
 
       // empty-state row
       var emptyRow = document.createElement('tr');
@@ -461,6 +464,18 @@ window.ruscker.imagePicker = (filenames) => ({
   }
 
   document.addEventListener('DOMContentLoaded', function () {
+    // Wrap every admin table in a horizontal-scroll box so a wide table
+    // scrolls inside its card on mobile, with the table kept as
+    // display:table so its columns always line up. (The earlier
+    // display:block trick split thead/tbody into separate column tracks
+    // and could overlap columns with some data — #845.)
+    document.querySelectorAll('table.admin-table').forEach(function (t) {
+      if (t.parentElement && t.parentElement.classList.contains('admin-table-scroll')) return;
+      var box = document.createElement('div');
+      box.className = 'admin-table-scroll';
+      t.parentNode.insertBefore(box, t);
+      box.appendChild(t);
+    });
     document.querySelectorAll('table[data-enhance]').forEach(enhance);
   });
 


### PR DESCRIPTION
Closes #845.

## O que muda (mobile)

1. **Header da landing icon-only** — `.chrome-signin` ("Sign in") vira ícone quadrado de 32px no ≤640px (label sr-only pra leitores de tela). Não aparece mais texto no header público.
2. **Colunas da tabela de apps alinhadas** — o `display:block` da v0.2.27 (que separava thead/tbody e, com `width:100%`, sobrepunha a 1ª coluna na 2ª) foi trocado por um **wrapper de scroll**: o JS do admin envolve toda `.admin-table` num `.admin-table-scroll` (overflow-x:auto); a tabela continua `display:table` com `min-width:max-content` no mobile → colunas sempre alinhadas, rola dentro do card. O toolbar de busca fica ancorado acima do wrapper.

## Verificação (Playwright, 360px touch)

`.chrome-signin` = 32px (label 1px/sr-only); tabela `display:table` dentro de `.admin-table-scroll`, TH/TD alinhados ao pixel, sem overflow horizontal de página. Desktop inalterado.

🤖 Generated with [Claude Code](https://claude.com/claude-code)