### PR TITLE
fix(admin): land on Apps + pause dashboard SSE when hidden (#852)

### DIFF
--- a/crates/ruscker-admin/src/auth.rs
+++ b/crates/ruscker-admin/src/auth.rs
@@ -82,9 +82,16 @@ impl Role {
     }
 
     /// The page a freshly-logged-in session of this role lands on.
-    /// The dashboard is visible to every role, so it's home for all.
+    /// Editor/Admin land on the **Apps list** — the main management
+    /// surface — not the dashboard, whose live-metrics SSE starves the
+    /// browser's connection pool on an HTTP/1.1 front end (#852). The
+    /// dashboard stays one click away. A Viewer can only reach the
+    /// dashboard (until #857 moves it to the portal), so it lands there.
     pub fn home(&self) -> &'static str {
-        "/admin/dashboard"
+        match self {
+            Role::Viewer => "/admin/dashboard",
+            _ => "/admin/specs",
+        }
     }
 
     /// Fluent message key for the human-readable role label.

--- a/crates/ruscker-admin/templates/admin/dashboard.html
+++ b/crates/ruscker-admin/templates/admin/dashboard.html
@@ -524,15 +524,31 @@
 
   if (!window.EventSource) return;
   var live = document.getElementById('dash-live');
-  var es = new EventSource((window.RUSCKER_BASE || '') + '/admin/dashboard/events');
-  es.onopen = function () { if (live) live.classList.remove('is-down'); };
-  es.onmessage = function (e) {
-    if (live) live.classList.remove('is-down');
-    try { apply(JSON.parse(e.data)); } catch (_) { /* ignore */ }
-  };
-  // EventSource auto-reconnects on network errors; we just dim the Live
-  // badge while it's down.
-  es.onerror = function () { if (live) live.classList.add('is-down'); };
+  var es = null;
+  function connect() {
+    if (es) return;
+    es = new EventSource((window.RUSCKER_BASE || '') + '/admin/dashboard/events');
+    es.onopen = function () { if (live) live.classList.remove('is-down'); };
+    es.onmessage = function (e) {
+      if (live) live.classList.remove('is-down');
+      try { apply(JSON.parse(e.data)); } catch (_) { /* ignore */ }
+    };
+    // EventSource auto-reconnects on network errors; we just dim the Live
+    // badge while it's down.
+    es.onerror = function () { if (live) live.classList.add('is-down'); };
+  }
+  function disconnect() {
+    if (es) { es.close(); es = null; }
+    if (live) live.classList.add('is-down');
+  }
+  // Pause the live stream while the tab is hidden (#852): a backgrounded
+  // dashboard tab otherwise holds an HTTP/1.1 connection open, starving
+  // the browser's ~6-per-host pool and stalling navigation in other tabs.
+  // Reconnect (with a fresh snapshot) when the tab is visible again.
+  document.addEventListener('visibilitychange', function () {
+    if (document.hidden) disconnect(); else connect();
+  });
+  if (!document.hidden) connect();
 })();
 
 // Dashboard filter band (#623): live search + state chips over the

--- a/crates/ruscker-admin/tests/user_accounts.rs
+++ b/crates/ruscker-admin/tests/user_accounts.rs
@@ -107,7 +107,8 @@ async fn password_login_succeeds_and_wrong_fails() {
     )
     .await;
     assert_eq!(ok_status, StatusCode::SEE_OTHER);
-    assert_eq!(ok_loc, "/admin/dashboard");
+    // Editor lands on the Apps list, not the dashboard (#852).
+    assert_eq!(ok_loc, "/admin/specs");
 
     let (bad_status, _) = post(state, "/admin/login", "username=alice&password=WRONG", None).await;
     assert_eq!(bad_status, StatusCode::UNAUTHORIZED);


### PR DESCRIPTION
Closes #852.

## Problem
The admin's live-metrics **SSE** (`/admin/dashboard/events`) holds a long-lived connection. On an **HTTP/1.1** front end (the ~6-connection-per-host cap), a backgrounded or default-opened dashboard starves the pool and **intermittently stalls navigation** (observed on hugo). `proxy_buffering off` was a prerequisite fix; this PR removes the remaining starvation without touching infra.

## Two code-side fixes
1. **Land Editor/Admin on the Apps list** — `Role::home()` → `/admin/specs` (not the dashboard). The live SSE then only runs when someone opens monitoring on purpose, which is the common-case fix. Viewer stays on the dashboard until #857 moves it to the portal.
2. **Pause the dashboard EventSource while the tab is hidden** (Page Visibility) — a backgrounded dashboard tab no longer holds a connection; it reconnects with a fresh snapshot when visible again.

## Durable infra fix (separate, recommended)
**HTTP/2 at the TLS terminator** removes the 6-connection limit entirely — the real fix for when the dashboard is open in the foreground. Out of code scope; recommended for the box when feasible.

## Gate
`cargo test -p ruscker-admin` (incl. `password_login_succeeds_and_wrong_fails`, now expecting the Editor login to land on `/admin/specs`), `clippy -D warnings`, i18n parity.

## Notes
- ⚠️ **Touches `Role::home()`, which #857 (PR #861) also changes** — whichever merges second needs a 1-line resolve (combine: Viewer→portal, Editor/Admin→Apps).
- Draft because fix #2 is **JS on the live SSE** — verify on the next cast deploy that backgrounding the dashboard tab frees the connection (and refocus reconnects). Fix #1 (the landing) is Rust-only and smoke-free.

🤖 Generated with [Claude Code](https://claude.com/claude-code)