### PR TITLE
feat(docker): per-spec container-network (create + attach)

### DIFF
--- a/crates/ruscker-admin/assets/i18n/en/landing.ftl
+++ b/crates/ruscker-admin/assets/i18n/en/landing.ftl
@@ -557,6 +557,8 @@ spec-form-container-port = Container port
 spec-help-container-port = Port the app listens on inside the container. Blank = per-kind default (3838 for Shiny). Set it for Streamlit (8501), Dash (8050) or Jupyter (8888).
 spec-form-platform = Platform
 spec-help-platform = Docker platform (e.g. linux/amd64) to run a cross-arch image under emulation. Blank = the daemon picks per the manifest.
+spec-form-container-network = Docker network
+spec-help-container-network = Docker network to attach the container to (created if missing). Blank = the daemon's default bridge. Use it to isolate this app's containers on their own network.
 spec-form-container-lifetime = Container lifetime (min)
 spec-help-container-lifetime = Soft cap in minutes before the container is recycled. Blank = no soft cap.
 spec-form-stop-on-logout = Stop on logout

--- a/crates/ruscker-admin/assets/i18n/es/landing.ftl
+++ b/crates/ruscker-admin/assets/i18n/es/landing.ftl
@@ -557,6 +557,8 @@ spec-form-container-port = Puerto del contenedor
 spec-help-container-port = Puerto en el que la app escucha dentro del contenedor. Vacío = predeterminado por tipo (3838 para Shiny). Defínelo para Streamlit (8501), Dash (8050) o Jupyter (8888).
 spec-form-platform = Plataforma
 spec-help-platform = Plataforma Docker (ej.: linux/amd64) para ejecutar una imagen de otra arquitectura por emulación. Vacío = el daemon elige según el manifiesto.
+spec-form-container-network = Red Docker
+spec-help-container-network = Red Docker a la que conectar el contenedor (se crea si no existe). Vacío = la bridge por defecto del daemon. Úsala para aislar los contenedores de esta app en su propia red.
 spec-form-container-lifetime = Vida útil del contenedor (min)
 spec-help-container-lifetime = Límite suave en minutos antes de reciclar el contenedor. Vacío = sin límite suave.
 spec-form-stop-on-logout = Detener al cerrar sesión

--- a/crates/ruscker-admin/assets/i18n/fr/landing.ftl
+++ b/crates/ruscker-admin/assets/i18n/fr/landing.ftl
@@ -557,6 +557,8 @@ spec-form-container-port = Port du conteneur
 spec-help-container-port = Port sur lequel l'app écoute dans le conteneur. Vide = défaut par type (3838 pour Shiny). À définir pour Streamlit (8501), Dash (8050) ou Jupyter (8888).
 spec-form-platform = Plateforme
 spec-help-platform = Plateforme Docker (ex. : linux/amd64) pour exécuter une image d'une autre architecture par émulation. Vide = le démon choisit selon le manifeste.
+spec-form-container-network = Réseau Docker
+spec-help-container-network = Réseau Docker auquel rattacher le conteneur (créé s'il n'existe pas). Vide = le bridge par défaut du démon. Permet d'isoler les conteneurs de cette app sur leur propre réseau.
 spec-form-container-lifetime = Durée de vie du conteneur (min)
 spec-help-container-lifetime = Limite souple en minutes avant recyclage du conteneur. Vide = pas de limite souple.
 spec-form-stop-on-logout = Arrêter à la déconnexion

--- a/crates/ruscker-admin/assets/i18n/pt/landing.ftl
+++ b/crates/ruscker-admin/assets/i18n/pt/landing.ftl
@@ -561,6 +561,8 @@ spec-form-container-port = Porta do container
 spec-help-container-port = Porta em que o app escuta dentro do container. Em branco = padrão por tipo (3838 para Shiny). Defina para Streamlit (8501), Dash (8050) ou Jupyter (8888).
 spec-form-platform = Plataforma
 spec-help-platform = Plataforma Docker (ex.: linux/amd64) para rodar imagens de outra arquitetura via emulação. Em branco = o daemon escolhe pelo manifesto.
