### PR TITLE
perf(admin): signature-validated cache for the effective spec catalog (#902)

### DIFF
--- a/crates/ruscker-admin/src/catalog.rs
+++ b/crates/ruscker-admin/src/catalog.rs
@@ -11,10 +11,17 @@
 //! `proxy::find_spec`'s per-id rule for the whole catalog.
 
 use std::collections::HashSet;
+use std::sync::Arc;
 
 use ruscker_config::{Config, Spec};
 
 use crate::db::{self, ConfigDb};
+use crate::AppState;
+
+/// Shared, signature-validated cache of the effective spec catalog for the
+/// admin pages (#902). Lives on [`AppState`]; see [`effective_specs_cached`].
+pub type CatalogCache =
+    Arc<tokio::sync::RwLock<Option<(db::specs::CatalogSignature, Arc<Vec<Spec>>)>>>;
 
 /// Every spec the runtime should act on.
 ///
@@ -51,6 +58,35 @@ pub(crate) async fn effective_specs(db: Option<&ConfigDb>, config: &Config) -> V
             config.proxy.specs.clone()
         }
     }
+}
+
+/// [`effective_specs`] with a signature-validated cache for the admin
+/// pages (#902). Reads the cheap [`db::specs::catalog_signature`]; on a
+/// match against `state.catalog_cache` it returns the cached
+/// `Arc<Vec<Spec>>` and skips the full `list_all` + per-spec
+/// `config_json` deserialize. Any catalog write moves the signature, so
+/// the cache is never stale (and HA-safe — the signature reflects writes
+/// from any node). With no DB, or if the signature query fails, it falls
+/// back to building uncached (never serving stale data).
+pub(crate) async fn effective_specs_cached(state: &AppState) -> Arc<Vec<Spec>> {
+    let Some(db) = state.db.as_ref() else {
+        return Arc::new(effective_specs(None, &state.config).await);
+    };
+    let sig = match db::specs::catalog_signature(db).await {
+        Ok(s) => s,
+        Err(e) => {
+            tracing::warn!(error = ?e, "catalog signature failed; bypassing cache");
+            return Arc::new(effective_specs(Some(db), &state.config).await);
+        }
+    };
+    if let Some((cached_sig, specs)) = state.catalog_cache.read().await.as_ref() {
+        if *cached_sig == sig {
+            return specs.clone();
+        }
+    }
+    let specs = Arc::new(effective_specs(Some(db), &state.config).await);
+    *state.catalog_cache.write().await = Some((sig, specs.clone()));
+    specs
 }
 
 #[cfg(test)]
@@ -95,5 +131,34 @@ mod tests {
         // DB shadows YAML on the collision.
         let shared = specs.iter().find(|s| s.id == "shared").unwrap();
         assert_eq!(shared.display_name.as_deref(), Some("from-db"));
+    }
+
+    // #902: the catalog signature must move on every write (insert /
+    // update / delete) so the cache it guards is never stale. Also pins
+    // that the dual-dialect aggregate query decodes (count + Σversion +
+    // max updated_at).
+    #[tokio::test]
+    async fn catalog_signature_moves_on_every_write() {
+        let cdb = ConfigDb::Sqlite(open_memory().await.unwrap());
+        let empty = db::specs::catalog_signature(&cdb).await.unwrap();
+        assert_eq!(empty.0, 0, "no specs yet");
+
+        let a: Spec = serde_yaml_ng::from_str("id: a\ncontainer-image: nginx").unwrap();
+        db::specs::upsert_one(&cdb, &a, None).await.unwrap();
+        let after_insert = db::specs::catalog_signature(&cdb).await.unwrap();
+        assert_ne!(after_insert, empty, "insert moved the signature");
+
+        // Update (version bumps) → signature changes.
+        let a2: Spec =
+            serde_yaml_ng::from_str("id: a\ncontainer-image: nginx\ndisplay-name: edited").unwrap();
+        db::specs::upsert_one(&cdb, &a2, None).await.unwrap();
+        let after_update = db::specs::catalog_signature(&cdb).await.unwrap();
+        assert_ne!(after_update, after_insert, "update moved the signature");
+
+        // Delete → signature changes.
+        db::specs::delete_one(&cdb, "a", None).await.unwrap();
+        let after_delete = db::specs::catalog_signature(&cdb).await.unwrap();
+        assert_ne!(after_delete, after_update, "delete moved the signature");
+        assert_eq!(after_delete.0, 0, "back to empty");
     }
 }

