### PR TITLE
docs: audit pass — cold-start default, footprint policy, freshness

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -1,0 +1,201 @@
+                                 Apache License
+                           Version 2.0, January 2004
+                        http://www.apache.org/licenses/
+
+   TERMS AND CONDITIONS FOR USE, REPRODUCTION, AND DISTRIBUTION
+
+   1. Definitions.
+
+      "License" shall mean the terms and conditions for use, reproduction,
+      and distribution as defined by Sections 1 through 9 of this document.
+
+      "Licensor" shall mean the copyright owner or entity authorized by
+      the copyright owner that is granting the License.
+
+      "Legal Entity" shall mean the union of the acting entity and all
+      other entities that control, are controlled by, or are under common
+      control with that entity. For the purposes of this definition,
+      "control" means (i) the power, direct or indirect, to cause the
+      direction or management of such entity, whether by contract or
+      otherwise, or (ii) ownership of fifty percent (50%) or more of the
+      outstanding shares, or (iii) beneficial ownership of such entity.
+
+      "You" (or "Your") shall mean an individual or Legal Entity
+      exercising permissions granted by this License.
+
+      "Source" form shall mean the preferred form for making modifications,
+      including but not limited to software source code, documentation
+      source, and configuration files.
+
+      "Object" form shall mean any form resulting from mechanical
+      transformation or translation of a Source form, including but
+      not limited to compiled object code, generated documentation,
+      and conversions to other media types.
+
+      "Work" shall mean the work of authorship, whether in Source or
+      Object form, made available under the License, as indicated by a
+      copyright notice that is included in or attached to the work
+      (an example is provided in the Appendix below).
+
+      "Derivative Works" shall mean any work, whether in Source or Object
+      form, that is based on (or derived from) the Work and for which the
+      editorial revisions, annotations, elaborations, or other modifications
+      represent, as a whole, an original work of authorship. For the purposes
+      of this License, Derivative Works shall not include works that remain
+      separable from, or merely link (or bind by name) to the interfaces of,
+      the Work and Derivative Works thereof.
+
+      "Contribution" shall mean any work of authorship, including
+      the original version of the Work and any modifications or additions
+      to that Work or Derivative Works thereof, that is intentionally
+      submitted to Licensor for inclusion in the Work by the copyright owner
+      or by an individual or Legal Entity authorized to submit on behalf of
+      the copyright owner. For the purposes of this definition, "submitted"
+      means any form of electronic, verbal, or written communication sent
+      to the Licensor or its representatives, including but not limited to
+      communication on electronic mailing lists, source code control systems,
+      and issue tracking systems that are managed by, or on behalf of, the
+      Licensor for the purpose of discussing and improving the Work, but
+      excluding communication that is conspicuously marked or otherwise
+      designated in writing by the copyright owner as "Not a Contribution."
+
+      "Contributor" shall mean Licensor and any individual or Legal Entity
+      on behalf of whom a Contribution has been received by Licensor and
+      subsequently incorporated within the Work.
+
+   2. Grant of Copyright License. Subject to the terms and conditions of
+      this License, each Contributor hereby grants to You a perpetual,
+      worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+      copyright license to reproduce, prepare Derivative Works of,
+      publicly display, publicly perform, sublicense, and distribute the
+      Work and such Derivative Works in Source or Object form.
+
+   3. Grant of Patent License. Subject to the terms and conditions of
+      this License, each Contributor hereby grants to You a perpetual,
+      worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+      (except as stated in this section) patent license to make, have made,
+      use, offer to sell, sell, import, and otherwise transfer the Work,
+      where such license applies only to those patent claims licensable
+      by such Contributor that are necessarily infringed by their
+      Contribution(s) alone or by combination of their Contribution(s)
+      with the Work to which such Contribution(s) was submitted. If You
+      institute patent litigation against any entity (including a
+      cross-claim or counterclaim in a lawsuit) alleging that the Work
+      or a Contribution incorporated within the Work constitutes direct
+      or contributory patent infringement, then any patent licenses
+      granted to You under this License for that Work shall terminate
+      as of the date such litigation is filed.
+
+   4. Redistribution. You may reproduce and distribute copies of the
+      Work or Derivative Works thereof in any medium, with or without
+      modifications, and in Source or Object form, provided that You
+      meet the following conditions:
+
+      (a) You must give any other recipients of the Work or Derivative
+          Works a copy of this License; and
+
+      (b) You must cause any modified files to carry prominent notices
+          stating that You changed the files; and
+
+      (c) You must retain, in the Source form of any Derivative Works
+          that You distribute, all copyright, patent, trademark, and
+          attribution notices from the Source form of the Work, excluding
+          those notices that do not pertain to any part of the Derivative
+          Works; and
+
+      (d) If the Work includes a "NOTICE" text file as part of its
+          distribution, then any Derivative Works that You distribute must
+          include a readable copy of the attribution notices contained
+          within such NOTICE file, excluding those notices that do not
+          pertain to any part of the Derivative Works, in at least one
+          of the following places: within a NOTICE text file distributed
+          as part of the Derivative Works; within the Source form or
+          documentation, if provided along with the Derivative Works; or,
+          within a display generated by the Derivative Works, if and
+          wherever such third-party notices normally appear. The contents
+          of the NOTICE file are for informational purposes only and do
+          not modify the License. You may add Your own attribution notices
+          within Derivative Works that You distribute, alongside or as an
+          addendum to the NOTICE text from the Work, provided that such
+          additional attribution notices cannot be construed as modifying
+          the License.
+
+      You may add Your own copyright statement to Your modifications and
+      may provide additional or different license terms and conditions
+      for use, reproduction, or distribution of Your modifications, or
+      for any such Derivative Works as a whole, provided Your use,
+      reproduction, and distribution of the Work otherwise complies with
+      the conditions stated in this License.
+
+   5. Submission of Contributions. Unless You explicitly state otherwise,
+      any Contribution intentionally submitted for inclusion in the Work
+      by You to the Licensor shall be under the terms and conditions of
+      this License, without any additional terms or conditions.
+      Notwithstanding the above, nothing herein shall supersede or modify
+      the terms of any separate license agreement you may have executed
+      with Licensor regarding such Contributions.
+
+   6. Trademarks. This License does not grant permission to use the trade
+      names, trademarks, service marks, or product names of the Licensor,
+      except as required for reasonable and customary use in describing the
+      origin of the Work and reproducing the content of the NOTICE file.
+
+   7. Disclaimer of Warranty. Unless required by applicable law or
+      agreed to in writing, Licensor provides the Work (and each
+      Contributor provides its Contributions) on an "AS IS" BASIS,
+      WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+      implied, including, without limitation, any warranties or conditions
+      of TITLE, NON-INFRINGEMENT, MERCHANTABILITY, or FITNESS FOR A
+      PARTICULAR PURPOSE. You are solely responsible for determining the
+      appropriateness of using or redistributing the Work and assume any
+      risks associated with Your exercise of permissions under this License.
+
+   8. Limitation of Liability. In no event and under no legal theory,
+      whether in tort (including negligence), contract, or otherwise,
+      unless required by applicable law (such as deliberate and grossly
+      negligent acts) or agreed to in writing, shall any Contributor be
+      liable to You for damages, including any direct, indirect, special,
+      incidental, or consequential damages of any character arising as a
+      result of this License or out of the use or inability to use the
+      Work (including but not limited to damages for loss of goodwill,
+      work stoppage, computer failure or malfunction, or any and all
+      other commercial damages or losses), even if such Contributor
+      has been advised of the possibility of such damages.
+
+   9. Accepting Warranty or Additional Liability. While redistributing
+      the Work or Derivative Works thereof, You may choose to offer,
+      and charge a fee for, acceptance of support, warranty, indemnity,
+      or other liability obligations and/or rights consistent with this
+      License. However, in accepting such obligations, You may act only
+      on Your own behalf and on Your sole responsibility, not on behalf
+      of any other Contributor, and only if You agree to indemnify,
+      defend, and hold each Contributor harmless for any liability
+      incurred by, or claims asserted against, such Contributor by reason
+      of your accepting any such warranty or additional liability.
+
+   END OF TERMS AND CONDITIONS
+
+   APPENDIX: How to apply the Apache License to your work.
+
+      To apply the Apache License to your work, attach the following
+      boilerplate notice, with the fields enclosed by brackets "[]"
+      replaced with your own identifying information. (Don't include
+      the brackets!)  The text should be enclosed in the appropriate
+      comment syntax for the file format. We also recommend that a
+      file or class name and description of purpose be included on the
+      same "printed page" as the copyright notice for easier
+      identification within third-party archives.
+
+   Copyright 2026 Ruscker contributors
+
+   Licensed under the Apache License, Version 2.0 (the "License");
+   you may not use this file except in compliance with the License.
+   You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+   Unless required by applicable law or agreed to in writing, software
+   distributed under the License is distributed on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+   See the License for the specific language governing permissions and
+   limitations under the License.

