### PR TITLE
ci: gate merges and releases

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,65 @@
+name: ci
+
+# This workflow is both the merge gate and the release gate. Keeping the
+# commands in one reusable workflow prevents a tag from being validated by a
+# weaker path than the commit that reached main.
+
+on:
+  push:
+    branches: [main]
+  pull_request:
+  workflow_call:
+  workflow_dispatch:
+
+permissions:
+  contents: read
+
+concurrency:
+  group: ci-${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  test:
+    name: Tests
+    runs-on: ubuntu-24.04
+    env:
+      DOCKER_REGISTRY_PASSWORD: test
+    steps:
+      - uses: actions/checkout@v6
+
+      - name: Install pinned Rust toolchain
+        run: rustup show
+
+      - uses: Swatinem/rust-cache@v2
+        with:
+          key: ci-test
+
+      - name: Test workspace
+        run: cargo test --locked
+
+  clippy:
+    name: Clippy
+    runs-on: ubuntu-24.04
+    env:
+      DOCKER_REGISTRY_PASSWORD: test
+    steps:
+      - uses: actions/checkout@v6
+
+      - name: Install pinned Rust toolchain
+        run: rustup show
+
+      - uses: Swatinem/rust-cache@v2
+        with:
+          key: ci-clippy
+
+      - name: Lint all targets
+        run: cargo clippy --locked --all-targets -- -D warnings
+
+  i18n:
+    name: i18n parity
+    runs-on: ubuntu-24.04
+    steps:
+      - uses: actions/checkout@v6
+
+      - name: Check i18n parity
+        run: ./scripts/i18n-check.sh

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -34,6 +34,19 @@ jobs:
       version: ${{ steps.m.outputs.version }}
       prerelease: ${{ steps.m.outputs.prerelease }}
     steps:
+      - uses: actions/checkout@v6
+
+      - name: Verify tag matches workspace version
+        env:
+          TAG: ${{ github.ref_name }}
+        run: |
+          workspace_version=$(sed -n 's/^version = "\([^"]*\)"/\1/p' Cargo.toml | head -n 1)
+          tag_version="${TAG#v}"
+          if [ -z "$workspace_version" ] || [ "$tag_version" != "$workspace_version" ]; then
+            echo "::error::tag ${TAG} does not match workspace version ${workspace_version:-<missing>}"
+            exit 1
+          fi
+
       - id: m
         run: |
           repo="${GITHUB_REPOSITORY,,}"
@@ -60,12 +73,20 @@ jobs:
       - name: Audit dependencies
         run: cargo audit
 
+  # Reuse the exact PR/main quality gate for the tagged revision. Publishing
+  # jobs below depend on it, so no artifact or image can leave the repository
+  # before tests, clippy, and translation parity pass.
+  quality:
+    permissions:
+      contents: read
+    uses: ./.github/workflows/ci.yml
+
   # --------------------------------------------------------------------
   # Per-arch native build of the static musl binary, then the tarball
   # and the .deb (cargo-deb, reusing that same binary via --no-build).
   # --------------------------------------------------------------------
   artifacts:
-    needs: [meta, cargo-audit]
+    needs: [meta, cargo-audit, quality]
     name: artifacts (${{ matrix.arch }})
     strategy:
       fail-fast: false
@@ -171,7 +192,7 @@ jobs:
   # Per-arch native Docker build, pushed to ghcr by digest (no tag yet).
   # --------------------------------------------------------------------
   docker-build:
-    needs: [meta, cargo-audit]
+    needs: [meta, cargo-audit, quality]
     name: docker (${{ matrix.arch }})
     strategy:
       fail-fast: false


### PR DESCRIPTION
Closes #943.

## Summary

- add a reusable CI workflow for every pull request and push to `main`
- run locked workspace tests and clippy as independent required checks, plus i18n key parity
- call the same quality workflow for release tags before artifact or container publication
- reject release tags whose version differs from `[workspace.package].version`

## Root cause and impact

The repository had healthy local checks but no general GitHub Actions gate. That left merges and tagged releases dependent on manual discipline, including the default SQLite/Postgres migration-filename parity test. The new workflow makes those checks enforceable through branch protection and blocks every publishing path transitively.

The dedicated MSRV workflow from #953 remains complementary and is not duplicated here.

## Verification

- `DOCKER_REGISTRY_PASSWORD=test cargo test --locked`
- `DOCKER_REGISTRY_PASSWORD=test cargo clippy --locked --all-targets -- -D warnings`
- `./scripts/i18n-check.sh`
- YAML parse check for `ci.yml` and `release.yml`
- tag/version smoke: accepts `v0.2.40`, rejects a divergent tag
- `git diff --check`
