### PR TITLE
docs: add Zenodo DOI badge + citation doi field

### DIFF
--- a/CITATION.cff
+++ b/CITATION.cff
@@ -34,6 +34,11 @@ authors:
     family-names: Nascimento Barreto
     email: juliabarreto@gd.seplag.pe.gov.br
     affiliation: Secretaria de Planejamento e Gestão de Pernambuco
+doi: 10.5281/zenodo.20849123
+identifiers:
+  - type: doi
+    value: 10.5281/zenodo.20849123
+    description: The concept DOI for all versions of Ruscker.
 repository-code: 'https://github.com/StrategicProjects/ruscker'
 url: 'https://ruscker.com'
 abstract: >-
@@ -54,5 +59,5 @@ keywords:
   - data-science
   - container-orchestration
 license: Apache-2.0
-version: 0.2.39
-date-released: '2026-06-18'
+version: 0.2.40
+date-released: '2026-06-25'

--- a/README.md
+++ b/README.md
@@ -8,6 +8,7 @@
 [![Latest release](https://img.shields.io/github/v/release/StrategicProjects/ruscker?sort=semver)](https://github.com/StrategicProjects/ruscker/releases)
 [![License](https://img.shields.io/badge/license-Apache--2.0-blue.svg)](LICENSE)
 [![Docs](https://img.shields.io/badge/docs-ruscker.com-0F6E56)](https://strategicprojects.github.io/ruscker/)
+[![DOI](https://zenodo.org/badge/DOI/10.5281/zenodo.20849123.svg)](https://doi.org/10.5281/zenodo.20849123)
 
 **Ruscker** is a lightweight, single-binary alternative to **ShinyProxy**
 and **Shiny Server Free** — a **portal and orchestrator** for


### PR DESCRIPTION
Ruscker now has a permanent **DOI** via Zenodo: [`10.5281/zenodo.20849123`](https://doi.org/10.5281/zenodo.20849123).

- README: DOI badge alongside release/license/docs.
- `CITATION.cff`: `doi` + `identifiers` (concept DOI), version bumped to v0.2.40.

🤖 Generated with [Claude Code](https://claude.com/claude-code)