### PR TITLE
feat(docker): per-spec custom container labels (#851)

### DIFF
--- a/crates/ruscker-admin/src/routes/admin/spec_form.rs
+++ b/crates/ruscker-admin/src/routes/admin/spec_form.rs
@@ -680,6 +680,10 @@ impl SpecForm {
             // Advanced field, form is authoritative (pre-filled from the
             // spec in `from_spec`): blank ⇒ None ⇒ daemon default bridge.
             container_network: empty_to_none(&self.container_network),
+            // `labels` (#851) has no form input yet — preserve the base
+            // spec's value so a YAML/import-set label map survives an
+            // admin edit instead of being wiped. UI input is a follow-up.
+            labels: base.and_then(|b| b.labels.clone()),
             container_lifetime: parse_opt(&self.container_lifetime),
             stop_on_logout: checkbox_opt(&self.stop_on_logout),
             container_env: parse_env(&self.container_env),

--- a/crates/ruscker-admin/src/routes/proxy.rs
+++ b/crates/ruscker-admin/src/routes/proxy.rs
@@ -1437,6 +1437,10 @@ async fn pick_or_spawn(state: &AppState, spec: &Spec) -> anyhow::Result<(Replica
     if let Some(net) = spec.effective_container_network() {
         req = req.with_network(net);
     }
+    let labels = spec.effective_labels();
+    if !labels.is_empty() {
+        req = req.with_labels(labels);
+    }
     if let Some(c) = creds {
         req = req.with_creds(c);
     }

--- a/crates/ruscker-admin/src/scaler.rs
+++ b/crates/ruscker-admin/src/scaler.rs
@@ -842,6 +842,10 @@ async fn spawn_one(
     if let Some(net) = spec.effective_container_network() {
         req = req.with_network(net);
     }
+    let labels = spec.effective_labels();
+    if !labels.is_empty() {
+        req = req.with_labels(labels);
+    }
     if let Some(c) = creds {
         req = req.with_creds(c);
     }

--- a/crates/ruscker-config/src/schema.rs
+++ b/crates/ruscker-config/src/schema.rs
@@ -899,6 +899,15 @@ pub struct Spec {
     #[serde(rename = "container-network", default)]
     pub container_network: Option<String>,
 
+    /// Extra Docker labels to stamp on the container (ShinyProxy
+    /// `labels`), as a `NAME: value` map. Merged onto the container's
+    /// labels at spawn; Ruscker's own `ruscker.*` labels always win on a
+    /// key collision (the registry / reconcile / disk panel depend on
+    /// them). `None`/empty ⇒ only the internal labels. A `BTreeMap` for a
+    /// deterministic order.
+    #[serde(rename = "labels", default)]
+    pub labels: Option<BTreeMap<String, String>>,
+
     /// Groups allowed to see and reach this app (ShinyProxy
     /// `access-groups`). A spec with neither `access-groups` nor
     /// `access-users` is **open** (visible to everyone, including
@@ -1320,6 +1329,24 @@ impl Spec {
             .as_deref()
             .map(str::trim)
             .filter(|s| !s.is_empty())
+    }
+
+    /// Extra container labels (`labels`) as cleaned `(key, value)`
+    /// pairs — keys trimmed, empty keys dropped. Empty when unset.
+    /// Ruscker's internal `ruscker.*` labels are applied separately by
+    /// the backend and win on a key collision.
+    pub fn effective_labels(&self) -> Vec<(String, String)> {
+        self.labels
+            .as_ref()
+            .map(|m| {
+                m.iter()
+                    .filter_map(|(k, v)| {
+                        let k = k.trim();
+                        (!k.is_empty()).then(|| (k.to_string(), v.clone()))
+                    })
+                    .collect()
+            })
+            .unwrap_or_default()
     }
 
     /// Effective routing strategy.
@@ -1917,6 +1944,7 @@ proxy:
             container_env: None,
             container_cmd: None,
             container_network: None,
+            labels: None,
             access_groups: None,
             access_users: None,
             template_properties: TemplateProperties::default(),
@@ -1966,6 +1994,7 @@ proxy:
             container_env: None,
             container_cmd: None,
             container_network: None,
+            labels: None,
             access_groups: None,
             access_users: None,
             template_properties: TemplateProperties::default(),
@@ -2015,6 +2044,7 @@ proxy:
             container_env: None,
             container_cmd: None,
             container_network: None,
+            labels: None,
             access_groups: None,
             access_users: None,
             template_properties: TemplateProperties::default(),
@@ -2085,6 +2115,31 @@ container-cmd:
         // Absent ⇒ None.
         let none = parse_spec("id: a\ncontainer-image: x");
         assert_eq!(none.effective_container_network(), None);
+    }
+
+    #[test]
+    fn parses_labels_map() {
+        let s = parse_spec(
+            "\
+id: a
+container-image: x
+labels:
+  team: data
+  '  ': dropped
+  cost-center: GAPE
+",
+        );
+        // BTreeMap order; blank keys dropped, values kept verbatim.
+        assert_eq!(
+            s.effective_labels(),
+            vec![
+                ("cost-center".to_string(), "GAPE".to_string()),
+                ("team".to_string(), "data".to_string()),
+            ]
+        );
+        // Absent ⇒ empty.
+        let none = parse_spec("id: a\ncontainer-image: x");
+        assert!(none.effective_labels().is_empty());
     }
 
     #[test]

--- a/crates/ruscker-config/src/validate.rs
+++ b/crates/ruscker-config/src/validate.rs
@@ -261,7 +261,6 @@ const UNSUPPORTED_SPEC_FIELDS: &[(&str, &str)] = &[
         "minimum-seats-available",
         "pre-warm pool not implemented — use `min-replicas`",
     ),
-    ("labels", "custom container labels are not applied (phase 3.5)"),
     (
         "network-connections",
         "multi-network attach is not implemented — map it to the single \

--- a/crates/ruscker-core/src/lib.rs
+++ b/crates/ruscker-core/src/lib.rs
@@ -154,6 +154,12 @@ pub struct SpawnRequest {
     /// local backend sets `HostConfig.network_mode` and creates the
     /// network (a user-defined bridge) if it's missing.
     pub network: Option<String>,
+
+    /// Extra Docker labels to stamp on the container (the spec's
+    /// `labels`), as `(key, value)` pairs. The backend merges these onto
+    /// the container's labels; its own `ruscker.*` labels win on a key
+    /// collision. Empty ⇒ only the internal labels.
+    pub labels: Vec<(String, String)>,
 }
 
 impl SpawnRequest {
@@ -171,6 +177,7 @@ impl SpawnRequest {
             env: Vec::new(),
             cmd: None,
             network: None,
+            labels: Vec::new(),
         }
     }
 
@@ -215,6 +222,11 @@ impl SpawnRequest {
 
     pub fn with_network(mut self, network: impl Into<String>) -> Self {
         self.network = Some(network.into());
+        self
+    }
+
+    pub fn with_labels(mut self, labels: Vec<(String, String)>) -> Self {
+        self.labels = labels;
         self
     }
 }

--- a/crates/ruscker-docker/src/lib.rs
+++ b/crates/ruscker-docker/src/lib.rs
@@ -204,6 +204,13 @@ impl LocalDockerBackend {
         );
 
         let mut labels = HashMap::new();
+        // Operator-supplied labels (`labels`, #851) go in FIRST so the
+        // internal `ruscker.*` labels below overwrite them on any key
+        // collision — those three are load-bearing (registry / reconcile
+        // / disk panel key off them) and must not be clobbered.
+        for (k, v) in &req.labels {
+            labels.insert(k.clone(), v.clone());
+        }
         labels.insert(LABEL_SPEC_ID.to_string(), req.spec_id.clone());
         labels.insert(LABEL_REPLICA_ID.to_string(), replica_id.to_string());
         labels.insert(LABEL_INNER_PORT.to_string(), inner_port.to_string());
@@ -1619,6 +1626,43 @@ mod tests {
         // Best-effort cleanup: the container is gone, so the network can
         // be removed — keeps the test idempotent across runs.
         let _ = backend.docker.remove_network(net).await;
+    }
+
+    /// `labels` (#851): operator labels are stamped on the container, and
+    /// the internal `ruscker.*` labels win on a key collision (an
+    /// operator can't clobber the load-bearing ones).
+    #[cfg(feature = "docker-it")]
+    #[tokio::test]
+    async fn spawn_stamps_operator_labels_internal_wins() {
+        let image =
+            std::env::var("RUSCKER_IT_IMAGE").unwrap_or_else(|_| "nginx:1.29-alpine".into());
+        let backend = LocalDockerBackend::local().expect("connect docker");
+        let req = ruscker_core::SpawnRequest::new("itest-labels", &image)
+            .with_port(80)
+            .with_labels(vec![
+                ("team".to_string(), "data".to_string()),
+                // Attempt to override an internal label — must NOT win.
+                (LABEL_SPEC_ID.to_string(), "hacked".to_string()),
+            ]);
+        let replica = backend.spawn_request(&req).await.expect("spawn");
+
+        let info = backend
+            .docker
+            .inspect_container(&replica.container_id, None)
+            .await
+            .expect("inspect");
+        let labels = info
+            .config
+            .and_then(|c| c.labels)
+            .unwrap_or_default();
+        assert_eq!(labels.get("team").map(String::as_str), Some("data"));
+        // Internal label kept its real value, not the operator's "hacked".
+        assert_eq!(
+            labels.get(LABEL_SPEC_ID).map(String::as_str),
+            Some("itest-labels")
+        );
+
+        backend.stop(&replica.id).await.expect("stop");
     }
 
     /// #550: a container that crashes on startup (e.g. it can't reach its

--- a/docs/YAML_SCHEMA.md
+++ b/docs/YAML_SCHEMA.md
@@ -331,6 +331,9 @@ A spec describes one app, API, or external link. Every spec has an
     - -e
     - shiny::runApp('/app', port=3838, host='0.0.0.0')
   container-network: ruscker_net      # attach to this Docker network (created if missing)
+  labels:                             # extra Docker labels stamped on the container
+    team: data                        #   (ShinyProxy-compatible)
+    cost-center: GAPE
   access-groups: [staff, ops]         # who may see/reach this app
   access-users: [alice]               #   (ShinyProxy-compatible)
 ```
@@ -362,6 +365,13 @@ loopback (`127.0.0.1`), so the proxy reaches the app exactly as before; the
 network only segments app-to-app traffic. ShinyProxy's per-spec
 `network-connections` list maps straight to this single field (Ruscker
 attaches one network; multi-network attach is still deferred).
+
+`labels` (ShinyProxy-compatible) is a `NAME: value` map of extra Docker
+labels stamped on the container — useful for external tooling
+(monitoring, log routing, cost attribution). Ruscker merges them onto the
+container's labels at spawn; its own `ruscker.*` labels always win on a
+key collision (they're load-bearing for the registry, reconcile and disk
+panel), so you can't override them. Blank keys are dropped.
 
 `access-groups` / `access-users` (ShinyProxy-compatible) scope who can
 **see** an app on the landing and **reach** it at `/app` / `/api`. A spec
@@ -712,14 +722,14 @@ ignored:
 
 - `proxy.specs[*].kubernetes-*` — Kubernetes backend (out of scope)
 - `proxy.specs[*].minimum-seats-available` — pre-warm pool (planned)
-- `proxy.specs[*].labels` — custom container labels (phase 3.5)
 - `proxy.specs[*].network-connections` — multi-network attach (phase
   3.5); map it to the single `container-network` field, which Ruscker
   creates + attaches
 - `proxy.docker.*` — global docker config (use defaults or env vars)
 
-(`proxy.specs[*].volumes`, `container-env` / `container-cmd` and
-`container-network` are now supported — see "Containerized specs" above.)
+(`proxy.specs[*].volumes`, `container-env` / `container-cmd`,
+`container-network` and `labels` are now supported — see "Containerized
+specs" above.)
 
 Setting any of these will produce a startup warning but not an error
 (`serve` runs the same validation `ruscker validate` does and logs


### PR DESCRIPTION
Closes #851.

## What
Honours ShinyProxy's per-spec **`labels`** map — extra Docker labels stamped on the container (monitoring, log routing, cost attribution). Ruscker's own `ruscker.*` labels **win on a key collision**, so the load-bearing ones (registry / reconcile / disk panel) can't be clobbered. Mirrors the `container-network` slice (#850).

## Changes
- **schema**: `labels: Option<BTreeMap<String,String>>` + `effective_labels()` (trims keys, drops blanks, deterministic order).
- **core**: `SpawnRequest.labels` (`Vec<(String,String)>`) + `with_labels()`.
- **admin**: scaler + proxy spawn paths pass the spec's labels.
- **docker**: operator labels merged in **first**, then the internal `ruscker.*` labels overwrite on collision.
- **spec_form**: preserve `labels` across admin edits (no UI input yet — set via YAML/import; a form editor is a follow-up, same as container-network slice 1).
- **validate / docs**: `labels` dropped from the ignored-fields list; `YAML_SCHEMA.md` documents it.

## Gate
- `cargo test` incl. `parses_labels_map` (map parse, blank-key drop, order).
- **docker-it** `spawn_stamps_operator_labels_internal_wins` on a real daemon: operator label `team=data` present; an operator attempt to override `ruscker.spec_id` is ignored (internal value kept).
- `clippy -D warnings`, i18n parity.

No Alpine/UI — backend + YAML path only, so no browser smoke needed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)