--- a/README.md
+++ b/README.md
@@ -5,12 +5,18 @@
        alt="Ruscker" height="56">
 </picture>
 
-**Ruscker** is a high-performance **portal and orchestrator** for
+[![Latest release](https://img.shields.io/github/v/release/StrategicProjects/ruscker?sort=semver)](https://github.com/StrategicProjects/ruscker/releases)
+[![License](https://img.shields.io/badge/license-Apache--2.0-blue.svg)](LICENSE)
+[![Docs](https://img.shields.io/badge/docs-ruscker.com-0F6E56)](https://strategicprojects.github.io/ruscker/)
+
+**Ruscker** is a lightweight, single-binary alternative to **ShinyProxy**
+and **Shiny Server Free** — a **portal and orchestrator** for
 containerized web workloads. It serves and load-balances
 container-per-session interactive apps (R/Shiny, Streamlit, Dash, Voilà,
 Jupyter, RStudio) and container-per-API stateless HTTP services
 (Plumber2, FastAPI) behind a single proxy, with a custom landing page and
-an admin panel.
+an admin panel. It reads an existing ShinyProxy `application.yml`
+unchanged, so migration is friction-free.
 
 It ships as a **single, ultra-lightweight static binary** with **instant
 startup** — the idle footprint sits in the low tens of megabytes.
@@ -71,8 +77,8 @@ tool" cases) is in
 ## Status
 
 **Production-ready and running in production.** The whole codebase
-went through a systematic bug / security / UX audit in June 2026
-(shipped as v0.2.5 with every finding fixed), followed by an
+went through a systematic bug / security / UX audit in June 2026 with
+every finding fixed, followed by an
 operator-driven design sprint that brought the entire admin — the
 Appearance editor in particular — to the product's design handoff,
 with per-theme (light/dark) portal styling throughout, plus a round of
@@ -80,8 +86,7 @@ private-image and deploy-robustness fixes from real production use.
 Releases are
 multi-arch (amd64 + arm64) and [cosign-signed]; the
 [releases page](https://github.com/StrategicProjects/ruscker/releases)
-has the current version. Built for efficiency, Ruscker's idle footprint
-sits in the low tens of megabytes:
+has the current version.
 
 [cosign-signed]: https://strategicprojects.github.io/ruscker/installation.html#verifying-release-artifacts
 
@@ -93,7 +98,7 @@ What's in the box:
 
 - **Reverse proxy + load balancer** — sticky sessions, WebSocket
   forwarding, per-spec replica pools, an auto-scaler, and absolute-URL
-  rewriting so unmodified Shiny/Streamlit apps work behind a subpath.
+  rewriting so unmodified Shiny/Streamlit apps work behind a sub-path.
 - **Container backend** (Docker) that spawns app containers on demand,
   applies per-container CPU/memory limits, and reaps idle ones.
 - **Admin panel** — full apps CRUD (every spec field editable from the
@@ -103,7 +108,7 @@ What's in the box:
   live preview (per-theme light/dark styling, logos, Markdown-enabled
   per-locale intros, SEO,
   social meta, analytics, custom HTML blocks), an audit log, **user
-  accounts with Viewer / Editor / Admin roles**, and a live SSE
+  accounts with Viewer / Editor / Admin roles**, and a live monitoring
   dashboard (CPU/memory sparklines, live-follow logs, stop/restart).
 - **Operations** — `/healthz` + `/readyz` probes, graceful shutdown,
   structured (JSON) logging, per-API rate limiting + CORS, request
@@ -113,7 +118,7 @@ What's in the box:
   hardened `systemd` unit, static musl tarballs, a Homebrew tap, and
   cosign-signed release artifacts.
 
-400+ unit + integration tests run green on `cargo test` (no Docker
+600+ unit + integration tests run green on `cargo test` (no Docker
 required); extra feature-gated suites exercise a real Docker daemon
 (`docker-it`) and a full proxy + WebSocket end-to-end run (`e2e`).
 
@@ -123,8 +128,8 @@ required); extra feature-gated suites exercise a real Docker daemon
 </p>
 
 <p align="center">
-  <img src="book/src/images/admin-dashboard.png" alt="The live monitoring dashboard: aggregate cards plus a per-replica table with CPU sparklines, memory, sessions and stop/restart/logs actions, streamed over SSE." width="860">
-  <br><em>Live monitoring dashboard — per-replica CPU/memory over Server-Sent Events.</em>
+  <img src="book/src/images/admin-dashboard.png" alt="The live monitoring dashboard: aggregate cards plus a per-replica table with CPU sparklines, memory, sessions and stop/restart/logs actions, refreshed on a short poll." width="860">
+  <br><em>Live monitoring dashboard — per-replica CPU/memory, refreshed on a short poll.</em>
 </p>
 
 ## Install
@@ -218,6 +223,7 @@ ruscker serve   --config <path> [--docker] [--db <file>]   # run the portal
 ruscker import  <path> --db <file>   # populate SQLite from YAML
 ruscker export  --db <file>          # round-trip back to YAML
 ruscker show    <path>               # render YAML with env vars interpolated
+ruscker inspect <path>               # dump the fully-parsed config as JSON
 ```
 
 ## YAML compatibility
@@ -268,7 +274,7 @@ scope and how to extend it.
 
 ```bash
 cargo build
-cargo test                                   # 300+ tests, no Docker needed
+cargo test                                   # 600+ tests, no Docker needed
 cargo test -p ruscker-docker --features docker-it   # + real Docker daemon
 cargo test -p ruscker-cli --features e2e            # + full proxy/WS e2e
 cargo clippy --all-targets -- -D warnings
@@ -280,6 +286,13 @@ cargo clippy --all-targets -- -D warnings
 > workspace `cargo fmt` produces a large unrelated diff; `cargo fmt
 > --check` is intentionally **not** part of the gate.
 
+## Contributing
+
+Issues and pull requests are welcome. See **Development** above for the
+build + test gate (`cargo test` · `cargo clippy --all-targets -- -D
+warnings` · `./scripts/i18n-check.sh`), and keep changes as small,
+reviewable slices.
+
 ## License
 
-Apache-2.0
+Licensed under [Apache-2.0](LICENSE).

--- a/book/src/SUMMARY.md
+++ b/book/src/SUMMARY.md
@@ -18,6 +18,6 @@
 # Reference
 
 - [Architecture](./architecture.md)
+- [Security](./security.md)
 - [Roadmap](./roadmap.md)
 - [Release notes](./news.md)
-- [Security](./security.md)

--- a/book/src/deploying.md
+++ b/book/src/deploying.md
@@ -55,10 +55,13 @@ sudo systemctl daemon-reload && sudo systemctl restart ruscker
 
 ### On-demand vs. pre-warmed
 
-Ruscker's auto-scaler keeps `min-replicas` (default **1**) warm per
-spec. With many specs that's a lot of idle containers. To match
-ShinyProxy's on-demand behaviour (spawn on first request, reap when
-idle), set `min-replicas: 0` on the specs.
+By default an app **cold-starts**: `min-replicas` defaults to **0**, so
+no container runs until the first visitor arrives (they see a brief
+splash while it spawns), and the auto-scaler reaps it once idle — the
+same on-demand behaviour as ShinyProxy and Shiny Server Free, and what
+keeps a many-app portal light. To keep an app **warm** (no cold-start
+latency on the first hit), set `min-replicas: 1` (or more) on that spec;
+the scaler then keeps that many replicas running at all times.
 
 ### Multiple Docker hosts (Phase 6)
 

--- a/book/src/faq.md
+++ b/book/src/faq.md
@@ -39,8 +39,10 @@ requirement — if you're all-in on k8s, see
 
 Each spec has a replica pool with `min`/`max` bounds. An auto-scaler keeps
 `min` replicas warm, spawns more on sustained saturation, and reaps idle
-ones after a grace period. Routing is least-connections (interactive) or
-round-robin (APIs). It's all in [Configuration](./configuration.md).
+ones after a grace period. `min` defaults to **0** — apps cold-start on
+the first request and are reaped when idle (set `min-replicas: 1` to keep
+one warm). Routing is least-connections (interactive) or round-robin
+(APIs). It's all in [Configuration](./configuration.md).
 
 ### How does authentication work?
 
@@ -83,7 +85,7 @@ sticky upstream for the login paths remains the fallback — see
 
 Yes. Phases 0–7 are complete, the proxy is production-ready and
 horizontally scalable, and the codebase was systematically audited for
-bugs, security and UX in June 2026 (shipped as v0.2.5).
+bugs, security and UX in June 2026, with every finding fixed.
 Releases are multi-arch and cosign-signed; see the
 [release notes](./news.md) and the [Roadmap](./roadmap.md).
 Phase 8 (external auth: OIDC / SAML / LDAP) is the main remaining

--- a/book/src/images/architecture.svg
+++ b/book/src/images/architecture.svg
@@ -26,7 +26,7 @@
     <polygon points="14,40 40,28 66,40 40,52" fill="#FFFFFF" opacity="0.72"/>
     <polygon points="14,28 40,16 66,28 40,40" fill="#FFFFFF"/>
   </g>
-  <text x="92" y="131" font-size="15" font-weight="600" fill="#FFFFFF">Ruscker — single static binary · ~16 MB · no JVM</text>
+  <text x="92" y="131" font-size="15" font-weight="600" fill="#FFFFFF">Ruscker — single static binary · ~14 MB · no JVM</text>
 
   <!-- component boxes -->
   <!-- (1) Landing -->

--- a/book/src/images/crate-map.svg
+++ b/book/src/images/crate-map.svg
@@ -38,7 +38,7 @@
   <!-- ruscker-core -->
   <rect x="210" y="296" width="300" height="52" rx="10" fill="#FFFFFF" stroke="#0F6E56" stroke-width="1.8"/>
   <text x="360" y="319" text-anchor="middle" font-size="13" font-weight="700" fill="#085041">ruscker-core</text>
-  <text x="360" y="337" text-anchor="middle" font-size="10.5" fill="#5B6B66">traits · types · routing · ReplicaRegistry</text>
+  <text x="360" y="337" text-anchor="middle" font-size="10.5" fill="#5B6B66">traits · types · ReplicaRegistry</text>
 
   <!-- ruscker-config -->
   <rect x="210" y="364" width="300" height="50" rx="10" fill="#FFFFFF" stroke="#0F6E56" stroke-width="1.8"/>

--- a/book/src/introduction.md
+++ b/book/src/introduction.md
@@ -51,7 +51,7 @@ engineered to keep the runtime light while staying compatible:
 Ruscker runs in production today — the
 [releases page](https://github.com/StrategicProjects/ruscker/releases)
 has the current version, and the whole codebase went through a
-systematic bug / security / UX audit in June 2026 (v0.2.5), with every
+systematic bug / security / UX audit in June 2026, with every
 finding fixed. Built for extreme efficiency, its idle footprint sits
 in the low tens of megabytes:
 

--- a/book/src/migrating.md
+++ b/book/src/migrating.md
@@ -9,7 +9,7 @@ Before switching anything, ask Ruscker what your config uses:
 
 ```sh
 ruscker validate application.yml                 # general report
-ruscker validate --strict-compat application.yml # migration pre-flight
+ruscker validate application.yml --strict-compat # migration pre-flight
 ```
 
 `--strict-compat` lists every ShinyProxy feature your config uses that
@@ -139,7 +139,8 @@ Beyond parity, you also get: a real admin panel (no more hand-editing
 YAML), a live monitoring dashboard, per-spec `container-env` /
 `container-cmd` injection, per-API rate-limiting and CORS, per-user
 and per-group app visibility, health probes, graceful shutdown, and a
-tiny footprint — idle memory drops from ~540 MB to ~14 MB. See
+tiny footprint — **~14 MB** idle, against the ~540 MB of the JVM-based
+proxy it replaced on the same machine. See
 [The admin panel](./admin.md).
 
 ## Not supported (yet)

--- a/book/src/roadmap.md
+++ b/book/src/roadmap.md
@@ -54,10 +54,10 @@ and distribution: a **multi-arch Docker image**, a **Debian package**
 with a hardened systemd unit, static **musl tarballs**, a `curl | sh`
 installer, a **Homebrew tap**, and **cosign-signed** release artifacts.
 
-> **Production milestone.** Ruscker replaced a JVM-based stack on the
-> same machine serving the same apps, cutting idle memory from
-> **~540 MB to ~14 MB** (~38×). A real 31-spec config migrated with no
-> unsupported features.
+> **Production milestone.** Ruscker's idle footprint is **~14 MB** — the
+> JVM-based proxy it replaced, on the same machine serving the same apps,
+> sat at ~540 MB. A real 31-spec config migrated with no unsupported
+> features.
 
 ### Phase 6 — Multi-host scheduling → **v0.1.1 / v0.1.2**
 A `MultiHostDockerBackend` that talks to several Docker hosts, with
@@ -201,9 +201,9 @@ Tracked in the GitHub issues; picked up as real usage asks for them:
   `milkway/ruscker-*-demo` images that serve at the root
   (issues #389–#397).
 - **Hardening follow-ups** — live end-to-end validation of the
-  WebSocket arc on Shiny/Streamlit (validated against Jupyter today),
-  and a post-drop cooldown for scale-down to finish off the
-  seats=1 long-session flap.
+  WebSocket arc on Shiny/Streamlit (validated against Jupyter today).
+  *(The post-drop scale-down cooldown that tamed the seats=1
+  long-session flap has since shipped.)*
 
 ### Phase 8 — External auth
 OIDC (Keycloak / Auth0 / Google), SAML, and LDAP, plus per-app access

--- a/book/src/troubleshooting.md
+++ b/book/src/troubleshooting.md
@@ -10,7 +10,7 @@ the editor/list screens return 503.
 The images aren't being served at `/assets/img/`. Either pass
 `--images-dir <dir>` pointing at the folder with the image files, or
 keep the config next to its `template-path`'s `assets/img/` so Ruscker
-auto-discovers it. Check: `curl -I http://localhost:8090/assets/img/<file>`.
+auto-discovers it. Check: `curl -I http://localhost:8080/assets/img/<file>`.
 With `--db`, you can also upload logos in **Media** and pick them in
 the spec form.
 
@@ -174,7 +174,9 @@ forward requests without authentication, and `--ServerApp.allow_origin=*`
 lets the kernel WebSocket connect. Do **not** set
 `--ServerApp.base_url=#{publicPath}`: under Ruscker's strip model the
 container never sees the mount prefix, so a non-root `base_url` makes
-Jupyter 404 every path.
+Jupyter 404 every path. See
+[Sub-path handling (the strip model)](./alternatives.md#sub-path-handling-the-strip-model)
+for why.
 
 **Do not set `SHINYPROXY_PUBLIC_PATH`** in `container-env` either. That
 variable is a ShinyProxy convention; Ruscker does not use it, and if a
@@ -189,6 +191,6 @@ image's server is listening on the port you set in `container-port`
 ```sh
 systemctl status ruscker
 journalctl -u ruscker -f
-curl -s localhost:8090/readyz
+curl -s localhost:8080/readyz
 docker ps --filter label=ruscker.replica_id
 ```

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -221,7 +221,12 @@ for git versioning, but the running config lives in SQLite.
 - Container spawns are direct `ContainerBackend` calls, serialized
   per spec by a coalescing mutex (`state.spawn_locks`) so concurrent
   visitors to a cold app produce one container, not N.
-- The auto-scaler runs as a periodic task (every 10s).
+- The auto-scaler runs as a periodic task (every 10s). Apps default to
+  `min-replicas: 0` (cold-start — spawn on the first visit, no pre-warm);
+  it scales up on sustained saturation, retires idle replicas after a
+  grace window, then waits out a post-drop cooldown (~60s) before it will
+  respawn on saturation, so a single-seat long session can't flap a
+  replica up and down. Set `min-replicas: 1`+ to keep an app warm.
 - The session-purger runs as a periodic task (every 5s).
 - `DashMap` for in-memory state (lock-free reads, sharded writes).
 

--- a/docs/IMAGES.md
+++ b/docs/IMAGES.md
@@ -48,20 +48,21 @@ filesystem path). The bit after is whatever filename you pick.
 
 - `object-fit: cover` by default — the image fills the slot, centered.
   Good for screenshots, photos, and full-bleed art.
-- For **SVG logos** with intentional whitespace around them, use
-  `object-fit: contain` (planned: detect via file extension).
-- `alt` text comes from `template-properties.alt` (planned for
-  Phase 2). For Phase 1, cards render `alt=""` (treated as
-  decorative — the title alongside provides the semantic context).
+- **SVG logos** are detected by file extension and rendered with
+  `object-fit: contain` automatically, so the intentional whitespace
+  around a mark is preserved instead of being cropped.
+- Card covers render with `alt=""` (treated as decorative — the visible
+  title alongside carries the semantic meaning), so screen readers don't
+  announce a redundant filename.
 - SVGs are loaded via `<img src=...>`, **not** inlined — this
   blocks SVG-script-tag XSS from operator uploads.
 
 ## Caching
 
-| Phase | Strategy |
+| Asset class | Strategy |
 |---|---|
-| **Phase 1 (now)** | `cache-control: public, max-age=0, must-revalidate`. Browsers cache but always revalidate on reload — minimal surprise for the operator iterating on YAML. |
-| **Phase 5 (planned)** | Hash-bearing URLs (`/assets/img/sales-dashboard-<sha>.png`) served back with `immutable` so production deployments get long-lived caching without losing the cache-bust on updates. |
+| **Versioned bundle assets** (`?v=<version>` on CSS/JS/built-in art) | `cache-control: public, max-age=31536000, immutable` — the `?v=` query busts the cache on every release, so the bytes behind a given URL never change. |
+| **Uploaded / dynamic images** (Media library, card covers) | Short `max-age` plus an `ETag`; a reload sends `If-None-Match` and gets a cheap `304` when unchanged. Editing an image changes its content hash, so the next request re-fetches. |
 
 > **Important:** never use `cache-control: immutable` on a URL whose
 > bytes can change. Chrome interprets `immutable` as "don't check on
@@ -92,13 +93,16 @@ re-reads from disk on every request.
 2. Ruscker re-encodes to WebP, returns a stable URL.
 3. Pick the image from a gallery dropdown when editing the spec.
 
-## Bundled examples
+## Example config and images
 
-The repository ships ~57 real card images at
-`examples/assets/img/` (extracted from a real-world ShinyProxy
-install, sanitized). They cover every spec in
-`examples/application.yml` — running `ruscker serve --config
-examples/application.yml` shows the portal with all images visible.
+`examples/application.yml` references a couple of `/assets/img/...`
+cover paths, but the image files themselves are **not** bundled in the
+repository (the originals came from a real install and were sanitized
+out). Running `ruscker serve --config examples/application.yml` renders
+the portal fine — those cards simply fall back to their tint/monogram
+cover. To see real covers, drop your own files in an `assets/img/`
+folder beside the config (or point `--images-dir` at one), or upload
+them in the admin **Media** library.
 
 ## What we explicitly don't do
 

--- a/docs/NEXT_STEPS.md
+++ b/docs/NEXT_STEPS.md
@@ -64,9 +64,10 @@ This makes nobody re-discover what we just debugged.
 Known refinements that matter under sustained real load (see CLAUDE.md
 "Known gaps"):
 
-- **Scale-down hysteresis / post-drop cooldown.** Today a `seats=1` spec
-  with long sessions can flap; hysteresis dampens but doesn't eliminate
-  it. Add a cooldown after a scale-down before the next one.
+- **Scale-down hysteresis / post-drop cooldown.** ✅ *Shipped.* A
+  `seats=1` spec with long sessions could flap; a post-drop cooldown
+  (`DEFAULT_SCALE_DOWN_COOLDOWN_TICKS`) now gates the saturation respawn
+  after a scale-down, on top of the existing hysteresis.
 - **Per-spec heartbeat-timeout override.** A single global timeout today;
   some apps need a longer idle window than others.
 - **Observability template.** The Prometheus endpoint already exists
@@ -104,8 +105,8 @@ Recommended regardless of the chosen direction.
    scenario).
 2. **A — deploy recipe** (nginx + systemd + compose + book chapter),
    capturing the footguns we just hit.
-3. **B — reliability** items as demand dictates (start with the
-   scale-down cooldown, the one with a user-visible symptom).
+3. **B — reliability** items as demand dictates (the scale-down
+   cooldown, which had the user-visible symptom, has since shipped).
 
 Open question to settle before slicing: is the deploy recipe targeting
 **root-mount**, **subpath-mount**, or **both** as first-class? (Both is

--- a/docs/ROADMAP.md
+++ b/docs/ROADMAP.md
@@ -6,8 +6,8 @@
 > For the narrative, up-to-date version with a timeline diagram, see
 > the [Roadmap chapter](https://strategicprojects.github.io/ruscker/roadmap.html)
 > on the docs site. The phase checklists below are the original
-> planning detail (they predate v0.1.0; treat the per-item boxes as
-> historical scope, not live status).
+> planning detail (they predate v0.1.0); every item in Phases 0–7 has
+> since shipped, so their boxes are ticked. Phase 8 shows what remains.
 
 Phased plan from "config parsing only" to "production-ready ShinyProxy
 replacement".
@@ -38,15 +38,15 @@ a useful report.
 **Goal**: replace the Thymeleaf-based ShinyProxy landing with Askama +
 Tailwind 4. Specs and template properties drive what gets rendered.
 
-- [ ] Add a new `ruscker-web` crate (or fold into `ruscker-admin`)
-- [ ] Askama templates matching `docs/mockups/landing-page.html`
-- [ ] Type badge colors and access icons driven by template properties
-- [ ] Filter chips with counts (matching
+- [x] Add a new `ruscker-web` crate (or fold into `ruscker-admin`)
+- [x] Askama templates matching `docs/mockups/landing-page.html`
+- [x] Type badge colors and access icons driven by template properties
+- [x] Filter chips with counts (matching
   `docs/mockups/landing-filters-cards-refined.html`)
-- [ ] Light/dark theme toggle (cookie + system preference)
-- [ ] Image library: serve static assets from a configurable
+- [x] Light/dark theme toggle (cookie + system preference)
+- [x] Image library: serve static assets from a configurable
   directory
-- [ ] Tailwind 4 build script (no Node required, uses standalone CLI)
+- [x] Tailwind 4 build script (no Node required, uses standalone CLI)
 
 **Deliverable**: visit `localhost:8080` and see the bundled
 `examples/application.yml` portal rendered, looking visually
@@ -57,18 +57,18 @@ equivalent to today but in Tailwind. Cards are not yet clickable
 
 **Goal**: edit specs via web UI, no YAML editing required.
 
-- [ ] SQLite schema + sqlx migrations
-- [ ] Importer: `ruscker import application.yml --db ruscker.db`
-- [ ] Exporter: `ruscker export --db ruscker.db > application.yml`
-- [ ] Admin login (basic auth or env-var token for MVP; OIDC later)
-- [ ] Apps list page (filter, search, bulk actions)
-- [ ] Add/Edit spec form with type-driven fields (mockup:
+- [x] SQLite schema + sqlx migrations
+- [x] Importer: `ruscker import application.yml --db ruscker.db`
+- [x] Exporter: `ruscker export --db ruscker.db > application.yml`
+- [x] Admin login (basic auth or env-var token for MVP; OIDC later)
+- [x] Apps list page (filter, search, bulk actions)
+- [x] Add/Edit spec form with type-driven fields (mockup:
   `admin-add-edit-app.html`)
-- [ ] Image library: upload, convert to WebP, optimize
-- [ ] Credentials store: named entries, encrypted at rest
-- [ ] Landing-page section editor (mockup:
+- [x] Image library: upload, convert to WebP, optimize
+- [x] Credentials store: named entries, encrypted at rest
+- [x] Landing-page section editor (mockup:
   `admin-landing-editor.html`)
-- [ ] Audit log of all admin actions
+- [x] Audit log of all admin actions
 
 **Deliverable**: the operator can fully manage Ruscker via web UI
 without touching files.
@@ -77,21 +77,21 @@ without touching files.
 
 **Goal**: actually run apps. The technically hardest phase.
 
-- [ ] `LocalDockerBackend` via bollard
+- [x] `LocalDockerBackend` via bollard
   - [ ] Image pulling with registry credentials
   - [ ] Container spawn with resource limits, env, volumes
   - [ ] Health-check polling
   - [ ] Graceful stop (drain → SIGTERM → SIGKILL)
-- [ ] HTTP request forwarding via hyper
-- [ ] WebSocket upgrade hijack + bidirectional pump
-- [ ] Path rewriting for Shiny's relative URLs
-- [ ] Sticky session cookie signing (HMAC-SHA256 via `ring`)
-- [ ] Session store (`DashMap` impl of `SessionStore`)
-- [ ] Replica pool per spec with `Router` plumbed in
-- [ ] Auto-scaler: spawn when utilization > threshold, retire when
+- [x] HTTP request forwarding via hyper
+- [x] WebSocket upgrade hijack + bidirectional pump
+- [x] Path rewriting for Shiny's relative URLs
+- [x] Sticky session cookie signing (HMAC-SHA256 via `ring`)
+- [x] Session store (`DashMap` impl of `SessionStore`)
+- [x] Replica pool per spec with `Router` plumbed in
+- [x] Auto-scaler: spawn when utilization > threshold, retire when
   under threshold for grace period
-- [ ] Heartbeat handling (per-spec timeout overrides, `-1` = never)
-- [ ] API spec branch: HTTP-only, round-robin, no cookie
+- [x] Heartbeat handling (per-spec timeout overrides, `-1` = never)
+- [x] API spec branch: HTTP-only, round-robin, no cookie
 
 **Deliverable**: end-to-end Shiny session works. Open Aurora Prime
 card on the landing, app loads, reactivity works, session survives
@@ -101,54 +101,57 @@ page refresh.
 
 **Goal**: visibility into running containers.
 
-- [ ] `/admin/dashboard` page (mockup: `admin-dashboard.html`)
-- [ ] Metric cards: containers, sessions, memory, CPU
-- [ ] Live container table with utilization bars (SSE updates)
-- [ ] Sessions-over-24h sparkline chart
-- [ ] Recent events feed
-- [ ] Logs streaming page with filter + regex + follow mode
-- [ ] Container detail view: live CPU/mem charts, environment, logs
-- [ ] Configurable alert thresholds (notification webhooks deferred)
-- [ ] Prometheus metrics endpoint at `/metrics`
+- [x] `/admin/dashboard` page (mockup: `admin-dashboard.html`)
+- [x] Metric cards: containers, sessions, memory, CPU
+- [x] Live container table with utilization bars (SSE updates)
+- [x] Sessions-over-24h sparkline chart
+- [x] Recent events feed
+- [x] Logs streaming page with filter + regex + follow mode
+- [x] Container detail view: live CPU/mem charts, environment, logs
+- [x] Configurable alert thresholds (notification webhooks deferred)
+- [x] Prometheus metrics endpoint at `/metrics`
 
 **Deliverable**: open the dashboard, see everything that's running,
 drill into any container.
 
 ## Phase 5 — Production polish (1 week)
 
-- [ ] Graceful shutdown (drain active sessions before exit)
-- [ ] structured logging via `tracing` + `tracing-subscriber`
-- [ ] Rate limiting on API specs (token bucket)
-- [ ] CORS support for API specs
-- [ ] Configurable max body sizes
-- [ ] Health endpoint `/healthz`
-- [ ] Readiness endpoint `/readyz`
-- [ ] Multi-stage Dockerfile for Ruscker itself
-- [ ] systemd unit file
-- [ ] Documentation: deployment guide, migration guide from
+- [x] Graceful shutdown (drain active sessions before exit)
+- [x] structured logging via `tracing` + `tracing-subscriber`
+- [x] Rate limiting on API specs (token bucket)
+- [x] CORS support for API specs
+- [x] Configurable max body sizes
+- [x] Health endpoint `/healthz`
+- [x] Readiness endpoint `/readyz`
+- [x] Multi-stage Dockerfile for Ruscker itself
+- [x] systemd unit file
+- [x] Documentation: deployment guide, migration guide from
   ShinyProxy, troubleshooting
 
 **Deliverable**: ready to drop into production.
 
 ## Phase 6 (optional) — Multi-host scheduling
 
-- [ ] `MultiHostDockerBackend` (talks to multiple Docker hosts)
-- [ ] Bin-pack vs spread strategies
-- [ ] Per-spec anti-affinity ("replicas must be on different hosts")
+- [x] `MultiHostDockerBackend` (talks to multiple Docker hosts)
+- [x] Bin-pack vs spread strategies
+- [x] Per-spec anti-affinity ("replicas must be on different hosts")
 
 ## Phase 7 (optional) — HA / multi-instance
 
-- [ ] Postgres `SessionStore` implementation
-- [ ] Postgres replication for SQLite admin DB
-- [ ] Coordination via Postgres advisory locks
-- [ ] Failover testing
+- [x] Postgres `SessionStore` implementation
+- [x] Postgres replication for SQLite admin DB
+- [x] Coordination via Postgres advisory locks
+- [x] Failover testing
 
 ## Phase 8 (optional) — Auth
 
 - [ ] OIDC integration (Keycloak, Auth0, Google)
 - [ ] SAML for enterprise
-- [ ] Role-based access control (viewer / operator / admin)
-- [ ] Per-spec access lists (only group X can use this app)
+- [x] Role-based access control (Viewer / Editor / Admin) — shipped
+- [x] Per-spec access lists (only group X can use this app) — shipped in Phase 6
+
+> Only the external identity-provider items (OIDC / SAML) remain; the
+> coarse role model and per-spec access lists already ship.
 
 ## What we explicitly defer / don't do
 

--- a/docs/SECURITY.md
+++ b/docs/SECURITY.md
@@ -5,10 +5,11 @@ Status: living document. Tracks the Phase 5 security audit
 **[accepted limitation]**, or **[deferred]**. File references use
 `crate/path:symbol` so they survive line-number drift.
 
-> **Scope.** This covers v0.2.5 (the 2026-06 audit release):
-> single-operator install, Ruscker behind a TLS-terminating reverse
-> proxy, Docker on one or more hosts. Multi-tenant / shared-team auth
-> (OIDC, SAML) is out of scope until Phase 8.
+> **Scope.** A single-operator install: Ruscker behind a
+> TLS-terminating reverse proxy, Docker on one or more hosts. The model
+> below reflects the hardening done in the 2026-06 security audit.
+> Multi-tenant / shared-team auth (OIDC, SAML) is out of scope until
+> Phase 8.
 
 ---
 
@@ -371,7 +372,7 @@ deliberate feature, not a config flip.
   slot is client-controlled whenever a proxy appends). Off on
   plain-HTTP dev so the browser doesn't drop the cookie.
 
-### Forwarded-header trust model (v0.2.5)
+### Forwarded-header trust model
 
 One switch — `server.useForwardHeaders: true` (or a
 `forward-headers-strategy` other than `none`) — gates **every**

--- a/docs/YAML_SCHEMA.md
+++ b/docs/YAML_SCHEMA.md
@@ -95,7 +95,7 @@ ignored by Ruscker.
 | `container-log-path` | path | none | **Ignored** (warned when set) — use `docker logs` / the admin Logs tab |
 | `port` | u16 | `8080` | HTTP listener port |
 | `bind-address` | string | `"0.0.0.0"` | Listener interface |
-| `authentication` | enum | `none` | `none` (MVP) / `openid` / `ldap` / `saml` / `simple` |
+| `authentication` | enum | `none` | `none` (only `none` is implemented today) / `openid` / `ldap` / `saml` / `simple` |
 | `landing-customization` | block | `{}` | Branding, SEO/social meta, analytics, custom HTML blocks, sign-in visibility — see [§ `proxy.landing-customization`](#proxylanding-customization). Ruscker extension |
 | `specs` | array | `[]` | List of apps/links/APIs |
 | `container-wait-time` | ms | `60000` | Max wait for container Ready |
@@ -149,10 +149,12 @@ and `tls` mismatched with the scheme.
 
 ### Authentication
 
-**MVP only supports `none`.** The other variants are accepted by the
-parser (so existing YAML doesn't fail) but Ruscker will warn at boot
-that auth is unimplemented and continue as if `none`. Phase 8 adds
-real auth support.
+**Ruscker currently supports only `none`.** The other variants are
+accepted by the parser (so existing YAML doesn't fail) but Ruscker will
+warn at boot that auth is unimplemented and continue as if `none`. An
+external identity provider (OIDC / SAML / LDAP) is the Phase 8 roadmap
+item; today, apps that handle their own auth are the common case, and
+`none` is correct — Ruscker just routes traffic.
 
 For applications that handle their own auth internally (a common
 case), `none` is the correct choice — Ruscker just routes traffic.
@@ -576,8 +578,8 @@ applied) and flagged by `ruscker validate`.
 
 | Field | Type | Default | Notes |
 |---|---|---|---|
-| `min-replicas` | u32 | `1` | Always running |
-| `max-replicas` | u32 | `5` (≥ `min-replicas`) | Per-container apps auto-scale to up to 5 independent replicas by default; set explicitly to raise/lower |
+| `min-replicas` | u32 | `0` | Always-warm replicas. Default `0` = **cold-start**: no container runs until the first visitor (they see a brief splash), reaped when idle — like ShinyProxy. Set `1`+ to keep an app hot (e.g. a single-user RStudio/Jupyter you don't want cold) |
+| `max-replicas` | u32 | `5` (≥ `min-replicas`) | Per-container apps auto-scale to up to 5 independent replicas by default. With `min-replicas` unset/`0` the app still scales up to 5 on demand (cold-start); set explicitly to raise/lower |
 | `scale-up-threshold` | float | unset | scale up when pool utilization exceeds this; unset ⇒ the built-in saturation rule (enforced, #333) |
 | `scale-down-threshold` | float | unset | only retire idle replicas while utilization is below this; unset ⇒ the built-in idle rule (enforced, #333) |
 | `scale-down-grace` | s | unset | idle-grace before retiring a replica; unset ⇒ the global ~30 s grace (enforced, #333) |

--- a/docs/adr/0001-rust-as-language.md
+++ b/docs/adr/0001-rust-as-language.md
@@ -21,10 +21,11 @@ Rust.
 
 ### What we gain
 
-- **Footprint**: a static binary around 15-25 MB, runtime memory in
-  the 20-50 MB range for the proxy itself. ShinyProxy (JVM) sits at
-  300-500 MB ocioso. For a portal serving 10-20 containers, this can
-  make Ruscker fit on machines where ShinyProxy can't.
+- **Footprint**: a static binary in the low tens of MB, idle memory
+  around ~14 MB for the proxy itself (measured in production). The
+  JVM-based proxy it replaced, on the same machine serving the same
+  apps, sat at ~540 MB idle. For a portal serving 10-20 containers,
+  this can make Ruscker fit on machines where ShinyProxy can't.
 - **Startup**: milliseconds vs seconds. Important for restarts during
   config changes.
 - **WebSocket performance**: Rust's async ecosystem (tokio + axum +

--- a/docs/adr/0002-sqlite-source-of-truth.md
+++ b/docs/adr/0002-sqlite-source-of-truth.md
@@ -28,8 +28,10 @@ import/export format.**
   bootstrap.
 - Operators can `ruscker export --db ruscker.db > application.yml` to
   produce a YAML representation (for git versioning, backup, sharing).
-- Optionally, Ruscker can watch a YAML file on disk and offer to apply
-  detected changes via the admin (with a diff view).
+- Optionally, Ruscker could watch a YAML file on disk and offer to apply
+  detected changes via the admin (with a diff view). *(Not implemented:
+  `import` is a one-shot command and `export` is manual; there is no
+  live file watcher today.)*
 - The running proxy reads from SQLite. Period.
 
 ## Consequences
@@ -53,8 +55,9 @@ import/export format.**
   YAML — operators can `cron` a daily export to a git repo for
   belt-and-suspenders durability.
 - **Drift between disk YAML and DB**: if an operator edits YAML
-  expecting it to apply, it won't until they import or accept the
-  diff. Mitigated by the YAML watcher + diff UI.
+  expecting it to apply, it won't until they re-run `ruscker import`.
+  (The YAML watcher + diff UI that would have auto-applied changes was
+  never built — see the proposed solution above.)
 
 ### What we explicitly don't do
 

--- a/docs/architecture.svg
+++ b/docs/architecture.svg
@@ -26,7 +26,7 @@
     <polygon points="14,40 40,28 66,40 40,52" fill="#FFFFFF" opacity="0.72"/>
     <polygon points="14,28 40,16 66,28 40,40" fill="#FFFFFF"/>
   </g>
-  <text x="92" y="131" font-size="15" font-weight="600" fill="#FFFFFF">Ruscker — single static binary · ~16 MB · no JVM</text>
+  <text x="92" y="131" font-size="15" font-weight="600" fill="#FFFFFF">Ruscker — single static binary · ~14 MB · no JVM</text>
 
   <!-- component boxes -->
   <!-- (1) Landing -->


### PR DESCRIPTION
Editorial + accuracy audit of **README, the mdBook site, `docs/`, the ADRs, and the doc diagrams**, applying the findings from a 4-agent review. No code changes.

## P1 — Inaccurate / policy
- **`min-replicas` cold-start (v0.2.39).** Docs still said "default 1 / pre-warm"; the new default is **0 (cold-start)**. Fixed `deploying.md` (guidance was fully inverted), `faq.md`, `docs/YAML_SCHEMA.md` (table), and `docs/ARCHITECTURE.md` (added the default + the post-drop scale-down cooldown).
- **Footprint policy.** Removed the banned `~540 MB to ~14 MB` arrow form in `roadmap.md`, `migrating.md` and ADR 0001 — all now lead with **~14 MB** and anchor ~540 MB to "the JVM-based proxy it replaced".
- **Evergreen versioning.** Dropped hardcoded `v0.2.5` current-version strings from README, `introduction.md`, `faq.md`, and the `SECURITY.md` scope line + section header (kept inline `since vX` provenance and the historical roadmap badges).
- **README freshness.** Dashboard described as **polling**, not SSE (it stopped holding an SSE stream in v0.2.37); test count reconciled to **600+** (was 400+/300+); added the ShinyProxy / Shiny Server positioning to the lead; documented the `inspect` subcommand; added release/license/docs **badges**, a **Contributing** section, and a real **`LICENSE`** file (the repo declared Apache-2.0 but shipped none).
- **`docs/IMAGES.md`.** Removed the **false** "~57 bundled images at `examples/assets/img/`" claim (the directory doesn't exist), replaced the stale "Phase 5 planned" caching table with the shipped immutable-`?v=` + ETag policy, and dropped dead `(planned)` object-fit/alt TODOs.

## P2 / P3
- `ROADMAP.md`: ticked the shipped Phases 1–7 boxes (were all `[ ]`, fighting the disclaimer); `NEXT_STEPS.md`: marked the scale-down cooldown shipped; noted RBAC + per-spec ACLs already ship. ADR 0002: noted the YAML watcher was never built.
- Standardized the `--strict-compat` flag order and the `:8080` bind port across the user guide; added a Jupyter → strip-model cross-link; reordered the Reference nav (Security before Release notes).

## Diagrams
Applied only the **safe, render-independent** text fixes:
- `architecture.svg` (both copies — `docs/` and `book/src/images/`): `~16 MB` → `~14 MB`.
- `crate-map.svg`: dropped the deleted `routing` module from the `ruscker-core` label (#743).

Deferred to a **render-verified manual pass** (lengthening text / arrow geometry I can't verify headless): the `crate-map` dependency edges (`cli` doesn't depend on `proxy` directly; the `admin → proxy` edge is missing), the per-spec/HMAC cookie label on `architecture.svg`, and `deployment.svg`'s Postgres scope ("config + session state") + the scaler-leader / pg-advisory-lock concept.

## Verification
- `mdbook build` clean; all three edited SVGs validate as well-formed XML (`xmllint`).
- Docs-only — no Rust/`.ftl`/template changes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)