### PR TITLE
feat(landing): per-user favorite star; drop decorative lock (#858)

### DIFF
--- a/crates/ruscker-admin/assets/i18n/en/landing.ftl
+++ b/crates/ruscker-admin/assets/i18n/en/landing.ftl
@@ -288,8 +288,6 @@ spec-form-monogram-help = Shown on the cover when there's no logo.
 spec-form-meta = Access & scale
 spec-form-restricted = Restricted access
 spec-form-restricted-hint = Requires sign-in to open
-spec-form-locked = Access lock
-spec-form-locked-hint = Only shows a closed padlock — the app handles its own sign-in (no Ruscker restriction)
 spec-form-initial-replicas = Initial replicas
 spec-form-autoscaling = Autoscaling
 spec-form-autoscaling-hint = Scales replicas with demand
@@ -807,6 +805,7 @@ admin-landing-theme-accent = Accent
 
 # Featured carousel (#506)
 highlights-title = Featured
+card-favorite = Favorite
 spec-form-featured = Feature this app
 spec-form-featured-help = Shows the app in the Featured carousel at the top of the landing (when the toggle is on).
 admin-landing-show-highlights = Show Featured carousel

--- a/crates/ruscker-admin/assets/i18n/es/landing.ftl
+++ b/crates/ruscker-admin/assets/i18n/es/landing.ftl
@@ -288,8 +288,6 @@ spec-form-monogram-help = Se muestra en la portada cuando no hay logo.
 spec-form-meta = Acceso y escala
 spec-form-restricted = Acceso restringido
 spec-form-restricted-hint = Requiere iniciar sesión para abrir
-spec-form-locked = Candado de acceso
-spec-form-locked-hint = Solo muestra un candado cerrado — la app gestiona su propio inicio de sesión (sin restricción en Ruscker)
 spec-form-initial-replicas = Réplicas iniciales
 spec-form-autoscaling = Autoescalado
 spec-form-autoscaling-hint = Escala réplicas según la demanda
@@ -807,6 +805,7 @@ admin-landing-theme-accent = Acento
 
 # Featured carousel (#506)
 highlights-title = Destacados
+card-favorite = Favorito
 spec-form-featured = Destacar esta app
 spec-form-featured-help = Muestra la app en el carrusel de Destacados arriba de la landing (si la opción está activada).
 admin-landing-show-highlights = Mostrar Destacados

--- a/crates/ruscker-admin/assets/i18n/fr/landing.ftl
+++ b/crates/ruscker-admin/assets/i18n/fr/landing.ftl
@@ -288,8 +288,6 @@ spec-form-monogram-help = Affiché sur la couverture sans logo.
 spec-form-meta = Accès et échelle
 spec-form-restricted = Accès restreint
 spec-form-restricted-hint = Nécessite une connexion pour ouvrir
-spec-form-locked = Cadenas d'accès
-spec-form-locked-hint = Affiche seulement un cadenas fermé — l'application gère sa propre connexion (sans restriction Ruscker)
 spec-form-initial-replicas = Répliques initiales
 spec-form-autoscaling = Mise à l'échelle automatique
 spec-form-autoscaling-hint = Adapte les répliques à la demande
@@ -807,6 +805,7 @@ admin-landing-theme-accent = Accent
 
 # Featured carousel (#506)
 highlights-title = À la une
+card-favorite = Favori
 spec-form-featured = Mettre cette app en avant
 spec-form-featured-help = Affiche l'app dans le carrousel « À la une » en haut de la landing (si l'option est activée).
 admin-landing-show-highlights = Afficher « À la une »

--- a/crates/ruscker-admin/assets/i18n/pt/landing.ftl
+++ b/crates/ruscker-admin/assets/i18n/pt/landing.ftl
@@ -292,8 +292,6 @@ spec-form-monogram-help = Mostrado na capa quando não há logo.
 spec-form-meta = Acesso & escala
 spec-form-restricted = Acesso restrito
 spec-form-restricted-hint = Exige login para abrir
-spec-form-locked = Cadeado de acesso
-spec-form-locked-hint = Só mostra o cadeado fechado — o próprio app pede a senha (não restringe no Ruscker)
 spec-form-initial-replicas = Réplicas iniciais
 spec-form-autoscaling = Autoescalonamento
 spec-form-autoscaling-hint = Escala réplicas conforme a demanda
