### PR TITLE
fix: make auto theme clear preference

### DIFF
--- a/crates/ruscker-admin/src/routes/prefs.rs
+++ b/crates/ruscker-admin/src/routes/prefs.rs
@@ -58,7 +58,7 @@ async fn set_theme(
         Some(val) => cookies.add(persistent_cookie(theme::COOKIE_NAME, val.to_string())),
         // Auto = no explicit choice; remove the cookie so the OS
         // preference takes over.
-        None => cookies.remove(Cookie::new(theme::COOKIE_NAME, "")),
+        None => cookies.remove(removal_cookie(theme::COOKIE_NAME)),
     }
     redirect_back(&headers).into_response()
 }
@@ -71,6 +71,15 @@ fn persistent_cookie(name: &'static str, value: String) -> Cookie<'static> {
     c.set_http_only(true);
     c.set_same_site(tower_cookies::cookie::SameSite::Lax);
     c.set_max_age(Duration::days(365));
+    c
+}
+
+/// Match the persisted cookie's path when removing it. Browsers identify
+/// cookies by name + domain + path, so a path-less removal would leave the
+/// explicit `Path=/` light/dark preference in place.
+fn removal_cookie(name: &'static str) -> Cookie<'static> {
+    let mut c = Cookie::new(name, "");
+    c.set_path("/");
     c
 }
 

--- a/crates/ruscker-admin/tests/landing_render.rs
+++ b/crates/ruscker-admin/tests/landing_render.rs
@@ -203,6 +203,34 @@ async fn landing_emits_data_theme_when_set() {
 }
 
 #[tokio::test]
+async fn set_theme_auto_removes_the_root_scoped_cookie() {
+    let app = router(app_state());
+    let response = app
+        .oneshot(
+            Request::builder()
+                .method("POST")
+                .uri("/__set/theme")
+                .header(header::COOKIE, "ruscker_theme=dark")
+                .header(header::CONTENT_TYPE, "application/x-www-form-urlencoded")
+                .body(Body::from("theme=auto"))
+                .unwrap(),
+        )
+        .await
+        .unwrap();
+
+    assert_eq!(response.status(), StatusCode::SEE_OTHER);
+    let removal = response
+        .headers()
+        .get(header::SET_COOKIE)
+        .expect("Auto emits a removal cookie")
+        .to_str()
+        .unwrap();
+    assert!(removal.starts_with("ruscker_theme="), "{removal}");
+    assert!(removal.contains("Path=/"), "{removal}");
+    assert!(removal.contains("Max-Age=0"), "{removal}");
+}
+
+#[tokio::test]
 async fn landing_stylesheet_link_is_present() {
     let (_, body) = get_with_cookie(None).await;
     // The URL carries a `?v=<version>` cache-buster (#289).


### PR DESCRIPTION
Closes #923.

## Summary

- remove the explicit theme cookie with the same root path used when persisting light/dark
- document why cookie path symmetry is required for browser deletion
- add a route regression covering an existing dark preference followed by `theme=auto`

## Root cause and user impact

Ruscker persisted `ruscker_theme` with `Path=/`, but the Auto handler emitted a path-less removal cookie. Because cookie identity includes the path, browsers kept the old light/dark preference and Auto reverted after navigation instead of following `prefers-color-scheme`.

## Verification

- `DOCKER_REGISTRY_PASSWORD=test cargo test --locked -p ruscker-admin --test landing_render set_theme_auto_removes_the_root_scoped_cookie`
- `DOCKER_REGISTRY_PASSWORD=test cargo test --locked -p ruscker-admin --test landing_render`
- `DOCKER_REGISTRY_PASSWORD=test cargo test --locked`
- `DOCKER_REGISTRY_PASSWORD=test cargo clippy --locked --all-targets -- -D warnings`
- `./scripts/i18n-check.sh`
- `git diff --check`
