### PR TITLE
feat(admin): "Reclaim space" button on the Disk panel (host-safe)

### DIFF
--- a/crates/ruscker-admin/assets/i18n/en/landing.ftl
+++ b/crates/ruscker-admin/assets/i18n/en/landing.ftl
@@ -884,3 +884,9 @@ admin-system-yes = yes
 admin-system-no = no
 admin-system-restart-title = Restart the service
 admin-system-restart-hint = Ruscker can't restart itself safely — run this on the host (in-flight requests drain on SIGTERM).
+
+# Disk reclaim (#766 follow-up)
+admin-disk-reclaim = Reclaim space
+admin-disk-reclaim-hint = Prune dangling images + build cache (host-safe — never a tagged image or any container).
+admin-disk-reclaim-confirm = Reclaim space? Prunes dangling images and the build cache (no tagged image or container is removed).
+admin-disk-flash-reclaimed = Space reclaimed (dangling images + build cache).

--- a/crates/ruscker-admin/assets/i18n/es/landing.ftl
+++ b/crates/ruscker-admin/assets/i18n/es/landing.ftl
@@ -884,3 +884,9 @@ admin-system-yes = sí
 admin-system-no = no
 admin-system-restart-title = Reiniciar el servicio
 admin-system-restart-hint = Ruscker no puede reiniciarse de forma segura por sí mismo — ejecuta esto en el host (las solicitudes en curso se drenan con SIGTERM).
+
+# Recuperar espacio en disco (#766)
+admin-disk-reclaim = Recuperar espacio
+admin-disk-reclaim-hint = Limpia imágenes dangling + caché de compilación (seguro — nunca una imagen con tag ni un contenedor).
+admin-disk-reclaim-confirm = ¿Recuperar espacio? Limpia imágenes dangling y la caché de compilación (no se elimina ninguna imagen con tag ni contenedor).
+admin-disk-flash-reclaimed = Espacio recuperado (imágenes dangling + caché de compilación).

--- a/crates/ruscker-admin/assets/i18n/fr/landing.ftl
+++ b/crates/ruscker-admin/assets/i18n/fr/landing.ftl
@@ -884,3 +884,9 @@ admin-system-yes = oui
 admin-system-no = non
 admin-system-restart-title = Redémarrer le service
 admin-system-restart-hint = Ruscker ne peut pas se redémarrer en toute sécurité — lancez ceci sur l'hôte (les requêtes en cours se vident au SIGTERM).
+
+# Récupérer de l'espace disque (#766)
+admin-disk-reclaim = Récupérer de l'espace
+admin-disk-reclaim-hint = Purge les images dangling + le cache de build (sûr — jamais une image taguée ni un conteneur).
+admin-disk-reclaim-confirm = Récupérer de l'espace ? Purge les images dangling et le cache de build (aucune image taguée ni conteneur supprimé).
+admin-disk-flash-reclaimed = Espace récupéré (images dangling + cache de build).

--- a/crates/ruscker-admin/assets/i18n/pt/landing.ftl
+++ b/crates/ruscker-admin/assets/i18n/pt/landing.ftl
@@ -888,3 +888,9 @@ admin-system-yes = sim
 admin-system-no = não
 admin-system-restart-title = Reiniciar o serviço
 admin-system-restart-hint = O Ruscker não se reinicia com segurança sozinho — rode isto no host (as requisições em voo drenam no SIGTERM).
+
+# Recuperar espaço no disco (#766)
+admin-disk-reclaim = Recuperar espaço
+admin-disk-reclaim-hint = Limpa imagens dangling + cache de build (seguro — nunca remove imagem nomeada nem container).
+admin-disk-reclaim-confirm = Recuperar espaço? Limpa imagens dangling e o cache de build (nenhuma imagem nomeada ou container é removido).
+admin-disk-flash-reclaimed = Espaço recuperado (imagens dangling + cache de build).

--- a/crates/ruscker-admin/src/routes/admin/disk.rs
+++ b/crates/ruscker-admin/src/routes/admin/disk.rs
@@ -30,6 +30,7 @@ pub fn routes() -> Router<AppState> {
         .route("/admin/disk/containers/prune", post(prune_stopped))
         .route("/admin/disk/images/remove", post(remove_image))
         .route("/admin/disk/images/prune", post(prune_images))
+        .route("/admin/disk/reclaim", post(reclaim))
 }
 
 /// One image row, enriched with whether it's safe to remove.
