### PR TITLE
fix(admin): handle DB-only specs in startup reconcile + duplicate (#907)

### DIFF
--- a/crates/ruscker-admin/src/lib.rs
+++ b/crates/ruscker-admin/src/lib.rs
@@ -383,24 +383,21 @@ impl AdminServer {
         if let Some(backend) = self.state.backend.as_ref() {
             match backend.list().await {
                 Ok(mut existing) => {
-                    // The backend can't know each replica's seat
-                    // cap — that lives in the spec config. Enrich
-                    // each reconciled replica with its spec's
-                    // `effective_seats` so `sessions_max` is
-                    // accurate and the scaler's saturation /
-                    // available-seats math works on first tick.
-                    for r in &mut existing {
-                        if let Some(spec) = self
-                            .state
-                            .config
-                            .proxy
-                            .specs
-                            .iter()
-                            .find(|s| s.id == r.spec_id)
-                        {
-                            r.sessions_max = spec.effective_seats();
-                        }
-                    }
+                    // The backend can't know each replica's seat cap —
+                    // that lives in the spec config. Enrich each reconciled
+                    // replica with its spec's `effective_seats` so
+                    // `sessions_max` is accurate and the scaler's saturation
+                    // / available-seats math works on first tick.
+                    //
+                    // Resolve from the EFFECTIVE catalog (DB ∪ YAML), not
+                    // just `proxy.specs`: a spec created in the admin is
+                    // DB-only, so a YAML-only lookup left its reconciled
+                    // replica at `sessions_max = 0` → `available_seats() == 0`
+                    // → never accepting, so after a restart an already-running
+                    // DB-only app looked permanently full (#907).
+                    let catalog =
+                        catalog::effective_specs(self.state.db.as_ref(), &self.state.config).await;
+                    apply_seat_caps(&mut existing, &catalog);
                     let n = existing.len();
                     self.state.replicas.write().await.reset(existing);
                     if n > 0 {
@@ -1016,6 +1013,24 @@ fn is_safe_csp_source(t: &str) -> bool {
     valid && (body.contains('.') || body.contains(':'))
 }
 
+/// Set each reconciled replica's `sessions_max` from its spec's
+/// `effective_seats`. `specs` must be the EFFECTIVE catalog (DB ∪ YAML),
+/// not just `proxy.specs`, so a spec created in the admin (DB-only) is
+/// found — otherwise its reconciled replica keeps `list()`'s
+/// `sessions_max = 0` and reads as permanently full after a restart
+/// (#907). A replica whose spec is no longer in the catalog is left as-is.
+fn apply_seat_caps(replicas: &mut [ruscker_core::Replica], specs: &[ruscker_config::Spec]) {
+    let caps: std::collections::HashMap<&str, u32> = specs
+        .iter()
+        .map(|s| (s.id.as_str(), s.effective_seats()))
+        .collect();
+    for r in replicas {
+        if let Some(max) = caps.get(r.spec_id.as_str()) {
+            r.sessions_max = *max;
+        }
+    }
+}
+
 #[cfg(test)]
 mod csrf_tests {
     use super::request_is_cross_origin;
@@ -1152,5 +1167,60 @@ mod csp_tests {
         assert!(csp.contains("https://a.example.com"));
         assert!(csp.contains("data:"));
         assert!(csp.contains("*.cdn.example.org"));
+    }
+}
+
+#[cfg(test)]
+mod reconcile_tests {
+    use super::apply_seat_caps;
+    use ruscker_config::Spec;
+    use ruscker_core::{Replica, ReplicaId, ReplicaState};
+
+    fn yaml_spec(s: &str) -> Spec {
+        std::env::set_var("DOCKER_REGISTRY_PASSWORD", "test");
+        serde_yaml_ng::from_str(s).unwrap()
+    }
+
+    // #907: a reconciled replica of a DB-only spec must get its seat cap
+    // from the effective catalog, or it reads as permanently full.
+    #[test]
+    fn seat_caps_cover_db_only_specs() {
+        // The backend's list() can't know seat caps → sessions_max = 0.
+        let mut replicas = vec![Replica {
+            id: ReplicaId::new(),
+            spec_id: "db-only".into(),
+            container_id: "c1".into(),
+            upstream: "127.0.0.1:8000".parse().unwrap(),
+            state: ReplicaState::Ready,
+            started_at: chrono::Utc::now(),
+            sessions_active: 0,
+            sessions_max: 0,
+            host: None,
+        }];
+        // The effective catalog (DB ∪ YAML) carries the DB-only spec.
+        let specs = vec![yaml_spec(
+            "id: db-only\ncontainer-image: nginx\nseats-per-container: 3",
+        )];
+        apply_seat_caps(&mut replicas, &specs);
+        assert_eq!(replicas[0].sessions_max, 3, "seat cap applied");
+        assert!(replicas[0].available_seats() > 0, "no longer reads as full");
+    }
+
+    // A replica whose spec vanished from the catalog is left untouched.
+    #[test]
+    fn seat_caps_leave_unknown_spec_alone() {
+        let mut replicas = vec![Replica {
+            id: ReplicaId::new(),
+            spec_id: "gone".into(),
+            container_id: "c1".into(),
+            upstream: "127.0.0.1:8000".parse().unwrap(),
+            state: ReplicaState::Ready,
+            started_at: chrono::Utc::now(),
+            sessions_active: 1,
+            sessions_max: 7,
+            host: None,
+        }];
+        apply_seat_caps(&mut replicas, &[]);
+        assert_eq!(replicas[0].sessions_max, 7, "untouched when spec is absent");
     }
 }

--- a/crates/ruscker-admin/src/routes/admin/spec_form.rs
+++ b/crates/ruscker-admin/src/routes/admin/spec_form.rs
@@ -1394,7 +1394,20 @@ async fn duplicate_form(
     };
     let spec = match db::specs::fetch_one(pool, &id).await {
         Ok(Some(s)) => s,
-        Ok(None) => return (StatusCode::NOT_FOUND, "spec not found").into_response(),
+        // A config-only (YAML) spec isn't in the DB. The duplicate button
+        // is shown for those rows and forking a YAML spec into an editable
+        // DB spec is a documented use, so fall back to the effective
+        // catalog instead of 404'ing (#907).
+        Ok(None) => {
+            match crate::catalog::effective_specs_cached(&state)
+                .await
+                .iter()
+                .find(|s| s.id == id)
+            {
+                Some(s) => s.clone(),
+                None => return (StatusCode::NOT_FOUND, "spec not found").into_response(),
+            }
+        }
         Err(e) => {
             tracing::error!(error = ?e, id, "fetch spec for duplicate failed");
             return (StatusCode::INTERNAL_SERVER_ERROR, "db error").into_response();

--- a/crates/ruscker-admin/tests/landing_access.rs
+++ b/crates/ruscker-admin/tests/landing_access.rs
@@ -527,6 +527,35 @@ async fn duplicate_opens_new_form_prefilled_with_fresh_id() {
 }
 
 #[tokio::test]
+async fn duplicate_works_for_a_config_only_spec() {
+    // #907: `open-app` lives only in the YAML config (never inserted into
+    // the DB). Duplicating it used to 404 (the handler only looked in the
+    // DB) even though the button is shown for config-only rows; it must
+    // fall back to the effective catalog and open the prefilled New form.
+    let db = open_db().await; // empty DB → `open-app` is config-only
+    let state = app_state(db).await;
+    let sid = state.admin_sessions.create(Role::Admin, None).await;
+    let app = router(state);
+    let resp = app
+        .oneshot(
+            Request::builder()
+                .uri("/admin/specs/open-app/duplicate")
+                .header(header::COOKIE, format!("{COOKIE_NAME}={sid}"))
+                .body(Body::empty())
+                .unwrap(),
+        )
+        .await
+        .unwrap();
+    assert_eq!(resp.status(), StatusCode::OK, "config-only duplicate must not 404");
+    let body = String::from_utf8(
+        axum::body::to_bytes(resp.into_body(), 1 << 20).await.unwrap().to_vec(),
+    )
+    .unwrap();
+    assert!(body.contains(r#"value="open-app-copy""#), "id suffixed to -copy");
+    assert!(body.contains(r#"action="/admin/specs""#), "New-mode create action");
+}
+
+#[tokio::test]
 async fn favicon_routes_serve_raster_with_correct_content_type() {
     // #374: Safari & co. ignore the SVG favicon and fall back to
     // `/favicon.ico` — previously unserved (black placeholder). Now the


### PR DESCRIPTION
Two code paths only consulted the YAML `proxy.specs`, breaking specs created in the admin (**DB-only** — exactly the production box's imported catalog).

## P1 — startup reconcile left DB-only replicas at `sessions_max = 0`
On startup, `backend.list()` reconstructs running replicas with `sessions_max = 0` (the daemon can't know seat caps). `AdminServer::run` enriched each from `proxy.specs` **only**, so a DB-only spec wasn't found → `sessions_max` stayed 0 → `available_seats() == 0` → `is_accepting() == false`. **After a Ruscker restart, an already-running DB-only app read as permanently full** (wrong routing/scaling). Now enriched from the **effective catalog (DB ∪ YAML)** via an extracted, unit-tested `apply_seat_caps`.

## P2 — duplicating a config-only (YAML) spec 404'd
`duplicate_form` fetched from the DB only → `Ok(None)` → 404 for a YAML spec, though the duplicate button is rendered for `config_only` rows and the handler doc says it works. Now falls back to the effective catalog.

## Test
- `seat_caps_cover_db_only_specs` (cap applied, no longer reads full) + `seat_caps_leave_unknown_spec_alone`.
- `duplicate_works_for_a_config_only_spec` (config-only duplicate → 200 prefilled New form, was 404).
- Full gate green; `clippy -D warnings`.

(P3 — Disk tab masking Docker-list failures as empty tables — filed separately as #908, UX/observability, not a correctness bug.)

Closes #907

🤖 Generated with [Claude Code](https://claude.com/claude-code)