### PR TITLE
feat(import): ingest a card-images dir into the Media library (#887)

### DIFF
--- a/book/src/admin.md
+++ b/book/src/admin.md
@@ -308,3 +308,24 @@ panel reads and writes the SQLite DB. Use `ruscker import` to populate
 the DB from a YAML, and `ruscker export` to round-trip it back — both
 preserve specs, landing customization, SEO/analytics and custom
 blocks.
+
+### Importing card images into the Media library
+
+A spec's logo/cover is a *reference* like `/assets/img/snap_aurora.png`;
+the YAML doesn't carry the image bytes. `ruscker import` ingests those
+binaries into the Media library from a directory, keeping each file's
+**original name** so the references resolve:
+
+```bash
+ruscker import application.yml --db ruscker.db \
+  --images-dir /etc/shinyproxy/templates/<tpl>/assets/img
+```
+
+When `--images-dir` is omitted it's auto-discovered next to the config
+just like `serve` (`<config-dir>/assets/img/`, then the ShinyProxy
+`template-path` layout). The import is idempotent — files already stored
+with identical bytes are left untouched. (Unlike an admin upload, the
+import keeps the original format rather than transcoding to WebP, so the
+existing references keep matching; re-upload through the Media page to
+optimize.) Without a Media copy, logos only render if `serve` is also
+pointed at the same `--images-dir` (the on-disk fallback).

--- a/crates/ruscker-admin/src/db/images.rs
+++ b/crates/ruscker-admin/src/db/images.rs
@@ -527,6 +527,65 @@ fn delete_diff(filename: Option<&(String,)>) -> serde_json::Value {
     }
 }
 
+/// Outcome of an [`import_dir`] sweep.
+#[derive(Debug, Default, Clone, Copy)]
+pub struct ImportImagesReport {
+    /// Newly stored (or changed-bytes) image files.
+    pub imported: usize,
+    /// Already present with identical bytes — left untouched.
+    pub unchanged: usize,
+    /// Not a supported image (or unreadable / oversize) — skipped.
+    pub skipped: usize,
+}
+
+/// Ingest every supported image file in `dir` into the Media library,
+/// preserving each file's ORIGINAL name so spec logo/cover references
+/// (`/assets/img/<file>`) resolve against the DB after a migration —
+/// the gap that left a ShinyProxy import's cards logo-less (the importer
+/// only read the YAML, never the referenced binaries).
+///
+/// Idempotent: a file already stored with identical bytes is counted
+/// `unchanged` and not rewritten, so re-running the import doesn't churn
+/// the audit log. Non-recursive (a ShinyProxy `assets/img` is flat).
+pub async fn import_dir(db: &ConfigDb, dir: &std::path::Path) -> Result<ImportImagesReport> {
+    let mut report = ImportImagesReport::default();
+    let entries = std::fs::read_dir(dir)
+        .with_context(|| format!("read images dir {}", dir.display()))?;
+    // Stable order so the audit log / output reads predictably.
+    let mut paths: Vec<std::path::PathBuf> = entries
+        .filter_map(|e| e.ok().map(|e| e.path()))
+        .filter(|p| p.is_file())
+        .collect();
+    paths.sort();
+
+    for path in paths {
+        let raw = match std::fs::read(&path) {
+            Ok(b) => b,
+            Err(err) => {
+                tracing::warn!(path = %path.display(), error = ?err, "skip unreadable image");
+                report.skipped += 1;
+                continue;
+            }
+        };
+        let name = path.file_name().and_then(|s| s.to_str()).unwrap_or_default();
+        let Some(processed) = crate::images::process_for_import(name, raw) else {
+            report.skipped += 1;
+            continue;
+        };
+        // Idempotency: skip when the same filename already holds the same
+        // bytes (re-import after the first run is then a no-op).
+        if let Some((_, existing)) = fetch_by_filename(db, &processed.filename).await? {
+            if existing == processed.bytes {
+                report.unchanged += 1;
+                continue;
+            }
+        }
+        insert(db, processed, Some("import")).await?;
+        report.imported += 1;
+    }
+    Ok(report)
+}
+
 #[cfg(all(test, feature = "postgres-it"))]
 mod pg_tests {
     use super::*;
@@ -758,5 +817,55 @@ mod tests {
             Some("/assets/img/ruscker-mark.svg"),
             "spec logo reset to the default mark"
         );
+    }
+
+    fn tiny_png(rgba: [u8; 4]) -> Vec<u8> {
+        let img = image::DynamicImage::ImageRgba8(image::RgbaImage::from_pixel(
+            2,
+            2,
+            image::Rgba(rgba),
+        ));
+        let mut png = Vec::new();
+        img.write_to(&mut std::io::Cursor::new(&mut png), image::ImageFormat::Png)
+            .unwrap();
+        png
+    }
+
+    // The migration gap: image files in a ShinyProxy `assets/img` dir
+    // land in the Media library under their original names, idempotently,
+    // and a card's `/assets/img/<file>` reference then resolves.
+    #[tokio::test]
+    async fn import_dir_ingests_preserving_names_and_is_idempotent() {
+        let db = ConfigDb::Sqlite(open_memory().await.unwrap());
+        let dir = std::env::temp_dir().join("ruscker-import-dir-test");
+        let _ = std::fs::remove_dir_all(&dir);
+        std::fs::create_dir_all(&dir).unwrap();
+        let png = tiny_png([10, 20, 30, 255]);
+        std::fs::write(dir.join("Snap_Aurora.png"), &png).unwrap();
+        std::fs::write(dir.join("notes.txt"), b"not an image").unwrap();
+
+        let r = import_dir(&db, &dir).await.unwrap();
+        assert_eq!(r.imported, 1, "the PNG");
+        assert_eq!(r.skipped, 1, "the .txt");
+
+        // The exact name (incl. case) is what a spec logo ref resolves.
+        let (mime, bytes) = fetch_by_filename(&db, "Snap_Aurora.png")
+            .await
+            .unwrap()
+            .expect("stored under its original name");
+        assert_eq!(mime, "image/png");
+        assert_eq!(bytes, png);
+
+        // Re-running is a no-op (same bytes → unchanged, no audit churn).
+        let again = import_dir(&db, &dir).await.unwrap();
+        assert_eq!(again.imported, 0);
+        assert_eq!(again.unchanged, 1);
+
+        // Changed bytes on the same name re-import.
+        std::fs::write(dir.join("Snap_Aurora.png"), tiny_png([99, 0, 0, 255])).unwrap();
+        let changed = import_dir(&db, &dir).await.unwrap();
+        assert_eq!(changed.imported, 1);
+
+        let _ = std::fs::remove_dir_all(&dir);
     }
 }

