### PR TITLE
fix(admin): don't cache must-change on DB error; copy-id checks full catalog

### DIFF
--- a/crates/ruscker-admin/src/lib.rs
+++ b/crates/ruscker-admin/src/lib.rs
@@ -782,21 +782,31 @@ async fn must_change_password_guard(
                             .validate(&id)
                             .await
                             .and_then(|info| info.actor);
-                        let v = match actor {
-                            Some(actor) => db::users::fetch(pool, &actor)
-                                .await
-                                .ok()
-                                .flatten()
-                                .map(|u| u.must_change_password)
-                                .unwrap_or(false),
-                            // No actor (break-glass token / unknown id): nothing
-                            // to rotate. Cache `false` so we don't re-check.
-                            None => false,
+                        // `(answer, cacheable)`. A DB **error** is NOT
+                        // cacheable: caching its `false` would let a real
+                        // must-change user skip the prompt for the whole TTL
+                        // on one transient blip (#903 follow-up). We still
+                        // let the request through this once (matching the
+                        // pre-cache fail-open), but re-check next request so
+                        // the user is caught as soon as the DB recovers.
+                        let (v, cacheable) = match actor {
+                            Some(actor) => match db::users::fetch(pool, &actor).await {
+                                Ok(u) => (u.map(|u| u.must_change_password).unwrap_or(false), true),
+                                Err(e) => {
+                                    tracing::warn!(error = ?e, "must-change lookup failed; not caching");
+                                    (false, false)
+                                }
+                            },
+                            // No actor (break-glass token / unknown id):
+                            // nothing to rotate — a definitive `false`.
+                            None => (false, true),
                         };
-                        if MUST_CHANGE_CACHE.len() >= MUST_CHANGE_CACHE_CAP {
-                            MUST_CHANGE_CACHE.retain(|_, e| e.0.elapsed() < MUST_CHANGE_TTL);
+                        if cacheable {
+                            if MUST_CHANGE_CACHE.len() >= MUST_CHANGE_CACHE_CAP {
+                                MUST_CHANGE_CACHE.retain(|_, e| e.0.elapsed() < MUST_CHANGE_TTL);
+                            }
+                            MUST_CHANGE_CACHE.insert(id.clone(), (std::time::Instant::now(), v));
                         }
-                        MUST_CHANGE_CACHE.insert(id.clone(), (std::time::Instant::now(), v));
                         v
                     }
                 };

--- a/crates/ruscker-admin/src/routes/admin/spec_form.rs
+++ b/crates/ruscker-admin/src/routes/admin/spec_form.rs
@@ -1355,20 +1355,31 @@ async fn edit_form(
 
 /// Pick a fresh `{base}-copy[-N]` id that no spec uses yet, so the
 /// duplicate doesn't collide with the source (or a previous copy).
-/// Falls back to the bare `-copy` after a sane cap — the create-time
-/// duplicate-id validation is the final backstop.
-async fn unique_copy_id(pool: &crate::db::ConfigDb, base: &str) -> String {
+/// Checks the **effective catalog** (DB ∪ YAML), not just the DB: a
+/// config-only YAML id is real too, and since a DB spec shadows a YAML id
+/// of the same name (catalog.rs), suggesting such an id would silently
+/// hide the YAML spec (#907 follow-up). Falls back to the bare `-copy`
+/// after a sane cap — the create-time duplicate-id validation is the
+/// final backstop.
+async fn unique_copy_id(state: &AppState, base: &str) -> String {
+    let taken: std::collections::HashSet<String> = crate::catalog::effective_specs_cached(state)
+        .await
+        .iter()
+        .map(|s| s.id.clone())
+        .collect();
+    pick_copy_id(base, &taken)
+}
+
+/// Pure id picker for [`unique_copy_id`] — first free `{base}-copy[-N]`
+/// not in `taken`, falling back to the bare `-copy` after the cap.
+fn pick_copy_id(base: &str, taken: &std::collections::HashSet<String>) -> String {
     let first = format!("{base}-copy");
-    let free = |id: &str| {
-        let id = id.to_string();
-        async move { matches!(db::specs::fetch_one(pool, &id).await, Ok(None)) }
-    };
-    if free(&first).await {
+    if !taken.contains(&first) {
         return first;
     }
     for n in 2..=99 {
         let candidate = format!("{base}-copy-{n}");
-        if free(&candidate).await {
+        if !taken.contains(&candidate) {
             return candidate;
         }
     }
@@ -1414,7 +1425,7 @@ async fn duplicate_form(
         }
     };
     let mut form = SpecForm::from_spec(&spec);
-    form.id = unique_copy_id(pool, &spec.id).await;
+    form.id = unique_copy_id(&state, &spec.id).await;
     let page = SpecFormPage {
         locale: loc,
         theme,
@@ -1861,6 +1872,19 @@ proxy:
         assert!(!ok
             .validate(FormMode::New)
             .contains(&"spec-form-error-max-replicas-zero"));
+    }
+
+    // #907 follow-up: the duplicate id must skip an id taken ANYWHERE in
+    // the effective catalog (incl. a config-only YAML spec), not just the
+    // DB — else a new copy would silently shadow an existing YAML spec.
+    #[test]
+    fn pick_copy_id_skips_ids_taken_in_the_catalog() {
+        use std::collections::HashSet;
+        let taken: HashSet<String> = ["app".to_string(), "app-copy".to_string()]
+            .into_iter()
+            .collect();
+        assert_eq!(pick_copy_id("app", &taken), "app-copy-2", "skips the taken -copy");
+        assert_eq!(pick_copy_id("x", &HashSet::new()), "x-copy", "bare -copy when free");
     }
 
     // #892: an invalid Docker network name is rejected at save (it would


### PR DESCRIPTION
Two follow-ups from review.

## P2 — must-change cache pinned a DB error as "no change needed"
`must_change_password_guard`'s user lookup collapsed a DB **error** to `false` (`.ok().flatten()...unwrap_or(false)`), and #903's per-session cache then **pinned that for the whole 5-min TTL**. So one transient DB blip during a must-change user's *first* guarded request let them skip the forced-password prompt for up to 5 minutes.

Fix: a DB error is **non-cacheable** — the request still passes (matching the prior per-request fail-open) but the **next** request re-checks, catching the user as soon as the DB recovers. A definitive answer (`Ok(...)` / break-glass no-actor) still caches.

## P3 — duplicate id could shadow a config-only YAML spec
`unique_copy_id` checked only the DB, so duplicating could suggest an id already used by a **config-only YAML** spec. Since a DB spec shadows a YAML id of the same name, the new copy would silently hide the YAML one. It now checks the **effective catalog (DB ∪ YAML)** via an extracted, unit-tested `pick_copy_id`.

## Test
- `pick_copy_id_skips_ids_taken_in_the_catalog` (a taken `-copy` skips to `-copy-2`).
- Full gate green; `clippy -D warnings`. (The DB-error path is a small conditional; the existing must-change integration tests cover the happy path.)

(P3 disk-empty-on-Docker-failure is already #908 — UX/observability, not a bug.)

🤖 Generated with [Claude Code](https://claude.com/claude-code)