### PR TITLE
build: align MSRV and Rust toolchains

### DIFF
--- a/.github/workflows/msrv.yml
+++ b/.github/workflows/msrv.yml
@@ -1,0 +1,56 @@
+name: msrv
+
+# Keep the workspace's rust-version promise honest. The development/release
+# toolchain is newer (rust-toolchain.toml), so this job invokes the MSRV
+# explicitly instead of relying on the directory override.
+
+on:
+  push:
+    branches: [main]
+    paths:
+      - "Cargo.toml"
+      - "Cargo.lock"
+      - "crates/**"
+      - "rust-toolchain.toml"
+      - ".github/workflows/msrv.yml"
+  pull_request:
+    paths:
+      - "Cargo.toml"
+      - "Cargo.lock"
+      - "crates/**"
+      - "rust-toolchain.toml"
+      - ".github/workflows/msrv.yml"
+  workflow_dispatch:
+
+permissions:
+  contents: read
+
+concurrency:
+  group: msrv-${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  check:
+    name: Declared MSRV
+    runs-on: ubuntu-24.04
+    env:
+      DOCKER_REGISTRY_PASSWORD: test
+    steps:
+      - uses: actions/checkout@v6
+
+      - name: Read workspace MSRV
+        id: msrv
+        run: |
+          version=$(sed -n 's/^rust-version = "\([^"]*\)"/\1/p' Cargo.toml)
+          test -n "$version"
+          echo "version=$version" >> "$GITHUB_OUTPUT"
+
+      - name: Install Rust ${{ steps.msrv.outputs.version }}
+        run: rustup toolchain install "${{ steps.msrv.outputs.version }}" --profile minimal --no-self-update
+
+      - uses: Swatinem/rust-cache@v2
+        with:
+          key: msrv-${{ steps.msrv.outputs.version }}
+
+      - name: Check workspace at MSRV
+        run: cargo +${{ steps.msrv.outputs.version }} check --workspace --all-targets --locked

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -12,7 +12,7 @@ members = [
 [workspace.package]
 version = "0.2.40"
 edition = "2021"
-rust-version = "1.85"
+rust-version = "1.94.0"
 license = "Apache-2.0"
 authors = ["Ruscker contributors"]
 repository = "https://github.com/StrategicProjects/ruscker"
@@ -59,7 +59,7 @@ clap = { version = "4.6", features = ["derive", "env"] }
 
 # Misc utilities
 regex = "1.12"
-# once_cell removed — Rust 1.95 std::sync::LazyLock is used instead
+# once_cell removed — std::sync::LazyLock is available at the 1.94.0 MSRV.
 url = "2.5.8"
 uuid = { version = "1.23", features = ["v4", "serde"] }
 chrono = { version = "0.4.44", features = ["serde"] }

--- a/Dockerfile
+++ b/Dockerfile
@@ -21,7 +21,7 @@
 # matches rust-toolchain.toml so the image's toolchain is used
 # directly (no extra rustup download).
 # ----------------------------------------------------------------------
-FROM rust:1.95-bookworm AS builder
+FROM rust:1.96-bookworm AS builder
 
 WORKDIR /build
 COPY . .

--- a/README.md
+++ b/README.md
@@ -185,6 +185,11 @@ cargo build --release          # rustup fetches the pinned toolchain on first ru
 ./target/release/ruscker --help
 ```
 
+Development and release builds use Rust 1.96.0 from
+`rust-toolchain.toml`. The MSRV source of truth is
+`workspace.package.rust-version` in `Cargo.toml` (currently 1.94.0), and
+the `msrv` workflow reads that same field when checking the locked graph.
+
 ## Quickstart
 
 ```bash

--- a/book/src/installation.md
+++ b/book/src/installation.md
@@ -140,6 +140,11 @@ cargo build --release --bin ruscker
 ./target/release/ruscker --help
 ```
 
+Development and release builds use Rust 1.96.0 from
+`rust-toolchain.toml`. The MSRV source of truth is
+`workspace.package.rust-version` in `Cargo.toml` (currently 1.94.0); the
+dedicated `msrv` workflow reads that field and checks the locked graph.
+
 ## Verifying release artifacts
 
 Every tagged release is signed with [cosign](https://docs.sigstore.dev/)

--- a/crates/ruscker-proxy/src/sticky.rs
+++ b/crates/ruscker-proxy/src/sticky.rs
@@ -221,7 +221,7 @@ fn ct_eq(a: &[u8], b: &[u8]) -> bool {
 }
 
 fn decode_hex(s: &str) -> Result<Vec<u8>> {
-    if s.len() % 2 != 0 {
+    if !s.len().is_multiple_of(2) {
         return Err(anyhow!("hex length must be even"));
     }
     let mut out = Vec::with_capacity(s.len() / 2);

--- a/docs/adr/0001-rust-as-language.md
+++ b/docs/adr/0001-rust-as-language.md
@@ -78,17 +78,15 @@ with the JVM.
 
 ## Stability constraints
 
-> Amendment (2026-06): MSRV has since moved to **1.85**
-> (`rust-version` in the workspace `Cargo.toml`; toolchain pinned via
-> `rust-toolchain.toml`) and the dependency pins below were lifted as
-> the ecosystem stabilized. The decision and rationale stand.
+> Amendment (2026-07): the current **MSRV is Rust 1.94.0**. The workspace
+> declares it once via `workspace.package.rust-version`; CI verifies the
+> locked graph with that toolchain. Development, release builds, and the
+> Docker builder use the pinned Rust 1.96.0 toolchain from
+> `rust-toolchain.toml`. The original 1.75/no-rustup goal is now historical:
+> the current latest-stable dependency policy (notably sqlx 0.9) made that
+> floor impossible.
 
-- **MSRV** (Minimum Supported Rust Version): 1.75. This is what
-  Ubuntu 24.04 ships, and we want a no-rustup install path.
-- **Edition**: 2021. Edition 2024 is not yet stable on MSRV.
-- Several transitive deps need pinning (`getrandom 0.2.15`,
-  `indexmap 2.7.0`, `clap 4.5.20`, `uuid 1.10.0`) because their
-  newer versions require Edition 2024. This is documented in the
-  workspace developer notes.
-
-If MSRV ever bumps, we can lift the pins.
+- **Current MSRV** (Minimum Supported Rust Version): 1.94.0.
+- **Development/release toolchain**: 1.96.0, pinned separately from MSRV so
+  contributors get deterministic rustfmt and clippy behavior.
+- **Edition**: 2021. Edition changes remain independent from MSRV changes.


### PR DESCRIPTION
Closes #947.

## Root cause

The workspace advertised Rust 1.85 even though the locked sqlx 0.9 graph requires Rust 1.94.0. Development was pinned to 1.96.0 while the Docker builder still used 1.95, which could make Docker builds invoke rustup unexpectedly.

## What changed

- declare the verified workspace MSRV as Rust 1.94.0
- keep development and release tooling pinned to Rust 1.96.0
- align the Docker builder with `rust:1.96-bookworm`
- add an MSRV workflow for pull requests and pushes to `main`
- make the workflow read `workspace.package.rust-version` from Cargo.toml rather than duplicate the version
- document the MSRV/toolchain distinction in README, mdBook, and the Rust ADR
- apply the Clippy-compatible `is_multiple_of` form enabled by the corrected MSRV

## Impact

Consumers receive an honest compiler requirement, Docker builds no longer need a hidden toolchain correction, and future dependency/source changes are checked against the declared minimum compiler.

## Verification

- `DOCKER_REGISTRY_PASSWORD=test cargo +1.94.0 check --workspace --all-targets --locked`
- `DOCKER_REGISTRY_PASSWORD=test cargo test`
- `DOCKER_REGISTRY_PASSWORD=test cargo clippy --all-targets -- -D warnings`
- `./scripts/i18n-check.sh`
- workflow YAML parsed locally
- `rust:1.96-bookworm` manifest verified for amd64 and arm64