### PR TITLE
fix(config): read ShinyProxy 'container-volumes' key on import

### DIFF
--- a/crates/ruscker-config/src/schema.rs
+++ b/crates/ruscker-config/src/schema.rs
@@ -865,11 +865,14 @@ pub struct Spec {
     pub max_body_size: Option<String>,
 
     /// Bind-mount volumes for the container, in Docker syntax —
-    /// `"/host:/container"` or `"/host:/container:ro"`. ShinyProxy-
-    /// compatible (`volumes:` is a list of such strings). The local
-    /// Docker backend maps these to `HostConfig.binds`. Bind-mounting
-    /// host paths is powerful and admin-only — see SECURITY.md.
-    #[serde(default)]
+    /// `"/host:/container"` or `"/host:/container:ro"`. The YAML key is
+    /// ShinyProxy's **`container-volumes`** (a list of such strings); the
+    /// bare `volumes` is kept as a deserialize alias so older Ruscker
+    /// configs still parse. Using the wrong key was why a real ShinyProxy
+    /// import silently dropped every mount. The local Docker backend maps
+    /// these to `HostConfig.binds`. Bind-mounting host paths is powerful
+    /// and admin-only — see SECURITY.md.
+    #[serde(rename = "container-volumes", alias = "volumes", default)]
     pub volumes: Option<Vec<String>>,
 
     /// Environment variables injected into the container, as a map of
@@ -1573,6 +1576,28 @@ mod max_body_size_tests {
             serde_yaml_ng::from_str("id: y\ncontainer-image: a:1\n").expect("parse");
         assert_eq!(none.effective_max_lifetime_secs(), None);
         assert_eq!(none.effective_container_lifetime_secs(), None);
+    }
+
+    #[test]
+    fn volumes_parse_from_shinyproxy_container_volumes_key() {
+        // Real ShinyProxy configs author bind mounts under
+        // `container-volumes`; a bare `volumes` was never the SP key, so
+        // an import silently dropped every mount. Accept the SP key, and
+        // keep `volumes` as a back-compat alias.
+        let sp: Spec = serde_yaml_ng::from_str(
+            "id: x\ncontainer-image: a:1\ncontainer-volumes:\n  - /srv/data:/data\n  - /srv/www:/www:ro\n",
+        )
+        .expect("parse");
+        assert_eq!(
+            sp.volumes,
+            Some(vec!["/srv/data:/data".into(), "/srv/www:/www:ro".into()])
+        );
+
+        let legacy: Spec = serde_yaml_ng::from_str(
+            "id: y\ncontainer-image: a:1\nvolumes:\n  - /srv/old:/old\n",
+        )
+        .expect("parse");
+        assert_eq!(legacy.volumes, Some(vec!["/srv/old:/old".into()]));
     }
 
     #[test]

--- a/docs/YAML_SCHEMA.md
+++ b/docs/YAML_SCHEMA.md
@@ -319,7 +319,7 @@ A spec describes one app, API, or external link. Every spec has an
   docker-registry-credential: dockerhub-acme   # OR reference a stored
                                       #   credential by name (Ruscker
                                       #   extension; see below)
-  volumes:                            # bind mounts (ShinyProxy-compatible)
+  container-volumes:                  # bind mounts (ShinyProxy key; `volumes` also accepted)
     - /srv/myapp/data:/data           #   persistent data
     - /srv/myapp/www:/www:ro          #   static assets, read-only
   container-env:                      # env vars injected into the container
@@ -338,9 +338,11 @@ A spec describes one app, API, or external link. Every spec has an
   access-users: [alice]               #   (ShinyProxy-compatible)
 ```
 
-`volumes` is a list of Docker bind specs (`/host:/container`, optionally
-`:ro`/`:rw`), mapped to the container's `HostConfig.binds`. Add as many
-as needed; editable in the admin **Advanced** form (one per line).
+`container-volumes` is a list of Docker bind specs (`/host:/container`,
+optionally `:ro`/`:rw`), mapped to the container's `HostConfig.binds`.
+This is ShinyProxy's key; the bare `volumes` is still accepted as an
+alias for older Ruscker configs. Add as many as needed; editable in the
+admin **Advanced** form (one per line).
 **Bind-mounting host paths is root-equivalent and admin-only** — see
 `SECURITY.md`.
 


### PR DESCRIPTION
## What

A real ShinyProxy config authors bind mounts under **`container-volumes`** (consistent with `container-env` / `container-cmd` / `container-network`). But the schema field was named `volumes` with **no `#[serde(rename)]`**, so importing a ShinyProxy YAML **silently dropped every mount** — confirmed against the production `application.yml` on the hugo box (9 specs use `container-volumes:`).

## Fix

- `#[serde(rename = "container-volumes", alias = "volumes", default)]` — accept the ShinyProxy key, keep the bare `volumes` as a back-compat alias for existing Ruscker configs.
- Export now writes the ShinyProxy-compatible key too.
- Docs (`YAML_SCHEMA.md`) updated.

## Test

`volumes_parse_from_shinyproxy_container_volumes_key` — both `container-volumes:` and the legacy `volumes:` parse into the same field. Full `ruscker-config` suite green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)