### PR TITLE
ux(admin+landing): action grouping, pull progress, CSV picker, dashboard logo fallback, drop access filter

### DIFF
--- a/crates/ruscker-admin/assets/i18n/en/landing.ftl
+++ b/crates/ruscker-admin/assets/i18n/en/landing.ftl
@@ -128,6 +128,7 @@ admin-users-celular = Mobile
 admin-users-col-profile = Profile
 admin-users-save-profile = Save profile
 admin-users-import = Import CSV
+admin-users-import-choose = Choose CSV file
 admin-users-import-help = Columns: username, role, password, groups, setor, email, celular. First row is the header.
 admin-users-import-title = Import users
 admin-users-import-preview-title = Import preview

--- a/crates/ruscker-admin/assets/i18n/en/landing.ftl
+++ b/crates/ruscker-admin/assets/i18n/en/landing.ftl
@@ -8,9 +8,6 @@ landing-signout = Sign out
 landing-signed-in-as = { $user }
 
 filter-search-placeholder = Search application…
-filter-access-all = All
-filter-access-public = Public
-filter-access-restricted = Restricted
 filter-clear = Clear filters
 
 type-all = All
@@ -770,7 +767,6 @@ admin-landing-default-theme = Default theme
 admin-landing-default-theme-help = The starting theme for first-time visitors. They can still switch.
 admin-landing-visible-sections = Visible sections
 admin-landing-show-search = Search bar
-admin-landing-show-filters = Access filters (public/restricted)
 admin-landing-brand-color = Brand color
 admin-landing-brand-custom = Custom colour
 admin-landing-brand-color-help = Shortcut for the accent (light and dark). Fine-tune below.

--- a/crates/ruscker-admin/assets/i18n/es/landing.ftl
+++ b/crates/ruscker-admin/assets/i18n/es/landing.ftl
@@ -8,9 +8,6 @@ landing-signout = Salir
 landing-signed-in-as = { $user }
 
 filter-search-placeholder = Buscar aplicación…
-filter-access-all = Todos
-filter-access-public = Públicos
-filter-access-restricted = Restringidos
 filter-clear = Limpiar filtros
 
 type-all = Todos
@@ -770,7 +767,6 @@ admin-landing-default-theme = Tema predeterminado
 admin-landing-default-theme-help = El tema inicial para quien nunca eligió. El visitante aún puede cambiar.
 admin-landing-visible-sections = Secciones visibles
 admin-landing-show-search = Barra de búsqueda
-admin-landing-show-filters = Filtros de acceso (público/restringido)
 admin-landing-brand-color = Color de marca
 admin-landing-brand-custom = Color personalizado
 admin-landing-brand-color-help = Atajo para el acento (claro y oscuro). Ajuste fino abajo.

--- a/crates/ruscker-admin/assets/i18n/es/landing.ftl
+++ b/crates/ruscker-admin/assets/i18n/es/landing.ftl
@@ -128,6 +128,7 @@ admin-users-celular = Móvil
 admin-users-col-profile = Perfil
 admin-users-save-profile = Guardar perfil
 admin-users-import = Importar CSV
+admin-users-import-choose = Elegir archivo CSV
 admin-users-import-help = Columnas: username, role, password, groups, setor, email, celular. La primera fila es el encabezado.
 admin-users-import-title = Importar usuarios
 admin-users-import-preview-title = Vista previa de importación

--- a/crates/ruscker-admin/assets/i18n/fr/landing.ftl
+++ b/crates/ruscker-admin/assets/i18n/fr/landing.ftl
@@ -128,6 +128,7 @@ admin-users-celular = Mobile
 admin-users-col-profile = Profil
 admin-users-save-profile = Enregistrer le profil
 admin-users-import = Importer un CSV
+admin-users-import-choose = Choisir un fichier CSV
 admin-users-import-help = Colonnes : username, role, password, groups, setor, email, celular. La première ligne est l'en-tête.
 admin-users-import-title = Importer des utilisateurs
 admin-users-import-preview-title = Aperçu de l'import

--- a/crates/ruscker-admin/assets/i18n/fr/landing.ftl
+++ b/crates/ruscker-admin/assets/i18n/fr/landing.ftl
@@ -8,9 +8,6 @@ landing-signout = Déconnexion
 landing-signed-in-as = { $user }
 
 filter-search-placeholder = Rechercher une application…
