### PR TITLE
feat(validate): warn on invalid/reserved labels + bad container-network (#892)

### DIFF
--- a/crates/ruscker-admin/assets/i18n/en/landing.ftl
+++ b/crates/ruscker-admin/assets/i18n/en/landing.ftl
@@ -568,6 +568,7 @@ spec-form-inject-base-href = Rewrite app HTML for the sub-path
 spec-form-inject-base-href-help = On by default. Ruscker rewrites <base href> and root-relative URLs so an app that assumes it lives at the server root works under its /app/ sub-path. Turn off only if the app reads X-Forwarded-Prefix and builds its own paths.
 spec-help-inject-base-href = Ruscker always forwards X-Forwarded-Prefix / X-Script-Name (plus X-Forwarded-Proto/-Host). Frameworks like FastAPI (root_path), Dash, and Streamlit can self-route from these — then this HTML rewriting is redundant.
 spec-form-error-volume = Each volume must be /host:/container (optionally :ro).
+spec-form-error-network = Invalid Docker network name (must start with a letter or digit, then letters/digits/_/./-).
 spec-form-error-env = Each environment variable must be NAME=value, with a valid NAME (letters, digits, _; starting with a letter or _). Fix or remove the invalid line.
 admin-nav-logs = Logs
 admin-proclog-title = Logs

--- a/crates/ruscker-admin/assets/i18n/es/landing.ftl
+++ b/crates/ruscker-admin/assets/i18n/es/landing.ftl
@@ -568,6 +568,7 @@ spec-form-inject-base-href = Reescribir el HTML de la app para el sub-path
 spec-form-inject-base-href-help = Activado por defecto. Ruscker reescribe <base href> y las URL relativas a la raíz para que una app que asume estar en la raíz del servidor funcione bajo su sub-path /app/. Desactiva solo si la app lee X-Forwarded-Prefix y construye sus propias rutas.
 spec-help-inject-base-href = Ruscker siempre reenvía X-Forwarded-Prefix / X-Script-Name (y X-Forwarded-Proto/-Host). Frameworks como FastAPI (root_path), Dash y Streamlit pueden auto-enrutarse con ellos — entonces esta reescritura de HTML es redundante.
 spec-form-error-volume = Cada volumen debe ser /host:/contenedor (opcional :ro).
+spec-form-error-network = Nombre de red Docker inválido (debe empezar con letra o número, luego letras/números/_/./-).
 spec-form-error-env = Cada variable de entorno debe ser NOMBRE=valor, con un NOMBRE válido (letras, números, _; empezando por letra o _). Corrige o elimina la línea inválida.
 admin-nav-logs = Registros
 admin-proclog-title = Registros

--- a/crates/ruscker-admin/assets/i18n/fr/landing.ftl
+++ b/crates/ruscker-admin/assets/i18n/fr/landing.ftl
@@ -568,6 +568,7 @@ spec-form-inject-base-href = Réécrire le HTML de l'app pour le sous-chemin
 spec-form-inject-base-href-help = Activé par défaut. Ruscker réécrit <base href> et les URL relatives à la racine pour qu'une app qui se croit à la racine du serveur fonctionne sous son sous-chemin /app/. Désactivez uniquement si l'app lit X-Forwarded-Prefix et construit ses propres chemins.
 spec-help-inject-base-href = Ruscker transmet toujours X-Forwarded-Prefix / X-Script-Name (et X-Forwarded-Proto/-Host). Des frameworks comme FastAPI (root_path), Dash et Streamlit peuvent s'auto-router avec — la réécriture HTML devient alors redondante.
 spec-form-error-volume = Chaque volume doit être /hôte:/conteneur (optionnel :ro).
+spec-form-error-network = Nom de réseau Docker invalide (doit commencer par une lettre ou un chiffre, puis lettres/chiffres/_/./-).
 spec-form-error-env = Chaque variable d'environnement doit être NOM=valeur, avec un NOM valide (lettres, chiffres, _ ; commençant par une lettre ou _). Corrigez ou supprimez la ligne invalide.
 admin-nav-logs = Journaux
 admin-proclog-title = Journaux

--- a/crates/ruscker-admin/assets/i18n/pt/landing.ftl
+++ b/crates/ruscker-admin/assets/i18n/pt/landing.ftl
@@ -572,6 +572,7 @@ spec-form-inject-base-href = Reescrever o HTML do app para o sub-caminho
 spec-form-inject-base-href-help = Ligado por padrão. O Ruscker reescreve <base href> e URLs relativas à raiz para que um app que assume estar na raiz do servidor funcione sob o sub-caminho /app/. Desligue só se o app lê X-Forwarded-Prefix e monta os próprios caminhos.
 spec-help-inject-base-href = O Ruscker sempre encaminha X-Forwarded-Prefix / X-Script-Name (e X-Forwarded-Proto/-Host). Frameworks como FastAPI (root_path), Dash e Streamlit se auto-roteiam por eles — aí esta reescrita de HTML fica redundante.
 spec-form-error-volume = Cada volume deve ser /host:/container (opcional :ro).
+spec-form-error-network = Nome de rede Docker inválido (precisa começar com letra ou número, depois letras/números/_/./-).
 spec-form-error-env = Cada variável de ambiente deve ser NOME=valor, com NOME válido (letras, números, _; começando por letra ou _). Corrija ou remova a linha inválida.
 admin-nav-logs = Logs
 admin-proclog-title = Logs

--- a/crates/ruscker-admin/src/routes/admin/spec_form.rs
+++ b/crates/ruscker-admin/src/routes/admin/spec_form.rs
@@ -924,6 +924,14 @@ impl SpecForm {
             errs.push("spec-form-error-volume");
         }
 
+        // container-network (when set) must be a valid Docker network name,
+        // else the container create fails at spawn (#892).
+        if !self.container_network.trim().is_empty()
+            && !ruscker_config::is_valid_network_name(self.container_network.trim())
+        {
+            errs.push("spec-form-error-network");
+        }
+
         // container-env: every non-blank line must be `NAME=value` with a
         // valid NAME. A typo'd line (missing `=`, or a key with spaces /
         // bad chars) used to be silently dropped by `parse_env` — turning
@@ -1832,6 +1840,28 @@ proxy:
         assert!(!ok
             .validate(FormMode::New)
             .contains(&"spec-form-error-max-replicas-zero"));
+    }
+
+    // #892: an invalid Docker network name is rejected at save (it would
+    // otherwise fail only at spawn); a valid one and the empty default pass.
+    #[test]
+    fn validate_rejects_bad_container_network() {
+        let mut bad = valid_form();
+        bad.container_network = "not a net".into();
+        assert!(bad
+            .validate(FormMode::New)
+            .contains(&"spec-form-error-network"));
+
+        let mut ok = valid_form();
+        ok.container_network = "ruscker_net".into();
+        assert!(!ok
+            .validate(FormMode::New)
+            .contains(&"spec-form-error-network"));
+
+        // Empty (the default) → daemon default bridge, no error.
+        assert!(!valid_form()
+            .validate(FormMode::New)
+            .contains(&"spec-form-error-network"));
     }
 
     // #874: a pull whose follower never connects (or disconnects) must

