### PR TITLE
fix(config): default min-replicas to 0 (cold-start), not 1

### DIFF
--- a/crates/ruscker-admin/templates/admin/spec_form.html
+++ b/crates/ruscker-admin/templates/admin/spec_form.html
@@ -584,7 +584,7 @@
         </div>
         <div class="stepper">
           <button type="button" tabindex="-1" @click="form.min_replicas = String(Math.max(0, (parseInt(form.min_replicas, 10) || 0) - 1))"><i class="ti ti-minus" aria-hidden="true"></i></button>
-          <input id="f-init-rep" type="number" name="min_replicas" min="0" placeholder="1"
+          <input id="f-init-rep" type="number" name="min_replicas" min="0" placeholder="0"
                  x-model="form.min_replicas" class="stepper__input">
           <button type="button" tabindex="-1" @click="form.min_replicas = String((parseInt(form.min_replicas, 10) || 0) + 1)"><i class="ti ti-plus" aria-hidden="true"></i></button>
         </div>
@@ -1084,7 +1084,7 @@
         </div>
         <div class="spec-summary__row">
           <i class="ti ti-stack-2" aria-hidden="true"></i>
-          <span x-text="((form.max_replicas || form.min_replicas) ? ((form.min_replicas || '1') + '–' + (form.max_replicas || form.min_replicas)) : '1') + ' {{ self.t("spec-form-summary-replicas") }}'"></span>
+          <span x-text="((form.max_replicas || form.min_replicas) ? ((form.min_replicas || '0') + '–' + (form.max_replicas || form.min_replicas)) : '0') + ' {{ self.t("spec-form-summary-replicas") }}'"></span>
         </div>
         <div class="spec-summary__row">
           <i class="ti ti-clock" aria-hidden="true"></i>

--- a/crates/ruscker-config/src/schema.rs
+++ b/crates/ruscker-config/src/schema.rs
@@ -1232,13 +1232,17 @@ impl Spec {
         self.featured.unwrap_or(false)
     }
 
-    /// Effective minimum replicas (default 1 for containerized, 0 for
-    /// external).
+    /// Effective minimum replicas. Defaults to **0 (cold-start, spawn on
+    /// demand)** when unset — matching ShinyProxy / Shiny Server Free,
+    /// which never pre-warm: the container starts when the first visitor
+    /// arrives (the splash) and the scaler reaps it once idle. An app you
+    /// want kept hot sets `min-replicas: 1` (or more) explicitly. This is
+    /// the sane default for a multi-app portal — defaulting to 1 used to
+    /// pre-spawn *every* app at boot, which is surprising and heavy when
+    /// hosting many apps (e.g. a 24-spec ShinyProxy import). `External`
+    /// specs have no container, so 0 is also correct for them.
     pub fn effective_min_replicas(&self) -> u32 {
-        self.min_replicas.unwrap_or_else(|| match self.kind() {
-            SpecKind::External => 0,
-            _ => 1,
-        })
+        self.min_replicas.unwrap_or(0)
     }
 
     /// Effective maximum replicas. When unset, a containerized spec
@@ -1918,9 +1922,16 @@ proxy:
         );
 
         // Default ceiling when nothing is set, and an explicit max is still
-        // honoured.
+        // honoured. With `min-replicas` unset the default is now 0 (cold
+        // start) — we never pre-spawn an app the operator didn't ask to
+        // keep hot, matching ShinyProxy. It still scales on demand.
         let dflt = "proxy:\n  specs:\n    - id: d\n      container-image: nginx\n";
         let s = &serde_yaml_ng::from_str::<Config>(dflt).unwrap().proxy.specs[0];
+        assert_eq!(
+            s.effective_min_replicas(),
+            0,
+            "unset min-replicas defaults to cold-start, not pre-warm"
+        );
         assert_eq!(s.effective_max_replicas(), DEFAULT_MAX_REPLICAS);
         let cap = "proxy:\n  specs:\n    - id: c\n      container-image: nginx\n      min-replicas: 0\n      max-replicas: 4\n";
         let s = &serde_yaml_ng::from_str::<Config>(cap).unwrap().proxy.specs[0];


### PR DESCRIPTION
## Problem

`Spec::effective_min_replicas()` returned **1** for every non-External spec with `min-replicas` unset:

```rust
self.min_replicas.unwrap_or_else(|| match self.kind() {
    SpecKind::External => 0,
    _ => 1,   // ← pre-warms every app
})
```

So the scaler pre-spawned **one always-on container per app at boot**. The ShinyProxy YAML has no `min-replicas` (it spawns per session, cold), so an imported 24-spec config lit ~20 idle containers on hugo — heavy, and a duplicate of the ShinyProxy running side-by-side. Reported by the operator on the SEPE migration.

The form help string already says **"Default 0" / "Padrão 0"** in all four locales — the runtime was the outlier, not the docs.

## Fix

- `effective_min_replicas()` → `self.min_replicas.unwrap_or(0)`. Unset = cold-start: the container starts on the first visitor (the splash) and the scaler reaps it once idle. `effective_max_replicas()` still floors at `DEFAULT_MAX_REPLICAS`, so a cold-start app scales on demand (the #743/#634 floor is untouched).
- Spec form: the now-misleading `placeholder="1"` and the summary fallback `'1'` → `0`.

## Impact

- **hugo**: the ~20 imported Shiny apps stop pre-warming as soon as the new binary is deployed — **no re-import needed** (specs keep `min = None`, only the effective default changed).
- **box/cast**: apps without an explicit `min-replicas` cold-start on next restart (desired; reversible per-spec). The showcase already sets `0`; the cast IDEs already set `1` explicitly → both unaffected.
- Apps you want kept hot: set `min-replicas: 1`.

## Tests

- New assertion in `cold_start_spec_still_scales_to_one`: unset `min-replicas` → `effective_min_replicas() == 0`.
- Full suite green (26 test binaries), clippy clean, i18n parity OK. All scaler tests set `min-replicas` explicitly, so none assumed the old default.

🤖 Generated with [Claude Code](https://claude.com/claude-code)