@@ -167,6 +168,7 @@ async fn index(
     let (flash, flash_error) = match q.flash.as_deref() {
         Some("removed") => (Some("admin-disk-flash-removed"), false),
         Some("pruned") => (Some("admin-disk-flash-pruned"), false),
+        Some("reclaimed") => (Some("admin-disk-flash-reclaimed"), false),
         Some("images-pruned") => (Some("admin-disk-flash-images-pruned"), false),
         Some("nothing") => (Some("admin-disk-flash-nothing"), false),
         Some("error") => (Some("admin-disk-flash-error"), true),
@@ -397,6 +399,27 @@ async fn prune_stopped(_: RequireAdmin, State(state): State<AppState>) -> Respon
         Ok(_) => redirect("pruned"),
         Err(e) => {
             tracing::warn!(error = %e, "disk: prune stopped failed");
+            redirect("error")
+        }
+    }
+}
+
+/// "Reclaim space" — host-SAFE cleanup: prune dangling images + the build
+/// cache. Never removes a tagged image or any container (Ruscker or not),
+/// unlike a full `docker system prune` — important on a host that also
+/// runs ShinyProxy or other containers.
+async fn reclaim(_: RequireAdmin, State(state): State<AppState>) -> Response {
+    let Some(backend) = state.backend.as_ref() else {
+        return redirect("error");
+    };
+    match backend.reclaim_space().await {
+        Ok(0) => redirect("nothing"),
+        Ok(bytes) => {
+            tracing::info!(bytes, "disk: reclaimed dangling images + build cache");
+            redirect("reclaimed")
+        }
+        Err(e) => {
+            tracing::warn!(error = %e, "disk: reclaim space failed");
             redirect("error")
         }
     }

--- a/crates/ruscker-admin/templates/admin/disk.html
+++ b/crates/ruscker-admin/templates/admin/disk.html
@@ -8,6 +8,18 @@
     <h1 class="text-xl font-medium tracking-tight">{{ self.t("admin-disk-title") }}</h1>
     <p class="text-xs text-[color:var(--text-muted)] mt-1">{{ self.t("admin-disk-subtitle") }}</p>
   </div>
+  {# Host-SAFE reclaim (#766 follow-up): dangling images + build cache
+     only — never a tagged image or any container, so a side-by-side
+     ShinyProxy is untouched. Confirm rides data-confirm (global listener). #}
+  {% if available %}
+  <form method="post" action="{{ base }}/admin/disk/reclaim"
+        data-confirm="{{ self.t("admin-disk-reclaim-confirm") }}">
+    <button type="submit" class="admin-login-btn" style="padding:7px 12px;font-size:12px"
+            data-busy="{{ self.t("admin-disk-cleaning") }}" title="{{ self.t("admin-disk-reclaim-hint") }}">
+      <i class="ti ti-trash" aria-hidden="true"></i> {{ self.t("admin-disk-reclaim") }}
+    </button>
+  </form>
+  {% endif %}
 </div>
 
 {# Flash split (#746) — see groups/users: persistent role="alert"

--- a/crates/ruscker-core/src/lib.rs
+++ b/crates/ruscker-core/src/lib.rs
@@ -391,6 +391,15 @@ pub trait ContainerBackend: Send + Sync {
         Ok(None)
     }
 
+    /// "Reclaim space" for the disk panel (#766 follow-up): prune
+    /// **dangling** images (untagged orphan layers) + the build cache.
+    /// Deliberately host-SAFE — it never removes a tagged image or any
+    /// container (Ruscker or not), unlike a full `docker system prune`.
+    /// Returns the number of bytes reclaimed.
+    async fn reclaim_space(&self) -> CoreResult<u64> {
+        Ok(0)
+    }
+
     /// Local images, for the disk panel's "what's eating space" view.
     /// Each carries its size and how many containers reference it (so the
     /// UI can flag "in use" and only offer to remove unused ones).

--- a/crates/ruscker-docker/src/lib.rs
+++ b/crates/ruscker-docker/src/lib.rs
@@ -838,6 +838,31 @@ impl ContainerBackend for LocalDockerBackend {
         Ok(self.docker.version().await.ok().and_then(|v| v.version))
     }
 
+    async fn reclaim_space(&self) -> CoreResult<u64> {
+        let mut bytes: i64 = 0;
+        // `prune_images(None)` removes ONLY dangling (untagged) images —
+        // orphan layers, never a tagged image or a container's image. No
+        // `dangling:false` filter, so it can't behave like `image prune -a`.
+        match self
+            .docker
+            .prune_images(None::<bollard::query_parameters::PruneImagesOptions>)
+            .await
+        {
+            Ok(r) => bytes += r.space_reclaimed.unwrap_or(0),
+            Err(e) => tracing::warn!(error = %e, "reclaim: prune dangling images failed"),
+        }
+        // Build cache (unreferenced layers from past builds).
+        match self
+            .docker
+            .prune_build(None::<bollard::query_parameters::PruneBuildOptions>)
+            .await
+        {
+            Ok(r) => bytes += r.space_reclaimed.unwrap_or(0),
+            Err(e) => tracing::warn!(error = %e, "reclaim: prune build cache failed"),
+        }
+        Ok(bytes.max(0) as u64)
+    }
+
     async fn list_images(&self) -> CoreResult<Vec<ImageInfo>> {
         let images = self
             .docker


### PR DESCRIPTION
Operator request (alongside #766): a "Docker cleanup" button on the Disk panel.

## What — and why NOT a raw `docker system prune`
You asked for a `docker system prune` button. That's **dangerous on this deployment**: Ruscker's Disk panel is deliberately label-scoped ("never touch non-Ruscker"), and hugo/box also run **ShinyProxy + other containers** — a full `system prune` would wipe their stopped containers, networks and dangling images host-wide.

So this is the **host-SAFE** equivalent — a one-click **"Reclaim space"** that only removes **unreferenced** data:
- `prune_images(None)` → **dangling (untagged) images only** — never a tagged image, never a container's image.
- `prune_build(None)` → the **build cache**.

Neither touches a named image or any container (Ruscker or not), so a side-by-side ShinyProxy is untouched.

## Changes
- `ContainerBackend::reclaim_space() -> u64` (default `Ok(0)`); `LocalDockerBackend` sums `space_reclaimed` from both prunes (best-effort — a failed prune logs + continues).
- `POST /admin/disk/reclaim` (Admin) → flash `reclaimed` / `nothing` / `error`; confirm via `data-confirm`. Button in the Disk header. Localized pt/en/es/fr.

## Gate
`cargo build`/`test`, `clippy -D warnings`, i18n parity. No Alpine — a plain form POST. **No docker-it test** — `reclaim_space` mutates the host's real Docker (would prune the CI/dev machine's dangling layers).

## If you really want a full `docker system prune -a`
Can add it as a separate, clearly-labelled "Host-wide prune (removes non-Ruscker too, incl. ShinyProxy)" with a strong confirm — say the word.

🤖 Generated with [Claude Code](https://claude.com/claude-code)