### PR TITLE
fix(landing): label link cards "Links", not "Packages" (#876)

### DIFF
--- a/crates/ruscker-admin/assets/i18n/en/landing.ftl
+++ b/crates/ruscker-admin/assets/i18n/en/landing.ftl
@@ -16,6 +16,7 @@ filter-clear = Clear filters
 type-all = All
 type-app = Applications
 type-package = Packages
+type-link = Links
 type-talk = Presentations
 type-report = Reports
 type-api = APIs

--- a/crates/ruscker-admin/assets/i18n/es/landing.ftl
+++ b/crates/ruscker-admin/assets/i18n/es/landing.ftl
@@ -16,6 +16,7 @@ filter-clear = Limpiar filtros
 type-all = Todos
 type-app = Aplicaciones
 type-package = Paquetes
+type-link = Enlaces
 type-talk = Presentaciones
 type-report = Informes
 type-api = APIs

--- a/crates/ruscker-admin/assets/i18n/fr/landing.ftl
+++ b/crates/ruscker-admin/assets/i18n/fr/landing.ftl
@@ -16,6 +16,7 @@ filter-clear = Effacer les filtres
 type-all = Tous
 type-app = Applications
 type-package = Paquets
+type-link = Liens
 type-talk = Présentations
 type-report = Rapports
 type-api = APIs

--- a/crates/ruscker-admin/assets/i18n/pt/landing.ftl
+++ b/crates/ruscker-admin/assets/i18n/pt/landing.ftl
@@ -17,6 +17,7 @@ filter-clear = Limpar filtros
 type-all = Todos
 type-app = Aplicações
 type-package = Pacotes
+type-link = Links
 type-talk = Apresentações
 type-report = Relatórios
 type-api = APIs

--- a/crates/ruscker-admin/src/view_model.rs
+++ b/crates/ruscker-admin/src/view_model.rs
@@ -122,7 +122,7 @@ impl DisplayType {
             DisplayType::Report => "type-report",
             DisplayType::Package => "type-package",
             DisplayType::Api => "type-api",
-            DisplayType::Link => "type-package",
+            DisplayType::Link => "type-link",
         }
     }
 


### PR DESCRIPTION
Closes #876 (P3). `DisplayType::Link` used `type-package` (no `type-link` key existed) → link cards' chip/section read "Packages". Added `type-link` (pt/en/es/fr) and pointed Link at it. i18n parity + tests green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)