### PR TITLE
fix: bound multihost and readiness probes

### DIFF
--- a/crates/ruscker-admin/src/routes/health.rs
+++ b/crates/ruscker-admin/src/routes/health.rs
@@ -33,9 +33,22 @@ use axum::{
     Json, Router,
 };
 use serde_json::json;
+use std::time::Duration;
 use tracing::warn;
 
 use crate::AppState;
+
+/// Finite budget for each readiness dependency. Multi-host Docker has its own
+/// longer reconcile budget, but the public probe is deliberately tighter so a
+/// dependency outage cannot pin probe tasks indefinitely. Operators should set
+/// their load-balancer probe timeout above this five-second application budget.
+const READINESS_CHECK_TIMEOUT: Duration = Duration::from_secs(5);
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+enum ProbeStatus {
+    Ok,
+    Unreachable,
+}
 
 pub fn routes() -> Router<AppState> {
     Router::new()
@@ -54,6 +67,67 @@ async fn healthz() -> Response {
     .into_response()
 }
 
+async fn probe_database(db: &crate::db::ConfigDb, budget: Duration) -> ProbeStatus {
+    use crate::db::ConfigDb;
+
+    let probe = async {
+        match db {
+            ConfigDb::Sqlite(pool) => sqlx::query("SELECT 1").fetch_one(pool).await.map(|_| ()),
+            ConfigDb::Postgres(pool) => sqlx::query("SELECT 1").fetch_one(pool).await.map(|_| ()),
+        }
+    };
+    match tokio::time::timeout(budget, probe).await {
+        Ok(Ok(())) => ProbeStatus::Ok,
+        Ok(Err(error)) => {
+            warn!(error = %error, "readyz: database check failed");
+            ProbeStatus::Unreachable
+        }
+        Err(_) => {
+            warn!(timeout_ms = budget.as_millis(), "readyz: database check timed out");
+            ProbeStatus::Unreachable
+        }
+    }
+}
+
+async fn probe_backend(
+    backend: &dyn ruscker_core::ContainerBackend,
+    budget: Duration,
+) -> ProbeStatus {
+    match tokio::time::timeout(budget, backend.list()).await {
+        Ok(Ok(_)) => ProbeStatus::Ok,
+        Ok(Err(error)) => {
+            warn!(error = %error, "readyz: container backend check failed");
+            ProbeStatus::Unreachable
+        }
+        Err(_) => {
+            warn!(timeout_ms = budget.as_millis(), "readyz: container backend check timed out");
+            ProbeStatus::Unreachable
+        }
+    }
+}
+
+/// Probe independent dependencies concurrently. Returning `Option` keeps the
+/// distinction between "not configured" and "configured but unreachable".
+async fn probe_dependencies(
+    db: Option<&crate::db::ConfigDb>,
+    backend: Option<&dyn ruscker_core::ContainerBackend>,
+    budget: Duration,
+) -> (Option<ProbeStatus>, Option<ProbeStatus>) {
+    let db_probe = async {
+        match db {
+            Some(db) => Some(probe_database(db, budget).await),
+            None => None,
+        }
+    };
+    let backend_probe = async {
+        match backend {
+            Some(backend) => Some(probe_backend(backend, budget).await),
+            None => None,
+        }
+    };
+    tokio::join!(db_probe, backend_probe)
+}
+
 /// Readiness: every configured dependency is reachable. Returns
 /// `200` with `{"status":"ready", ...}` when all checks pass, or
 /// `503` with `{"status":"not_ready", ...}` when any fails.
@@ -70,45 +144,35 @@ async fn readyz(State(state): State<AppState>) -> Response {
             .into_response();
     }
 
+    // The DB and Docker checks are independent. Probe them concurrently so
+    // readiness latency is bounded by the slowest dependency, not their sum.
+    let (db_status, backend_status) = probe_dependencies(
+        state.db.as_ref(),
+        state.backend.as_deref(),
+        READINESS_CHECK_TIMEOUT,
+    )
+    .await;
     let mut checks = serde_json::Map::new();
     let mut ready = true;
-
-    // Config database: a trivial round-trip confirms the pool can hand
-    // out a live connection (catches a deleted/locked SQLite file, an
-    // unreachable Postgres, or an exhausted pool). Probes whichever
-    // backend is attached.
-    if let Some(db) = state.db.as_ref() {
-        use crate::db::ConfigDb;
-        let probe = match db {
-            ConfigDb::Sqlite(pool) => sqlx::query("SELECT 1").fetch_one(pool).await.map(|_| ()),
-            ConfigDb::Postgres(pool) => sqlx::query("SELECT 1").fetch_one(pool).await.map(|_| ()),
+    if let Some(status) = db_status {
+        let value = match status {
+            ProbeStatus::Ok => "ok",
+            ProbeStatus::Unreachable => {
+                ready = false;
+                "unreachable"
+            }
         };
-        match probe {
-            Ok(()) => {
-                checks.insert("db".into(), json!("ok"));
-            }
-            Err(err) => {
-                ready = false;
-                warn!(error = %err, "readyz: database check failed");
-                checks.insert("db".into(), json!("unreachable"));
-            }
-        }
+        checks.insert("db".into(), json!(value));
     }
-
-    // Container backend: `list()` is the cheapest "can I reach the
-    // Docker daemon?" call on the trait — it's the same one the
-    // startup reconcile uses.
-    if let Some(backend) = &state.backend {
-        match backend.list().await {
-            Ok(_) => {
-                checks.insert("docker".into(), json!("ok"));
-            }
-            Err(err) => {
+    if let Some(status) = backend_status {
+        let value = match status {
+            ProbeStatus::Ok => "ok",
+            ProbeStatus::Unreachable => {
                 ready = false;
-                warn!(error = %err, "readyz: container backend check failed");
-                checks.insert("docker".into(), json!("unreachable"));
+                "unreachable"
             }
-        }
+        };
+        checks.insert("docker".into(), json!(value));
     }
 
     let status = if ready {
@@ -121,4 +185,62 @@ async fn readyz(State(state): State<AppState>) -> Response {
         "checks": checks,
     });
     (status, Json(body)).into_response()
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use async_trait::async_trait;
+    use ruscker_core::{
+        ContainerBackend, CoreError, CoreResult, Replica, ReplicaId, ReplicaMetrics,
+    };
+
+    struct PendingBackend;
+
+    #[async_trait]
+    impl ContainerBackend for PendingBackend {
+        async fn spawn(&self, _spec_id: &str, _image: &str) -> CoreResult<Replica> {
+            Err(CoreError::Backend("unused".into()))
+        }
+
+        async fn stop(&self, _replica_id: &ReplicaId) -> CoreResult<()> {
+            Err(CoreError::Backend("unused".into()))
+        }
+
+        async fn list(&self) -> CoreResult<Vec<Replica>> {
+            std::future::pending().await
+        }
+
+        async fn metrics(&self, _replica_id: &ReplicaId) -> CoreResult<ReplicaMetrics> {
+            Err(CoreError::Backend("unused".into()))
+        }
+    }
+
+    #[tokio::test]
+    async fn dependency_timeouts_run_concurrently() {
+        // Exhaust a one-connection SQLite pool so SELECT 1 waits for a slot,
+        // while the backend also stays pending forever. Both probes must time
+        // out in one shared wall-clock window rather than serially (#945).
+        let pool = sqlx::sqlite::SqlitePoolOptions::new()
+            .max_connections(1)
+            .connect("sqlite::memory:")
+            .await
+            .unwrap();
+        let _held_connection = pool.acquire().await.unwrap();
+        let db = crate::db::ConfigDb::Sqlite(pool);
+        let backend = PendingBackend;
+        let budget = Duration::from_millis(100);
+        let started = std::time::Instant::now();
+
+        let (db_status, backend_status) =
+            probe_dependencies(Some(&db), Some(&backend), budget).await;
+
+        assert_eq!(db_status, Some(ProbeStatus::Unreachable));
+        assert_eq!(backend_status, Some(ProbeStatus::Unreachable));
+        assert!(
+            started.elapsed() < Duration::from_millis(175),
+            "dependency timeouts ran serially: {:?}",
+            started.elapsed()
+        );
+    }
 }

--- a/crates/ruscker-docker/src/multihost.rs
+++ b/crates/ruscker-docker/src/multihost.rs
@@ -19,6 +19,7 @@ use ruscker_core::{
     ContainerBackend, CoreError, CoreResult, ImageInfo, LogStream, ManagedContainer,
     RegistryCredentials, Replica, ReplicaId, ReplicaMetrics, SpawnRequest,
 };
+use std::collections::HashSet;
 
 use crate::LocalDockerBackend;
 
@@ -156,6 +157,69 @@ pub struct MultiHostDockerBackend {
     /// many of a spec already run on each host). Populated on `spawn`
     /// and refreshed on `list`.
     placement: DashMap<ReplicaId, (String, String)>,
+}
+
+type HostListCall<'a> = (
+    String,
+    futures_util::future::BoxFuture<'a, CoreResult<Vec<Replica>>>,
+);
+
+/// Results from the hosts that answered plus the ids of hosts whose state is
+/// unknown. A successful empty list is different from an error/timeout: the
+/// former authoritatively says the host has no replicas; the latter must keep
+/// its previous placements until a later reconcile succeeds.
+#[derive(Debug)]
+struct HostListBatch {
+    reported: Vec<(String, Vec<Replica>)>,
+    failed_hosts: HashSet<String>,
+}
+
+/// Run all host list calls concurrently with an independent budget per host.
+/// Partial success is useful degraded state; zero successful hosts is an
+/// outage and must surface as an error instead of masquerading as `Ok([])`.
+async fn list_hosts_with_timeout(
+    calls: Vec<HostListCall<'_>>,
+    budget: std::time::Duration,
+) -> CoreResult<HostListBatch> {
+    let total = calls.len();
+    let results = futures_util::future::join_all(calls.into_iter().map(|(id, call)| async move {
+        (id, tokio::time::timeout(budget, call).await)
+    }))
+    .await;
+
+    let mut reported = Vec::new();
+    let mut failed_hosts = HashSet::new();
+    for (id, result) in results {
+        match result {
+            Ok(Ok(replicas)) => reported.push((id, replicas)),
+            Ok(Err(error)) => {
+                tracing::warn!(host = %id, error = %error, "list on host failed; skipping");
+                failed_hosts.insert(id);
+            }
+            Err(_) => {
+                tracing::warn!(host = %id, "list on host timed out; skipping");
+                failed_hosts.insert(id);
+            }
+        }
+    }
+
+    if reported.is_empty() {
+        return Err(CoreError::Backend(format!(
+            "replica list failed on every docker host ({total} configured)"
+        )));
+    }
+    Ok(HostListBatch {
+        reported,
+        failed_hosts,
+    })
+}
+
+fn retain_confirmed_or_unknown_placements(
+    placement: &DashMap<ReplicaId, (String, String)>,
+    live: &HashSet<ReplicaId>,
+    failed_hosts: &HashSet<String>,
+) {
+    placement.retain(|id, (host, _)| live.contains(id) || failed_hosts.contains(host));
 }
 
 /// One host's current load — the input to the pure placement decision.
@@ -369,35 +433,38 @@ impl ContainerBackend for MultiHostDockerBackend {
     }
 
     async fn list(&self) -> CoreResult<Vec<Replica>> {
-        // Fan out over every host; tag each replica's placement so
-        // later stop/metrics/logs route correctly. A host that fails to
-        // answer is logged and skipped (degraded, not fatal).
+        // Fan out concurrently over every host; tag each replica's placement
+        // so later stop/metrics/logs route correctly. A failed host is skipped
+        // when at least one sibling answers, but an all-host outage is fatal.
+        let calls: Vec<HostListCall<'_>> = self
+            .hosts
+            .iter()
+            .map(|host| {
+                (
+                    host.id.clone(),
+                    Box::pin(host.backend.list()) as futures_util::future::BoxFuture<'_, _>,
+                )
+            })
+            .collect();
+        let batch = list_hosts_with_timeout(calls, HOST_FANOUT_TIMEOUT).await?;
         let mut all = Vec::new();
-        let mut live: std::collections::HashSet<ReplicaId> = std::collections::HashSet::new();
-        let mut failed_hosts: std::collections::HashSet<String> = std::collections::HashSet::new();
-        for h in &self.hosts {
-            match h.backend.list().await {
-                Ok(mut replicas) => {
-                    for r in &mut replicas {
-                        self.placement
-                            .insert(r.id.clone(), (h.id.clone(), r.spec_id.clone()));
-                        r.host = Some(h.id.clone());
-                        live.insert(r.id.clone());
-                    }
-                    all.extend(replicas);
-                }
-                Err(e) => {
-                    tracing::warn!(host = %h.id, error = %e, "list on host failed; skipping");
-                    failed_hosts.insert(h.id.clone());
-                }
+        let mut live = HashSet::new();
+        for (host_id, mut replicas) in batch.reported {
+            for replica in &mut replicas {
+                self.placement.insert(
+                    replica.id.clone(),
+                    (host_id.clone(), replica.spec_id.clone()),
+                );
+                replica.host = Some(host_id.clone());
+                live.insert(replica.id.clone());
             }
+            all.extend(replicas);
         }
         // Authoritative prune (#160 D1): drop placement for replicas no
         // host reported, so dead/crashed containers stop inflating
         // `pick_host`'s load counts. Keep entries whose owning host
         // *didn't answer* — we can't tell if those are gone.
-        self.placement
-            .retain(|id, (host, _)| live.contains(id) || failed_hosts.contains(host));
+        retain_confirmed_or_unknown_placements(&self.placement, &live, &batch.failed_hosts);
         Ok(all)
     }
 
@@ -663,6 +730,7 @@ impl ContainerBackend for MultiHostDockerBackend {
 mod tests {
     use super::*;
     use ruscker_config::{Host, HostTls};
+    use std::future::Future;
     use std::path::PathBuf;
 
     fn host(id: &str, address: &str) -> Host {
@@ -771,6 +839,95 @@ mod tests {
     #[test]
     fn empty_loads_is_none() {
         assert_eq!(choose_host(&[], Placement::Spread, false), None);
+    }
+
+    fn list_call<F>(id: &str, future: F) -> HostListCall<'static>
+    where
+        F: Future<Output = CoreResult<Vec<Replica>>> + Send + 'static,
+    {
+        (id.to_string(), Box::pin(future))
+    }
+
+    fn fake_replica(spec_id: &str) -> Replica {
+        Replica {
+            id: ReplicaId::new(),
+            spec_id: spec_id.into(),
+            container_id: "fake".into(),
+            upstream: "127.0.0.1:1".parse().unwrap(),
+            state: ruscker_core::ReplicaState::Ready,
+            started_at: chrono::Utc::now(),
+            sessions_active: 0,
+            sessions_max: 1,
+            host: None,
+        }
+    }
+
+    #[tokio::test]
+    async fn list_fanout_returns_healthy_host_without_waiting_forever() {
+        // #945: a host that never answers must not block a healthy sibling.
+        let expected = fake_replica("healthy-app");
+        let calls = vec![
+            list_call(
+                "stuck",
+                std::future::pending::<CoreResult<Vec<Replica>>>(),
+            ),
+            list_call("healthy", async move { Ok(vec![expected]) }),
+        ];
+        let started = std::time::Instant::now();
+        let batch = list_hosts_with_timeout(calls, std::time::Duration::from_millis(20))
+            .await
+            .expect("partial success is degraded but usable");
+
+        assert!(
+            started.elapsed() < std::time::Duration::from_millis(100),
+            "fan-out exceeded its per-host timeout"
+        );
+        assert_eq!(batch.reported.len(), 1);
+        assert_eq!(batch.reported[0].0, "healthy");
+        assert_eq!(batch.reported[0].1[0].spec_id, "healthy-app");
+        assert!(batch.failed_hosts.contains("stuck"));
+    }
+
+    #[tokio::test]
+    async fn list_fanout_errors_when_every_host_fails() {
+        let calls = vec![
+            list_call("error", async {
+                Err(CoreError::Backend("daemon down".into()))
+            }),
+            list_call(
+                "stuck",
+                std::future::pending::<CoreResult<Vec<Replica>>>(),
+            ),
+        ];
+        let error = list_hosts_with_timeout(calls, std::time::Duration::from_millis(20))
+            .await
+            .expect_err("total outage must not look like an empty cluster");
+        assert!(error.to_string().contains("every docker host"));
+    }
+
+    #[test]
+    fn placement_prune_keeps_entries_from_failed_hosts() {
+        let placement = DashMap::new();
+        let live = fake_replica("live");
+        let stale = fake_replica("stale");
+        let unknown = fake_replica("unknown");
+        placement.insert(live.id.clone(), ("healthy".into(), live.spec_id.clone()));
+        placement.insert(stale.id.clone(), ("healthy".into(), stale.spec_id.clone()));
+        placement.insert(
+            unknown.id.clone(),
+            ("unreachable".into(), unknown.spec_id.clone()),
+        );
+        let live_ids = HashSet::from([live.id.clone()]);
+        let failed_hosts = HashSet::from(["unreachable".to_string()]);
+
+        retain_confirmed_or_unknown_placements(&placement, &live_ids, &failed_hosts);
+
+        assert!(placement.contains_key(&live.id));
+        assert!(!placement.contains_key(&stale.id));
+        assert!(
+            placement.contains_key(&unknown.id),
+            "failed host placement remains unknown, not dead"
+        );
     }
 
     // `LocalDockerBackend` isn't `Debug`, so extract the error message


### PR DESCRIPTION
Closes #945.

## Root cause

`MultiHostDockerBackend::list()` queried hosts sequentially without the timeout already used by other fan-outs. It also returned `Ok([])` when every host failed, so readiness could report a healthy Docker dependency during a total outage. Database and backend readiness probes were also sequential and unbounded locally.

## What changed

- fan out replica listing concurrently with a 10-second per-host timeout
- preserve degraded partial results when at least one Docker host responds
- return an error when every configured host errors or times out
- preserve placements owned by hosts whose state remains unknown
- run DB and backend readiness checks concurrently with a five-second per-dependency budget
- keep dependency details in logs while returning only sanitized `unreachable` states
- add pending/error/success regressions for fan-out, placement pruning, and readiness latency

## Impact

A slow Docker daemon no longer serializes or indefinitely blocks the cluster inventory. Total Docker outages now make `/readyz` return 503, and dependency probe latency is bounded by the slowest check instead of their sum.

## Verification

- `DOCKER_REGISTRY_PASSWORD=test cargo test`
- `DOCKER_REGISTRY_PASSWORD=test cargo clippy --all-targets -- -D warnings`
- `./scripts/i18n-check.sh`