--- a/crates/ruscker-cli/src/main.rs
+++ b/crates/ruscker-cli/src/main.rs
@@ -975,6 +975,23 @@ fn format_warning(w: &Warning) -> String {
         Warning::IgnoredCompatField { field } => {
             format!("`{field}` is set but has no effect in Ruscker — the configured behaviour is NOT applied")
         }
+        Warning::InvalidLabelKey { spec_id, key } => {
+            format!(
+                "spec {spec_id} has an invalid label key `{key}` \
+                 (Docker keys allow only letters, digits, `.`, `_`, `-`) — the container create may be rejected at spawn"
+            )
+        }
+        Warning::ReservedLabelKey { spec_id, key } => {
+            format!(
+                "spec {spec_id} sets the reserved label `{key}` — Ruscker stamps `ruscker.*` itself and overrides it; rename the label"
+            )
+        }
+        Warning::InvalidContainerNetwork { spec_id, value } => {
+            format!(
+                "spec {spec_id} has an invalid container-network `{value}` \
+                 (must start alphanumeric, then letters/digits/`_`/`.`/`-`) — the container create will fail at spawn"
+            )
+        }
     }
 }
 

--- a/crates/ruscker-config/src/lib.rs
+++ b/crates/ruscker-config/src/lib.rs
@@ -50,7 +50,10 @@ pub use schema::{
     LandingCustomization, LandingLogo, Logging, Placement, Proxy, RatePolicy, RoutingStrategy,
     Server, Spec, SpecKind, SpecKindOverride, TemplateProperties, ThemeColors, ThemePalette,
 };
