### PR TITLE
feat(admin): Viewer is a portal user, not a panel operator (#857)

### DIFF
--- a/crates/ruscker-admin/src/auth.rs
+++ b/crates/ruscker-admin/src/auth.rs
@@ -64,10 +64,11 @@ impl Role {
     /// `landing`, `blocks`, `audit`).
     pub fn can_access_section(&self, section: &str) -> bool {
         match section {
-            // Anyone logged in can view the dashboard.
-            "dashboard" => true,
-            // Editors (and admins) manage apps and media.
-            "specs" | "images" => *self >= Role::Editor,
+            // Dashboard + apps + media: Editor and up. A Viewer is NOT
+            // an admin-panel operator (#857) — it's the portal's
+            // authenticated-end-user role (group-based card visibility,
+            // #155), so it reaches NO admin section.
+            "dashboard" | "specs" | "images" => *self >= Role::Editor,
             // Everything else is admin-only.
             _ => *self == Role::Admin,
         }
@@ -82,9 +83,14 @@ impl Role {
     }
 
     /// The page a freshly-logged-in session of this role lands on.
-    /// The dashboard is visible to every role, so it's home for all.
+    /// Editor/Admin → the panel (dashboard). A **Viewer** has no panel
+    /// access (#857) — it logs in to unlock its group's cards on the
+    /// portal, so it lands on the public landing instead.
     pub fn home(&self) -> &'static str {
-        "/admin/dashboard"
+        match self {
+            Role::Viewer => "/",
+            _ => "/admin/dashboard",
+        }
     }
 
     /// Fluent message key for the human-readable role label.
@@ -692,16 +698,17 @@ mod tests {
         assert!(Role::Admin > Role::Editor);
         assert!(Role::Editor > Role::Viewer);
 
-        // Dashboard: everyone.
-        for r in [Role::Viewer, Role::Editor, Role::Admin] {
-            assert!(r.can_access_section("dashboard"));
-        }
-        // Apps + media: Editor and up.
-        for sec in ["specs", "images"] {
+        // Dashboard + apps + media: Editor and up — a Viewer reaches no
+        // admin section (#857).
+        for sec in ["dashboard", "specs", "images"] {
             assert!(!Role::Viewer.can_access_section(sec));
             assert!(Role::Editor.can_access_section(sec));
             assert!(Role::Admin.can_access_section(sec));
         }
+        // A Viewer's home is the portal (no panel); operators land on it.
+        assert_eq!(Role::Viewer.home(), "/");
+        assert_eq!(Role::Editor.home(), "/admin/dashboard");
+        assert_eq!(Role::Admin.home(), "/admin/dashboard");
         // Admin-only sections.
         for sec in ["credentials", "landing", "blocks", "audit"] {
             assert!(!Role::Viewer.can_access_section(sec));

--- a/crates/ruscker-admin/src/routes/admin.rs
+++ b/crates/ruscker-admin/src/routes/admin.rs
@@ -135,8 +135,10 @@ impl AccountPasswordPage<'_> {
 
 // ── Handlers ─────────────────────────────────────────────────────
 
-async fn redirect_to_dashboard(_: AdminSession) -> Redirect {
-    Redirect::to("/admin/dashboard")
+async fn redirect_to_dashboard(session: AdminSession) -> Redirect {
+    // A Viewer has no panel (#857) — `/admin` sends it to its home (the
+    // portal), not the dashboard it can't open.
+    Redirect::to(session.role.home())
 }
 
 /// Issue the admin session cookie. 24h lifetime; `Secure` only under
@@ -634,7 +636,9 @@ async fn password_submit(
         .create(session.role, Some(actor.clone()))
         .await;
     issue_session_cookie(&state, &cookies, &headers, session_id);
-    Redirect::to("/admin/dashboard").into_response()
+    // Land on the role's home — a Viewer goes to the portal (#857), not
+    // the dashboard it can't open.
+    Redirect::to(session.role.home()).into_response()
 }
 
 /// Map an `/admin/...` path to the `nav_section` it belongs to, for

--- a/crates/ruscker-admin/src/routes/admin/dashboard.rs
+++ b/crates/ruscker-admin/src/routes/admin/dashboard.rs
@@ -353,6 +353,11 @@ async fn index(
     loc: Locale,
     theme: Theme,
 ) -> Response {
+    // A Viewer has no panel access (#857) — it logs in for portal card
+    // visibility, not the dashboard. Send it back to the landing.
+    if !session.role.can_access_section("dashboard") {
+        return Redirect::to("/").into_response();
+    }
     let snap = build_snapshot(&state, loc).await;
     let snapshot_json = json_for_html_script(&snap);
     let page = DashboardPage {
@@ -551,10 +556,15 @@ fn sse_no_buffer_headers() -> [(axum::http::HeaderName, &'static str); 2] {
 }
 
 async fn events(
-    _: AdminSession,
+    session: AdminSession,
     State(state): State<AppState>,
     loc: Locale,
-) -> impl IntoResponse {
+) -> Response {
+    // Same gate as the dashboard page (#857): a Viewer never gets the
+    // live metrics feed.
+    if !session.role.can_access_section("dashboard") {
+        return (StatusCode::FORBIDDEN, "forbidden").into_response();
+    }
     use async_stream::stream;
     let stream = stream! {
         // Emit the first snapshot immediately so the client
@@ -577,7 +587,7 @@ async fn events(
         }
     };
     let sse = Sse::new(stream).keep_alive(KeepAlive::new().interval(SSE_KEEPALIVE_INTERVAL));
-    (sse_no_buffer_headers(), sse)
+    (sse_no_buffer_headers(), sse).into_response()
 }
 
 /// Per-replica logs page. Fetches the last [`LOGS_TAIL`] lines

--- a/crates/ruscker-admin/src/routes/landing.rs
+++ b/crates/ruscker-admin/src/routes/landing.rs
@@ -95,6 +95,11 @@ struct LandingPage<'a> {
     /// Display name of the signed-in viewer (username, or empty for a
     /// break-glass token session). Shown next to the panel link.
     viewer_name: String,
+    /// Whether the signed-in viewer may reach the admin panel (Editor+).
+    /// A **Viewer** logs in only to unlock its group's cards (#155/#857),
+    /// so the header shows just change-password + sign-out — no "Panel"
+    /// link.
+    can_panel: bool,
     /// Whether to render the anonymous "Sign in" entrance (#156). A
     /// deploy policy from `landing-customization.show-admin-link`
     /// (default true); false hides the admin entrance on public portals.
@@ -537,6 +542,7 @@ async fn index(
         blocks_bottom,
         signed_in: session.is_some(),
         viewer_name: username.unwrap_or_default(),
+        can_panel: session.as_ref().map(|s| s.role.can_manage()).unwrap_or(false),
         // Deploy policy from YAML config (not the DB editor): whether
         // anonymous visitors see the "Sign in" entrance (#156).
         show_admin_link: state

--- a/crates/ruscker-admin/templates/_chrome_cluster.html
+++ b/crates/ruscker-admin/templates/_chrome_cluster.html
@@ -68,9 +68,14 @@
           </div>
           <div class="chrome-popover-sep"></div>
         {% endif %}
+        {# Panel link only for operators (Editor+). A Viewer signs in for
+           portal card visibility (#857), so it sees only change-password
+           + sign-out. #}
+        {% if can_panel %}
         <a class="chrome-popover-item" href="{{ base }}/admin/dashboard">
           <i class="ti ti-layout-dashboard" aria-hidden="true"></i> {{ self.t("chrome-panel") }}
         </a>
+        {% endif %}
         <a class="chrome-popover-item" href="{{ base }}/admin/account/password">
           <i class="ti ti-key" aria-hidden="true"></i> {{ self.t("chrome-change-password") }}
         </a>

--- a/crates/ruscker-admin/tests/rbac.rs
+++ b/crates/ruscker-admin/tests/rbac.rs
@@ -81,16 +81,18 @@ async fn send(state: AppState, method: &str, uri: &str, cookie: Option<&str>) ->
     app.oneshot(req).await.unwrap().status()
 }
 
-// ── Viewer: dashboard only ──────────────────────────────────────────
+// ── Viewer: no panel — portal authenticated-user role (#857) ─────────
 
 #[tokio::test]
-async fn viewer_can_view_dashboard() {
+async fn viewer_redirected_from_dashboard_to_portal() {
     let st = state();
     let c = cookie_for(&st, Role::Viewer).await;
-    // No DB needed for the dashboard render, so this is a clean 200.
+    // A Viewer is NOT a panel operator (#857): it signs in to unlock its
+    // group's cards on the portal, so the dashboard sends it back to the
+    // landing (303) instead of rendering.
     assert_eq!(
         send(st, "GET", "/admin/dashboard", Some(&c)).await,
-        StatusCode::OK
+        StatusCode::SEE_OTHER
     );
 }
 

--- a/crates/ruscker-admin/tests/user_accounts.rs
+++ b/crates/ruscker-admin/tests/user_accounts.rs
@@ -312,11 +312,15 @@ async fn must_change_user_is_pinned_to_password_page() {
 #[tokio::test]
 async fn changing_password_lifts_the_guard() {
     let (state, pool) = state_with_db().await;
+    // Editor (not Viewer): this test is about the must-change guard
+    // lifting, which is role-agnostic. An Editor's home is the dashboard,
+    // so the post-change landing assertions below stay valid — a Viewer's
+    // home is now the portal (#857), covered separately in rbac.rs.
     ruscker_admin::db::users::create(
         &ruscker_admin::db::ConfigDb::Sqlite(pool.clone()),
         "bob",
         "bobpass12",
-        Role::Viewer,
+        Role::Editor,
         true,
         &[],
         None,
@@ -325,7 +329,7 @@ async fn changing_password_lifts_the_guard() {
     .unwrap();
     let sid = state
         .admin_sessions
-        .create(Role::Viewer, Some("bob".into()))
+        .create(Role::Editor, Some("bob".into()))
         .await;
     let cookie = format!("{COOKIE_NAME}={sid}");
 


### PR DESCRIPTION
Closes #857.

## What
A **Viewer** signs in only to unlock its **group's restricted cards** on the portal (#155) — it is **not** an admin-panel operator. So now:
- It reaches **no** admin section.
- Its **home is the landing** (`/`), where its group cards appear.
- It gets only **change password + sign out**.

The role stays — it's essential for group-based card visibility.

## Changes
- **auth**: `can_access_section` drops `"dashboard"` to **Editor+** (a Viewer reaches no section); `home()` → `/` for Viewer, `/admin/dashboard` for Editor/Admin.
- **dashboard**: `index` redirects a Viewer to `/`; `events` (SSE) `403`s it. (`logs` + stop/restart were already Editor+.)
- **routing**: `/admin` (`redirect_to_dashboard`) and the **post-password-change** redirect now go to `role.home()` — a Viewer lands on the portal, not a dashboard it can't open.
- **landing**: `_chrome_cluster` hides the **"Panel"** link unless the viewer is Editor+ (`can_panel`); a Viewer's account menu is just change-password + sign-out.
- **tests**: rbac `viewer_redirected_from_dashboard_to_portal` (replaces `viewer_can_view_dashboard`); the must-change guard-lift test now uses an Editor (role-agnostic intent); auth matrix + `home()` asserted.

## Gate
`cargo test -p ruscker-admin` (rbac + user_accounts + auth matrix + template_lint + load_default), `clippy -D warnings`, i18n parity — all green.

## ⚠️ Pending smoke (why draft)
Touches the landing chrome (the `can_panel` gate) and redirects. Backend is unit/integration-tested, but verify in a browser on the next **cast** deploy: a Viewer logs in → lands on the portal with its group cards → account menu shows only change-password + sign-out → `/admin/*` bounces to `/`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)