--- a/crates/ruscker-admin/src/db/specs.rs
+++ b/crates/ruscker-admin/src/db/specs.rs
@@ -224,6 +224,27 @@ pub async fn list_all(db: &ConfigDb) -> Result<Vec<Spec>> {
     Ok(out)
 }
 
+/// A cheap fingerprint of the spec catalog, for validating the admin
+/// catalog cache (#902): `(row count, Σ version, max updated_at)`. It
+/// changes on **any** insert / update / delete — `version` bumps on every
+/// upsert, `count` on insert/delete, `updated_at` on every write — yet
+/// reads **no** `config_json`, so it's far cheaper than `list_all`. A
+/// write on any node moves it for every reader, so the cache it guards is
+/// never stale in HA. Cast the SUM to BIGINT so Postgres returns a plain
+/// integer (not NUMERIC) and both dialects decode to `i64`.
+pub type CatalogSignature = (i64, i64, Option<DateTime<Utc>>);
+
+pub async fn catalog_signature(db: &ConfigDb) -> Result<CatalogSignature> {
+    const SQL: &str =
+        "SELECT COUNT(*), CAST(COALESCE(SUM(version), 0) AS BIGINT), MAX(updated_at) FROM specs";
+    let sig: CatalogSignature = match db {
+        ConfigDb::Sqlite(pool) => sqlx::query_as(SQL).fetch_one(pool).await,
+        ConfigDb::Postgres(pool) => sqlx::query_as(SQL).fetch_one(pool).await,
+    }
+    .context("catalog signature")?;
+    Ok(sig)
+}
+
 /// Fetch a single spec by id, deserializing `config_json` back to
 /// a [`Spec`]. Returns `None` if no row matches.
 ///

