### PR TITLE
fix(dashboard): show the app logo in the replica grid (was monogram only)

### DIFF
--- a/crates/ruscker-admin/src/routes/admin/dashboard.rs
+++ b/crates/ruscker-admin/src/routes/admin/dashboard.rs
@@ -98,6 +98,9 @@ struct ReplicaRow {
     /// `display-name` from the spec config, or the spec_id if
     /// the spec was renamed/deleted out from under the registry.
     display_name: String,
+    /// Card logo URL (already base-prefixed), or `None` for the
+    /// monogram fallback. Serialized so the SSE JS can render it too.
+    logo: Option<String>,
     /// Lowercase state string ("ready", "starting", …).
     /// Kept stable across versions — the JS uses it to pick
     /// the dot CSS class and (via the i18n keys baked into the
@@ -155,8 +158,11 @@ struct DashboardSnapshot {
 struct AppGroup {
     spec_id: String,
     display_name: String,
-    /// Single uppercase letter for the avatar tile.
+    /// Single uppercase letter for the avatar tile (monogram fallback).
     initial: String,
+    /// Card logo URL (base-prefixed) when the spec has one; the head
+    /// renders it instead of the monogram.
+    logo: Option<String>,
     /// Replica count.
     n: usize,
     /// The worst replica's dot class + label, so the collapsed head
@@ -216,10 +222,12 @@ fn group_rows(rows: &[ReplicaRow]) -> Vec<AppGroup> {
             let has_metrics = reps.iter().any(|r| r.cpu_display.is_some());
             let cpu_sum: f64 = reps.iter().filter_map(|r| r.cpu_history.last().copied()).sum();
             let mem_sum: u64 = reps.iter().filter_map(|r| r.mem_history.last().copied()).sum();
+            let logo = reps.first().and_then(|r| r.logo.clone());
             AppGroup {
                 spec_id: spec_id.to_string(),
                 display_name,
                 initial,
+                logo,
                 n: reps.len(),
                 state_dot,
                 state_label,
@@ -450,6 +458,29 @@ async fn build_snapshot_uncached(state: &AppState, locale: Locale) -> DashboardS
         })
         .collect();
 
+    // Card logo per spec (#dashboard-logo): the same
+    // `template-properties.logo` the landing + apps list show. Root-
+    // absolute values are base-prefixed here so the URL is correct under
+    // `--base-path` (and ready for the SSE JS to use verbatim); an `http`
+    // logo is left as-is.
+    let logo_of: std::collections::HashMap<String, String> = name_of
+        .keys()
+        .filter_map(|sid| {
+            catalog
+                .iter()
+                .find(|s| &s.id == sid)
+                .and_then(|s| s.template_properties.get_str("logo"))
+                .map(|l| {
+                    let url = if l.starts_with("http") {
+                        l.to_string()
+                    } else {
+                        format!("{}{}", state.base_path, l)
+                    };
+                    (sid.clone(), url)
+                })
+        })
+        .collect();
+
     let mut total_memory_bytes: u64 = 0;
     let rows: Vec<ReplicaRow> = snap
         .into_iter()
@@ -470,10 +501,12 @@ async fn build_snapshot_uncached(state: &AppState, locale: Locale) -> DashboardS
             }
             let (state_code, state_dot) = state_codes(r.state);
             let state_label = state.locales.t(locale, state_label_key(r.state), None);
+            let logo = logo_of.get(&r.spec_id).cloned();
             ReplicaRow {
                 replica_id: r.id.0.to_string(),
                 spec_id: r.spec_id,
                 display_name,
+                logo,
                 state: state_code,
                 state_dot,
                 state_label,
@@ -932,6 +965,7 @@ mod tests {
             replica_id: uuid::Uuid::new_v4().to_string(),
             spec_id: spec.into(),
             display_name: name.into(),
+            logo: None,
             state: state_code,
             state_dot,
             // Hard-coded pt labels — keeps the test independent

--- a/crates/ruscker-admin/templates/admin/dashboard.html
+++ b/crates/ruscker-admin/templates/admin/dashboard.html
@@ -133,7 +133,10 @@
     <div class="app-group__head" role="button" tabindex="0" aria-expanded="true">
       <span class="app-group__chev"><i class="ti ti-chevron-right" aria-hidden="true"></i></span>
       <span class="app-group__name">
-        <span class="app-group__logo">{{ g.initial }}</span>
+        {# Card logo when the spec has one (mirrors the landing + apps
+           list); falls back to the monogram initial. A broken image hides
+           itself, leaving the tile's background. #}
+        <span class="app-group__logo">{% match g.logo %}{% when Some with (l) %}<img src="{{ l }}" alt="" loading="lazy" onerror="this.style.display='none'" style="width:100%;height:100%;object-fit:contain">{% when None %}{{ g.initial }}{% endmatch %}</span>
         <span><span class="truncate">{{ g.display_name }}</span><span class="app-group__id">{{ g.spec_id }}</span></span>
       </span>
       <span class="app-group__replicas"><i class="ti ti-stack-2" aria-hidden="true"></i>{{ g.n }}</span>
@@ -268,6 +271,7 @@
       var name = reps[0].display_name || id;
       return {
         spec_id: id, display_name: name,
+        logo: reps[0].logo || null,
         initial: (name.charAt(0) || '').toUpperCase(),
         n: reps.length, state_dot: worst.state_dot, state_label: worst.state_label,
         sessions_active: sa, sessions_max: sm,
@@ -306,7 +310,9 @@
     return '<div class="app-group' + (isOpen ? ' is-open' : '') + '" data-spec-id="' + escapeHtml(g.spec_id) + '">'
       + '<div class="app-group__head" role="button" tabindex="0" aria-expanded="' + (isOpen ? 'true' : 'false') + '">'
         + '<span class="app-group__chev"><i class="ti ti-chevron-right"></i></span>'
-        + '<span class="app-group__name"><span class="app-group__logo">' + escapeHtml(g.initial) + '</span>'
+        + '<span class="app-group__name"><span class="app-group__logo">'
+          + (g.logo ? '<img src="' + escapeHtml(g.logo) + '" alt="" loading="lazy" onerror="this.style.display=&apos;none&apos;" style="width:100%;height:100%;object-fit:contain">' : escapeHtml(g.initial))
+          + '</span>'
           + '<span><span class="truncate">' + escapeHtml(g.display_name) + '</span>'
           + '<span class="app-group__id">' + escapeHtml(g.spec_id) + '</span></span></span>'
         + '<span class="app-group__replicas"><i class="ti ti-stack-2"></i>' + g.n + '</span>'


### PR DESCRIPTION
## Bug
On the **Painel** (dashboard), the grouped-by-app head showed only the **monogram initial** (a bare "N" / "P" tile) — it never rendered the app's actual **logo**, unlike the landing cards and the Apps list. Reported with a screenshot (Novo Aurora Prime, Pikup — both have logos elsewhere).

## Cause
`AppGroup` carried only `initial`; the dashboard never read `template-properties.logo`. So it was a missing feature, not a load failure.

## Fix
- `build_snapshot` resolves each spec's `logo` (base-prefixed so it's correct under `--base-path`; `http` logos left as-is) into a per-spec map, set on `ReplicaRow.logo` (serialized) and the grouped `AppGroup.logo`.
- The group head renders an `<img>` (`object-fit: contain`, hides itself on error) when a logo is present, falling back to the monogram initial otherwise.
- **Both** surfaces fixed: the server-side Askama render **and** the SSE JS rebuild (`groupHtml`) — so the logo survives the live updates.

## Gate
`cargo test -p ruscker-admin` (incl. the dashboard grouping test, updated), `clippy -D warnings`, i18n parity.

## Draft — needs cast smoke
Touches the dashboard SSE JS rebuild. Verify on the next cast deploy that apps with a logo show it in the Painel (and the monogram fallback still works for logo-less apps), including after a live SSE update.

🤖 Generated with [Claude Code](https://claude.com/claude-code)