-filter-access-all = Tous
-filter-access-public = Publics
-filter-access-restricted = Restreints
 filter-clear = Effacer les filtres
 
 type-all = Tous
@@ -770,7 +767,6 @@ admin-landing-default-theme = Thème par défaut
 admin-landing-default-theme-help = Le thème initial pour qui n'a jamais choisi. Le visiteur peut toujours changer.
 admin-landing-visible-sections = Sections visibles
 admin-landing-show-search = Barre de recherche
-admin-landing-show-filters = Filtres d'accès (public/restreint)
 admin-landing-brand-color = Couleur de marque
 admin-landing-brand-custom = Couleur personnalisée
 admin-landing-brand-color-help = Raccourci pour l'accent (clair et sombre). Réglage fin ci-dessous.

--- a/crates/ruscker-admin/assets/i18n/pt/landing.ftl
+++ b/crates/ruscker-admin/assets/i18n/pt/landing.ftl
@@ -9,9 +9,6 @@ landing-signout = Sair
 landing-signed-in-as = { $user }
 
 filter-search-placeholder = Buscar aplicação…
-filter-access-all = Todos
-filter-access-public = Públicos
-filter-access-restricted = Restritos
 filter-clear = Limpar filtros
 
 type-all = Todos
@@ -774,7 +771,6 @@ admin-landing-default-theme = Tema padrão
 admin-landing-default-theme-help = O tema inicial para quem nunca escolheu. O visitante ainda pode trocar.
 admin-landing-visible-sections = Seções visíveis
 admin-landing-show-search = Barra de busca
-admin-landing-show-filters = Filtros de acesso (público/restrito)
 admin-landing-brand-color = Cor da marca
 admin-landing-brand-custom = Cor personalizada
 admin-landing-brand-color-help = Atalho para o acento (claro e escuro). Ajuste fino abaixo.

--- a/crates/ruscker-admin/assets/i18n/pt/landing.ftl
+++ b/crates/ruscker-admin/assets/i18n/pt/landing.ftl
@@ -132,6 +132,7 @@ admin-users-celular = Celular
 admin-users-col-profile = Perfil
 admin-users-save-profile = Salvar perfil
 admin-users-import = Importar CSV
+admin-users-import-choose = Escolher arquivo CSV
 admin-users-import-help = Colunas: username, role, password, groups, setor, email, celular. A primeira linha é o cabeçalho.
 admin-users-import-title = Importar usuários
 admin-users-import-preview-title = Prévia da importação

--- a/crates/ruscker-admin/assets/tailwind/input.css
+++ b/crates/ruscker-admin/assets/tailwind/input.css
@@ -1654,6 +1654,43 @@ input[type="range"]::-moz-range-thumb {
   text-align: right;
   white-space: nowrap;
 }
