### PR TITLE
fix: return users to requested app after login

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2890,6 +2890,7 @@ dependencies = [
  "tower-http",
  "tracing",
  "unic-langid",
+ "url",
  "uuid",
  "zeroize",
 ]

--- a/crates/ruscker-admin/Cargo.toml
+++ b/crates/ruscker-admin/Cargo.toml
@@ -65,6 +65,7 @@ serde_json = { workspace = true }
 serde_yaml_ng = { workspace = true }
 chrono = { workspace = true }
 regex = { workspace = true }
+url = { workspace = true }
 uuid = { workspace = true }
 
 # Persistence (Phase 2)

--- a/crates/ruscker-admin/src/routes/admin.rs
+++ b/crates/ruscker-admin/src/routes/admin.rs
@@ -85,6 +85,10 @@ struct LoginPage<'a> {
     /// `true` ⇒ render the break-glass **token** form (bootstrap or
     /// `?token=1`); `false` ⇒ the username/password form.
     bootstrap: bool,
+    /// Validated root-relative app destination carried through the form.
+    next: String,
+    /// Percent-encoded twin used by the password/token login switch links.
+    next_encoded: String,
 }
 
 impl LoginPage<'_> {
@@ -127,6 +131,9 @@ struct AccountPasswordPage<'a> {
     first: bool,
     /// "" | "wrong-current" | "mismatch" | "short".
     error: &'static str,
+    /// Validated app destination carried through a mandatory first-login
+    /// password change.
+    next: String,
 }
 
 impl AccountPasswordPage<'_> {