-pub use validate::{is_valid_volume_bind, CompatWarning, ValidationReport, Warning};
+pub use validate::{
+    is_reserved_label_key, is_valid_label_key, is_valid_network_name, is_valid_volume_bind,
+    CompatWarning, ValidationReport, Warning,
+};
 
 use std::path::Path;
 

--- a/crates/ruscker-config/src/validate.rs
+++ b/crates/ruscker-config/src/validate.rs
@@ -169,6 +169,29 @@ pub enum Warning {
     IgnoredCompatField {
         field: &'static str,
     },
+    /// A `labels` key isn't valid Docker label syntax (Docker keys are
+    /// `[A-Za-z0-9._-]`, reverse-DNS style). The label is stamped verbatim,
+    /// so the daemon can reject the whole container create at spawn — and
+    /// the failure only surfaces when a visitor first opens the app (#892).
+    InvalidLabelKey {
+        spec_id: String,
+        key: String,
+    },
+    /// A `labels` key is in Ruscker's reserved `ruscker.*` namespace. Those
+    /// labels are stamped by the backend (e.g. `ruscker.replica_id`, which
+    /// the disk-panel host-safety guards key on) and WIN on a collision, so
+    /// the operator's value is silently dropped. Rename it (#892).
+    ReservedLabelKey {
+        spec_id: String,
+        key: String,
+    },
+    /// `container-network` isn't a valid Docker network name (names are
+    /// `[a-zA-Z0-9][a-zA-Z0-9_.-]*`). The container create fails at spawn,
+    /// only when a visitor first opens the app (#892).
+    InvalidContainerNetwork {
+        spec_id: String,
+        value: String,
+    },
 }
 
 const KNOWN_TYPES: &[&str] = &["app", "package", "talk", "report", "api"];
@@ -662,6 +685,68 @@ fn check_spec(spec: &Spec, warnings: &mut Vec<Warning>) {
             }
         }
     }
