### PR TITLE
fix: clear RustSec advisories

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -46,12 +46,26 @@ jobs:
             echo "prerelease=false" >> "$GITHUB_OUTPUT"
           fi
 
+  # Do not publish a tag whose locked dependency tree is rejected by
+  # RustSec. The regular security workflow already covers dependency
+  # changes on PRs/main; this gate protects an arbitrary release tag too.
+  cargo-audit:
+    runs-on: ubuntu-24.04
+    permissions:
+      contents: read
+    steps:
+      - uses: actions/checkout@v6
+      - name: Install cargo-audit
+        run: cargo install cargo-audit --locked
+      - name: Audit dependencies
+        run: cargo audit
+
   # --------------------------------------------------------------------
   # Per-arch native build of the static musl binary, then the tarball
   # and the .deb (cargo-deb, reusing that same binary via --no-build).
   # --------------------------------------------------------------------
   artifacts:
-    needs: meta
+    needs: [meta, cargo-audit]
     name: artifacts (${{ matrix.arch }})
     strategy:
       fail-fast: false
@@ -157,7 +171,7 @@ jobs:
   # Per-arch native Docker build, pushed to ghcr by digest (no tag yet).
   # --------------------------------------------------------------------
   docker-build:
-    needs: meta
+    needs: [meta, cargo-audit]
     name: docker (${{ matrix.arch }})
     strategy:
       fail-fast: false

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -152,9 +152,9 @@ dependencies = [
 
 [[package]]
 name = "anyhow"
-version = "1.0.102"
+version = "1.0.103"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7f202df86484c868dbad7eaa557ef785d5c66295e41b460ef922eca0723b842c"
+checksum = "2a4385e2e34eb35d6b3efe798b9eb88096925d87726c0798709bf56d9ed84af3"
 
 [[package]]
 name = "arbitrary"
@@ -875,9 +875,9 @@ dependencies = [
 
 [[package]]
 name = "crossbeam-epoch"
-version = "0.9.18"
+version = "0.9.20"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5b82ac4a3c2ca9c3460964f020e1402edd5753411d7737aa39c3714ad1b5420e"
+checksum = "2d6914041f254d6e9176c01941b21115dcfb7089e55135a35411081bd106ef3f"
 dependencies = [
  "crossbeam-utils",
 ]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -48,7 +48,7 @@ serde_json = "1.0.150"
 
 # Error handling
 thiserror = "2.0"
-anyhow = "1.0.102"
+anyhow = "1.0.103"
 
 # Logging / tracing
 tracing = "0.1.44"

--- a/docs/SECURITY.md
+++ b/docs/SECURITY.md
@@ -508,6 +508,11 @@ Non-blocking follow-ups:
 - [x] `audit_log.diff_json` verified to record metadata only — never a
       password/token/cookie (regression test in `db::credentials`)
 - [x] Automated `cargo audit` in CI (`.github/workflows/security.yml`,
-      weekly + on dependency changes)
+      weekly + on dependency changes) and as a blocking release gate.
+      The remaining `RUSTSEC-2024-0436` unmaintained warning is visible but
+      non-fatal: `paste` is only present through `image`'s optional `ravif`
+      lockfile edge, while Ruscker enables only `png`, `jpeg`, `webp`, and
+      `rayon`. Re-evaluate this exception whenever the `image` feature set
+      changes.
 - [ ] Nonce-based CSP, drop `unsafe-inline` (§7)
 - [ ] `semgrep` in CI (cargo-audit is wired; semgrep deferred)


### PR DESCRIPTION
Closes #946.

## Summary

- update `anyhow` to 1.0.103 and `crossbeam-epoch` to 0.9.20, removing the active RustSec vulnerability and unsoundness advisory from the locked graph
- add a blocking `cargo-audit` job to the release workflow, with read-only permissions, so artifacts and images are not published from a rejected tag
- document why the remaining `paste` unmaintained warning is visible but non-fatal: it belongs only to the inactive optional `image -> ravif` lockfile edge

## Root cause and impact

The weekly/PR security workflow detected advisories, but the lockfile still pinned affected versions and the release workflow could publish a tag without waiting for an audit. This change fixes the locked versions and makes RustSec a release prerequisite.

## Verification

- `cargo audit --no-fetch` — 0 vulnerabilities; one documented inactive unmaintained warning
- `DOCKER_REGISTRY_PASSWORD=test cargo test --locked` — 585 tests passed
- `DOCKER_REGISTRY_PASSWORD=test cargo clippy --locked --all-targets -- -D warnings`
- `./scripts/i18n-check.sh`
- `git diff --check`
- release workflow parsed as valid YAML