--- a/crates/ruscker-admin/src/lib.rs
+++ b/crates/ruscker-admin/src/lib.rs
@@ -182,6 +182,18 @@ pub struct AppState {
     /// explicit invalidation wiring. Shared so every cloned `AppState`
     /// sees the same cache.
     pub spec_cache: Arc<dashmap::DashMap<String, (Arc<ruscker_config::Spec>, std::time::Instant)>>,
+
+    /// Short-circuit cache of the **effective spec catalog** for admin
+    /// pages (#902). The admin tabs (Apps/Disk/Media/Groups/System +
+    /// landing) each rebuilt the full catalog — `list_all` + a
+    /// `config_json` deserialize of every spec — on every navigation.
+    /// This holds the last-built `Arc<Vec<Spec>>` keyed by a cheap catalog
+    /// signature (`db::specs::catalog_signature`: count + Σversion + max
+    /// updated_at); a cache hit skips the deserialize entirely, and any
+    /// write moves the signature so it's never stale (HA-safe — a write on
+    /// any node changes the signature every reader observes). `Arc` so all
+    /// cloned `AppState`s share it in-process while each test gets its own.
+    pub catalog_cache: catalog::CatalogCache,
 }
 
 impl AppState {
@@ -238,6 +250,7 @@ impl AdminServer {
             metrics: metrics_cache::MetricsCache::new(),
             draining: Arc::new(std::sync::atomic::AtomicBool::new(false)),
             spec_cache: Arc::new(dashmap::DashMap::new()),
+            catalog_cache: Arc::new(tokio::sync::RwLock::new(None)),
         };
         Ok(Self {
             addr,

--- a/crates/ruscker-admin/src/routes/admin.rs
+++ b/crates/ruscker-admin/src/routes/admin.rs
@@ -749,6 +749,7 @@ mod tests {
             metrics: crate::metrics_cache::MetricsCache::new(),
             draining: Arc::new(std::sync::atomic::AtomicBool::new(false)),
             spec_cache: Arc::new(dashmap::DashMap::new()),
+            catalog_cache: Arc::new(tokio::sync::RwLock::new(None)),
         }
     }
 

--- a/crates/ruscker-admin/src/routes/admin/dashboard.rs
+++ b/crates/ruscker-admin/src/routes/admin/dashboard.rs
@@ -442,7 +442,7 @@ async fn build_snapshot_uncached(state: &AppState, locale: Locale) -> DashboardS
     // round-trip per spec, which on the 5s SSE tick (× every open tab)
     // hammered the DB (#281). Still DB-first, so a renamed-in-admin spec
     // shows its current name (#275).
-    let catalog = crate::catalog::effective_specs(state.db.as_ref(), &state.config).await;
+    let catalog = crate::catalog::effective_specs_cached(state).await;
     let name_of: std::collections::HashMap<String, String> = snap
         .iter()
         .map(|r| r.spec_id.clone())

--- a/crates/ruscker-admin/src/routes/admin/disk.rs
+++ b/crates/ruscker-admin/src/routes/admin/disk.rs
@@ -348,7 +348,7 @@ async fn index(
 /// image carrying one of these tags is "in use by a spec" and is never
 /// offered for removal.
 async fn spec_image_refs(state: &AppState) -> HashSet<String> {
-    crate::catalog::effective_specs(state.db.as_ref(), &state.config)
+    crate::catalog::effective_specs_cached(state)
         .await
         .iter()
         .filter_map(|s| s.container_image.clone())

--- a/crates/ruscker-admin/src/routes/admin/groups.rs
+++ b/crates/ruscker-admin/src/routes/admin/groups.rs
@@ -125,8 +125,8 @@ async fn index(
     all_users.sort();
 
     // Specs contribute apps (by `access-groups`).
-    let specs = crate::catalog::effective_specs(state.db.as_ref(), &state.config).await;
-    for s in &specs {
+    let specs = crate::catalog::effective_specs_cached(&state).await;
+    for s in specs.iter() {
         if let Some(groups) = s.access_groups.as_ref() {
             let name = s.display_name.clone().unwrap_or_else(|| s.id.clone());
             for g in groups {

--- a/crates/ruscker-admin/src/routes/admin/images.rs
+++ b/crates/ruscker-admin/src/routes/admin/images.rs
@@ -185,8 +185,11 @@ async fn render_index(
     // can warn before deleting one that's in use (#433): each spec's logo +
     // cover, and the landing header/footer logos.
     let mut refs = String::new();
-    if let Ok(specs) = db::specs::list_all(pool).await {
-        for s in &specs {
+    {
+        // #902: reuse the cached effective catalog instead of a fresh
+        // full-deserialize just to scrape logo/cover URLs.
+        let specs = crate::catalog::effective_specs_cached(state).await;
+        for s in specs.iter() {
             for key in ["logo", "cover"] {
                 if let Some(v) = s.template_properties.0.get(key).and_then(|v| v.as_str()) {
                     refs.push_str(v);

--- a/crates/ruscker-admin/src/routes/admin/specs.rs
+++ b/crates/ruscker-admin/src/routes/admin/specs.rs
@@ -424,13 +424,13 @@ async fn index(
     // catalog deserializes each spec once — fine here (admin page, not the
     // proxy/dashboard hot path the lean SELECT of #588 protects).
     let meta: std::collections::HashMap<String, (Option<String>, Vec<String>)> =
-        crate::catalog::effective_specs(state.db.as_ref(), &state.config)
+        crate::catalog::effective_specs_cached(&state)
             .await
-            .into_iter()
+            .iter()
             .map(|s| {
                 let logo = s.template_properties.get_str("logo").map(str::to_string);
                 let groups = s.access_groups.clone().unwrap_or_default();
-                (s.id, (logo, groups))
+                (s.id.clone(), (logo, groups))
             })
             .collect();
 

--- a/crates/ruscker-admin/src/routes/admin/system.rs
+++ b/crates/ruscker-admin/src/routes/admin/system.rs
@@ -75,7 +75,7 @@ async fn index(
         Some(crate::db::ConfigDb::Sqlite(_)) => "sqlite",
         Some(crate::db::ConfigDb::Postgres(_)) => "postgres",
     };
-    let spec_count = crate::catalog::effective_specs(state.db.as_ref(), &state.config)
+    let spec_count = crate::catalog::effective_specs_cached(&state)
         .await
         .len();
     let replica_count = state.replicas.read().await.all().count();

--- a/crates/ruscker-admin/src/routes/landing.rs
+++ b/crates/ruscker-admin/src/routes/landing.rs
@@ -344,7 +344,7 @@ async fn index(
     // from disagreeing on what specs exist (an earlier "DB-only when
     // non-empty" rule here hid an admin-deleted spec from the landing
     // while `find_spec` still resolved it from the YAML and spawned it).
-    let owned_specs = crate::catalog::effective_specs(state.db.as_ref(), &state.config).await;
+    let owned_specs = crate::catalog::effective_specs_cached(&state).await;
     let mut cards: Vec<CardCtx<'_>> = owned_specs
         .iter()
         .filter(|spec| spec.access_allows(is_admin, username.as_deref(), &groups))

--- a/crates/ruscker-admin/src/routes/proxy.rs
+++ b/crates/ruscker-admin/src/routes/proxy.rs
@@ -2204,6 +2204,7 @@ mod tests {
             metrics: crate::metrics_cache::MetricsCache::new(),
             draining: StdArc::new(std::sync::atomic::AtomicBool::new(false)),
             spec_cache: StdArc::new(dashmap::DashMap::new()),
+            catalog_cache: StdArc::new(tokio::sync::RwLock::new(None)),
         }
     }
 

--- a/crates/ruscker-admin/src/scaler.rs
+++ b/crates/ruscker-admin/src/scaler.rs
@@ -1051,6 +1051,7 @@ mod tests {
             metrics: crate::metrics_cache::MetricsCache::new(),
             draining: Arc::new(std::sync::atomic::AtomicBool::new(false)),
             spec_cache: Arc::new(dashmap::DashMap::new()),
+            catalog_cache: Arc::new(tokio::sync::RwLock::new(None)),
         }
     }
 

--- a/crates/ruscker-admin/tests/admin_landing_picker.rs
+++ b/crates/ruscker-admin/tests/admin_landing_picker.rs
@@ -44,6 +44,7 @@ async fn state_with_db() -> AppState {
         metrics: ruscker_admin::metrics_cache::MetricsCache::new(),
         draining: Arc::new(std::sync::atomic::AtomicBool::new(false)),
         spec_cache: std::sync::Arc::new(dashmap::DashMap::new()),
+        catalog_cache: std::sync::Arc::new(tokio::sync::RwLock::new(None)),
     }
 }
 

--- a/crates/ruscker-admin/tests/api_policies.rs
+++ b/crates/ruscker-admin/tests/api_policies.rs
@@ -61,6 +61,7 @@ fn state() -> AppState {
         metrics: ruscker_admin::metrics_cache::MetricsCache::new(),
         draining: Arc::new(std::sync::atomic::AtomicBool::new(false)),
         spec_cache: std::sync::Arc::new(dashmap::DashMap::new()),
+        catalog_cache: std::sync::Arc::new(tokio::sync::RwLock::new(None)),
     }
 }
 

--- a/crates/ruscker-admin/tests/health_probes.rs
+++ b/crates/ruscker-admin/tests/health_probes.rs
@@ -45,6 +45,7 @@ fn base_state() -> AppState {
         metrics: ruscker_admin::metrics_cache::MetricsCache::new(),
         draining: Arc::new(std::sync::atomic::AtomicBool::new(false)),
         spec_cache: std::sync::Arc::new(dashmap::DashMap::new()),
+        catalog_cache: std::sync::Arc::new(tokio::sync::RwLock::new(None)),
     }
 }
 

--- a/crates/ruscker-admin/tests/landing_access.rs
+++ b/crates/ruscker-admin/tests/landing_access.rs
@@ -83,6 +83,7 @@ async fn app_state(db: ConfigDb) -> AppState {
         metrics: ruscker_admin::metrics_cache::MetricsCache::new(),
         draining: Arc::new(std::sync::atomic::AtomicBool::new(false)),
         spec_cache: std::sync::Arc::new(dashmap::DashMap::new()),
+        catalog_cache: std::sync::Arc::new(tokio::sync::RwLock::new(None)),
     }
 }
 

--- a/crates/ruscker-admin/tests/landing_render.rs
+++ b/crates/ruscker-admin/tests/landing_render.rs
@@ -50,6 +50,7 @@ fn state_from_yaml(yaml: &str) -> AppState {
         metrics: ruscker_admin::metrics_cache::MetricsCache::new(),
         draining: std::sync::Arc::new(std::sync::atomic::AtomicBool::new(false)),
         spec_cache: std::sync::Arc::new(dashmap::DashMap::new()),
+        catalog_cache: std::sync::Arc::new(tokio::sync::RwLock::new(None)),
     }
 }
 

--- a/crates/ruscker-admin/tests/max_body_size.rs
+++ b/crates/ruscker-admin/tests/max_body_size.rs
@@ -60,6 +60,7 @@ fn state() -> AppState {
         metrics: ruscker_admin::metrics_cache::MetricsCache::new(),
         draining: Arc::new(std::sync::atomic::AtomicBool::new(false)),
         spec_cache: std::sync::Arc::new(dashmap::DashMap::new()),
+        catalog_cache: std::sync::Arc::new(tokio::sync::RwLock::new(None)),
     }
 }
 

--- a/crates/ruscker-admin/tests/metrics.rs
+++ b/crates/ruscker-admin/tests/metrics.rs
@@ -33,6 +33,7 @@ fn state(yaml: &str) -> AppState {
         metrics: ruscker_admin::metrics_cache::MetricsCache::new(),
         draining: Arc::new(std::sync::atomic::AtomicBool::new(false)),
         spec_cache: std::sync::Arc::new(dashmap::DashMap::new()),
+        catalog_cache: std::sync::Arc::new(tokio::sync::RwLock::new(None)),
     }
 }
 

--- a/crates/ruscker-admin/tests/proxy_access.rs
+++ b/crates/ruscker-admin/tests/proxy_access.rs
@@ -80,6 +80,7 @@ async fn app_state(db: ConfigDb) -> AppState {
         metrics: ruscker_admin::metrics_cache::MetricsCache::new(),
         draining: Arc::new(std::sync::atomic::AtomicBool::new(false)),
         spec_cache: std::sync::Arc::new(dashmap::DashMap::new()),
+        catalog_cache: std::sync::Arc::new(tokio::sync::RwLock::new(None)),
     }
 }
 

--- a/crates/ruscker-admin/tests/rbac.rs
+++ b/crates/ruscker-admin/tests/rbac.rs
@@ -57,6 +57,7 @@ fn state() -> AppState {
         metrics: ruscker_admin::metrics_cache::MetricsCache::new(),
         draining: Arc::new(std::sync::atomic::AtomicBool::new(false)),
         spec_cache: std::sync::Arc::new(dashmap::DashMap::new()),
+        catalog_cache: std::sync::Arc::new(tokio::sync::RwLock::new(None)),
     }
 }
 

--- a/crates/ruscker-admin/tests/user_accounts.rs
+++ b/crates/ruscker-admin/tests/user_accounts.rs
@@ -44,6 +44,7 @@ async fn state_with_db() -> (AppState, sqlx::SqlitePool) {
         metrics: ruscker_admin::metrics_cache::MetricsCache::new(),
         draining: Arc::new(std::sync::atomic::AtomicBool::new(false)),
         spec_cache: std::sync::Arc::new(dashmap::DashMap::new()),
+        catalog_cache: std::sync::Arc::new(tokio::sync::RwLock::new(None)),
     };
     (state, pool)
 }


### PR DESCRIPTION
## What
The admin tabs (Apps/Disk/Media/Groups/System) and the public landing each rebuilt the **full effective catalog** per navigation — `list_all` + a `config_json` deserialize of **every** spec — which defeated the lean SELECT the Apps list got in #588.

`effective_specs_cached(state)` returns a shared `Arc<Vec<Spec>>` (on `AppState`), validated by a **cheap catalog signature** — `db::specs::catalog_signature` = `COUNT(*) + Σversion + MAX(updated_at)`, reading **no** `config_json`. A cache hit skips the deserialize entirely.

## Correctness
- Any insert/update/delete moves the signature (version bumps on every upsert, count on insert/delete) → the cache is **never stale**, with **no TTL** to tune.
- **HA-safe**: the signature reflects writes from any node, so every reader rebuilds when the shared catalog changes.
- **Per-`AppState` `Arc`** → shared across cloned states in-process (real win), isolated per test (no module static → no cross-test collision).
- Background callers (scaler, heartbeat sweeper) and the save-path duplicate-id check keep the uncached `effective_specs`.

## Test
- `catalog_signature_moves_on_every_write` (insert/update/delete each move it; back to empty after delete).
- Full gate green incl. **postgres-it (381)** for the dual-dialect signature query (`CAST(SUM AS BIGINT)` + `MAX(updated_at)` decode on both dialects); `clippy -D warnings`; `i18n-check`.

Closes #902

🤖 Generated with [Claude Code](https://claude.com/claude-code)