### PR TITLE
fix(users): CSV import — don't silently drop a profile-write failure (#875)

### DIFF
--- a/crates/ruscker-admin/src/routes/admin/users.rs
+++ b/crates/ruscker-admin/src/routes/admin/users.rs
@@ -630,7 +630,13 @@ async fn import_confirm(
         {
             Ok(()) => {
                 if !r.setor.is_empty() || !r.email.is_empty() || !r.celular.is_empty() {
-                    let _ = db::users::update_profile(
+                    // #875: don't silently swallow a profile-write failure.
+                    // The user was created but the profile didn't take →
+                    // compensate by removing the half-created account and
+                    // counting the row as skipped, so create+profile is
+                    // effectively all-or-nothing. (A CSV row is never the
+                    // last admin, so the delete guard can't block this.)
+                    if let Err(e) = db::users::update_profile(
                         pool,
                         &r.username,
                         Some(&r.setor),
@@ -638,7 +644,13 @@ async fn import_confirm(
                         Some(&r.celular),
                         Some(admin.actor()),
                     )
-                    .await;
+                    .await
+                    {
+                        tracing::warn!(user = %r.username, error = ?e, "csv import: profile write failed; rolling back the user");
+                        let _ = db::users::delete(pool, &r.username, Some(admin.actor())).await;
+                        skipped += 1;
+                        continue;
+                    }
                 }
                 imported += 1;
             }


### PR DESCRIPTION
Closes #875 (P3). `import_confirm` discarded `update_profile` with `let _ =` → a user with a failed profile write counted as imported (partial). Now it logs + **rolls back the user** (compensating delete) and counts the row as skipped — create+profile is all-or-nothing. cargo test + clippy green; backend only.

🤖 Generated with [Claude Code](https://claude.com/claude-code)