@@ -811,6 +809,7 @@ admin-landing-theme-accent = Acento
 
 # Featured carousel (#506)
 highlights-title = Destaques
+card-favorite = Favoritar
 spec-form-featured = Destacar este app
 spec-form-featured-help = Mostra o app no carrossel de Destaques no topo da landing (quando a opção estiver ligada).
 admin-landing-show-highlights = Mostrar Destaques

--- a/crates/ruscker-admin/migrations-pg/0025_user_favorites.sql
+++ b/crates/ruscker-admin/migrations-pg/0025_user_favorites.sql
@@ -1,0 +1,9 @@
+-- Per-user favorite apps (#858): the landing card star toggle. The
+-- "Featured" section shows a viewer's own favorites first, then the
+-- admin-pinned `featured` cards. Composite PK = one favorite per
+-- (user, spec); orphan rows from a deleted user are harmless.
+CREATE TABLE IF NOT EXISTS user_favorites (
+    username TEXT NOT NULL,
+    spec_id  TEXT NOT NULL,
+    PRIMARY KEY (username, spec_id)
+);

--- a/crates/ruscker-admin/migrations/0025_user_favorites.sql
+++ b/crates/ruscker-admin/migrations/0025_user_favorites.sql
@@ -1,0 +1,9 @@
+-- Per-user favorite apps (#858): the landing card star toggle. The
+-- "Featured" section shows a viewer's own favorites first, then the
+-- admin-pinned `featured` cards. Composite PK = one favorite per
+-- (user, spec); orphan rows from a deleted user are harmless.
+CREATE TABLE IF NOT EXISTS user_favorites (
+    username TEXT NOT NULL,
+    spec_id  TEXT NOT NULL,
+    PRIMARY KEY (username, spec_id)
+);

--- a/crates/ruscker-admin/src/db.rs
+++ b/crates/ruscker-admin/src/db.rs
@@ -167,6 +167,7 @@ pub mod landing_blocks;
 pub mod showcase;
 pub mod spec_access;
 pub mod specs;
+pub mod user_favorites;
 pub mod users;
 
 #[cfg(test)]

--- a/crates/ruscker-admin/src/db/user_favorites.rs
+++ b/crates/ruscker-admin/src/db/user_favorites.rs
@@ -1,0 +1,111 @@
+//! Per-user favorite apps (#858) — the landing card star toggle.
+//!
+//! A favorite is a `(username, spec_id)` row. The public landing reads a
+//! viewer's favorites to fill the star state + order the "Featured"
+//! section (favorites first, then admin-pinned `featured` cards).
+//! Favorites need a real user account — a break-glass token session
+//! (no username) can't favorite.
+
+use anyhow::{Context, Result};
+
+use crate::db::ConfigDb;
+
+/// Toggle a favorite for `(username, spec_id)`. Returns the new state:
+/// `true` ⇒ now favorited, `false` ⇒ removed. Implemented as
+/// delete-then-insert so it's a single round-trip in the common cases
+/// and naturally idempotent.
+pub async fn toggle(db: &ConfigDb, username: &str, spec_id: &str) -> Result<bool> {
+    let removed = match db {
+        ConfigDb::Sqlite(p) => {
+            sqlx::query("DELETE FROM user_favorites WHERE username = ? AND spec_id = ?")
+                .bind(username)
+                .bind(spec_id)
+                .execute(p)
+                .await
+                .context("toggle favorite (delete, sqlite)")?
+                .rows_affected()
+        }
+        ConfigDb::Postgres(p) => {
+            sqlx::query("DELETE FROM user_favorites WHERE username = $1 AND spec_id = $2")
+                .bind(username)
+                .bind(spec_id)
+                .execute(p)
+                .await
+                .context("toggle favorite (delete, pg)")?
+                .rows_affected()
+        }
+    } > 0;
+    if removed {
+        return Ok(false);
+    }
+    match db {
+        ConfigDb::Sqlite(p) => {
+            sqlx::query(
+                "INSERT INTO user_favorites (username, spec_id) VALUES (?, ?)
+                 ON CONFLICT DO NOTHING",
+            )
+            .bind(username)
+            .bind(spec_id)
+            .execute(p)
+            .await
+            .context("toggle favorite (insert, sqlite)")?;
+        }
+        ConfigDb::Postgres(p) => {
+            sqlx::query(
+                "INSERT INTO user_favorites (username, spec_id) VALUES ($1, $2)
+                 ON CONFLICT DO NOTHING",
+            )
+            .bind(username)
+            .bind(spec_id)
+            .execute(p)
+            .await
+            .context("toggle favorite (insert, pg)")?;
+        }
+    }
+    Ok(true)
+}
+
+/// The spec ids `username` has favorited, ordered by `spec_id` for a
+/// stable carousel order. Empty for an unknown user.
+pub async fn list(db: &ConfigDb, username: &str) -> Result<Vec<String>> {
+    let rows: Vec<(String,)> = match db {
+        ConfigDb::Sqlite(p) => {
+            sqlx::query_as("SELECT spec_id FROM user_favorites WHERE username = ? ORDER BY spec_id")
+                .bind(username)
+                .fetch_all(p)
+                .await
+        }
+        ConfigDb::Postgres(p) => {
+            sqlx::query_as("SELECT spec_id FROM user_favorites WHERE username = $1 ORDER BY spec_id")
+                .bind(username)
+                .fetch_all(p)
+                .await
+        }
+    }
+    .context("list favorites")?;
+    Ok(rows.into_iter().map(|(s,)| s).collect())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::db::open_memory;
+
+    #[tokio::test]
+    async fn toggle_and_list_roundtrip() {
+        let db = ConfigDb::Sqlite(open_memory().await.unwrap());
+        assert!(list(&db, "alice").await.unwrap().is_empty());
+
+        // First toggle adds it.
+        assert!(toggle(&db, "alice", "ips").await.unwrap());
+        assert!(toggle(&db, "alice", "aurora").await.unwrap());
+        // Ordered by spec_id.
+        assert_eq!(list(&db, "alice").await.unwrap(), vec!["aurora", "ips"]);
+        // Scoped per user.
+        assert!(list(&db, "bob").await.unwrap().is_empty());
+
+        // Second toggle removes it.
+        assert!(!toggle(&db, "alice", "ips").await.unwrap());
+        assert_eq!(list(&db, "alice").await.unwrap(), vec!["aurora"]);
+    }
+}

--- a/crates/ruscker-admin/src/routes/admin/spec_form.rs
+++ b/crates/ruscker-admin/src/routes/admin/spec_form.rs
@@ -360,12 +360,6 @@ pub struct SpecForm {
     /// "Featured" carousel flag (#506) — an HTML checkbox: present ("on")
     /// when checked, absent when not.
     pub featured: String,
-    /// Decorative "requires login" padlock (#839) — an HTML checkbox like
-    /// `featured`: "on" when checked. Stored in `template-properties.locked`;
-    /// closes the card lock without restricting access in Ruscker (the
-    /// wrapped app self-authenticates). Independent of access-groups/users.
-    #[serde(default)]
-    pub locked: String,
     pub logo: String,
     /// Card-cover CSS background (`template-properties.cover`):
     /// a solid color or a gradient string. Empty ⇒ fall back to
@@ -502,8 +496,6 @@ impl SpecForm {
             subject: tp.get_str("subject").map(str::to_string).unwrap_or_default(),
             // Pre-check the "Featured" box from the spec (#506).
             featured: if spec.is_featured() { "on".into() } else { String::new() },
-            // Pre-check the decorative-lock box from the spec (#839).
-            locked: if spec.shows_lock_badge() { "on".into() } else { String::new() },
             logo: tp.get_str("logo").map(str::to_string).unwrap_or_default(),
             cover: tp.get_str("cover").map(str::to_string).unwrap_or_default(),
             accent: tp.get_str("accent").map(str::to_string).unwrap_or_default(),
@@ -668,13 +660,9 @@ impl SpecForm {
         set_or_remove(&mut tp_map, "accent", &self.accent);
         set_or_remove(&mut tp_map, "monogram", &self.monogram);
         set_or_remove(&mut tp_map, "link", &self.link);
-        // Decorative "requires login" padlock (#839): store "true" when the
-        // box is checked, prune otherwise. Independent of the access lists.
-        if self.locked.trim().is_empty() {
-            tp_map.remove("locked");
-        } else {
-            tp_map.insert("locked".into(), YamlValue::String("true".into()));
-        }
+        // Prune the dead decorative-lock flag (#839, removed in #858) from
+        // any spec that still carries it, on save.
+        tp_map.remove("locked");
 
         let container_image = match dt {
             DisplayType::Package | DisplayType::Link => None,

--- a/crates/ruscker-admin/src/routes/landing.rs
+++ b/crates/ruscker-admin/src/routes/landing.rs
@@ -6,11 +6,11 @@
 
 use askama::Template;
 use axum::{
-    extract::State,
+    extract::{Path, State},
     http::{header, HeaderValue, StatusCode},
     response::{Html, IntoResponse, Response},
-    routing::get,
-    Router,
+    routing::{get, post},
+    Json, Router,
 };
 use fluent_bundle::{FluentArgs, FluentValue};
 
@@ -22,8 +22,34 @@ use crate::view_model::{
 };
 use crate::AppState;
 
+/// `POST /favorite/{spec_id}` — toggle the current user's favorite for a
+/// card (#858). Returns `{ "favorited": bool }`. Needs a real user
+/// account; an anonymous or break-glass-token visitor gets 401 (the star
+/// isn't shown to them anyway).
+async fn toggle_favorite(
+    State(state): State<AppState>,
+    MaybeSession(session): MaybeSession,
+    Path(spec_id): Path<String>,
+) -> Response {
+    let Some(username) = session.and_then(|s| s.actor) else {
+        return (StatusCode::UNAUTHORIZED, "sign in to favorite").into_response();
+    };
+    let Some(db) = state.db.as_ref() else {
+        return (StatusCode::SERVICE_UNAVAILABLE, "no db").into_response();
+    };
+    match crate::db::user_favorites::toggle(db, &username, &spec_id).await {
+        Ok(favorited) => Json(serde_json::json!({ "favorited": favorited })).into_response(),
+        Err(e) => {
+            tracing::error!(spec_id, error = ?e, "toggle favorite failed");
+            (StatusCode::INTERNAL_SERVER_ERROR, "toggle failed").into_response()
+        }
+    }
+}
+
 pub fn routes() -> Router<AppState> {
-    Router::new().route("/", get(index))
+    Router::new()
+        .route("/favorite/{spec_id}", post(toggle_favorite))
+        .route("/", get(index))
 }
 
 #[derive(Template)]
@@ -104,9 +130,15 @@ struct LandingPage<'a> {
     /// deploy policy from `landing-customization.show-admin-link`
     /// (default true); false hides the admin entrance on public portals.
     show_admin_link: bool,
-    /// Whether the "Featured" carousel may render (#506). The template also
-    /// checks that at least one card is featured via [`Self::has_featured`].
+    /// Whether the "Featured" carousel may render (#506). The template
+    /// also checks the highlight set is non-empty.
     show_highlights: bool,
+    /// The "Featured" section's cards in display order (#858): the
+    /// viewer's favorites first, then admin-pinned `featured` cards.
+    highlights: Vec<CardCtx<'a>>,
+    /// Whether to show the per-card favorite star — only for a logged-in
+    /// user account (#858). Anonymous / token visitors don't get stars.
+    signed_in_user: bool,
     /// Appearance toggles/options (#623 / ruscker-06), resolved to their
     /// effective values. The templates gate elements and pick CSS classes
     /// from these.
@@ -170,10 +202,10 @@ impl<'a> LandingPage<'a> {
     /// whether to render a slot's chrome insert (header-left replaces the
     /// Ruscker mark; header-right sits after the chrome cluster; the
     /// `center` bucket still renders as a separate bar). See #468.
-    /// Any featured card? Gates the "Featured" carousel together with
-    /// `show_highlights` (#506).
+    /// Any card in the "Featured" section? Gates the carousel together
+    /// with `show_highlights` (#506/#858 — favorites ∪ admin-featured).
     fn has_featured(&self) -> bool {
-        self.cards.iter().any(|c| c.featured)
+        !self.highlights.is_empty()
     }
 
     fn has_logos_at(&self, slot: &str, align: &str) -> bool {
@@ -319,6 +351,35 @@ async fn index(
         .map(|spec| CardCtx::from_spec(spec, &state.base_path))
         .collect();
     sort_by_recent(&mut cards);
+
+    // Per-user favorites (#858): mark the viewer's starred cards, then
+    // build the "Featured" order — the viewer's favorites first (in their
+    // stored order), then admin-pinned `featured` cards not already
+    // starred. Anonymous / break-glass-token visitors get no favorites.
+    let favorites: Vec<String> = match (username.as_deref(), state.db.as_ref()) {
+        (Some(user), Some(db)) => crate::db::user_favorites::list(db, user)
+            .await
+            .unwrap_or_default(),
+        _ => Vec::new(),
+    };
+    let fav_set: std::collections::HashSet<&str> =
+        favorites.iter().map(String::as_str).collect();
+    for c in &mut cards {
+        c.favorited = fav_set.contains(c.id);
+    }
+    let mut highlights: Vec<CardCtx<'_>> = Vec::new();
+    for fav_id in &favorites {
+        if let Some(c) = cards.iter().find(|c| c.id == fav_id.as_str()) {
+            highlights.push(c.clone());
+        }
+    }
+    for c in &cards {
+        if c.featured && !c.favorited {
+            highlights.push(c.clone());
+        }
+    }
+    let signed_in_user = username.is_some();
+
     let type_chips = build_type_chips(&cards);
     let subjects = unique_subjects(&cards);
     let counts = CardCounts {
@@ -552,6 +613,8 @@ async fn index(
             .effective_show_admin_link(),
         // Carousel toggle from the DB-backed editor (#506).
         show_highlights: lc.effective_show_highlights(),
+        highlights,
+        signed_in_user,
         // Appearance options (#623 / ruscker-06).
         show_search: lc.effective_show_search(),
         show_filters: lc.effective_show_filters(),

--- a/crates/ruscker-admin/src/view_model.rs
+++ b/crates/ruscker-admin/src/view_model.rs
@@ -210,8 +210,14 @@ pub struct CardCtx<'a> {
     /// verbatim from `template-properties.subject` and rendered as-is
     /// in the UI — operators choose their own taxonomy.
     pub subject: Option<&'a str>,
-    /// Highlighted in the landing's "Featured" carousel (#506).
+    /// Highlighted in the landing's "Featured" carousel (#506) —
+    /// admin-pinned, shown to everyone.
     pub featured: bool,
+    /// The current viewer has starred this card (#858). Per-user; set
+    /// after construction from the viewer's favorites (always `false`
+    /// for an anonymous visitor). Drives the star's filled state and the
+    /// favorites-first ordering of the Featured section.
+    pub favorited: bool,
     /// Card logo URL. Stored base-agnostic; a root-absolute value
     /// (e.g. `/assets/img/x.png`) is prefixed with the portal base
     /// path at construction (#294) so it resolves under `--base-path`.
@@ -250,16 +256,12 @@ impl<'a> CardCtx<'a> {
     pub fn from_spec(spec: &'a Spec, base: &str) -> Self {
         let display_type = DisplayType::from_spec(spec);
         let tp = &spec.template_properties;
-        // The card's access lock reflects the *real* access rule
-        // (`Spec::is_open()` — no `access-groups`/`access-users`), NOT the
-        // legacy decorative `template-properties.icon` flag (#346). It also
-        // honours the explicit `locked` badge (#839): an app whose own
-        // internal auth gates access shows a closed lock without Ruscker
-        // restricting it. Both surfaces — this icon and the `data-access`
-        // filter chip — close when access is restricted OR `locked` is set;
-        // enforcement and landing visibility still key off `access_allows`,
-        // so a bare `locked` app stays open to all through the proxy.
-        let access_open = spec.is_open() && !spec.shows_lock_badge();
+        // `access_open` drives the Public/Restricted filter chip and
+        // reflects the *real* access rule (`Spec::is_open()` — no
+        // `access-groups`/`access-users`). The decorative `locked` padlock
+        // (#839) was removed in #858 (replaced by the per-user favorite
+        // star), so this no longer consults `shows_lock_badge`.
+        let access_open = spec.is_open();
         let active = tp.is_active();
         let subject = tp.get_str("subject");
         let logo = tp.get_str("logo").map(|l| prefix_asset_url(l, base));
@@ -307,6 +309,9 @@ impl<'a> CardCtx<'a> {
             active,
             subject,
             featured: spec.is_featured(),
+            // Per-viewer; the landing handler sets it from the user's
+            // favorites after building the cards.
+            favorited: false,
             logo,
             cover,
             monogram,
@@ -644,22 +649,23 @@ mod tests {
     }
 
     #[test]
-    fn decorative_locked_flag_closes_the_card_lock_without_restricting() {
-        // #839: the explicit `template-properties.locked` flag closes the
-        // card padlock even though there's NO access list — for an app that
-        // self-authenticates. It must NOT restrict in Ruscker: `is_open()`
-        // (which drives enforcement + landing visibility) stays true.
+    fn decorative_locked_flag_no_longer_affects_the_card() {
+        // #858 removed the decorative `template-properties.locked` padlock
+        // (replaced by the per-user favorite star). `access_open` now follows
+        // only the real access rule (`is_open()`), so a `locked` flag with no
+        // access list leaves the card OPEN.
         let locked = spec_with_tp("  locked: \"true\"\n");
-        assert!(locked.is_open(), "locked is decorative — stays open for enforcement");
-        assert!(locked.shows_lock_badge(), "the flag is read");
+        assert!(locked.is_open());
         assert!(
-            !CardCtx::from_spec(&locked, "").access_open,
-            "locked ⇒ the card shows a closed padlock"
+            CardCtx::from_spec(&locked, "").access_open,
+            "the decorative locked flag is ignored now"
         );
 
-        // Without the flag (and no access lists) the card is open.
-        let plain = spec_with_tp("  subject: X\n");
-        assert!(CardCtx::from_spec(&plain, "").access_open);
+        // A real access restriction still closes the chip.
+        let restricted = spec_with_tp("");
+        let mut restricted = restricted;
+        restricted.access_groups = Some(vec!["staff".into()]);
+        assert!(!CardCtx::from_spec(&restricted, "").access_open);
     }
 
     // #745: an explicit cover is sanitized — `accent` already was, but

--- a/crates/ruscker-admin/templates/admin/spec_form.html
+++ b/crates/ruscker-admin/templates/admin/spec_form.html
@@ -507,22 +507,8 @@
         </span>
       </label>
 
-      {# Decorative "requires login" lock (#839) — INDEPENDENT of the
-         Ruscker access lists below. It only flips the card padlock to
-         closed, to signal that the wrapped app authenticates internally;
-         it does NOT restrict access in Ruscker (everyone still sees and
-         can reach the app — the app itself asks for the password). #}
-      <label class="toggle-row">
-        <div>
-          <div class="toggle-row__label">{{ self.t("spec-form-locked") }}</div>
-          <div class="toggle-row__hint">{{ self.t("spec-form-locked-hint") }}</div>
-        </div>
-        <span class="switch">
-          <input type="checkbox" name="locked" value="on" x-model="locked"
-                 {% if !form.locked.is_empty() %}checked{% endif %}>
-          <span class="switch__track"><span class="switch__dot"></span></span>
-        </span>
-      </label>
+      {# The decorative "requires login" lock (#839) was removed in #858 —
+         replaced by the per-user favorite star on the landing cards. #}
 
       {# Restricted access (#701) — a toggle over the access lists. Off ⇒
          public (lists cleared); on ⇒ reveal the group/user pickers. This
@@ -1076,11 +1062,6 @@
             {# Live subject ("tema") pill — mirrors the landing card (#507). #}
             <span class="rbadge rbadge--subject" x-show="(form.subject || '').trim()" x-text="form.subject" :title="form.subject" x-cloak></span>
           </div>
-          <span class="rlock">
-            <i class="ti" :class="isOpenAccess()
-                ? 'ti-lock-open text-[color:var(--color-lock-open)]'
-                : 'ti-lock text-[color:var(--color-lock)]'"></i>
-          </span>
         </div>
         <div class="rbody">
           <div class="rtitle" x-text="form.display_name || form.id || '—'"></div>
@@ -1355,15 +1336,6 @@ window.ruscker.specForm = (initial, logoImages, availableGroups) => ({
       : this.form.cover;
     return 'background:' + css + ';';
   },
-  // The preview card's lock mirrors the card view (#346/#839): open only
-  // when the decorative `locked` flag is OFF *and* both access lists are
-  // blank; closed when either the operator set the lock or a real
-  // restriction exists. Updates live as the admin edits.
-  isOpenAccess() {
-    return !this.locked
-        && !((this.form.access_groups || '').trim()
-          || (this.form.access_users || '').trim());
-  },
   // (imgUploading / imgError come from the imagePicker mixin.)
   // Advanced starts collapsed by default — even when editing a spec that
   // has advanced config set — so the form opens clean and uncluttered
@@ -1372,9 +1344,6 @@ window.ruscker.specForm = (initial, logoImages, availableGroups) => ({
   // Restricted-access toggle (#701): on when the spec already has any
   // group/user access list; off ⇒ public. Toggling off clears the lists.
   restricted: !((initial.access_groups || '').trim() === '' && (initial.access_users || '').trim() === ''),
-  // Decorative "requires login" lock (#839): independent boolean, drives
-  // only the preview/card padlock. Seeded from the saved `locked` flag.
-  locked: (initial.locked || '').trim() !== '',
   // Autoscaling toggle (#701): on when a max-replicas ceiling above 1 is
   // set. Off ⇒ the ceiling + thresholds are cleared (run at the floor).
   // Autoscaling is "on" when custom thresholds/grace are set — the

--- a/crates/ruscker-admin/templates/landing.html
+++ b/crates/ruscker-admin/templates/landing.html
@@ -128,11 +128,10 @@
               aria-label="{{ self.t("highlights-prev") }}"><i class="ti ti-chevron-left" aria-hidden="true"></i></button>
       <div class="highlights-viewport">
         <div class="highlights-track" x-ref="track" :style="trackStyle()">
-      {% for card in cards %}
-        {% if card.featured %}
-        {# An inactive card is not a destination (#746): no href (placeholder
-           link — not a tab stop, not announced as a link), aria-disabled for
-           AT, and the old `href="#"` scroll-to-top click is gone. #}
+      {% for card in highlights %}
+        {# Featured section (#858): the viewer's favorites first, then
+           admin-pinned `featured` cards (built in the handler). An inactive
+           card is not a destination (#746): no href, aria-disabled for AT. #}
         <a class="rcard {% if !card.active %}inactive{% endif %}"
            {% if card.active %}href="{{ card.href }}"{% else %}aria-disabled="true"{% endif %}>
           <div class="rcover">
@@ -150,8 +149,21 @@
               <span class="rbadge b-{{ card.display_type.key() }}">{{ self.t(card.display_type.abbr_key()) }}</span>
               {% if let Some(subj) = card.subject %}<span class="rbadge rbadge--subject" title="{{ subj }}">{{ subj }}</span>{% endif %}
             </div>
+            {# Per-user favorite star (#858) — replaces the old decorative
+               padlock. Logged-in only; clicking toggles over fetch without
+               navigating the card link. Anonymous visitors see nothing here. #}
             <span class="rlock">
-              <i class="ti ti-{% if card.access_open %}lock-open text-[color:var(--color-lock-open)]{% else %}lock text-[color:var(--color-lock)]{% endif %} text-[12px]" aria-hidden="true"></i>
+              {% if signed_in_user %}
+              <span class="rstar" role="button" tabindex="0" data-spec="{{ card.id }}"
+                    style="cursor:pointer;display:inline-flex;line-height:0"
+                    x-data="{ on: {{ card.favorited }}, busy: false }" :style="busy ? 'opacity:.5' : ''"
+                    :aria-pressed="on ? 'true' : 'false'"
+                    aria-label="{{ self.t("card-favorite") }}" title="{{ self.t("card-favorite") }}"
+                    @click.prevent.stop="busy=true; const prev=on; on=!on; fetch((window.RUSCKER_BASE||'')+'/favorite/'+encodeURIComponent($el.dataset.spec),{method:'POST'}).then(r=>r.ok?r.json():Promise.reject()).then(d=>{on=d.favorited}).catch(()=>{on=prev}).finally(()=>{busy=false})"
+                    @keydown.enter.prevent.stop="$el.click()" @keydown.space.prevent.stop="$el.click()">
+                <svg viewBox="0 0 24 24" width="13" height="13" aria-hidden="true" :fill="on ? '#f5a623' : 'none'" :stroke="on ? '#f5a623' : 'currentColor'" stroke-width="1.6" stroke-linejoin="round"><path d="M12 17.27L18.18 21l-1.64-7.03L22 9.24l-7.19-.61L12 2 9.19 8.63 2 9.24l5.46 4.73L5.82 21z"/></svg>
+              </span>
+              {% endif %}
             </span>
           </div>
           <div class="rbody">
@@ -173,7 +185,6 @@
             </div>
           </div>
         </a>
-        {% endif %}
       {% endfor %}
         </div>
       </div>
@@ -337,8 +348,20 @@
                compete with the coloured type badge (#507). #}
             {% if let Some(subj) = card.subject %}<span class="rbadge rbadge--subject" title="{{ subj }}">{{ subj }}</span>{% endif %}
           </div>
+          {# Per-user favorite star (#858) — replaces the decorative padlock.
+             Logged-in only; toggles over fetch without navigating the card. #}
           <span class="rlock">
-            <i class="ti ti-{% if card.access_open %}lock-open text-[color:var(--color-lock-open)]{% else %}lock text-[color:var(--color-lock)]{% endif %} text-[12px]" aria-hidden="true"></i>
+            {% if signed_in_user %}
+            <span class="rstar" role="button" tabindex="0" data-spec="{{ card.id }}"
+                  style="cursor:pointer;display:inline-flex;line-height:0"
+                  x-data="{ on: {{ card.favorited }}, busy: false }" :style="busy ? 'opacity:.5' : ''"
+                  :aria-pressed="on ? 'true' : 'false'"
+                  aria-label="{{ self.t("card-favorite") }}" title="{{ self.t("card-favorite") }}"
+                  @click.prevent.stop="busy=true; const prev=on; on=!on; fetch((window.RUSCKER_BASE||'')+'/favorite/'+encodeURIComponent($el.dataset.spec),{method:'POST'}).then(r=>r.ok?r.json():Promise.reject()).then(d=>{on=d.favorited}).catch(()=>{on=prev}).finally(()=>{busy=false})"
+                  @keydown.enter.prevent.stop="$el.click()" @keydown.space.prevent.stop="$el.click()">
+              <svg viewBox="0 0 24 24" width="13" height="13" aria-hidden="true" :fill="on ? '#f5a623' : 'none'" :stroke="on ? '#f5a623' : 'currentColor'" stroke-width="1.6" stroke-linejoin="round"><path d="M12 17.27L18.18 21l-1.64-7.03L22 9.24l-7.19-.61L12 2 9.19 8.63 2 9.24l5.46 4.73L5.82 21z"/></svg>
+            </span>
+            {% endif %}
           </span>
         </div>
 


### PR DESCRIPTION
Closes #858.

## What
Replaces the decorative `template-properties.locked` **padlock** (#839) with a **per-user favorite star** on the landing cards, and merges favorites into the "Featured" section.

## Behavior (as decided)
- **Star on each card** — only for a logged-in user account. Clicking toggles the favorite over `fetch` without navigating the card link. **Anonymous visitors get no star** and see only the admin-featured set.
- **One merged "Featured" section** — the viewer's **favorites first** (their stored order), then admin-pinned `featured` cards, de-duplicated (built in the handler as `highlights`).
- **Decorative lock removed** — no padlock on cards; no `locked` toggle in the spec form. The **real** access control (`is_open` / `access_allows` for enforcement + visibility, and the Public/Restricted filter chip) is untouched.

## Changes
- **DB**: migration `0025_user_favorites(username, spec_id)` (sqlite + `migrations-pg`, lockstep) + `db::user_favorites` (`toggle` / `list`, dual-dialect).
- **Route**: `POST /favorite/{spec_id}` — needs a real account (anonymous / break-glass-token → 401).
- **Landing** (`landing.rs` + `landing.html`): favorites fetched per user, each card marked `favorited`; the carousel iterates the new `highlights`; star markup (logged-in) replaces the `.rlock` padlock.
- **view_model**: `CardCtx.favorited`; `access_open = is_open()` (dropped `shows_lock_badge`); test rewritten.
- **spec_form**: removed the `locked` field + toggle + preview padlock + Alpine; saving prunes the stale `locked` flag; `spec-form-locked*` i18n removed; `card-favorite` i18n added (pt/en/es/fr).

## Gate
`cargo test` (incl. `user_favorites::toggle_and_list_roundtrip` + the rewritten view_model test), `clippy -D warnings`, i18n parity, **postgres-it** (0025 migration + dual-dialect queries green).

## Notes / follow-ups
- ⚠️ **Draft — needs cast smoke**: the star is Alpine + a `fetch` POST on the public landing. Verify on the next cast deploy: a logged-in user stars/unstars a card (persists across reload), the Featured section lists favorites first, and an anonymous visitor sees no star.
- The card star is a clickable `<span role="button">` inside the card `<a>` (`@click.prevent.stop`) — keyboard handlers included; full a11y polish could be a follow-up.
- `Spec::shows_lock_badge()` in `ruscker-config` is now unused (left as a harmless pub method; could be pruned later).

🤖 Generated with [Claude Code](https://claude.com/claude-code)