+spec-form-container-network = Rede Docker
+spec-help-container-network = Rede Docker à qual anexar o container (criada se não existir). Em branco = a bridge padrão do daemon. Use para isolar os containers deste app na própria rede.
 spec-form-container-lifetime = Vida útil do container (min)
 spec-help-container-lifetime = Limite suave em minutos antes de reciclar o container. Em branco = sem limite suave.
 spec-form-stop-on-logout = Parar ao sair (logout)

--- a/crates/ruscker-admin/src/routes/admin/spec_form.rs
+++ b/crates/ruscker-admin/src/routes/admin/spec_form.rs
@@ -673,6 +673,11 @@ impl SpecForm {
             //    clears it; an untouched field round-trips. ──────────
             container_port: parse_opt(&self.container_port),
             platform: empty_to_none(&self.platform),
+            // `container-network` has no form input yet (slice 1 wires the
+            // backend + YAML/import path). Preserve the base spec's value
+            // so an import-set network round-trips through an admin edit
+            // instead of being silently wiped. UI input is a follow-up.
+            container_network: base.and_then(|b| b.container_network.clone()),
             container_lifetime: parse_opt(&self.container_lifetime),
             stop_on_logout: checkbox_opt(&self.stop_on_logout),
             container_env: parse_env(&self.container_env),

--- a/crates/ruscker-admin/src/routes/admin/spec_form.rs
+++ b/crates/ruscker-admin/src/routes/admin/spec_form.rs
@@ -356,6 +356,9 @@ pub struct SpecForm {
     pub container_port: String,
     /// Docker `--platform` (`linux/amd64`) for emulated images.
     pub platform: String,
+    /// Docker network to attach the container to (`container-network`).
+    /// Blank ⇒ the daemon default bridge; created if missing.
+    pub container_network: String,
     /// Soft lifetime cap in minutes (`container-lifetime`).
     pub container_lifetime: String,
     /// Checkbox ("on") ⇒ stop the container when the user logs out.
@@ -498,6 +501,7 @@ impl SpecForm {
             // ── Advanced (new) ──────────────────────────────────
             container_port: spec.container_port.map(|n| n.to_string()).unwrap_or_default(),
             platform: spec.platform.clone().unwrap_or_default(),
+            container_network: spec.container_network.clone().unwrap_or_default(),
             container_lifetime: spec.container_lifetime.map(|n| n.to_string()).unwrap_or_default(),
             stop_on_logout: checkbox(spec.stop_on_logout.unwrap_or(false)),
             // `container-env` shown as sorted `NAME=value` lines.
@@ -673,11 +677,9 @@ impl SpecForm {
             //    clears it; an untouched field round-trips. ──────────
             container_port: parse_opt(&self.container_port),
             platform: empty_to_none(&self.platform),
-            // `container-network` has no form input yet (slice 1 wires the
-            // backend + YAML/import path). Preserve the base spec's value
-            // so an import-set network round-trips through an admin edit
-            // instead of being silently wiped. UI input is a follow-up.
-            container_network: base.and_then(|b| b.container_network.clone()),
+            // Advanced field, form is authoritative (pre-filled from the
+            // spec in `from_spec`): blank ⇒ None ⇒ daemon default bridge.
+            container_network: empty_to_none(&self.container_network),
             container_lifetime: parse_opt(&self.container_lifetime),
             stop_on_logout: checkbox_opt(&self.stop_on_logout),
             container_env: parse_env(&self.container_env),

--- a/crates/ruscker-admin/src/routes/proxy.rs
+++ b/crates/ruscker-admin/src/routes/proxy.rs
@@ -1434,6 +1434,9 @@ async fn pick_or_spawn(state: &AppState, spec: &Spec) -> anyhow::Result<(Replica
     if let Some(cmd) = spec.container_cmd.clone() {
         req = req.with_cmd(cmd);
     }
+    if let Some(net) = spec.effective_container_network() {
+        req = req.with_network(net);
+    }
     if let Some(c) = creds {
         req = req.with_creds(c);
     }

--- a/crates/ruscker-admin/src/scaler.rs
+++ b/crates/ruscker-admin/src/scaler.rs
@@ -839,6 +839,9 @@ async fn spawn_one(
     if let Some(cmd) = cmd {
         req = req.with_cmd(cmd);
     }
+    if let Some(net) = spec.effective_container_network() {
+        req = req.with_network(net);
+    }
     if let Some(c) = creds {
         req = req.with_creds(c);
     }

--- a/crates/ruscker-admin/templates/admin/spec_form.html
+++ b/crates/ruscker-admin/templates/admin/spec_form.html
@@ -752,6 +752,15 @@
             </div>
             <div class="spec-form-field">
               <div class="spec-form-label-row">
+                <label for="f-cnet" class="spec-form-label">{{ self.t("spec-form-container-network") }}</label>
+                {% call help(self.t("spec-help-container-network")) %}{% endcall %}
+              </div>
+              <input id="f-cnet" type="text" name="container_network"
+                     value="{{ form.container_network }}" placeholder="ruscker_net"
+                     class="spec-form-input spec-form-input--mono">
+            </div>
+            <div class="spec-form-field">
+              <div class="spec-form-label-row">
                 <label for="f-clife" class="spec-form-label">{{ self.t("spec-form-container-lifetime") }}</label>
                 {% call help(self.t("spec-help-container-lifetime")) %}{% endcall %}
               </div>

--- a/crates/ruscker-config/src/schema.rs
+++ b/crates/ruscker-config/src/schema.rs
@@ -888,6 +888,17 @@ pub struct Spec {
     #[serde(rename = "container-cmd", default)]
     pub container_cmd: Option<Vec<String>>,
 
+    /// Docker network to attach this spec's containers to (Ruscker
+    /// extension). The local Docker backend sets `HostConfig.network_mode`
+    /// and **creates the network** (a plain user-defined bridge) if it
+    /// doesn't exist yet. `None`/whitespace ⇒ the daemon's default bridge.
+    /// Use it to isolate Ruscker's app containers on their own L2 segment
+    /// (e.g. `container-network: ruscker_net`) — the ShinyProxy analogue
+    /// is the per-spec `network-connections` list, which an operator maps
+    /// straight to this single field.
+    #[serde(rename = "container-network", default)]
+    pub container_network: Option<String>,
+
     /// Groups allowed to see and reach this app (ShinyProxy
     /// `access-groups`). A spec with neither `access-groups` nor
     /// `access-users` is **open** (visible to everyone, including
@@ -1299,6 +1310,16 @@ impl Spec {
     /// Whether replicas should prefer distinct hosts (default false).
     pub fn effective_anti_affinity(&self) -> bool {
         self.anti_affinity.unwrap_or(false)
+    }
+
+    /// The Docker network to attach this spec's containers to, trimmed.
+    /// `None` or an all-whitespace value ⇒ the daemon's default bridge
+    /// (the backend leaves `network_mode` unset).
+    pub fn effective_container_network(&self) -> Option<&str> {
+        self.container_network
+            .as_deref()
+            .map(str::trim)
+            .filter(|s| !s.is_empty())
     }
 
     /// Effective routing strategy.
@@ -1895,6 +1916,7 @@ proxy:
             volumes: None,
             container_env: None,
             container_cmd: None,
+            container_network: None,
             access_groups: None,
             access_users: None,
             template_properties: TemplateProperties::default(),
@@ -1943,6 +1965,7 @@ proxy:
             volumes: None,
             container_env: None,
             container_cmd: None,
+            container_network: None,
             access_groups: None,
             access_users: None,
             template_properties: TemplateProperties::default(),
@@ -1991,6 +2014,7 @@ proxy:
             volumes: None,
             container_env: None,
             container_cmd: None,
+            container_network: None,
             access_groups: None,
             access_users: None,
             template_properties: TemplateProperties::default(),
@@ -2047,6 +2071,20 @@ container-cmd:
         let s = parse_spec("id: a\ncontainer-image: x");
         assert!(s.env_pairs().is_empty());
         assert!(s.container_cmd.is_none());
+    }
+
+    #[test]
+    fn parses_container_network_and_trims() {
+        let s = parse_spec("id: a\ncontainer-image: x\ncontainer-network: ruscker_net");
+        assert_eq!(s.effective_container_network(), Some("ruscker_net"));
+
+        // Whitespace-only ⇒ treated as unset (default bridge).
+        let blank = parse_spec("id: a\ncontainer-image: x\ncontainer-network: '   '");
+        assert_eq!(blank.effective_container_network(), None);
+
+        // Absent ⇒ None.
+        let none = parse_spec("id: a\ncontainer-image: x");
+        assert_eq!(none.effective_container_network(), None);
     }
 
     #[test]

--- a/crates/ruscker-config/src/validate.rs
+++ b/crates/ruscker-config/src/validate.rs
@@ -264,7 +264,8 @@ const UNSUPPORTED_SPEC_FIELDS: &[(&str, &str)] = &[
     ("labels", "custom container labels are not applied (phase 3.5)"),
     (
         "network-connections",
-        "container network wiring is not implemented (phase 3.5)",
+        "multi-network attach is not implemented — map it to the single \
+         `container-network` field (Ruscker creates + attaches that one)",
     ),
     // NOTE: per-spec env/cmd injection IS now supported — map your
     // ShinyProxy `container-env` / `container-cmd` straight across. They

--- a/crates/ruscker-core/src/lib.rs
+++ b/crates/ruscker-core/src/lib.rs
@@ -148,6 +148,12 @@ pub struct SpawnRequest {
     /// `None` ⇒ the image's baked `CMD` is used; the local backend maps
     /// this to `Config.Cmd`.
     pub cmd: Option<Vec<String>>,
+
+    /// Docker network to attach the container to (the spec's
+    /// `container-network`). `None` ⇒ the daemon's default bridge. The
+    /// local backend sets `HostConfig.network_mode` and creates the
+    /// network (a user-defined bridge) if it's missing.
+    pub network: Option<String>,
 }
 
 impl SpawnRequest {
@@ -164,6 +170,7 @@ impl SpawnRequest {
             platform: None,
             env: Vec::new(),
             cmd: None,
+            network: None,
         }
     }
 
@@ -203,6 +210,11 @@ impl SpawnRequest {
     }
     pub fn with_cmd(mut self, cmd: Vec<String>) -> Self {
         self.cmd = Some(cmd);
+        self
+    }
+
+    pub fn with_network(mut self, network: impl Into<String>) -> Self {
+        self.network = Some(network.into());
         self
     }
 }

--- a/crates/ruscker-docker/src/lib.rs
+++ b/crates/ruscker-docker/src/lib.rs
@@ -18,7 +18,7 @@
 
 use async_trait::async_trait;
 use bollard::models::{
-    ContainerCreateBody, ContainerSummaryStateEnum, HostConfig, PortBinding,
+    ContainerCreateBody, ContainerSummaryStateEnum, HostConfig, NetworkCreateRequest, PortBinding,
 };
 use bollard::query_parameters::{
     CreateContainerOptions, CreateImageOptions, ListContainersOptions, ListImagesOptions,
@@ -221,6 +221,18 @@ impl LocalDockerBackend {
         // up in `inspect` output and confuse operators.
         apply_limits(&mut host_config, &req.limits);
 
+        // Attach to an explicit Docker network if the spec set
+        // `container-network` (phase 3.5). We create the network (a
+        // plain user-defined bridge) when it's missing so the operator
+        // doesn't have to pre-create it. `network_mode` names it on the
+        // container; the published port still binds on `publish_ip`, so
+        // the proxy reaches the app exactly as before — the network only
+        // isolates app-to-app traffic on its own L2 segment.
+        if let Some(network) = req.network.as_deref() {
+            self.ensure_network(network).await?;
+            host_config.network_mode = Some(network.to_string());
+        }
+
         let body = ContainerCreateBody {
             image: Some(req.image.clone()),
             // bollard 0.21 takes a flat Vec<String> here, not a
@@ -392,6 +404,38 @@ impl LocalDockerBackend {
             event.map_err(|e| backend_err(&format!("pull image ({auth})"), e))?;
         }
         Ok(())
+    }
+
+    /// Ensure a user-defined Docker network exists, creating a plain
+    /// bridge when it's missing. Idempotent: an existing network (any
+    /// driver) is left untouched. Called before `create_container` when a
+    /// spec sets `container-network` so operators don't have to
+    /// pre-create the network. Tolerates the create/create race between
+    /// two concurrent spawns by re-inspecting on a create error.
+    async fn ensure_network(&self, name: &str) -> CoreResult<()> {
+        if self.docker.inspect_network(name, None).await.is_ok() {
+            return Ok(());
+        }
+        match self
+            .docker
+            .create_network(NetworkCreateRequest {
+                name: name.to_string(),
+                driver: Some("bridge".to_string()),
+                ..Default::default()
+            })
+            .await
+        {
+            Ok(_) => Ok(()),
+            // A concurrent spawn may have created it between our inspect
+            // and our create — a now-present network means success.
+            Err(e) => {
+                if self.docker.inspect_network(name, None).await.is_ok() {
+                    Ok(())
+                } else {
+                    Err(backend_err("create network", e))
+                }
+            }
+        }
     }
 
     async fn bound_host_port(&self, container_id: &str, port_key: &str) -> CoreResult<u16> {
@@ -1538,6 +1582,43 @@ mod tests {
         assert_eq!(cfg.cmd, Some(cmd), "cmd override not applied");
 
         backend.stop(&replica.id).await.expect("stop");
+    }
+
+    /// `container-network` (phase 3.5): the backend creates the named
+    /// network when it's missing and attaches the container to it.
+    /// Verifies via inspect that the container joined the network, then
+    /// reaps the container + the network so the test is repeatable.
+    #[cfg(feature = "docker-it")]
+    #[tokio::test]
+    async fn spawn_attaches_to_named_network() {
+        let image =
+            std::env::var("RUSCKER_IT_IMAGE").unwrap_or_else(|_| "nginx:1.29-alpine".into());
+        let backend = LocalDockerBackend::local().expect("connect docker");
+        let net = "ruscker-it-net";
+        let req = ruscker_core::SpawnRequest::new("itest-net", &image)
+            .with_port(80)
+            .with_network(net);
+        let replica = backend.spawn_request(&req).await.expect("spawn");
+
+        let info = backend
+            .docker
+            .inspect_container(&replica.container_id, None)
+            .await
+            .expect("inspect");
+        let networks = info
+            .network_settings
+            .and_then(|ns| ns.networks)
+            .unwrap_or_default();
+        assert!(
+            networks.contains_key(net),
+            "container not attached to `{net}`; joined: {:?}",
+            networks.keys().collect::<Vec<_>>()
+        );
+
+        backend.stop(&replica.id).await.expect("stop");
+        // Best-effort cleanup: the container is gone, so the network can
+        // be removed — keeps the test idempotent across runs.
+        let _ = backend.docker.remove_network(net).await;
     }
 
     /// #550: a container that crashes on startup (e.g. it can't reach its

--- a/docs/YAML_SCHEMA.md
+++ b/docs/YAML_SCHEMA.md
@@ -330,6 +330,7 @@ A spec describes one app, API, or external link. Every spec has an
     - R
     - -e
     - shiny::runApp('/app', port=3838, host='0.0.0.0')
+  container-network: ruscker_net      # attach to this Docker network (created if missing)
   access-groups: [staff, ops]         # who may see/reach this app
   access-users: [alice]               #   (ShinyProxy-compatible)
 ```
@@ -350,6 +351,17 @@ created — so an app secret passed this way never lands in the database.
 is an argv list that overrides the image's baked `CMD` (Docker
 `Config.Cmd`); omit it to keep the image default. Both are
 ShinyProxy-compatible and editable per spec.
+
+`container-network` (Ruscker extension) attaches the spec's containers to
+a named Docker network, mapped to the container's `HostConfig.NetworkMode`.
+The backend **creates the network** (a plain user-defined bridge) if it
+doesn't exist yet, so you don't have to pre-create it. Omit it (or leave
+it blank) to use the daemon's default bridge. Use it to isolate Ruscker's
+app containers on their own L2 segment — the published port still binds on
+loopback (`127.0.0.1`), so the proxy reaches the app exactly as before; the
+network only segments app-to-app traffic. ShinyProxy's per-spec
+`network-connections` list maps straight to this single field (Ruscker
+attaches one network; multi-network attach is still deferred).
 
 `access-groups` / `access-users` (ShinyProxy-compatible) scope who can
 **see** an app on the landing and **reach** it at `/app` / `/api`. A spec
@@ -700,12 +712,14 @@ ignored:
 
 - `proxy.specs[*].kubernetes-*` — Kubernetes backend (out of scope)
 - `proxy.specs[*].minimum-seats-available` — pre-warm pool (planned)
-- `proxy.specs[*].labels`, `proxy.specs[*].network-connections` — phase
-  3.5
+- `proxy.specs[*].labels` — custom container labels (phase 3.5)
+- `proxy.specs[*].network-connections` — multi-network attach (phase
+  3.5); map it to the single `container-network` field, which Ruscker
+  creates + attaches
 - `proxy.docker.*` — global docker config (use defaults or env vars)
 
-(`proxy.specs[*].volumes` and `container-env` / `container-cmd` are now
-supported — see "Containerized specs" above.)
+(`proxy.specs[*].volumes`, `container-env` / `container-cmd` and
+`container-network` are now supported — see "Containerized specs" above.)
 
 Setting any of these will produce a startup warning but not an error
 (`serve` runs the same validation `ruscker validate` does and logs


### PR DESCRIPTION
## What

Adds a per-spec **`container-network`** field (Ruscker extension) that attaches a spec's containers to a named Docker network, **creating it** (a plain user-defined bridge) if it's missing. Implements the long-deferred phase-3.5 "container network wiring".

The published port still binds on the loopback `publish_ip` (`127.0.0.1` for the local daemon), so the proxy reaches the app exactly as before — the network only **isolates app-to-app traffic** on its own L2 segment (defense-in-depth, e.g. keeping Ruscker's containers off the same segment as a side-by-side ShinyProxy's).

## Changes

- **schema** (`ruscker-config`): `container-network: Option<String>` + `effective_container_network()` (trims; blank ⇒ `None` ⇒ daemon default bridge).
- **core**: `SpawnRequest.network` + `with_network()` builder.
- **admin**: scaler + proxy spawn paths set the network from the spec.
- **docker** (`ruscker-docker`): `ensure_network()` — idempotent, creates a `bridge` network when missing, tolerates the create/create race between concurrent spawns — and sets `HostConfig.network_mode`.
- **spec_form**: preserves the value across admin edits so an import-set network isn't wiped (no UI input yet — see follow-up).
- **docs/compat**: `network-connections` ignored-field note now points operators to the single `container-network`; `YAML_SCHEMA.md` documents the field.

## ShinyProxy compat

ShinyProxy's per-spec `network-connections` (a list) maps straight to this single field. Multi-network attach stays deferred.

## Verification

- `cargo test` — config / core / docker / admin / cli + `shinyproxy_compat` all green.
- `cargo clippy --all-targets -- -D warnings` — clean.
- `./scripts/i18n-check.sh` — key parity OK.
- **docker-it smoke** (`spawn_attaches_to_named_network`) against a real daemon: network created, container joined (verified via inspect), then reaped.
- No new dependencies (uses the pinned `bollard` 0.21 network API).

## Follow-up (separate slice)

Admin **form input** to set `container-network` from the UI (SpecForm field + template input + 4-locale i18n) — kept out of this PR to avoid the Fluent-parity / template-lint gates landing alongside the backend change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)