### PR TITLE
fix(admin): reject max-containers=0 at spec save (#877)

### DIFF
--- a/crates/ruscker-admin/assets/i18n/en/landing.ftl
+++ b/crates/ruscker-admin/assets/i18n/en/landing.ftl
@@ -306,6 +306,7 @@ spec-form-error-id-shape = ID must start with a letter and contain only letters,
 spec-form-error-id-duplicate = An app with that ID already exists.
 spec-form-error-name-required = Display name is required.
 spec-form-error-number = A numeric field has a non-numeric value.
+spec-form-error-max-replicas-zero = Max containers must be at least 1 (0 means the app can never start).
 spec-form-error-cpu = CPU limit must be a positive number (e.g. 0.5).
 spec-form-error-memory = Memory limit must be a size like 512m or 1.5g.
 spec-form-error-replica-range = Max replicas must be greater than or equal to min replicas.

--- a/crates/ruscker-admin/assets/i18n/es/landing.ftl
+++ b/crates/ruscker-admin/assets/i18n/es/landing.ftl
@@ -306,6 +306,7 @@ spec-form-error-id-shape = El ID debe empezar con una letra y contener solo letr
 spec-form-error-id-duplicate = Ya existe una aplicación con ese ID.
 spec-form-error-name-required = El nombre visible es obligatorio.
 spec-form-error-number = Un campo numérico tiene un valor no numérico.
+spec-form-error-max-replicas-zero = Máx. de contenedores debe ser al menos 1 (0 hace que la app nunca inicie).
 spec-form-error-cpu = El límite de CPU debe ser un número positivo (ej.: 0.5).
 spec-form-error-memory = El límite de memoria debe ser un tamaño como 512m o 1.5g.
 spec-form-error-replica-range = Réplicas máx. debe ser mayor o igual que réplicas mín.

--- a/crates/ruscker-admin/assets/i18n/fr/landing.ftl
+++ b/crates/ruscker-admin/assets/i18n/fr/landing.ftl
@@ -306,6 +306,7 @@ spec-form-error-id-shape = L'ID doit commencer par une lettre et contenir unique
 spec-form-error-id-duplicate = Une application avec cet ID existe déjà.
 spec-form-error-name-required = Le nom d'affichage est obligatoire.
 spec-form-error-number = Un champ numérique a une valeur non numérique.
+spec-form-error-max-replicas-zero = Le nombre max. de conteneurs doit être au moins 1 (0 empêche l'app de démarrer).
 spec-form-error-cpu = La limite CPU doit être un nombre positif (ex. 0.5).
 spec-form-error-memory = La limite mémoire doit être une taille comme 512m ou 1.5g.
 spec-form-error-replica-range = Le max de réplicas doit être supérieur ou égal au min.

--- a/crates/ruscker-admin/assets/i18n/pt/landing.ftl
+++ b/crates/ruscker-admin/assets/i18n/pt/landing.ftl
@@ -310,6 +310,7 @@ spec-form-error-id-shape = ID deve começar com letra e conter apenas letras, n�
 spec-form-error-id-duplicate = Já existe uma aplicação com esse ID.
 spec-form-error-name-required = Nome de exibição é obrigatório.
 spec-form-error-number = Um campo numérico tem valor não numérico.
+spec-form-error-max-replicas-zero = Máx. de containers deve ser ao menos 1 (0 faz o app nunca iniciar).
 spec-form-error-cpu = O limite de CPU deve ser um número positivo (ex.: 0.5).
 spec-form-error-memory = O limite de memória deve ser um tamanho como 512m ou 1.5g.
 spec-form-error-replica-range = Réplicas máx. deve ser maior ou igual a réplicas mín.

--- a/crates/ruscker-admin/src/routes/admin/spec_form.rs
+++ b/crates/ruscker-admin/src/routes/admin/spec_form.rs
@@ -809,6 +809,12 @@ impl SpecForm {
         {
             errs.push("spec-form-error-number");
         }
+        // A max-containers ceiling of 0 refuses every spawn (`live >= max`),
+        // so the app can never start. Reject it server-side, not just via
+        // the HTML `min=1` a crafted POST can bypass (#877).
+        if matches!(self.max_replicas.trim().parse::<i64>(), Ok(n) if n <= 0) {
+            errs.push("spec-form-error-max-replicas-zero");
+        }
         // Ports are 1–65535.
         for p in [&self.container_port, &self.api_port] {
             if !p.trim().is_empty()
@@ -1762,6 +1768,25 @@ proxy:
         assert!(f
             .validate(FormMode::New)
             .contains(&"spec-form-error-replica-range"));
+    }
+
+    // #877: a max-containers ceiling of 0 (or negative) refuses every
+    // spawn, so the app could never start — reject it at save instead of
+    // relying on the HTML `min=1` a crafted POST bypasses.
+    #[test]
+    fn validate_rejects_zero_max_replicas() {
+        let mut f = valid_form();
+        f.max_replicas = "0".into();
+        assert!(f
+            .validate(FormMode::New)
+            .contains(&"spec-form-error-max-replicas-zero"));
+
+        // A normal ceiling is fine.
+        let mut ok = valid_form();
+        ok.max_replicas = "3".into();
+        assert!(!ok
+            .validate(FormMode::New)
+            .contains(&"spec-form-error-max-replicas-zero"));
     }
 
     #[test]


### PR DESCRIPTION
## What

A max-containers (`max-replicas`) ceiling of **0** refuses every spawn (the scaler gate is `live >= max`), so the app can **never start**. Until now only the HTML `min=1` attribute guarded it — a crafted POST or an imported config could set 0 and the app would silently never come up.

`SpecForm::validate` now rejects `max_replicas <= 0` with a new `spec-form-error-max-replicas-zero` error, localized pt/en/es/fr.

## Test

`validate_rejects_zero_max_replicas` (0 rejected, 3 accepted). Full gate green: `cargo test`, `clippy --all-targets -D warnings`, `i18n-check`.

Closes #877

🤖 Generated with [Claude Code](https://claude.com/claude-code)