### PR TITLE
fix(multihost): fail closed when a host is unavailable; test --images-dir paths

### DIFF
--- a/crates/ruscker-admin/src/routes/admin/disk.rs
+++ b/crates/ruscker-admin/src/routes/admin/disk.rs
@@ -471,11 +471,20 @@ async fn remove_image(
     }
 }
 
-/// Remove every **unused** image in one click (#463) — `containers == 0`
-/// and not referenced by any current spec. Never `--force`s, and never
-/// runs a host-wide `docker image prune`: it only removes the exact
-/// subset the panel flags as unused, so a non-Ruscker image the host
-/// happens to have stays put.
+/// Remove every **unused** image in one click (#463) — no container is
+/// built from it (on ANY host) **and** no current spec references it.
+/// Never `--force`s, and never runs a host-wide `docker image prune`: it
+/// removes only the exact subset the panel flags as unused.
+///
+/// Caveat (#892 follow-up): "unused" is about *current use*, not
+/// *provenance*. An image a side-by-side ShinyProxy pulled but isn't
+/// running a container from right now reads as unused and WILL be removed
+/// — which hurts on a host that can't re-pull (offline / CDN-blocked).
+/// Ruscker doesn't yet track which images it pulled, so it can't tell its
+/// own orphans from a neighbour's; tracked as an enhancement. The
+/// container cross-reference (#871) still protects anything actually
+/// running, and the fail-closed in-use signal (#889/multi-host) prevents
+/// deleting an image whose usage can't be determined.
 async fn prune_images(_: RequireAdmin, State(state): State<AppState>) -> Response {
     let Some(backend) = state.backend.as_ref() else {
         return redirect("error");

--- a/crates/ruscker-cli/src/main.rs
+++ b/crates/ruscker-cli/src/main.rs
@@ -298,29 +298,7 @@ fn cmd_import(
         format!("failed to load config from {}", yaml_path.display())
     })?;
 
-    // Resolve the Media source dir, matching the flag's help exactly:
-    //   * an explicit non-empty path is used as-is;
-    //   * an explicit EMPTY value (`--images-dir ""`) skips media import —
-    //     it does NOT fall back to auto-discovery;
-    //   * omitting the flag auto-discovers beside the config like `serve`.
-    // A resolved path that isn't a directory (a typo, or a missing
-    // ShinyProxy assets dir) is warned about and skipped — it must never
-    // abort the spec import.
-    let images_dir = match images_dir_override {
-        Some(p) if p.as_os_str().is_empty() => None,
-        Some(p) => Some(p),
-        None => discover_images_dir(yaml_path, &config),
-    }
-    .filter(|d| {
-        let ok = d.is_dir();
-        if !ok {
-            eprintln!(
-                "note: images dir {} not found — skipping media import",
-                d.display()
-            );
-        }
-        ok
-    });
+    let images_dir = resolve_images_dir(images_dir_override, yaml_path, &config);
 
     let rt = tokio::runtime::Builder::new_current_thread()
         .enable_all()
@@ -426,6 +404,39 @@ fn discover_images_dir(config_path: &Path, config: &Config) -> Option<PathBuf> {
     }
 
     None
+}
+
+/// Resolve the Media source dir for `import`, matching `--images-dir`'s
+/// help exactly:
+///   * an explicit non-empty path is used as-is;
+///   * an explicit EMPTY value (`--images-dir ""`) skips media import —
+///     it does NOT fall back to auto-discovery;
+///   * omitting the flag auto-discovers beside the config like `serve`.
+///
+/// A resolved path that isn't a directory (a typo, or a missing ShinyProxy
+/// assets dir) is warned about and dropped to `None` — media import must
+/// never abort the spec import. Pure but for the on-disk `is_dir` probe +
+/// the warning, so it's unit-testable.
+fn resolve_images_dir(
+    images_dir_override: Option<PathBuf>,
+    yaml_path: &Path,
+    config: &Config,
+) -> Option<PathBuf> {
+    match images_dir_override {
+        Some(p) if p.as_os_str().is_empty() => None,
+        Some(p) => Some(p),
+        None => discover_images_dir(yaml_path, config),
+    }
+    .filter(|d| {
+        let ok = d.is_dir();
+        if !ok {
+            eprintln!(
+                "note: images dir {} not found — skipping media import",
+                d.display()
+            );
+        }
+        ok
+    })
 }
 
 /// Default Docker socket path on Linux. Pulled out as a constant so