+
+    // Label keys: Docker syntax + Ruscker's reserved `ruscker.*` namespace.
+    // An empty/whitespace key is dropped silently by `effective_labels`, so
+    // skip it here (not worth a warning).
+    if let Some(labels) = &spec.labels {
+        for key in labels.keys() {
+            let key = key.trim();
+            if key.is_empty() {
+                continue;
+            }
+            if is_reserved_label_key(key) {
+                warnings.push(Warning::ReservedLabelKey {
+                    spec_id: spec.id.clone(),
+                    key: key.to_string(),
+                });
+            } else if !is_valid_label_key(key) {
+                warnings.push(Warning::InvalidLabelKey {
+                    spec_id: spec.id.clone(),
+                    key: key.to_string(),
+                });
+            }
+        }
+    }
+
+    // Container network name (when set) must follow Docker's naming rules,
+    // else the create fails at spawn.
+    if let Some(net) = spec.effective_container_network() {
+        if !is_valid_network_name(net) {
+            warnings.push(Warning::InvalidContainerNetwork {
+                spec_id: spec.id.clone(),
+                value: net.to_string(),
+            });
+        }
+    }
+}
+
+/// A Docker label key Ruscker accepts: non-empty and only `[A-Za-z0-9._-]`
+/// (the reverse-DNS style Docker recommends). Public so the admin spec
+/// form can validate with the exact same rule.
+pub fn is_valid_label_key(key: &str) -> bool {
+    !key.is_empty()
+        && key
+            .chars()
+            .all(|c| c.is_ascii_alphanumeric() || matches!(c, '.' | '_' | '-'))
+}
+
+/// Whether a label key falls in Ruscker's reserved `ruscker.*` namespace
+/// (case-insensitive) — those are stamped by the backend and override an
+/// operator value, so they should be refused. Public for admin-form reuse.
+pub fn is_reserved_label_key(key: &str) -> bool {
+    key.to_ascii_lowercase().starts_with("ruscker.")
+}
+
+/// A valid Docker network name: a leading alphanumeric, then any of
+/// `[a-zA-Z0-9_.-]`. Public so the admin spec form validates identically.
+pub fn is_valid_network_name(name: &str) -> bool {
+    let mut chars = name.chars();
+    match chars.next() {
+        Some(c) if c.is_ascii_alphanumeric() => {}
+        _ => return false,
+    }
+    chars.all(|c| c.is_ascii_alphanumeric() || matches!(c, '_' | '.' | '-'))
 }
 
 /// A Docker bind spec: `host:container` plus an optional `:ro`/`:rw`
@@ -1316,6 +1401,101 @@ proxy:
                 .any(|w| matches!(w, Warning::IgnoredCompatField { .. })),
             "got {:?}",
             clean.warnings
+        );
+    }
+
+    #[test]
+    fn label_and_network_predicates() {
+        // Label keys.
+        assert!(is_valid_label_key("com.acme.team"));
+        assert!(is_valid_label_key("cost-center"));
+        assert!(!is_valid_label_key("")); // empty
+        assert!(!is_valid_label_key("has space"));
+        assert!(!is_valid_label_key("weird*char"));
+        // Reserved namespace (case-insensitive).
+        assert!(is_reserved_label_key("ruscker.replica_id"));
+        assert!(is_reserved_label_key("RUSCKER.spec_id"));
+        assert!(!is_reserved_label_key("rusckers")); // no dot, not the namespace
+        assert!(!is_reserved_label_key("acme.ruscker.x"));
+        // Network names.
+        assert!(is_valid_network_name("ruscker_net"));
+        assert!(is_valid_network_name("br0.idge-1"));
+        assert!(!is_valid_network_name("")); // empty
+        assert!(!is_valid_network_name("_leading")); // must start alphanumeric
+        assert!(!is_valid_network_name("has space"));
+    }
+
+    #[test]
+    fn flags_invalid_and_reserved_labels() {
+        let yaml = r#"
+proxy:
+  specs:
+    - id: app1
+      container-image: org/app:1
+      labels:
+        "bad key": x
+        ruscker.replica_id: hijack
+        good.key: ok
+"#;
+        let report = Config::from_yaml(yaml).expect("parse").validate();
+        assert!(
+            report.warnings.iter().any(|w| matches!(
+                w, Warning::InvalidLabelKey { spec_id, key } if spec_id == "app1" && key == "bad key"
+            )),
+            "expected InvalidLabelKey, got {:?}",
+            report.warnings
+        );
+        assert!(
+            report.warnings.iter().any(|w| matches!(
+                w, Warning::ReservedLabelKey { spec_id, key } if spec_id == "app1" && key == "ruscker.replica_id"
+            )),
+            "expected ReservedLabelKey, got {:?}",
+            report.warnings
+        );
+        // The valid key produces no label warning.
+        assert!(
+            !report.warnings.iter().any(|w| matches!(
+                w, Warning::InvalidLabelKey { key, .. } if key == "good.key"
+            )),
+            "a valid key must not warn"
+        );
+    }
+
+    #[test]
+    fn flags_invalid_container_network() {
+        let yaml = r#"
+proxy:
+  specs:
+    - id: app1
+      container-image: org/app:1
+      container-network: "not a net"
+"#;
+        let report = Config::from_yaml(yaml).expect("parse").validate();
+        assert!(
+            report.warnings.iter().any(|w| matches!(
+                w, Warning::InvalidContainerNetwork { spec_id, value }
+                    if spec_id == "app1" && value == "not a net"
+            )),
+            "expected InvalidContainerNetwork, got {:?}",
+            report.warnings
+        );
+
+        // A valid network name is silent.
+        let ok = r#"
+proxy:
+  specs:
+    - id: app2
+      container-image: org/app:1
+      container-network: ruscker_net
+"#;
+        let report = Config::from_yaml(ok).expect("parse").validate();
+        assert!(
+            !report
+                .warnings
+                .iter()
+                .any(|w| matches!(w, Warning::InvalidContainerNetwork { .. })),
+            "valid network must not warn, got {:?}",
+            report.warnings
         );
     }
 }

