### PR TITLE
perf(dashboard): poll a snapshot endpoint instead of holding an SSE stream (#852)

### DIFF
--- a/crates/ruscker-admin/src/routes/admin/dashboard.rs
+++ b/crates/ruscker-admin/src/routes/admin/dashboard.rs
@@ -45,7 +45,7 @@ use crate::AppState;
 pub fn routes() -> Router<AppState> {
     Router::new()
         .route("/admin/dashboard", get(index))
-        .route("/admin/dashboard/events", get(events))
+        .route("/admin/dashboard/snapshot", get(snapshot))
         .route("/admin/dashboard/logs/{replica_id}", get(logs))
         .route("/admin/dashboard/logs/{replica_id}/stream", get(logs_stream))
         .route("/admin/dashboard/replicas/{replica_id}/stop", post(stop_replica))
@@ -563,23 +563,10 @@ fn format_bytes(bytes: u64) -> String {
     }
 }
 
-/// Server-Sent Events stream of dashboard snapshots. The
-/// client connects with `EventSource('/admin/dashboard/events')`
-/// and receives a JSON-encoded [`DashboardSnapshot`] every
-/// [`SSE_INTERVAL`], plus a comment keep-alive every
-/// [`SSE_KEEPALIVE_INTERVAL`] to defeat proxy idle timeouts.
-///
-/// Each emission is independent; reconnecting after a network
-/// blip just resumes the cadence — there's no event-id /
-/// last-event-id handshake to manage, and replaying a snapshot
-/// is idempotent on the client side anyway.
 /// Headers that keep an SSE response *streaming* through a reverse proxy
-/// instead of being buffered. `X-Accel-Buffering: no` tells nginx (and
-/// compatible proxies) not to buffer this response, and `Cache-Control:
-/// no-cache` keeps intermediaries from caching the stream. Without these,
-/// nginx buffers the event stream and the live dashboard appears frozen
-/// behind a reverse proxy (e.g. a `/box` subpath mount) — the WebSocket
-/// pump has `proxy_buffering off`, but a plain SSE response doesn't.
+/// instead of being buffered (still used by the live **logs** stream).
+/// `X-Accel-Buffering: no` tells nginx not to buffer; `Cache-Control:
+/// no-cache` keeps intermediaries from caching the stream.
 fn sse_no_buffer_headers() -> [(axum::http::HeaderName, &'static str); 2] {
     use axum::http::header::{HeaderName, CACHE_CONTROL};
     [
@@ -588,7 +575,20 @@ fn sse_no_buffer_headers() -> [(axum::http::HeaderName, &'static str); 2] {
     ]
 }
 
-async fn events(
+/// JSON dashboard snapshot for the live view's poller. The dashboard page
+/// fetches this every few seconds (`GET /admin/dashboard/snapshot`) rather
+/// than holding a long-lived SSE stream: a persistent `EventSource` keeps
+/// one HTTP/1.1 connection open, which over a shared-origin reverse proxy
+/// (nginx fronting Ruscker AND a side-by-side ShinyProxy) starves the
+/// browser's ~6-per-host connection pool and stalls **every** request to
+/// that origin — both apps freeze until the stream is dropped (#852
+/// follow-up). A short poll returns and frees the connection between
+/// ticks; the snapshot is memoized for [`SSE_INTERVAL`] server-side, so
+/// concurrent tabs share one build and the cost is tiny.
+///
+/// `no-store` so the browser always re-polls (freshness comes from the
+/// server-side cache, not the HTTP cache).
+async fn snapshot(
     session: AdminSession,
     State(state): State<AppState>,
     loc: Locale,
@@ -598,29 +598,12 @@ async fn events(
     if !session.role.can_access_section("dashboard") {
         return (StatusCode::FORBIDDEN, "forbidden").into_response();
     }
-    use async_stream::stream;
-    let stream = stream! {
-        // Emit the first snapshot immediately so the client
-        // patches on connect instead of waiting one full
-        // interval. Avoids a visible "stale" gap right after
-        // page load.
-        let first = build_snapshot(&state, loc).await;
-        let body = json_for_html_script(&first);
-        yield Ok::<_, Infallible>(Event::default().data(body));
-
-        let mut ticker = tokio::time::interval(SSE_INTERVAL);
-        ticker.set_missed_tick_behavior(tokio::time::MissedTickBehavior::Skip);
-        // Burn the immediate first tick — we already emitted.
-        ticker.tick().await;
-        loop {
-            ticker.tick().await;
-            let snap = build_snapshot(&state, loc).await;
-            let body = json_for_html_script(&snap);
-            yield Ok::<_, Infallible>(Event::default().data(body));
-        }
-    };
-    let sse = Sse::new(stream).keep_alive(KeepAlive::new().interval(SSE_KEEPALIVE_INTERVAL));
-    (sse_no_buffer_headers(), sse).into_response()
+    let snap = build_snapshot(&state, loc).await;
+    (
+        [(axum::http::header::CACHE_CONTROL, "no-store")],
+        axum::Json(snap),
+    )
+        .into_response()
 }
 
 /// Per-replica logs page. Fetches the last [`LOGS_TAIL`] lines

--- a/crates/ruscker-admin/templates/admin/dashboard.html
+++ b/crates/ruscker-admin/templates/admin/dashboard.html
@@ -181,9 +181,10 @@
 </div>
 </div>{# /.dash-scroll #}
 
-{# Tiny SSE patcher. No framework — just EventSource +
-   targeted DOM updates. Initial state already came in the
-   server-rendered HTML; this only handles refreshes. #}
+{# Tiny live patcher. No framework — a periodic fetch of the snapshot
+   JSON (#852: polling, not a held EventSource) + targeted DOM updates.
+   Initial state already came in the server-rendered HTML; this only
+   handles refreshes. #}
 <script id="dash-initial-snapshot" type="application/json">{{ snapshot_json|safe }}</script>
 <script>
 (function () {
@@ -531,33 +532,41 @@
   }
   ['containers', 'specs', 'sessions', 'tracker'].forEach(countUp);
 
-  if (!window.EventSource) return;
+  // Live updates via short polling (#852 follow-up). A persistent
+  // EventSource holds an HTTP/1.1 connection open, which over a
+  // shared-origin reverse proxy (nginx fronting Ruscker AND a side-by-side
+  // ShinyProxy) starves the browser's ~6-per-host connection pool and
+  // stalls every request to that origin — both apps freeze. A periodic
+  // fetch returns and frees the connection between ticks; the snapshot is
+  // server-cached so the cost is tiny. Paused while the tab is hidden.
   var live = document.getElementById('dash-live');
-  var es = null;
-  function connect() {
-    if (es) return;
-    es = new EventSource((window.RUSCKER_BASE || '') + '/admin/dashboard/events');
-    es.onopen = function () { if (live) live.classList.remove('is-down'); };
-    es.onmessage = function (e) {
-      if (live) live.classList.remove('is-down');
-      try { apply(JSON.parse(e.data)); } catch (_) { /* ignore */ }
-    };
-    // EventSource auto-reconnects on network errors; we just dim the Live
-    // badge while it's down.
-    es.onerror = function () { if (live) live.classList.add('is-down'); };
+  var POLL_MS = 5000;
+  var timer = null, inflight = false;
+  function poll() {
+    if (inflight) return;            // never overlap a slow request
+    inflight = true;
+    fetch((window.RUSCKER_BASE || '') + '/admin/dashboard/snapshot',
+          { headers: { 'X-Requested-With': 'fetch' } })
+      .then(function (r) { return r.ok ? r.json() : Promise.reject(); })
+      .then(function (snap) { if (live) live.classList.remove('is-down'); apply(snap); })
+      .catch(function () { if (live) live.classList.add('is-down'); })
+      .finally(function () { inflight = false; });
   }
-  function disconnect() {
-    if (es) { es.close(); es = null; }
+  function start() {
+    if (timer) return;
+    poll();                          // immediate refresh, then on a cadence
+    timer = setInterval(poll, POLL_MS);
+  }
+  function stop() {
+    if (timer) { clearInterval(timer); timer = null; }
     if (live) live.classList.add('is-down');
   }
-  // Pause the live stream while the tab is hidden (#852): a backgrounded
-  // dashboard tab otherwise holds an HTTP/1.1 connection open, starving
-  // the browser's ~6-per-host pool and stalling navigation in other tabs.
-  // Reconnect (with a fresh snapshot) when the tab is visible again.
+  // Pause while the tab is hidden so a backgrounded dashboard isn't
+  // polling needlessly; resume (with an immediate refresh) when visible.
   document.addEventListener('visibilitychange', function () {
-    if (document.hidden) disconnect(); else connect();
+    if (document.hidden) stop(); else start();
   });
-  if (!document.hidden) connect();
+  if (!document.hidden) start();
 })();
 
 // Dashboard filter band (#623): live search + state chips over the


### PR DESCRIPTION
## Why
The live dashboard held a persistent `EventSource`. Over a **shared-origin reverse proxy on HTTP/1.1** — nginx fronting Ruscker **and** a side-by-side ShinyProxy on one hostname (the hugo box) — that long-lived connection starves the browser's ~6-per-host pool, so **every** request to the origin stalls and **both apps freeze** until the stream is dropped. The operator hit exactly this: clicking the Painel froze Ruscker *and* ShinyProxy; only `restart ruscker` recovered it.

HTTP/2 at the TLS edge is the durable fix, but that edge is centrally managed (out of our control here).

## What
Replace the held stream with **short polling**:
- New `GET /admin/dashboard/snapshot` → the (already `SSE_INTERVAL`-cached) `DashboardSnapshot` as JSON, `Cache-Control: no-store`, same Viewer gate.
- The page fetches it every 5s; each request **returns and frees the connection**, so nothing is held → no pool starvation.
- Keeps the visibility pause (don't poll a hidden tab) + an in-flight guard so a slow request never overlaps.
- The live **logs** stream and the **image-pull** progress keep their short-lived / opt-in SSE — only the always-on dashboard metrics feed changed.

## Test
Full gate green (dashboard tests, `clippy -D warnings`, `i18n-check`). Visual smoke on cast after release.

Refs #852

🤖 Generated with [Claude Code](https://claude.com/claude-code)