@@ -1111,6 +1122,49 @@ mod tests {
         let config =
             Config::from_yaml("proxy:\n  template-path: templates/x\n  specs: []\n").unwrap();
         assert!(discover_images_dir(&cfg_path, &config).is_none());
+    }
+
+    // #891 follow-up: the explicit `--images-dir` paths the help promises.
+    #[test]
+    fn resolve_images_dir_honours_explicit_flag() {
+        use std::fs;
+        let tmp = std::env::temp_dir().join(format!("ruscker-resolve-{}", std::process::id()));
+        let _ = fs::remove_dir_all(&tmp);
+        let cfg_dir = tmp.join("etc");
+        // An auto-discoverable dir exists beside the config, so we can prove
+        // an empty override does NOT fall back to it.
+        let auto = cfg_dir.join("assets/img");
+        fs::create_dir_all(&auto).unwrap();
+        let cfg_path = cfg_dir.join("application.yml");
+        let config = Config::from_yaml("proxy:\n  specs: []\n").unwrap();
+
+        // Empty value → skip entirely, no auto-discovery.
+        assert_eq!(
+            resolve_images_dir(Some(PathBuf::from("")), &cfg_path, &config),
+            None,
+            "empty --images-dir must skip, not auto-discover"
+        );
+
+        // A non-existent explicit path → warn + skip (never used).
+        let missing = tmp.join("nope/does-not-exist");
+        assert_eq!(
+            resolve_images_dir(Some(missing), &cfg_path, &config),
+            None,
+            "a missing dir must be dropped, not used"
+        );
+
+        // An explicit real dir → used as-is.
+        let explicit = tmp.join("my-imgs");
+        fs::create_dir_all(&explicit).unwrap();
+        assert_eq!(
+            resolve_images_dir(Some(explicit.clone()), &cfg_path, &config),
+            Some(explicit)
+        );
+
+        // Omitted → auto-discovers beside the config.
+        assert_eq!(resolve_images_dir(None, &cfg_path, &config), Some(auto));
+
+        fs::remove_dir_all(&tmp).ok();
     }
 
     #[cfg(unix)]

--- a/crates/ruscker-docker/src/multihost.rs
+++ b/crates/ruscker-docker/src/multihost.rs
@@ -454,17 +454,27 @@ impl ContainerBackend for MultiHostDockerBackend {
     }
 
     async fn all_container_image_refs(&self) -> CoreResult<Vec<String>> {
-        // Fan out so the disk panel's in-use signal covers every host's
-        // containers (#871). A degraded host is skipped (its images just
-        // aren't protected on that host — same best-effort as the rest).
+        // This feeds the disk panel's "image in use" signal, which MUST
+        // cover every host: an image backing a container on an unreachable
+        // host would otherwise look unused and become removable — the very
+        // fail-open the local backend was hardened against (#889). So a
+        // single host failure fails the WHOLE call; the panel then enters
+        // its usage-unknown / fail-closed mode instead of trusting a
+        // partial inventory (#892 follow-up).
+        //
+        // Contrast `list_managed_containers`, deliberately kept tolerant:
+        // the scaler's liveness prune treats an absent host's containers as
+        // "not stopped", so a degraded fan-out there can't cause a false
+        // prune. The safe failure direction is opposite for the two.
         let mut all = Vec::new();
         for h in &self.hosts {
-            match h.backend.all_container_image_refs().await {
-                Ok(refs) => all.extend(refs),
-                Err(e) => {
-                    tracing::warn!(host = %h.id, error = %e, "all container image refs on host failed; skipping");
-                }
-            }
+            let refs = h.backend.all_container_image_refs().await.map_err(|e| {
+                CoreError::Backend(format!(
+                    "host {} container image refs failed: {e}",
+                    h.id
+                ))
+            })?;
+            all.extend(refs);
         }
         Ok(all)
     }


### PR DESCRIPTION
## What

Follow-ups from the latest code review.

**P2 — multi-host disk fail-open (#896).** The disk panel's fail-closed (#889) only triggers on a top-level `Err`, but `MultiHostDockerBackend::all_container_image_refs` swallowed per-host errors into a partial inventory and returned `Ok`. In a partially-down cluster, an image backing a container on an **unreachable** host looked unused → removable/prunable. It now **propagates `Err` if any host fails**, so the panel enters `usage_unknown` (no remove, no prune, banner). `list_managed_containers` stays tolerant on purpose — the scaler's liveness prune treats an absent host as "not stopped", the opposite safe direction.

**P2/P3 — `prune_images` doc over-promised host-safety.** The comment claimed a non-Ruscker image "stays put", but "unused" is about *current use*, not *provenance* — a side-by-side ShinyProxy's idle image cache can still be removed. The comment now states this honestly; true provenance-based safety is tracked as #894.

**P3 — `--images-dir` explicit paths now tested.** Extracted `resolve_images_dir` and unit-tested empty (`""` → skip, no auto-discovery) and missing (warn + skip) — previously only auto-discovery was covered (#891 follow-up).

## Verdicts on the review

- P2 multi-host fail-open — **real bug**, fixed here (#896).
- "host-safe images more promised than implemented" — **doc accuracy real** (fixed) + per-row remove is **by-design** (only shows for `!in_use()`); deeper provenance tracking → #894.
- Serial fan-out latency — **valid perf**, not a bug → #895.
- `--images-dir` coverage — **valid**, tests added here.

## Test

`resolve_images_dir_honours_explicit_flag`; existing disk fail-closed test (`unknown_container_set_makes_every_image_in_use`) covers the panel side. Gate green: `cargo test`, `clippy --all-targets -D warnings`.

Closes #896

🤖 Generated with [Claude Code](https://claude.com/claude-code)