--- a/docs/YAML_SCHEMA.md
+++ b/docs/YAML_SCHEMA.md
@@ -709,6 +709,9 @@ effect, so treat warnings in production logs as action items.
 | invalid scale threshold | `scale-up`/`scale-down` thresholds inverted or out of `0..1` |
 | container fields without image | `seats-per-container` etc. on a spec with no image |
 | invalid rate-limit / max-body-size / cpu / memory / volume | The value doesn't parse, so the intended cap or mount is **not enforced** |
+| invalid label key | A `labels` key uses characters outside `[A-Za-z0-9._-]` — Docker may reject the container create at spawn |
+| reserved label key | A `labels` key in Ruscker's `ruscker.*` namespace — the backend stamps those itself and overrides the value; rename it |
+| invalid container-network | `container-network` isn't a valid Docker network name (`[a-zA-Z0-9][a-zA-Z0-9_.-]*`) — the create fails at spawn |
 | zero seats | `seats-per-container: 0` confuses the auto-scaler |
 | invalid docker host | A `proxy.hosts` entry that will fail to connect at startup |
 | ignored compat field (v0.2.5) | A modeled ShinyProxy field with no runtime effect is set (`server.secure-cookies`, `server.servlet.session.timeout`, `proxy.heartbeat-rate`, `proxy.hide-navbar`, `proxy.landing-page`, `proxy.container-log-path`, `logging.file`) |


### PR DESCRIPTION
## What

P3 from the code review — hardening, not a bug (Docker would reject these at spawn). Three new `validate` warnings + a server-side form check:

- **InvalidLabelKey** — a `labels` key outside `[A-Za-z0-9._-]`.
- **ReservedLabelKey** — a key in Ruscker's `ruscker.*` namespace, which the backend stamps and overrides (e.g. `ruscker.replica_id`, which the disk-panel host-safety guards key on) → the operator's value is silently dropped.
- **InvalidContainerNetwork** — a `container-network` that isn't a valid Docker network name (`[a-zA-Z0-9][a-zA-Z0-9_.-]*`).

The predicates (`is_valid_label_key` / `is_reserved_label_key` / `is_valid_network_name`) are public and reused: the admin spec form now rejects a bad `container-network` at **save** (`spec-form-error-network`, pt/en/es/fr) instead of failing only when the app is first visited. Labels have no form input yet, so they're config-layer only.

## Test

- `label_and_network_predicates`, `flags_invalid_and_reserved_labels`, `flags_invalid_container_network` (config), `validate_rejects_bad_container_network` (admin form).
- Gate green: `cargo test`, `clippy --all-targets -D warnings`, `i18n-check`.

Closes #892

🤖 Generated with [Claude Code](https://claude.com/claude-code)