### PR TITLE
fix(disk): enforce Ruscker ownership in the backend — host-safe (#871)

### DIFF
--- a/crates/ruscker-admin/src/routes/admin/disk.rs
+++ b/crates/ruscker-admin/src/routes/admin/disk.rs
@@ -213,10 +213,17 @@ async fn index(
     // image as "in use by a spec" so the panel won't offer to remove it.
     let spec_images = spec_image_refs(&state).await;
 
-    // The image refs live containers are actually built from — the
-    // reliable in-use signal (the daemon's per-image container count is
-    // unreliable, #585).
-    let container_images = container_image_refs(&containers);
+    // The image refs **every** container on the host is built from —
+    // not just Ruscker-managed ones (#871) — so an image backing a
+    // non-Ruscker container (e.g. ShinyProxy) is never flagged "unused".
+    // (The daemon's per-image count is unreliable, #585, so we derive it
+    // from the live container set.)
+    let container_images: HashSet<String> = backend
+        .all_container_image_refs()
+        .await
+        .unwrap_or_default()
+        .into_iter()
+        .collect();
 
     let stopped_count = containers.iter().filter(|c| !c.running).count();
     let images_total_bytes: i64 = images.iter().map(|i| i.size_bytes).sum();
@@ -308,18 +315,11 @@ async fn spec_image_refs(state: &AppState) -> HashSet<String> {
         .collect()
 }
 
-/// Image refs (tags + ids) that a live managed container is built from.
-/// This is the reliable "in use by a container" signal: the daemon's
-/// `ImageSummary.containers` count is `-1` (uncomputed) on a plain
-/// `list_images`, so a positive count can't be relied on (#585). A
-/// non-Ruscker container isn't in this set, but `remove_image` (no
-/// `--force`) refuses a truly in-use image, so the actual removal stays
-/// safe — only the displayed count could be optimistic for those.
-fn container_image_refs(containers: &[ManagedContainer]) -> HashSet<String> {
-    containers.iter().map(|c| c.image.clone()).collect()
-}
-
-/// True when a managed container is built from this image (by tag or id).
+/// True when **any** host container is built from this image (by tag or
+/// id). `container_images` is the all-container ref set (#871), so an
+/// image backing a non-Ruscker container counts as in-use. The daemon's
+/// `ImageSummary.containers` count is unreliable on a plain `list_images`
+/// (#585), so we derive in-use from the live container set instead.
 fn image_used_by_container(i: &ImageInfo, container_images: &HashSet<String>) -> bool {
     container_images.contains(&i.id) || i.tags.iter().any(|t| container_images.contains(t))
 }
@@ -461,8 +461,14 @@ async fn prune_images(_: RequireAdmin, State(state): State<AppState>) -> Respons
         }
     };
     let spec_images = spec_image_refs(&state).await;
-    let container_images =
-        container_image_refs(&backend.list_managed_containers().await.unwrap_or_default());
+    // ALL host containers (#871) — never prune an image a non-Ruscker
+    // container is built from.
+    let container_images: HashSet<String> = backend
+        .all_container_image_refs()
+        .await
+        .unwrap_or_default()
+        .into_iter()
+        .collect();
     let unused: Vec<String> = images
         .into_iter()
         .filter(|i| image_unused(i, &spec_images, &container_images))

--- a/crates/ruscker-core/src/lib.rs
+++ b/crates/ruscker-core/src/lib.rs
@@ -372,7 +372,18 @@ pub trait ContainerBackend: Send + Sync {
         Ok(Vec::new())
     }
 
+    /// Image refs (name/tag AND sha id) of **every** container on the
+    /// host — not just Ruscker-managed ones (#871). The disk panel uses
+    /// this so an image backing a non-Ruscker container (e.g. ShinyProxy)
+    /// is never flagged "unused" or removed.
+    async fn all_container_image_refs(&self) -> CoreResult<Vec<String>> {
+        Ok(Vec::new())
+    }
+
     /// Force-remove a single container by id (stops it first if running).