@@ -190,6 +197,8 @@ async fn show_token_form(state: &AppState, force_token: bool) -> bool {
 pub struct LoginQuery {
     /// `?token=1` forces the break-glass token form.
     pub token: Option<String>,
+    /// Optional app destination captured by the restricted-app guard.
+    pub next: Option<String>,
 }
 
 async fn login_form(
@@ -199,16 +208,31 @@ async fn login_form(
     Query(q): Query<LoginQuery>,
 ) -> Response {
     let bootstrap = show_token_form(&state, q.token.is_some()).await;
-    let page = LoginPage {
+    let next = app_next_path(q.next.as_deref(), &state.base_path).unwrap_or_default();
+    let page = login_page(&state, loc, theme, "", bootstrap, next);
+    render(&page)
+}
+
+fn login_page<'a>(
+    state: &'a AppState,
+    loc: Locale,
+    theme: Theme,
+    error: &'static str,
+    bootstrap: bool,
+    next: String,
+) -> LoginPage<'a> {
+    let next_encoded = url::form_urlencoded::byte_serialize(next.as_bytes()).collect();
+    LoginPage {
         locale: loc,
         theme,
         locales: &state.locales,
         locales_all: &Locale::ALL,
         base: state.base_path.clone(),
-        error: "",
+        error,
         bootstrap,
-    };
-    render(&page)
+        next,
+        next_encoded,
+    }
 }
 
 fn login_error(
@@ -217,16 +241,9 @@ fn login_error(
     theme: Theme,
     error: &'static str,
     bootstrap: bool,
+    next: String,
 ) -> Response {
-    let page = LoginPage {
-        locale: loc,
-        theme,
-        locales: &state.locales,
-        locales_all: &Locale::ALL,
-        base: state.base_path.clone(),
-        error,
-        bootstrap,
-    };
+    let page = login_page(state, loc, theme, error, bootstrap, next);
     let body = match page.render() {
         Ok(s) => s,
         Err(_) => return (StatusCode::INTERNAL_SERVER_ERROR, "render").into_response(),
@@ -241,6 +258,7 @@ fn login_error(
 pub struct LoginForm {
     pub username: String,
     pub password: String,
+    pub next: Option<String>,
 }
 
 /// Primary login: username + password against the `users` table.
@@ -262,6 +280,7 @@ async fn login_submit(
     if !state.login_limiter.allow() {
         return rate_limited();
     }
+    let next = app_next_path(form.next.as_deref(), &state.base_path);
 
     // Username/password login needs the user store. Without a DB the
     // only way in is the break-glass token.
@@ -270,14 +289,28 @@ async fn login_submit(
         // DB-present and token paths, so a no-DB deploy can't be probed
         // without tripping the same backoff.
         state.login_limiter.record_failure();
-        return login_error(&state, loc, theme, "wrong-login", false);
+        return login_error(
+            &state,
+            loc,
+            theme,
+            "wrong-login",
+            false,
+            next.clone().unwrap_or_default(),
+        );
     };
 
     let user = match db::users::verify_login(pool, &form.username, &form.password).await {
         Ok(Some(u)) => u,
         Ok(None) => {
             state.login_limiter.record_failure();
-            return login_error(&state, loc, theme, "wrong-login", false);
+            return login_error(
+                &state,
+                loc,
+                theme,
+                "wrong-login",
+                false,
+                next.clone().unwrap_or_default(),
+            );
         }
         Err(e) => {
             tracing::error!(error = ?e, "login lookup failed");
@@ -295,29 +328,38 @@ async fn login_submit(
     // First login with an admin-assigned password ⇒ ask whether to
     // change it.
     if user.must_change_password {
-        return Redirect::to("/admin/account/password").into_response();
+        let target = next
+            .as_deref()
+            .map(|next| super::with_next_query("/admin/account/password", next))
+            .unwrap_or_else(|| "/admin/account/password".to_string());
+        return Redirect::to(&target).into_response();
     }
 
-    let referer = headers.get(REFERER).and_then(|v| v.to_str().ok());
-    let raw_path = super::same_origin_path(referer, user.role.home());
-    // Under a base path (#173), referer paths come in as
-    // `/box/admin/specs` — strip the prefix before the `/admin/`
-    // and `/` checks so a non-admin signing in from `/box/admin/X`
-    // returns to `X`, not the dashboard. The response middleware
-    // re-prefixes the `Location` on the way out.
-    let path = strip_base_prefix(&raw_path, &state.base_path);
-    let target = if path == "/" {
-        // Signed in from the public landing — return there so the
-        // viewer sees the apps their groups unlock (#155), rather than
-        // bouncing a non-admin into the panel.
-        path.to_string()
-    } else if path.starts_with("/admin/")
-        && !path.starts_with("/admin/login")
-        && user.role.can_access_section(section_for_admin_path(path))
-    {
-        path.to_string()
-    } else {
-        user.role.home().to_string()
+    let target = match next {
+        Some(target) => target,
+        None => {
+            let referer = headers.get(REFERER).and_then(|v| v.to_str().ok());
+            let raw_path = super::same_origin_path(referer, user.role.home());
+            // Under a base path (#173), referer paths come in as
+            // `/box/admin/specs` — strip the prefix before the `/admin/`
+            // and `/` checks so a non-admin signing in from `/box/admin/X`
+            // returns to `X`, not the dashboard. The response middleware
+            // re-prefixes the `Location` on the way out.
+            let path = strip_base_prefix(&raw_path, &state.base_path);
+            if path == "/" {
+                // Signed in from the public landing — return there so the
+                // viewer sees the apps their groups unlock (#155), rather
+                // than bouncing a non-admin into the panel.
+                path.to_string()
+            } else if path.starts_with("/admin/")
+                && !path.starts_with("/admin/login")
+                && user.role.can_access_section(section_for_admin_path(path))
+            {
+                path.to_string()
+            } else {
+                user.role.home().to_string()
+            }
+        }
     };
     Redirect::to(&target).into_response()
 }
@@ -359,9 +401,23 @@ fn strip_base_prefix<'a>(path: &'a str, base: &str) -> &'a str {
     }
 }
 
+/// Validate an explicit post-login destination and normalize it to the
+/// router's base-less form. The restricted-app guard is the only producer
+/// today, so deliberately accept `/app/...` destinations only: arbitrary
+/// admin paths keep using the existing role-aware Referer fallback.
+fn app_next_path(next: Option<&str>, base: &str) -> Option<String> {
+    let path = super::local_next_path(next)?;
+    let path = strip_base_prefix(path, base);
+    let path_only = path.split(['?', '#']).next().unwrap_or(path);
+    path_only
+        .starts_with("/app/")
+        .then(|| path.to_string())
+}
+
 #[derive(Debug, Deserialize)]
 pub struct TokenForm {
     pub token: String,
+    pub next: Option<String>,
 }
 
 /// Break-glass login with `RUSCKER_ADMIN_TOKEN`. Always grants an
@@ -385,10 +441,18 @@ async fn token_login(
     if !state.login_limiter.allow() {
         return rate_limited();
     }
+    let next = app_next_path(form.next.as_deref(), &state.base_path);
     if !state.admin_auth.matches_token(&form.token) {
         state.login_limiter.record_failure();
         cookies.remove(Cookie::new(COOKIE_NAME, ""));
-        return login_error(&state, loc, theme, "wrong-token", true);
+        return login_error(
+            &state,
+            loc,
+            theme,
+            "wrong-token",
+            true,
+            next.clone().unwrap_or_default(),
+        );
     }
 
     state.login_limiter.record_success();
@@ -403,7 +467,7 @@ async fn token_login(
     if need_setup {
         Redirect::to("/admin/setup").into_response()
     } else {
-        Redirect::to("/admin/dashboard").into_response()
+        Redirect::to(next.as_deref().unwrap_or("/admin/dashboard")).into_response()
     }
 }
 
@@ -519,11 +583,17 @@ async fn setup_submit(
 
 // ── Self-service password change + first-login prompt ─────────────
 
+#[derive(Debug, Deserialize)]
+struct PasswordQuery {
+    next: Option<String>,
+}
+
 async fn password_form(
     session: AdminSession,
     State(state): State<AppState>,
     loc: Locale,
     theme: Theme,
+    Query(query): Query<PasswordQuery>,
 ) -> Response {
     // Break-glass token sessions have no account to change.
     let Some(actor) = session.actor.clone() else {
@@ -538,6 +608,7 @@ async fn password_form(
             .unwrap_or(false),
         None => false,
     };
+    let next = app_next_path(query.next.as_deref(), &state.base_path).unwrap_or_default();
     render(&AccountPasswordPage {
         locale: loc,
         theme,
@@ -548,6 +619,7 @@ async fn password_form(
         role: session.role,
         first,
         error: "",
+        next,
     })
 }
 
@@ -556,6 +628,7 @@ pub struct PasswordForm {
     pub current: String,
     pub new_password: String,
     pub confirm: String,
+    pub next: Option<String>,
 }
 
 async fn password_submit(
@@ -577,6 +650,7 @@ async fn password_submit(
         )
             .into_response();
     };
+    let next = app_next_path(form.next.as_deref(), &state.base_path);
 
     // First login is mandatory (#454): there is no "keep current"
     // escape — the only way past the prompt is a real password change
@@ -598,6 +672,7 @@ async fn password_submit(
             role: session.role,
             first,
             error,
+            next: next.clone().unwrap_or_default(),
         })
     };
 
@@ -638,9 +713,10 @@ async fn password_submit(
         .create(session.role, Some(actor.clone()))
         .await;
     issue_session_cookie(&state, &cookies, &headers, session_id);
-    // Land on the role's home — a Viewer goes to the portal (#857), not
-    // the dashboard it can't open.
-    Redirect::to(session.role.home()).into_response()
+    // Return to the app that triggered authentication when one was carried
+    // through the mandatory password rotation. Otherwise use the role home
+    // (a Viewer goes to the portal, not the dashboard it cannot open).
+    Redirect::to(next.as_deref().unwrap_or(session.role.home())).into_response()
 }
 
 /// Map an `/admin/...` path to the `nav_section` it belongs to, for
@@ -716,7 +792,7 @@ pub(crate) fn render<T: Template>(t: &T) -> Response {
 
 #[cfg(test)]
 mod tests {
-    use super::strip_base_prefix;
+    use super::{app_next_path, strip_base_prefix};
     use super::{LoginPage, SetupPage};
     use crate::i18n::{Locale, Locales};
     use crate::theme::Theme;
@@ -879,6 +955,46 @@ mod tests {
         assert_eq!(strip_base_prefix("/box/?theme=dark", "/box"), "/?theme=dark");
     }
 
+    #[test]
+    fn app_next_accepts_only_app_paths_and_strips_the_base_path() {
+        assert_eq!(
+            app_next_path(Some("/box/app/analysts/report?tab=2"), "/box"),
+            Some("/app/analysts/report?tab=2".to_string())
+        );
+        assert_eq!(
+            app_next_path(Some("/app/demo/"), ""),
+            Some("/app/demo/".to_string())
+        );
+        assert_eq!(
+            app_next_path(Some("https://evil.example/app/demo"), ""),
+            None
+        );
+        assert_eq!(app_next_path(Some("//evil.example/app/demo"), ""), None);
+        assert_eq!(app_next_path(Some("/admin/dashboard"), ""), None);
+    }
+
+    #[test]
+    fn login_page_carries_app_next_across_login_modes() {
+        let locales = Locales::load().expect("load locales");
+        let html = LoginPage {
+            locale: Locale::En,
+            theme: Theme::Auto,
+            locales: &locales,
+            locales_all: &Locale::ALL,
+            base: std::sync::Arc::from(""),
+            error: "",
+            bootstrap: false,
+            next: "/app/demo/?tab=1".to_string(),
+            next_encoded: "%2Fapp%2Fdemo%2F%3Ftab%3D1".to_string(),
+        }
+        .render()
+        .expect("render login");
+        assert!(html.contains(r#"name="next" value="/app/demo/?tab=1""#));
+        assert!(html.contains(
+            r#"href="/admin/login?token=1&amp;next=%2Fapp%2Fdemo%2F%3Ftab%3D1""#
+        ));
+    }
+
     // The favicon set lives in the shared `_favicons.html` partial; the
     // standalone login/setup heads must include it so Safari has the raster
     // .ico/.png to fall back on (Safari can ignore the SVG favicon and
@@ -894,6 +1010,8 @@ mod tests {
             base: std::sync::Arc::from(""),
             error: "",
             bootstrap: false,
+            next: String::new(),
+            next_encoded: String::new(),
         }
         .render()
         .expect("render login");
@@ -940,6 +1058,8 @@ mod tests {
             base: std::sync::Arc::from(""),
             error: "",
             bootstrap: false,
+            next: String::new(),
+            next_encoded: String::new(),
         }
         .render()
         .expect("render login");

--- a/crates/ruscker-admin/src/routes/mod.rs
+++ b/crates/ruscker-admin/src/routes/mod.rs
@@ -47,9 +47,31 @@ pub(crate) fn same_origin_path(referer: Option<&str>, fallback: &'static str) ->
     after_authority.to_string()
 }
 
+/// Accept an explicit post-login destination only when it is already a
+/// root-relative path on this origin. Unlike [`same_origin_path`], this does
+/// not translate an absolute external URL into a local path: an operator- or
+/// attacker-supplied `next=https://evil.example/x` is rejected outright.
+pub(crate) fn local_next_path(value: Option<&str>) -> Option<&str> {
+    let value = value?;
+    let safe = value.starts_with('/')
+        && !value.starts_with("//")
+        && !value.contains('\\')
+        && !value.bytes().any(|b| b < 0x20 || b == 0x7f);
+    safe.then_some(value)
+}
+
+/// Append a percent-encoded `next` query parameter to a local path. The path
+/// may already carry another query parameter (the token-login selector does),
+/// in which case `next` is appended with `&`.
+pub(crate) fn with_next_query(path: &str, next: &str) -> String {
+    let separator = if path.contains('?') { '&' } else { '?' };
+    let encoded: String = url::form_urlencoded::byte_serialize(next.as_bytes()).collect();
+    format!("{path}{separator}next={encoded}")
+}
+
 #[cfg(test)]
 mod same_origin_tests {
-    use super::same_origin_path;
+    use super::{local_next_path, same_origin_path, with_next_query};
 
     #[test]
     fn keeps_path_from_absolute_referer() {
@@ -85,5 +107,26 @@ mod same_origin_tests {
     #[test]
     fn accepts_already_relative_referer() {
         assert_eq!(same_origin_path(Some("/dashboard"), "/"), "/dashboard");
+    }
+
+    #[test]
+    fn explicit_next_accepts_only_root_relative_paths() {
+        assert_eq!(local_next_path(Some("/app/foo?q=1")), Some("/app/foo?q=1"));
+        assert_eq!(local_next_path(Some("https://evil.example/x")), None);
+        assert_eq!(local_next_path(Some("//evil.example/x")), None);
+        assert_eq!(local_next_path(Some("/\\evil.example/x")), None);
+        assert_eq!(local_next_path(Some("/app/foo\nset-cookie:x")), None);
+    }
+
+    #[test]
+    fn next_query_is_encoded_and_appends_to_existing_query() {
+        assert_eq!(
+            with_next_query("/admin/login", "/app/foo?tab=1&sort=name"),
+            "/admin/login?next=%2Fapp%2Ffoo%3Ftab%3D1%26sort%3Dname"
+        );
+        assert_eq!(
+            with_next_query("/admin/login?token=1", "/app/foo/"),
+            "/admin/login?token=1&next=%2Fapp%2Ffoo%2F"
+        );
     }
 }

--- a/crates/ruscker-admin/src/routes/proxy.rs
+++ b/crates/ruscker-admin/src/routes/proxy.rs
@@ -383,8 +383,19 @@ async fn forward(
                 // base-prefixed login URL ourselves (#294) — otherwise a
                 // `/box/app/<spec>` visitor is bounced to a `/admin/login`
                 // that 404s outside the mount.
-                return Redirect::to(&format!("{}/admin/login", state.base_path))
-                    .into_response();
+                // `nest` has already stripped `state.base_path` from this
+                // URI. Carry its untouched path-and-query rather than the
+                // decoded `Path` extractors, preserving percent-encoding.
+                let next = req
+                    .uri()
+                    .path_and_query()
+                    .map(|value| value.as_str())
+                    .unwrap_or_else(|| req.uri().path());
+                let login = super::with_next_query(
+                    &format!("{}/admin/login", state.base_path),
+                    next,
+                );
+                return Redirect::to(&login).into_response();
             }
             return with_cors(
                 (StatusCode::FORBIDDEN, "access denied\n").into_response(),

--- a/crates/ruscker-admin/templates/admin/account_password.html
+++ b/crates/ruscker-admin/templates/admin/account_password.html
@@ -22,6 +22,7 @@
   {% endif %}
 
   <form method="post" action="{{ base }}/admin/account/password" class="flex flex-col gap-3 mt-4" autocomplete="off">
+    {% if next != "" %}<input type="hidden" name="next" value="{{ next }}">{% endif %}
     <label class="admin-login-field">
       <span class="admin-login-label">{{ self.t("admin-pw-current-label") }}</span>
       <input type="password" name="current" required autocomplete="current-password">

--- a/crates/ruscker-admin/templates/admin/login.html
+++ b/crates/ruscker-admin/templates/admin/login.html
@@ -23,6 +23,8 @@
 <form method="post" action="{% if bootstrap %}{{ base }}/admin/login/token{% else %}{{ base }}/admin/login{% endif %}"
       class="admin-login-card" autocomplete="off">
 
+  {% if next != "" %}<input type="hidden" name="next" value="{{ next }}">{% endif %}
+
   <div class="admin-login-brand">
     <svg viewBox="0 0 80 80" width="48" height="48" aria-hidden="true">
       <polygon points="14,52 40,40 66,52 40,64" fill="#0F6E56"/>
@@ -74,9 +76,9 @@
      chrome cluster (#182 + #183). #}
   <div class="admin-login-footer admin-login-footer--end">
     {% if bootstrap %}
-      <a href="{{ base }}/admin/login">{{ self.t("admin-login-use-password") }}</a>
+      <a href="{{ base }}/admin/login{% if next != "" %}?next={{ next_encoded }}{% endif %}">{{ self.t("admin-login-use-password") }}</a>
     {% else %}
-      <a href="{{ base }}/admin/login?token=1">{{ self.t("admin-login-use-token") }}</a>
+      <a href="{{ base }}/admin/login?token=1{% if next != "" %}&amp;next={{ next_encoded }}{% endif %}">{{ self.t("admin-login-use-token") }}</a>
     {% endif %}
     <a href="{{ base }}/">{{ self.t("admin-login-back-portal") }}</a>
   </div>

--- a/crates/ruscker-admin/tests/proxy_access.rs
+++ b/crates/ruscker-admin/tests/proxy_access.rs
@@ -9,6 +9,7 @@
 
 use axum::body::Body;
 use axum::http::{header, Request, StatusCode};
+use axum::response::Response;
 use ruscker_admin::auth::{AdminAuth, Role, COOKIE_NAME};
 use ruscker_admin::db::ConfigDb;
 use ruscker_admin::i18n::Locales;
@@ -84,14 +85,17 @@ async fn app_state(db: ConfigDb) -> AppState {
     }
 }
 
-async fn get(state: AppState, path: &str, cookie: Option<String>) -> StatusCode {
+async fn get_response(state: AppState, path: &str, cookie: Option<String>) -> Response {
     let app = router(state);
     let mut req = Request::builder().method("GET").uri(path);
     if let Some(c) = cookie {
         req = req.header(header::COOKIE, c);
     }
-    let resp = app.oneshot(req.body(Body::empty()).unwrap()).await.unwrap();
-    resp.status()
+    app.oneshot(req.body(Body::empty()).unwrap()).await.unwrap()
+}
+
+async fn get(state: AppState, path: &str, cookie: Option<String>) -> StatusCode {
+    get_response(state, path, cookie).await.status()
 }
 
 /// A request that the guard lets through lands on the "no backend"
@@ -113,10 +117,43 @@ async fn open_api_reachable_anonymously() {
 #[tokio::test]
 async fn restricted_app_redirects_anonymous_to_login() {
     let state = app_state(open_db().await).await;
-    // Redirect::to ⇒ 303 See Other to /admin/login (guard fires before
-    // the backend check, so this is not a 503).
-    let st = get(state, "/app/analysts-app/", None).await;
-    assert_eq!(st, StatusCode::SEE_OTHER, "anon → login redirect");
+    // Redirect::to ⇒ 303 See Other. The original path and query are
+    // carried in `next`, so a successful login can return here (#924).
+    let response = get_response(
+        state,
+        "/app/analysts-app/report%20name?tab=a%2Fb",
+        None,
+    )
+    .await;
+    assert_eq!(
+        response.status(),
+        StatusCode::SEE_OTHER,
+        "anon → login redirect"
+    );
+    assert_eq!(
+        response
+            .headers()
+            .get(header::LOCATION)
+            .and_then(|value| value.to_str().ok()),
+        Some(
+            "/admin/login?next=%2Fapp%2Fanalysts-app%2Freport%2520name%3Ftab%3Da%252Fb"
+        )
+    );
+}
+
+#[tokio::test]
+async fn restricted_app_login_redirect_keeps_the_base_path() {
+    let mut state = app_state(open_db().await).await;
+    state.base_path = Arc::from("/box");
+    let response = get_response(state, "/box/app/analysts-app/report?tab=2", None).await;
+    assert_eq!(response.status(), StatusCode::SEE_OTHER);
+    assert_eq!(
+        response
+            .headers()
+            .get(header::LOCATION)
+            .and_then(|value| value.to_str().ok()),
+        Some("/box/admin/login?next=%2Fapp%2Fanalysts-app%2Freport%3Ftab%3D2")
+    );
 }
 
 #[tokio::test]

--- a/crates/ruscker-admin/tests/user_accounts.rs
+++ b/crates/ruscker-admin/tests/user_accounts.rs
@@ -116,6 +116,98 @@ async fn password_login_succeeds_and_wrong_fails() {
 }
 
 #[tokio::test]
+async fn password_login_honors_only_a_local_app_next() {
+    let (state, pool) = state_with_db().await;
+    ruscker_admin::db::users::create(
+        &ruscker_admin::db::ConfigDb::Sqlite(pool),
+        "alice",
+        "alicepass1",
+        Role::Viewer,
+        false,
+        &[],
+        None,
+    )
+    .await
+    .unwrap();
+
+    let (safe_status, safe_location) = post(
+        state.clone(),
+        "/admin/login",
+        "username=alice&password=alicepass1&next=%2Fapp%2Fanalysts-app%2F%3Ftab%3D1",
+        None,
+    )
+    .await;
+    assert_eq!(safe_status, StatusCode::SEE_OTHER);
+    assert_eq!(safe_location, "/app/analysts-app/?tab=1");
+
+    let (external_status, external_location) = post(
+        state,
+        "/admin/login",
+        "username=alice&password=alicepass1&next=https%3A%2F%2Fevil.example%2Fpwn",
+        None,
+    )
+    .await;
+    assert_eq!(external_status, StatusCode::SEE_OTHER);
+    assert_eq!(
+        external_location, "/",
+        "external next falls back to role home"
+    );
+}
+
+#[tokio::test]
+async fn app_next_is_reprefixed_under_a_base_path() {
+    let (mut state, pool) = state_with_db().await;
+    state.base_path = Arc::from("/box");
+    ruscker_admin::db::users::create(
+        &ruscker_admin::db::ConfigDb::Sqlite(pool),
+        "alice",
+        "alicepass1",
+        Role::Viewer,
+        false,
+        &[],
+        None,
+    )
+    .await
+    .unwrap();
+
+    let (status, location) = post(
+        state,
+        "/box/admin/login",
+        "username=alice&password=alicepass1&next=%2Fapp%2Fanalysts-app%2F",
+        None,
+    )
+    .await;
+    assert_eq!(status, StatusCode::SEE_OTHER);
+    assert_eq!(location, "/box/app/analysts-app/");
+}
+
+#[tokio::test]
+async fn token_login_honors_a_local_app_next_after_bootstrap() {
+    let (state, pool) = state_with_db().await;
+    ruscker_admin::db::users::create(
+        &ruscker_admin::db::ConfigDb::Sqlite(pool),
+        "admin",
+        "adminpass1",
+        Role::Admin,
+        false,
+        &[],
+        None,
+    )
+    .await
+    .unwrap();
+
+    let (status, location) = post(
+        state,
+        "/admin/login/token",
+        "token=break-glass-tok&next=%2Fapp%2Fanalysts-app%2F",
+        None,
+    )
+    .await;
+    assert_eq!(status, StatusCode::SEE_OTHER);
+    assert_eq!(location, "/app/analysts-app/");
+}
+
+#[tokio::test]
 async fn first_login_with_must_change_redirects_to_password() {
     let (state, pool) = state_with_db().await;
     // must_change = true ⇒ first login lands on the change-password page.
@@ -131,6 +223,98 @@ async fn first_login_with_must_change_redirects_to_password() {
     .await;
     assert_eq!(status, StatusCode::SEE_OTHER);
     assert_eq!(loc, "/admin/account/password");
+}
+
+#[tokio::test]
+async fn app_next_survives_mandatory_password_rotation() {
+    let (state, pool) = state_with_db().await;
+    ruscker_admin::db::users::create(
+        &ruscker_admin::db::ConfigDb::Sqlite(pool),
+        "bob",
+        "bobpass12",
+        Role::Viewer,
+        true,
+        &[],
+        None,
+    )
+    .await
+    .unwrap();
+    let app = router(state);
+
+    let login = app
+        .clone()
+        .oneshot(
+            Request::builder()
+                .method("POST")
+                .uri("/admin/login")
+                .header("content-type", "application/x-www-form-urlencoded")
+                .body(Body::from(
+                    "username=bob&password=bobpass12&next=%2Fapp%2Fanalysts-app%2F%3Ftab%3D1",
+                ))
+                .unwrap(),
+        )
+        .await
+        .unwrap();
+    assert_eq!(login.status(), StatusCode::SEE_OTHER);
+    assert_eq!(
+        login
+            .headers()
+            .get("location")
+            .and_then(|value| value.to_str().ok()),
+        Some("/admin/account/password?next=%2Fapp%2Fanalysts-app%2F%3Ftab%3D1")
+    );
+    let cookie = login
+        .headers()
+        .get("set-cookie")
+        .and_then(|value| value.to_str().ok())
+        .and_then(|value| value.split(';').next())
+        .expect("login issues a session cookie")
+        .to_string();
+
+    let password_page = app
+        .clone()
+        .oneshot(
+            Request::builder()
+                .uri("/admin/account/password?next=%2Fapp%2Fanalysts-app%2F%3Ftab%3D1")
+                .header("cookie", &cookie)
+                .body(Body::empty())
+                .unwrap(),
+        )
+        .await
+        .unwrap();
+    assert_eq!(password_page.status(), StatusCode::OK);
+    let body = axum::body::to_bytes(password_page.into_body(), 1 << 20)
+        .await
+        .unwrap();
+    assert!(
+        std::str::from_utf8(&body)
+            .unwrap()
+            .contains(r#"name="next" value="/app/analysts-app/?tab=1""#),
+        "password form must preserve the validated destination"
+    );
+
+    let changed = app
+        .oneshot(
+            Request::builder()
+                .method("POST")
+                .uri("/admin/account/password")
+                .header("content-type", "application/x-www-form-urlencoded")
+                .header("cookie", cookie)
+                .body(Body::from(
+                    "current=bobpass12&new_password=bobpass-new9&confirm=bobpass-new9&next=%2Fapp%2Fanalysts-app%2F%3Ftab%3D1",
+                ))
+                .unwrap(),
+        )
+        .await
+        .unwrap();
+    assert_eq!(changed.status(), StatusCode::SEE_OTHER);
+    assert_eq!(
+        changed
+            .headers()
+            .get("location")
+            .and_then(|value| value.to_str().ok()),
+        Some("/app/analysts-app/?tab=1")
+    );
 }
 
 /// Count `<form ` opens, then verify none of them is nested inside


### PR DESCRIPTION
Closes #924.

## Summary
- preserve the original restricted-app path and query in the anonymous login redirect
- validate post-login destinations as local `/app/...` paths to prevent open redirects
- honor the destination across password login, token login, login errors, mandatory password rotation, and base-path mounts
- preserve percent-encoded path/query bytes when constructing `next`

## User impact
Users who open a direct link to a restricted app now return to that app after authenticating instead of landing on the portal or admin home.

## Root cause
The restricted-app access guard redirected anonymous requests to a fixed login URL, so the login handlers had no record of the app URL that initiated authentication. The mandatory password-change flow also used fixed redirects.

## Verification
- `DOCKER_REGISTRY_PASSWORD=test cargo test --locked`
- `DOCKER_REGISTRY_PASSWORD=test cargo clippy --locked --all-targets -- -D warnings`
- `./scripts/i18n-check.sh`
- `git diff --check`
