### PR TITLE
feat(admin): surface max-containers as an always-visible field (#854)

### DIFF
--- a/crates/ruscker-admin/assets/i18n/en/landing.ftl
+++ b/crates/ruscker-admin/assets/i18n/en/landing.ftl
@@ -504,7 +504,7 @@ spec-form-api-docs-path = Docs path
 spec-form-api-health-path = Health path
 spec-form-api-cors = Enable permissive CORS
 spec-form-min-replicas = Min replicas
-spec-form-max-replicas = Max replicas
+spec-form-max-replicas = Max containers
 spec-form-concurrent = Requests per replica
 spec-form-cpu-limit = CPU limit
 spec-form-memory-limit = Memory limit
@@ -528,7 +528,7 @@ spec-help-api-docs-path = Path where the API serves its OpenAPI/Swagger docs. De
 spec-help-api-health-path = Path probed for readiness before a replica joins the pool. Default /__healthz__.
 spec-help-api-cors = Add permissive CORS headers and answer preflight requests. Off by default.
 spec-help-min-replicas = Containers kept warm at all times — the pool never scales below this. Default 0.
-spec-help-max-replicas = Upper bound the auto-scaler may spawn up to. Blank = unlimited.
+spec-help-max-replicas = Hard ceiling — the most containers Ruscker will run for this app (the auto-scaler scales up to it). Blank = the default (5, or the initial replicas if higher).
 spec-help-concurrent = Requests one API replica handles before the scaler adds another.
 spec-help-cpu-limit = Max CPU as fractional cores (e.g. 0.5 = half a core). Blank = unlimited.
 spec-help-memory-limit = Max memory, e.g. 512m or 1.5g. Blank = unlimited.

--- a/crates/ruscker-admin/assets/i18n/es/landing.ftl
+++ b/crates/ruscker-admin/assets/i18n/es/landing.ftl
@@ -504,7 +504,7 @@ spec-form-api-docs-path = Ruta de docs
 spec-form-api-health-path = Ruta de health
 spec-form-api-cors = Habilitar CORS permisivo
 spec-form-min-replicas = Réplicas mín.
-spec-form-max-replicas = Réplicas máx.
+spec-form-max-replicas = Máx. de contenedores
 spec-form-concurrent = Solicitudes por réplica
 spec-form-cpu-limit = Límite de CPU
 spec-form-memory-limit = Límite de memoria
@@ -528,7 +528,7 @@ spec-help-api-docs-path = Ruta donde la API sirve la documentación OpenAPI/Swag
 spec-help-api-health-path = Ruta consultada para readiness antes de que la réplica entre al pool. Por defecto /__healthz__.
 spec-help-api-cors = Añade cabeceras CORS permisivas y responde al preflight. Desactivado por defecto.
 spec-help-min-replicas = Contenedores siempre activos — el pool nunca baja de aquí. Por defecto 0.
-spec-help-max-replicas = Tope hasta donde el auto-escalado puede crecer. Vacío = ilimitado.
+spec-help-max-replicas = Tope rígido — el máximo de contenedores que Ruscker ejecuta para esta app (el auto-escalado crece hasta él). Vacío = el valor por defecto (5, o las réplicas iniciales si es mayor).
 spec-help-concurrent = Solicitudes que atiende una réplica de API antes de que el escalado añada otra.
 spec-help-cpu-limit = CPU máxima en núcleos fraccionarios (p. ej. 0,5 = medio núcleo). Vacío = ilimitado.
 spec-help-memory-limit = Memoria máxima, p. ej. 512m o 1.5g. Vacío = ilimitado.

--- a/crates/ruscker-admin/assets/i18n/fr/landing.ftl
+++ b/crates/ruscker-admin/assets/i18n/fr/landing.ftl
@@ -504,7 +504,7 @@ spec-form-api-docs-path = Chemin des docs
 spec-form-api-health-path = Chemin de santé
 spec-form-api-cors = Activer CORS permissif
 spec-form-min-replicas = Réplicas min.
-spec-form-max-replicas = Réplicas max.
+spec-form-max-replicas = Conteneurs max.
 spec-form-concurrent = Requêtes par réplica
 spec-form-cpu-limit = Limite CPU
 spec-form-memory-limit = Limite mémoire
@@ -528,7 +528,7 @@ spec-help-api-docs-path = Chemin où l'API sert la doc OpenAPI/Swagger. Par déf
 spec-help-api-health-path = Chemin sondé pour la disponibilité avant qu'une réplica rejoigne le pool. Par défaut /__healthz__.
 spec-help-api-cors = Ajoute des en-têtes CORS permissifs et répond au préflight. Désactivé par défaut.
 spec-help-min-replicas = Conteneurs gardés actifs en permanence — le pool ne descend jamais en dessous. Par défaut 0.
-spec-help-max-replicas = Plafond jusqu'auquel l'auto-scaler peut monter. Vide = illimité.
+spec-help-max-replicas = Plafond strict — le maximum de conteneurs que Ruscker exécute pour cette app (l'auto-scaler monte jusqu'à lui). Vide = la valeur par défaut (5, ou les réplicas initiales si supérieur).
 spec-help-concurrent = Requêtes qu'une réplica d'API gère avant que le scaler en ajoute une.
 spec-help-cpu-limit = CPU max en cœurs fractionnaires (ex. 0,5 = un demi-cœur). Vide = illimité.
 spec-help-memory-limit = Mémoire max, ex. 512m ou 1.5g. Vide = illimité.

--- a/crates/ruscker-admin/assets/i18n/pt/landing.ftl
+++ b/crates/ruscker-admin/assets/i18n/pt/landing.ftl
@@ -508,7 +508,7 @@ spec-form-api-docs-path = Caminho dos docs
 spec-form-api-health-path = Caminho de health
 spec-form-api-cors = Habilitar CORS permissivo
 spec-form-min-replicas = Réplicas mín.
-spec-form-max-replicas = Réplicas máx.
+spec-form-max-replicas = Máx. de containers
 spec-form-concurrent = Requisições por réplica
 spec-form-cpu-limit = Limite de CPU
 spec-form-memory-limit = Limite de memória
@@ -532,7 +532,7 @@ spec-help-api-docs-path = Caminho onde a API serve a documentação OpenAPI/Swag
 spec-help-api-health-path = Caminho consultado para readiness antes da réplica entrar no pool. Padrão /__healthz__.
 spec-help-api-cors = Adiciona cabeçalhos CORS permissivos e responde ao preflight. Desligado por padrão.
 spec-help-min-replicas = Containers mantidos sempre quentes — o pool nunca desce abaixo disso. Padrão 0.
-spec-help-max-replicas = Teto até onde o auto-scaler pode subir. Vazio = ilimitado.
+spec-help-max-replicas = Teto rígido — o máximo de containers que o Ruscker roda para este app (o auto-scaler sobe até ele). Vazio = o padrão (5, ou as réplicas iniciais se for maior).
 spec-help-concurrent = Requisições que uma réplica de API atende antes do scaler adicionar outra.
 spec-help-cpu-limit = CPU máxima em núcleos fracionários (ex.: 0,5 = meio núcleo). Vazio = ilimitado.
 spec-help-memory-limit = Memória máxima, ex.: 512m ou 1.5g. Vazio = ilimitado.

--- a/crates/ruscker-admin/templates/admin/spec_form.html
+++ b/crates/ruscker-admin/templates/admin/spec_form.html
@@ -605,6 +605,24 @@
       </div>
       </template>
 
+      {# Max containers (#854) — the hard ceiling for this app, always
+         visible (not gated behind the Autoscaling toggle). The scaler
+         never spawns past it even when autoscaling is off. #}
+      <template x-if="needsContainer()">
+      <div class="spec-form-field">
+        <div class="spec-form-label-row">
+          <label for="f-max-rep" class="spec-form-label">{{ self.t("spec-form-max-replicas") }}</label>
+          {% call help(self.t("spec-help-max-replicas")) %}{% endcall %}
+        </div>
+        <div class="stepper">
+          <button type="button" tabindex="-1" @click="form.max_replicas = String(Math.max(1, (parseInt(form.max_replicas, 10) || 1) - 1))"><i class="ti ti-minus" aria-hidden="true"></i></button>
+          <input id="f-max-rep" type="number" name="max_replicas" min="1" placeholder="5"
+                 x-model="form.max_replicas" class="stepper__input">
+          <button type="button" tabindex="-1" @click="form.max_replicas = String((parseInt(form.max_replicas, 10) || 0) + 1)"><i class="ti ti-plus" aria-hidden="true"></i></button>
+        </div>
+      </div>
+      </template>
+
       <div class="spec-form-field">
         <div class="spec-form-label-row">
           <label for="f-updated" class="spec-form-label">{{ self.t("spec-form-updated") }}</label>
@@ -835,32 +853,21 @@
             </div>
             <span class="switch">
               <input type="checkbox" x-model="autoscaling"
-                     @change="if (!autoscaling) { form.max_replicas = ''; form.scale_up_threshold = ''; form.scale_down_threshold = ''; form.scale_down_grace = ''; }">
+                     @change="if (!autoscaling) { form.scale_up_threshold = ''; form.scale_down_threshold = ''; form.scale_down_grace = ''; }">
               <span class="switch__track"><span class="switch__dot"></span></span>
             </span>
           </label>
           <div x-show="autoscaling" x-cloak>
-          <div class="grid grid-cols-2 gap-3">
-            <div class="spec-form-field">
-              <div class="spec-form-label-row">
-                <label for="f-max-rep" class="spec-form-label">{{ self.t("spec-form-max-replicas") }}</label>
-                {% call help(self.t("spec-help-max-replicas")) %}{% endcall %}
-              </div>
-              <div class="stepper">
-                <button type="button" tabindex="-1" @click="form.max_replicas = String(Math.max(1, (parseInt(form.max_replicas, 10) || 1) - 1))"><i class="ti ti-minus" aria-hidden="true"></i></button>
-                <input id="f-max-rep" type="number" name="max_replicas" min="1" placeholder="5"
-                       x-model="form.max_replicas" class="stepper__input">
-                <button type="button" tabindex="-1" @click="form.max_replicas = String((parseInt(form.max_replicas, 10) || 0) + 1)"><i class="ti ti-plus" aria-hidden="true"></i></button>
-              </div>
+          {# The ceiling (max containers) is a first-class field up in
+             Access & scale (#854); autoscaling only tunes how it scales
+             toward that cap. #}
+          <div class="spec-form-field">
+            <div class="spec-form-label-row">
+              <label for="f-concurrent" class="spec-form-label">{{ self.t("spec-form-concurrent") }}</label>
+              {% call help(self.t("spec-help-concurrent")) %}{% endcall %}
             </div>
-            <div class="spec-form-field">
-              <div class="spec-form-label-row">
-                <label for="f-concurrent" class="spec-form-label">{{ self.t("spec-form-concurrent") }}</label>
-                {% call help(self.t("spec-help-concurrent")) %}{% endcall %}
-              </div>
-              <input id="f-concurrent" type="number" name="concurrent_requests_per_replica" min="1"
-                     value="{{ form.concurrent_requests_per_replica }}" placeholder="100" class="spec-form-input">
-            </div>
+            <input id="f-concurrent" type="number" name="concurrent_requests_per_replica" min="1"
+                   value="{{ form.concurrent_requests_per_replica }}" placeholder="100" class="spec-form-input">
           </div>
           <div class="grid grid-cols-2 gap-3" style="margin-top:8px">
             <div class="spec-form-field">
@@ -1370,7 +1377,12 @@ window.ruscker.specForm = (initial, logoImages, availableGroups) => ({
   locked: (initial.locked || '').trim() !== '',
   // Autoscaling toggle (#701): on when a max-replicas ceiling above 1 is
   // set. Off ⇒ the ceiling + thresholds are cleared (run at the floor).
-  autoscaling: (parseInt(initial.max_replicas, 10) || 0) > 1,
+  // Autoscaling is "on" when custom thresholds/grace are set — the
+  // ceiling (max_replicas) is now an always-visible field, not the
+  // toggle's signal (#854).
+  autoscaling: !!((initial.scale_up_threshold || '').toString().trim()
+    || (initial.scale_down_threshold || '').toString().trim()
+    || (initial.scale_down_grace || '').toString().trim()),
   // Card-cover editing mode: 'auto' (kind tint, empty cover),
   // 'solid' (color), 'gradient' (builder), or 'legacy' for a saved
   // image cover (`url(...)`) from before image covers were retired —


### PR DESCRIPTION
Closes #854.

## What
`max-replicas` (the hard container ceiling) was only reachable **inside the Autoscaling toggle** in the spec form, so an app without autoscaling had no visible way to cap its container count — it read as "missing".

## Changes (template + i18n only — no Rust)
- **Move** the max-containers stepper up into **Access & scale**, always visible for container-backed kinds (next to *Initial replicas*).
- **Remove** the duplicate from the Autoscaling block (now only tunes thresholds + concurrency); the toggle no longer clears `max_replicas`.
- **Decouple** the Autoscaling toggle's initial state from `max_replicas` — it's now driven by whether custom thresholds/grace are set (`scale_up`/`scale_down`/`scale_down_grace`).
- **Relabel** "Max replicas" → "Max containers" and fix the help (blank = default **5**, not "unlimited"), pt/en/es/fr.

`max_replicas` was already on `SpecForm` + the builder, and the scaler already enforces the cap (default 5) regardless of autoscaling — so no backend change.

## Gate
`cargo build` + `cargo test -p ruscker-admin` (incl. `load_default_succeeds`), `clippy -D warnings`, i18n parity — all green.

## ⚠️ Pending smoke (why draft)
This touches **Alpine** (the autoscaling toggle's init + the `x-if` field blocks). Per the project's "test Alpine in a browser, not curl" rule, the toggle/field-visibility behavior should be **verified in a browser** — best done on the next **cast** deploy (can't drive the live admin reactivity headless until released). Mark ready / merge after that smoke, or I can verify on cast once it picks up a build.

🤖 Generated with [Claude Code](https://claude.com/claude-code)