+    /// MUST refuse a container that isn't Ruscker-managed (#871) — the
+    /// caller passes an operator-supplied id, so the label check is the
+    /// backstop against removing a non-Ruscker container on a shared host.
     async fn remove_container(&self, _container_id: &str) -> CoreResult<()> {
         Ok(())
     }

--- a/crates/ruscker-docker/src/lib.rs
+++ b/crates/ruscker-docker/src/lib.rs
@@ -788,7 +788,50 @@ impl ContainerBackend for LocalDockerBackend {
         Ok(managed)
     }
 
+    async fn all_container_image_refs(&self) -> CoreResult<Vec<String>> {
+        // ALL containers (running + stopped), no label filter.
+        let opts = ListContainersOptions {
+            all: true,
+            ..Default::default()
+        };
+        let list = self
+            .docker
+            .list_containers(Some(opts))
+            .await
+            .map_err(|e| backend_err("list all containers", e))?;
+        let mut refs = Vec::with_capacity(list.len() * 2);
+        for c in list {
+            if let Some(img) = c.image {
+                refs.push(img);
+            }
+            if let Some(id) = c.image_id {
+                refs.push(id);
+            }
+        }
+        Ok(refs)
+    }
+
     async fn remove_container(&self, container_id: &str) -> CoreResult<()> {
+        // #871: the id comes from an operator POST, and `force=true` would
+        // stop+remove ANY container (incl. a running non-Ruscker one,
+        // bypassing the daemon's in-use refusal). Re-inspect and refuse
+        // anything without our `ruscker.replica_id` label — the listing is
+        // label-scoped, but the backend is the real backstop.
+        let info = self
+            .docker
+            .inspect_container(container_id, None)
+            .await
+            .map_err(|e| backend_err("inspect container", e))?;
+        let is_ruscker = info
+            .config
+            .as_ref()
+            .and_then(|c| c.labels.as_ref())
+            .is_some_and(|l| l.contains_key(LABEL_REPLICA_ID));
+        if !is_ruscker {
+            return Err(CoreError::Backend(format!(
+                "refusing to remove non-Ruscker container {container_id}"
+            )));
+        }
         // force=true also stops a running container first, mirroring `stop`.
         self.docker
             .remove_container(
@@ -1695,6 +1738,71 @@ mod tests {
         );
 
         backend.stop(&replica.id).await.expect("stop");
+    }
+
+    /// #871: the disk panel must never touch a non-Ruscker container or
+    /// its image on a shared host. `remove_container` refuses a container
+    /// without our label, and `all_container_image_refs` includes the
+    /// foreign container's image so the panel won't flag it "unused".
+    #[cfg(feature = "docker-it")]
+    #[tokio::test]
+    async fn disk_ops_spare_non_ruscker_container_and_image() {
+        let image =
+            std::env::var("RUSCKER_IT_IMAGE").unwrap_or_else(|_| "nginx:1.29-alpine".into());
+        let backend = LocalDockerBackend::local().expect("connect docker");
+        backend
+            .ensure_image_pulled(&image, None, None)
+            .await
+            .expect("pull");
+        // A plain container with NO ruscker labels (stands in for a
+        // ShinyProxy / unrelated container on the host).
+        let created = backend
+            .docker
+            .create_container(
+                Some(CreateContainerOptions {
+                    name: Some("ruscker-it-foreign".into()),
+                    ..Default::default()
+                }),
+                ContainerCreateBody {
+                    image: Some(image.clone()),
+                    cmd: Some(vec!["sleep".into(), "30".into()]),
+                    ..Default::default()
+                },
+            )
+            .await
+            .expect("create foreign container");
+        let id = created.id;
+
+        // remove_container must REFUSE it (not Ruscker-labeled).
+        let err = backend
+            .remove_container(&id)
+            .await
+            .expect_err("must refuse a non-Ruscker container");
+        assert!(err.to_string().contains("non-Ruscker"), "got: {err}");
+        assert!(
+            backend.docker.inspect_container(&id, None).await.is_ok(),
+            "the foreign container must NOT have been removed"
+        );
+
+        // Its image shows up in the all-container ref set → the disk panel
+        // counts it in-use and won't offer to prune it.
+        let refs = backend.all_container_image_refs().await.expect("refs");
+        assert!(
+            refs.iter().any(|r| r == &image || r.starts_with("sha256:")),
+            "foreign image must be in the in-use set: {refs:?}"
+        );
+
+        // Cleanup directly (bypassing the guard).
+        let _ = backend
+            .docker
+            .remove_container(
+                &id,
+                Some(RemoveContainerOptions {
+                    force: true,
+                    ..Default::default()
+                }),
+            )
+            .await;
     }
 
     /// #550: a container that crashes on startup (e.g. it can't reach its

--- a/crates/ruscker-docker/src/multihost.rs
+++ b/crates/ruscker-docker/src/multihost.rs
@@ -453,6 +453,22 @@ impl ContainerBackend for MultiHostDockerBackend {
         Ok(all)
     }
 
+    async fn all_container_image_refs(&self) -> CoreResult<Vec<String>> {
+        // Fan out so the disk panel's in-use signal covers every host's
+        // containers (#871). A degraded host is skipped (its images just
+        // aren't protected on that host — same best-effort as the rest).
+        let mut all = Vec::new();
+        for h in &self.hosts {
+            match h.backend.all_container_image_refs().await {
+                Ok(refs) => all.extend(refs),
+                Err(e) => {
+                    tracing::warn!(host = %h.id, error = %e, "all container image refs on host failed; skipping");
+                }
+            }
+        }
+        Ok(all)
+    }
+
     async fn remove_container(&self, container_id: &str) -> CoreResult<()> {
         // Container ids aren't in the placement map (that's keyed by
         // replica id), so mirror `stop`'s placement-miss path: try every


### PR DESCRIPTION
Closes #871 (P1).

## Problem
On a shared host (hugo/box run **ShinyProxy** + other containers alongside Ruscker), the Disk panel could remove **non-Ruscker** images and containers — the label-scoping was only in the UI/listing, not enforced in the backend.
- **P1b**: `remove_container` passed an operator-POST'd id straight to `remove_container(force=true)` — no label check → force-remove **any** container (incl. a running non-Ruscker one, bypassing the daemon's in-use refusal).
- **P1a**: the "unused image" signal came from **Ruscker-managed** containers only, so an image backing a non-Ruscker container was flagged "unused" and offered for removal / bulk prune.

## Fix (backend is the backstop)
- **`remove_container`** re-inspects the container and **refuses any without `ruscker.replica_id`**. Multihost fans out to each host's local backend, so the check applies per host.
- **New `ContainerBackend::all_container_image_refs()`** (default empty; local lists **all** host containers; multihost fans out). The disk panel's in-use check **and** the bulk prune now use it → an image backing a non-Ruscker container (e.g. a ShinyProxy app image) is never flagged "unused" or pruned.
- **docker-it** `disk_ops_spare_non_ruscker_container_and_image`: a plain unlabeled container is **not** removed, and its image **is** in the in-use set.

## Residual (documented)
A tagged image with **zero** host containers can't be attributed to Ruscker and is still individually removable — image ownership is unprovable. The daemon's no-force already protects any image with a container; this PR closes the worst cases (force-remove of a non-Ruscker container; pruning images of *running/stopped* non-Ruscker containers). A host-wide-opt-in gate for the fully-idle tagged-image case can be a follow-up.

## Gate
`cargo test`, `clippy -D warnings`, and the new **docker-it** test against a real daemon. No template/Alpine — backend + disk handler only.

🤖 Generated with [Claude Code](https://claude.com/claude-code)