+/* Grouped action buttons (#: Apps tab polish) — cluster related actions
+   (marker | manage | operate) and set the destructive Delete apart so it's
+   never bumped by mistake. Thin dividers separate the groups. */
+.admin-table .actions-cell .row-actions {
+  display: inline-flex;
+  align-items: center;
+  justify-content: flex-end;
+  gap: 2px;
+}
+.row-actions .ra-group {
+  display: inline-flex;
+  align-items: center;
+  gap: 2px;
+}
+.row-actions .ra-sep {
+  width: 1px;
+  align-self: stretch;
+  min-height: 16px;
+  margin: 0 5px;
+  background: var(--border);
+}
+/* The destructive group sits after a wider gap from the rest. */
+.row-actions .ra-danger { margin-left: 8px; }
+/* Live image-pull progress shown inline while a re-pull runs (#: follow
+   the steps). Capped width + ellipsis so a long Docker status line can't
+   blow the row out; it only appears during the operation. */
+.row-actions .pull-status {
+  display: inline-flex;
+  align-items: center;
+  max-width: 200px;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+  font-size: 11px;
+  color: var(--text-muted);
+  font-variant-numeric: tabular-nums;
+}
 /* Access counter column (#549) — tabular figures so totals line up,
    with a faint daily-usage sparkline beside the total. */
 .admin-table .access-cell {

--- a/crates/ruscker-admin/templates/admin/dashboard.html
+++ b/crates/ruscker-admin/templates/admin/dashboard.html
@@ -134,9 +134,12 @@
       <span class="app-group__chev"><i class="ti ti-chevron-right" aria-hidden="true"></i></span>
       <span class="app-group__name">
         {# Card logo when the spec has one (mirrors the landing + apps
-           list); falls back to the monogram initial. A broken image hides
-           itself, leaving the tile's background. #}
-        <span class="app-group__logo">{% match g.logo %}{% when Some with (l) %}<img src="{{ l }}" alt="" loading="lazy" onerror="this.style.display='none'" style="width:100%;height:100%;object-fit:contain">{% when None %}{{ g.initial }}{% endmatch %}</span>
+           list); falls back to the monogram initial. A broken image (the
+           logo file isn't on this host) falls back to the initial too,
+           instead of hiding to a blank tile — so the column is never empty
+           where a logo failed to load. The initial rides data-* (not a
+           localized string, so no inline-handler i18n trap). #}
+        <span class="app-group__logo" data-initial="{{ g.initial }}">{% match g.logo %}{% when Some with (l) %}<img src="{{ l }}" alt="" loading="lazy" onerror="this.parentElement.textContent=this.parentElement.dataset.initial" style="width:100%;height:100%;object-fit:contain">{% when None %}{{ g.initial }}{% endmatch %}</span>
         <span><span class="truncate">{{ g.display_name }}</span><span class="app-group__id">{{ g.spec_id }}</span></span>
       </span>
       <span class="app-group__replicas"><i class="ti ti-stack-2" aria-hidden="true"></i>{{ g.n }}</span>
@@ -310,8 +313,8 @@
     return '<div class="app-group' + (isOpen ? ' is-open' : '') + '" data-spec-id="' + escapeHtml(g.spec_id) + '">'
       + '<div class="app-group__head" role="button" tabindex="0" aria-expanded="' + (isOpen ? 'true' : 'false') + '">'
         + '<span class="app-group__chev"><i class="ti ti-chevron-right"></i></span>'
-        + '<span class="app-group__name"><span class="app-group__logo">'
-          + (g.logo ? '<img src="' + escapeHtml(g.logo) + '" alt="" loading="lazy" onerror="this.style.display=&apos;none&apos;" style="width:100%;height:100%;object-fit:contain">' : escapeHtml(g.initial))
+        + '<span class="app-group__name"><span class="app-group__logo" data-initial="' + escapeHtml(g.initial) + '">'
+          + (g.logo ? '<img src="' + escapeHtml(g.logo) + '" alt="" loading="lazy" onerror="this.parentElement.textContent=this.parentElement.dataset.initial" style="width:100%;height:100%;object-fit:contain">' : escapeHtml(g.initial))
           + '</span>'
           + '<span><span class="truncate">' + escapeHtml(g.display_name) + '</span>'
           + '<span class="app-group__id">' + escapeHtml(g.spec_id) + '</span></span></span>'

--- a/crates/ruscker-admin/templates/admin/landing.html
+++ b/crates/ruscker-admin/templates/admin/landing.html
@@ -745,15 +745,6 @@
             <span>{{ self.t("admin-landing-show-search") }}</span>
           </label>
         </div>
-        <div class="spec-form-field">
-          <label class="spec-form-check" style="cursor:pointer;gap:10px">
-            <span class="switch">
-              <input type="checkbox" name="show_filters" value="on" x-model="form.show_filters" {% if !form.show_filters.is_empty() %}checked{% endif %}>
-              <span class="switch__track"><span class="switch__dot"></span></span>
-            </span>
-            <span>{{ self.t("admin-landing-show-filters") }}</span>
-          </label>
-        </div>
         {# "Featured" carousel toggle (#506), moved here from the Header
            card (#803) — it is a visible portal section like search and
            filters. The carousel only shows when this is on AND at least
@@ -1012,11 +1003,8 @@
              x-html="pvIntroHtml() || $el.dataset.placeholder"
              data-placeholder="{{ self.t("admin-landing-preview-empty") }}"
              :class="!previewIntro() ? 'opacity-40 italic' : ''"></p>
-          {# Search pill + filter chips honour the Visible-sections toggles. #}
+          {# Search pill honours the Visible-search toggle. #}
           <div class="landing-preview-mockfilter" x-show="!!form.show_search" x-cloak><i class="ti ti-search" aria-hidden="true"></i><span class="lp-search-ph"></span></div>
-          <div class="landing-preview-mockchips" x-show="!!form.show_filters" x-cloak>
-            <span class="lp-chip"></span><span class="lp-chip"></span><span class="lp-chip"></span>
-          </div>
 
           {# Catalog mock: reacts to layout (grid/list/sections), density,
              accent and card-cover style. Sections renders two grouped

--- a/crates/ruscker-admin/templates/admin/specs.html
+++ b/crates/ruscker-admin/templates/admin/specs.html
@@ -186,6 +186,8 @@
             {% if !spec.trend_svg.is_empty() %}<span class="sparkline-wrap" title="{{ self.t("admin-specs-col-access-help") }}">{{ spec.trend_svg|safe }}</span>{% endif %}
           </td>
           <td class="actions-cell">
+            <div class="row-actions">
+            <span class="ra-group ra-marker">
             {# Featured star (#521): inline toggle, solid when featured, right
                in the actions column. URL + titles ride in `data-*`
                (HTML-escaped), read via `$el.dataset` — never interpolated
@@ -209,6 +211,9 @@
                 <path d="M12 17.27L18.18 21l-1.64-7.03L22 9.24l-7.19-.61L12 2 9.19 8.63 2 9.24l5.46 4.73L5.82 21z"/>
               </svg>
             </button>
+            </span>
+            <span class="ra-sep" aria-hidden="true"></span>
+            <span class="ra-group">
             <a href="{{ base }}/admin/specs/{{ spec.id }}/edit"
                class="admin-nav-link"
                title="{{ self.t("admin-specs-edit") }}">
@@ -219,6 +224,9 @@
                title="{{ self.t("admin-specs-duplicate") }}">
               <i class="ti ti-copy" aria-hidden="true"></i>
             </a>
+            </span>
+            <span class="ra-sep" aria-hidden="true"></span>
+            <span class="ra-group">
             {# Update image (#855): force a re-pull of this app's image in
                place. Containerized kinds only (external/link cards have no
                image). Starts the pull (POST → job token), then follows the
@@ -226,7 +234,13 @@
                then a brief ✓/✗ flash. Titles ride data-* (never a localized
                string inside the JS handler — template_lint). #}
             {% if spec.kind != "external" %}
-            <button type="button" class="admin-nav-link" x-data="{ busy: false, ok: null }"
+            <span class="ra-pull" x-data="{ busy: false, ok: null, line: '' }">
+            {# Live step indication (#: follow the pull) — the latest SSE
+               progress line shows inline while the re-pull runs, so the
+               user can watch Pulling → Downloading → Extracting → done
+               instead of just a spinner. Capped + ellipsized in CSS. #}
+            <span class="pull-status" x-show="busy && line" x-cloak x-text="line"></span>
+            <button type="button" class="admin-nav-link"
                     data-repull-url="{{ base }}/admin/specs/{{ spec.id }}/repull"
                     data-events-url="{{ base }}/admin/specs/image-pull/events"
                     data-title="{{ self.t("admin-specs-update-image") }}"
@@ -240,12 +254,14 @@
                               .then(r => r.ok ? r.json() : Promise.reject())
                               .then(d => {
                                 const es = new EventSource($el.dataset.eventsUrl + '?job=' + encodeURIComponent(d.job));
-                                es.addEventListener('done', () => { es.close(); busy = false; ok = true; setTimeout(() => { ok = null }, 4000); });
+                                es.onmessage = (e) => { line = e.data };
+                                es.addEventListener('done', () => { es.close(); busy = false; line = ''; ok = true; setTimeout(() => { ok = null }, 4000); });
                                 es.onerror = () => { es.close(); busy = false; if (ok === null) { ok = false; setTimeout(() => { ok = null }, 6000); } };
                               })
                               .catch(() => { busy = false; ok = false; setTimeout(() => { ok = null }, 6000); })">
               <i class="ti" :class="busy ? 'ti-loader-2 animate-spin' : (ok === true ? 'ti-check' : (ok === false ? 'ti-alert-triangle' : 'ti-cloud-download'))" aria-hidden="true"></i>
             </button>
+            </span>
             {% endif %}
             {# Archive toggle (#775): active ⇄ inactive without opening the
                editor. An inactive app keeps everything (config, history,
@@ -277,6 +293,8 @@
                               .finally(() => { busy = false })">
               <i class="ti {% if spec.state == "active" %}ti-archive{% else %}ti-archive-off{% endif %}" aria-hidden="true"></i>
             </button>
+            </span>
+            <span class="ra-group ra-danger">
             {# Delete (#775): same handler the edit form uses (stops the
                app's containers, audits). The confirm rides `data-confirm`
                + the global capture-phase submit listener in _layout.html —
@@ -287,6 +305,8 @@
                 <i class="ti ti-trash" aria-hidden="true"></i>
               </button>
             </form>
+            </span>
+            </div>
           </td>
           {% endif %}
         </tr>

--- a/crates/ruscker-admin/templates/admin/users.html
+++ b/crates/ruscker-admin/templates/admin/users.html
@@ -92,14 +92,41 @@
 </form>
 
 {# ── Bulk import from CSV (#862) ────────────────────────────────── #}
+{# The native file input renders the browser's own "Choose file / No file
+   chosen" text in the BROWSER's language — untranslatable. Hide it and
+   drive it from a styled, localized <label>, mirroring the YAML import in
+   Applications (import_editor.html). This page is intentionally Alpine-free
+   (#433), so the chosen-filename echo + submit gating are vanilla JS below.
+   `required` on a display:none input breaks native validation, so the
+   submit starts disabled and enables on pick. The filename is set via
+   textContent (XSS-safe) and is never a localized string. #}
 <form method="post" action="{{ base }}/admin/users/import" enctype="multipart/form-data"
       style="display:flex;gap:8px;align-items:center;flex-wrap:wrap;margin-bottom:20px">
-  <input type="file" name="file" accept=".csv,text/csv" required>
-  <button type="submit" class="admin-nav-link" style="width:auto">
+  <label class="admin-nav-link" style="width:auto;cursor:pointer">
+    <i class="ti ti-file-spreadsheet" aria-hidden="true"></i> {{ self.t("admin-users-import-choose") }}
+    <input type="file" name="file" id="csv-import-input" accept=".csv,text/csv" class="hidden">
+  </label>
+  <span class="text-xs text-[color:var(--text-muted)]" id="csv-import-name" style="word-break:break-all"></span>
+  <button type="submit" id="csv-import-submit" class="admin-nav-link" style="width:auto" disabled>
     <i class="ti ti-file-upload" aria-hidden="true"></i> {{ self.t("admin-users-import") }}
   </button>
   <span class="text-xs text-[color:var(--text-faint)]">{{ self.t("admin-users-import-help") }}</span>
 </form>
+<script>
+  // Framework-free (this page avoids Alpine, #433): reflect the chosen file
+  // name and enable the submit only once a file is picked.
+  (function () {
+    var input = document.getElementById('csv-import-input');
+    var name = document.getElementById('csv-import-name');
+    var submit = document.getElementById('csv-import-submit');
+    if (!input || !name || !submit) return;
+    input.addEventListener('change', function () {
+      var f = input.files && input.files.length ? input.files[0].name : '';
+      name.textContent = f;
+      submit.disabled = !f;
+    });
+  })();
+</script>
 
 {# ── Existing users ────────────────────────────────────────────── #}
 <table class="admin-table" data-enhance>

--- a/crates/ruscker-admin/templates/landing.html
+++ b/crates/ruscker-admin/templates/landing.html
@@ -245,7 +245,7 @@
     </div>
   </div>
 
-  {# ── Filter row 2: type chips with long labels + access ───── #}
+  {# ── Filter row 2: type chips with long labels ───── #}
   <div class="flex flex-wrap items-center gap-1.5 mb-2">
     <button class="chip"
             :class="type_ === 'all' ? 'on-all' : ''"
@@ -262,29 +262,13 @@
       </button>
     {% endfor %}
 
-    {% if show_filters %}
-    <span class="chip-divider"></span>
-
-    <button class="access-chip"
-            :class="access === 'open' ? 'on' : ''"
-            @click="access = (access === 'open' ? 'all' : 'open')">
-      <i class="ti ti-lock-open text-[12px] text-[color:var(--color-lock-open)]" aria-hidden="true"></i>
-      <span>{{ self.t("filter-access-public") }}</span>
-    </button>
-    <button class="access-chip"
-            :class="access === 'closed' ? 'on' : ''"
-            @click="access = (access === 'closed' ? 'all' : 'closed')">
-      <i class="ti ti-lock text-[12px] text-[color:var(--color-lock)]" aria-hidden="true"></i>
-      <span>{{ self.t("filter-access-restricted") }}</span>
-    </button>
-    {% endif %}
   </div>
 
   {# ── Meta row: count + clear filters ───────────────────────── #}
   <div class="text-[11px] text-[color:var(--text-faint)] mb-3.5 flex items-center gap-1.5">
     <span><span x-text="visible"></span> / <span x-text="counts.all"></span></span>
-    <button x-show="type_ !== 'all' || access !== 'all' || search !== '' || subject !== 'all' || status_ !== 'active' || sort !== 'recent'"
-            @click="type_ = 'all'; access = 'all'; search = ''; subject = 'all'; status_ = 'active'; sort = 'recent'"
+    <button x-show="type_ !== 'all' || search !== '' || subject !== 'all' || status_ !== 'active' || sort !== 'recent'"
+            @click="type_ = 'all'; search = ''; subject = 'all'; status_ = 'active'; sort = 'recent'"
             class="text-[10px] px-2 py-0.5 text-[color:var(--text-faint)] underline hover:text-[color:var(--text)]">
       {{ self.t("filter-clear") }}
     </button>
@@ -311,7 +295,6 @@
       <a class="rcard {% if !card.active %}inactive{% endif %}"
          {% if card.active %}href="{{ card.href }}"{% else %}aria-disabled="true"{% endif %}
          data-type="{{ card.display_type.key() }}"
-         data-access="{% if card.access_open %}open{% else %}closed{% endif %}"
          data-active="{% if card.active %}active{% else %}inactive{% endif %}"
          data-subject="{% if let Some(t) = card.subject %}{{ t }}{% endif %}"
          data-name="{{ card.display_name|lower }}"
@@ -419,7 +402,6 @@ window.ruscker = window.ruscker || {};
 window.ruscker.landing = () => ({
   search: '',
   type_: 'all',
-  access: 'all',
   subject: 'all',
   // status filter: 'active' (default), 'all', or 'inactive'.
   // Inactive items are hidden by default so the landing only shows
@@ -439,7 +421,6 @@ window.ruscker.landing = () => ({
   init() {
     this.$watch('search', () => this.recount());
     this.$watch('type_',  () => this.recount());
-    this.$watch('access', () => this.recount());
     this.$watch('subject',   () => this.recount());
     this.$watch('status_',() => this.recount());
     this.$nextTick(() => this.recount());
@@ -502,9 +483,6 @@ window.ruscker.landing = () => ({
       (this.status_ === 'active' && status === 'active') ||
       (this.status_ === 'inactive' && status === 'inactive');
     if (!okStatus) return false;
-
-    const okAccess = this.access === 'all' || el.dataset.access === this.access;
-    if (!okAccess) return false;
 
     const okSubject = this.subject === 'all' || el.dataset.subject === this.subject;
     if (!okSubject) return false;


### PR DESCRIPTION
UI polish bundle (all user-requested), shipping together:

1. **Apps action column — logical grouping.** Cluster icon buttons into groups (marker | manage edit/duplicate | operate update-image/archive) with thin dividers; destructive **Delete** set apart. CSS `.row-actions`/`.ra-group`/`.ra-sep`/`.ra-danger`.
2. **"Update image" live progress (#855).** The per-row re-pull now shows the latest Docker pull step inline (Pulling → Downloading → Extracting → done) via `es.onmessage`, capped + ellipsized, cleared on done — instead of just a spinner.
3. **Users CSV import — localized file picker (#862).** The native `<input type=file>` showed the browser's own "Choose file" in the browser language. Hidden + driven by a styled localized `<label>` (`admin-users-import-choose`); chosen filename echoes, submit gated. Framework-free (page avoids Alpine, #433).
4. **Dashboard replica logo fallback.** A broken logo image (file absent on the host) now falls back to the monogram initial instead of hiding to a blank tile — server render + SSE rebuild.
5. **Drop the portal public/private access filter.** With the decorative lock gone (#858) it no longer distinguishes anything a visitor can see (restricted apps are hidden). Removed the chips, Alpine state, `data-access`, the `filter-access-*` keys (4 locales), and the Appearance toggle. `show_filters` column + `access_open` stay dormant (no migration); real enforcement/visibility untouched.

## Test
Build (Tailwind regen verified), `i18n-check` (parity OK after key removals), `template_lint` (2), `clippy -D warnings`, full `cargo test` — all green. Visual smoke on cast after release.

🤖 Generated with [Claude Code](https://claude.com/claude-code)