--- a/crates/ruscker-admin/src/images.rs
+++ b/crates/ruscker-admin/src/images.rs
@@ -147,6 +147,47 @@ pub fn process_upload(
     }
 }
 
+/// Build a [`Processed`] for a **migration import**: preserve the
+/// ORIGINAL basename (case + extension) and the raw bytes, so a
+/// ShinyProxy spec's `/assets/img/Snap_Aurora.png` logo reference keeps
+/// resolving once the binary lands in the Media library (the lookup is an
+/// exact, case-sensitive filename match).
+///
+/// This deliberately differs from [`process_upload`], which lowercases
+/// the name and transcodes PNG/JPEG to WebP — that renames the file and
+/// would break the reference, the opposite of what a migration wants. The
+/// operator can re-upload through the admin later to get the WebP
+/// optimization. Only the directory components are stripped (no
+/// traversal); `None` for anything that doesn't sniff as a supported
+/// image, or an oversize file.
+pub fn process_for_import(raw_filename: &str, bytes: Vec<u8>) -> Option<Processed> {
+    if bytes.is_empty() || bytes.len() > MAX_UPLOAD_BYTES {
+        return None;
+    }
+    let kind = SourceKind::detect(&bytes, None)?;
+    // Keep the original basename verbatim — only drop directory parts.
+    let filename = std::path::Path::new(raw_filename)
+        .file_name()
+        .and_then(|s| s.to_str())
+        .map(str::to_string)?;
+    if filename.is_empty() || filename.starts_with('.') {
+        return None;
+    }
+    let (mime, dims) = match kind {
+        SourceKind::Png => ("image/png", decode_dimensions(&bytes).ok()),
+        SourceKind::Jpeg => ("image/jpeg", decode_dimensions(&bytes).ok()),
+        SourceKind::Webp => ("image/webp", decode_dimensions(&bytes).ok()),
+        SourceKind::Svg => ("image/svg+xml", None),
+    };
+    Some(Processed {
+        filename,
+        mime_type: mime.into(),
+        bytes,
+        width: dims.map(|(w, _)| w),
+        height: dims.map(|(_, h)| h),
+    })
+}
+
 /// Strip any directory components and any leading dots, lowercase
 /// the result. Prevents path-traversal via crafted filenames.
 pub(crate) fn sanitize_basename(name: &str) -> String {
@@ -256,5 +297,38 @@ mod tests {
     fn process_rejects_oversize() {
         let bytes = vec![0u8; MAX_UPLOAD_BYTES + 1];
         assert!(process_upload("x.png", Some("image/png"), bytes).is_err());
+    }
+
+    fn tiny_png() -> Vec<u8> {
+        let img = image::DynamicImage::ImageRgba8(image::RgbaImage::from_pixel(
+            2,
+            2,
+            image::Rgba([1, 2, 3, 255]),
+        ));
+        let mut png = Vec::new();
+        img.write_to(&mut std::io::Cursor::new(&mut png), image::ImageFormat::Png)
+            .unwrap();
+        png
+    }
+
+    #[test]
+    fn process_for_import_preserves_name_and_does_not_transcode() {
+        // A ShinyProxy logo ref is `/assets/img/Snap_Aurora.png`; the
+        // import must keep the exact name + PNG bytes so the (case-
+        // sensitive) Media lookup resolves it. Unlike process_upload,
+        // which would lowercase + rewrite to .webp.
+        let png = tiny_png();
+        let p = super::process_for_import("/etc/sp/assets/img/Snap_Aurora.png", png.clone())
+            .expect("png accepted");
+        assert_eq!(p.filename, "Snap_Aurora.png", "name + case + ext preserved");
+        assert_eq!(p.mime_type, "image/png", "kept as PNG, not transcoded");
+        assert_eq!(p.bytes, png, "bytes untouched");
+        assert_eq!(p.width, Some(2));
+    }
+
+    #[test]
+    fn process_for_import_rejects_non_images_and_dotfiles() {
+        assert!(super::process_for_import("x.png", b"not an image".to_vec()).is_none());
+        assert!(super::process_for_import(".hidden.png", tiny_png()).is_none());
     }
 }

--- a/crates/ruscker-cli/src/main.rs
+++ b/crates/ruscker-cli/src/main.rs
@@ -106,6 +106,16 @@ enum Command {
         /// `--db` when both are given.
         #[arg(long, env = "RUSCKER_CONFIG_DB_URL")]
         config_db_url: Option<String>,
+
+        /// Directory of image files (card logos / covers) to ingest into
+        /// the Media library, keeping each file's original name so spec
+        /// `/assets/img/<file>` references resolve. When omitted, it's
+        /// auto-discovered next to the config exactly like `serve`
+        /// (`<config-dir>/assets/img/`, then the ShinyProxy
+        /// `template-path` layout). Pass an empty value or a missing dir
+        /// to skip media import entirely.
+        #[arg(long)]
+        images_dir: Option<PathBuf>,
     },
 
     /// Reconstruct an application.yml from a SQLite admin database
@@ -217,7 +227,8 @@ fn main() -> Result<()> {
             path,
             db,
             config_db_url,
-        } => cmd_import(&path, db, config_db_url),
+            images_dir,
+        } => cmd_import(&path, db, config_db_url, images_dir),
         Command::Export { db } => cmd_export(&db),
         Command::Serve {
             config,
@@ -273,6 +284,7 @@ fn cmd_import(
     yaml_path: &PathBuf,
     db_path: Option<PathBuf>,
     config_db_url: Option<String>,
+    images_dir_override: Option<PathBuf>,
 ) -> Result<()> {
     // Need a destination. Postgres wins if both are given.
     if config_db_url.is_none() && db_path.is_none() {
@@ -286,13 +298,40 @@ fn cmd_import(
         format!("failed to load config from {}", yaml_path.display())
     })?;
 
+    // Resolve the Media source dir: explicit flag wins, else auto-discover
+    // beside the config the same way `serve` does, so a migrated config's
+    // card logos land in the library with no extra flag.
+    let images_dir = images_dir_override
+        .filter(|p| !p.as_os_str().is_empty())
+        .or_else(|| discover_images_dir(yaml_path, &config));
+
     let rt = tokio::runtime::Builder::new_current_thread()
         .enable_all()
         .build()?;
 
-    // Returns the import report plus a human label for the destination
-    // (never the raw DSN — it may carry a password).
-    let (report, target) = rt.block_on(async {
+    // Returns the spec import report, the optional media report, and a
+    // human label for the destination (never the raw DSN — it may carry a
+    // password).
+    let (report, media, target) = rt.block_on(async {
+        let run = |db: ruscker_admin::db::ConfigDb| {
+            let config = &config;
+            let images_dir = images_dir.as_deref();
+            async move {
+                let r = ruscker_admin::db::specs::import_all(&db, config).await?;
+                let media = match images_dir {
+                    Some(dir) => Some(
+                        ruscker_admin::db::images::import_dir(&db, dir)
+                            .await
+                            .with_context(|| {
+                                format!("import images from {}", dir.display())
+                            })?,
+                    ),
+                    None => None,
+                };
+                anyhow::Ok((r, media))
+            }
+        };
+
         if let Some(url) = config_db_url {
             if db_path.is_some() {
                 eprintln!("note: both --config-db-url and --db given; using Postgres");
@@ -300,23 +339,17 @@ fn cmd_import(
             let pool = ruscker_admin::db::open_pg(&url)
                 .await
                 .context("connect to the Postgres admin catalog")?;
-            let r = ruscker_admin::db::specs::import_all(
-                &ruscker_admin::db::ConfigDb::Postgres(pool.clone()),
-                &config,
-            )
-            .await?;
+            let (r, media) =
+                run(ruscker_admin::db::ConfigDb::Postgres(pool.clone())).await?;
             pool.close().await;
-            anyhow::Ok((r, "Postgres admin catalog".to_string()))
+            anyhow::Ok((r, media, "Postgres admin catalog".to_string()))
         } else {
             let path = db_path.expect("db_path present");
             let pool = ruscker_admin::db::open(&path).await?;
-            let r = ruscker_admin::db::specs::import_all(
-                &ruscker_admin::db::ConfigDb::Sqlite(pool.clone()),
-                &config,
-            )
-            .await?;
+            let (r, media) =
+                run(ruscker_admin::db::ConfigDb::Sqlite(pool.clone())).await?;
             pool.close().await;
-            anyhow::Ok((r, path.display().to_string()))
+            anyhow::Ok((r, media, path.display().to_string()))
         }
     })?;
 
@@ -330,6 +363,16 @@ fn cmd_import(
     println!("    created    {:>4}", report.created);
     println!("    updated    {:>4}", report.updated);
     println!("    unchanged  {:>4}", report.unchanged);
+    if let Some(m) = media {
+        println!();
+        println!("  media (from {}):", images_dir.as_deref().unwrap().display());
+        println!("    imported   {:>4}", m.imported);
+        println!("    unchanged  {:>4}", m.unchanged);
+        println!("    skipped    {:>4}", m.skipped);
+    } else {
+        println!();
+        println!("  media: no images dir found (cards fall back to tint covers)");
+    }
     println!();
     println!("  ✓ done. {} specs in the DB.",
         report.created + report.updated + report.unchanged);


### PR DESCRIPTION
## What

`ruscker import` read only the YAML, so a spec's logo reference (`/assets/img/snap_aurora.png`) had no backing bytes in the **Media library** — cards rendered logo-less after a ShinyProxy migration (confirmed on the hugo box: logos live at `/etc/shinyproxy/templates/mlk/assets/img/`, never copied in).

Now `ruscker import` takes **`--images-dir <dir>`** (auto-discovered beside the config like `serve`) and ingests every supported image into Media, **preserving each file's original name** (case + extension, no WebP transcode) so the case-sensitive `/assets/img/<file>` lookup resolves. Idempotent — identical bytes are left untouched.

```bash
ruscker import application.yml --db ruscker.db \
  --images-dir /etc/shinyproxy/templates/mlk/assets/img
```

## Why preserve the original (not transcode)

The interactive upload path lowercases the name and converts PNG/JPEG → WebP. For a migration that would *rename* the file and break every existing reference — the opposite of what's wanted. `process_for_import` keeps the bytes/name as-is; operators can re-upload through the Media page to optimize.

## Test

- `process_for_import_preserves_name_and_does_not_transcode` / `_rejects_non_images_and_dotfiles`
- `import_dir_ingests_preserving_names_and_is_idempotent` — PNG ingested under its exact name, `.txt` skipped, re-run is a no-op, changed bytes re-import.
- Gate green: `cargo test`, `clippy --all-targets -D warnings`.

Closes #887

🤖 Generated with [Claude Code](https://claude.com/claude-code)