### PR TITLE
fix: make Tailwind offline failures actionable

### DIFF
--- a/README.md
+++ b/README.md
@@ -185,6 +185,12 @@ cargo build --release          # rustup fetches the pinned toolchain on first ru
 ./target/release/ruscker --help
 ```
 
+The first source build downloads the pinned standalone Tailwind CLI to
+`~/.cache/ruscker`. For an offline build, provide a previously downloaded
+binary with `TAILWIND_BIN=/path/to/tailwindcss cargo build --release`.
+Backend-only builds and tests may use `TAILWIND_SKIP=1`, which deliberately
+embeds placeholder CSS and therefore produces an unstyled admin UI.
+
 Development and release builds use Rust 1.96.0 from
 `rust-toolchain.toml`. The MSRV source of truth is
 `workspace.package.rust-version` in `Cargo.toml` (currently 1.94.0), and

--- a/book/src/troubleshooting.md
+++ b/book/src/troubleshooting.md
@@ -68,6 +68,22 @@ container on a machine with full internet, or in CI — and copy the
 artifact over. Docker pulls and the `build.rs` Tailwind download (from
 GitHub) still work from a connected builder.
 
+If crates and the Rust toolchain are already cached but GitHub is unavailable,
+the admin build script cannot download its pinned standalone Tailwind CLI.
+Choose one of these explicit offline modes:
+
+```bash
+# Production/UI build: supply a previously downloaded Tailwind executable.
+TAILWIND_BIN=/opt/tailwindcss cargo build --release
+
+# Backend-only development/tests: compile with placeholder, unstyled CSS.
+TAILWIND_SKIP=1 cargo test --locked
+```
+
+`TAILWIND_SKIP` is not suitable for a production admin UI. Without either
+setting, a missing download now fails with a concise error explaining these
+options instead of a Rust panic.
+
 ## `perl: warning: Setting locale failed` during `apt`/`dpkg`
 Cosmetic — the install still succeeds. It means a locale your SSH
 session forwards (commonly `LC_CTYPE=UTF-8` from a macOS client via

--- a/crates/ruscker-admin/build.rs
+++ b/crates/ruscker-admin/build.rs
@@ -20,8 +20,9 @@
 //! ## Offline / air-gapped builds
 //!
 //! Set `TAILWIND_BIN=/path/to/tailwindcss` to skip the download and
-//! use a pre-installed binary. CI caches the download under
-//! `~/.cache/ruscker/tailwindcss-<ver>`.
+//! use a pre-installed binary. `TAILWIND_SKIP=1` emits placeholder CSS
+//! for backend-only builds/tests where the admin UI is not needed. CI
+//! caches the download under `~/.cache/ruscker/tailwindcss-<ver>`.
 
 use std::env;
 use std::fs;
@@ -31,6 +32,17 @@ use std::process::Command;
 const TAILWIND_VERSION: &str = "4.3.0";
 
 fn main() {
+    if let Err(error) = run() {
+        eprintln!("ruscker-admin build error: {error}");
+        eprintln!(
+            "offline build: set TAILWIND_BIN=/path/to/tailwindcss, or use \
+             TAILWIND_SKIP=1 only when an unstyled admin UI is acceptable"
+        );
+        std::process::exit(1);
+    }
+}
+
+fn run() -> Result<(), String> {
     // Rerun triggers — only the things that actually affect the
     // generated CSS or the Tailwind binary choice.
     println!("cargo:rerun-if-changed=build.rs");
@@ -40,49 +52,70 @@ fn main() {
     println!("cargo:rerun-if-env-changed=TAILWIND_BIN");
     println!("cargo:rerun-if-env-changed=TAILWIND_SKIP");
 
-    let out_dir = PathBuf::from(env::var("OUT_DIR").expect("OUT_DIR set by cargo"));
+    let out_dir = PathBuf::from(
+        env::var("OUT_DIR").map_err(|error| format!("Cargo did not set OUT_DIR: {error}"))?,
+    );
     let css_out = out_dir.join("styles.css");
 
     if env::var("TAILWIND_SKIP").is_ok() {
         // Still emit something so include_bytes! works in src/routes.
-        if !css_out.exists() {
-            fs::write(&css_out, b"/* tailwind skipped */\n").unwrap();
-        }
+        fs::write(&css_out, b"/* tailwind skipped */\n").map_err(|error| {
+            format!(
+                "failed to write placeholder CSS to {}: {error}",
+                css_out.display()
+            )
+        })?;
         println!("cargo:warning=TAILWIND_SKIP set — emitted placeholder styles.css");
-        return;
+        return Ok(());
     }
 
     let bin = match env::var("TAILWIND_BIN") {
         Ok(p) => PathBuf::from(p),
-        Err(_) => ensure_binary(),
+        Err(_) => ensure_binary()?,
     };
 
-    let manifest_dir = PathBuf::from(env::var("CARGO_MANIFEST_DIR").unwrap());
+    let manifest_dir = PathBuf::from(env::var("CARGO_MANIFEST_DIR").map_err(|error| {
+        format!("Cargo did not set CARGO_MANIFEST_DIR: {error}")
+    })?);
     let input = manifest_dir.join("assets/tailwind/input.css");
 
     let status = Command::new(&bin)
-        .args(["-i".as_ref(), input.as_os_str(), "-o".as_ref(), css_out.as_os_str()])
+        .args([
+            "-i".as_ref(),
+            input.as_os_str(),
+            "-o".as_ref(),
+            css_out.as_os_str(),
+        ])
         .arg("--minify")
         .status()
-        .unwrap_or_else(|e| panic!("failed to invoke tailwind ({}): {e}", bin.display()));
+        .map_err(|error| format!("failed to invoke tailwind ({}): {error}", bin.display()))?;
 
     if !status.success() {
-        panic!("tailwindcss compile failed (exit {:?})", status.code());
+        return Err(format!(
+            "tailwindcss compile failed (exit {:?})",
+            status.code()
+        ));
     }
+    Ok(())
 }
 
 /// Resolve the standalone Tailwind binary for the host platform,
 /// downloading once and caching under `~/.cache/ruscker/`.
-fn ensure_binary() -> PathBuf {
-    let asset = host_asset_name();
-    let cache_root = cache_dir().join("ruscker");
+fn ensure_binary() -> Result<PathBuf, String> {
+    let asset = host_asset_name()?;
+    let cache_root = cache_dir()?.join("ruscker");
     let cache_path = cache_root.join(format!("tailwindcss-{TAILWIND_VERSION}-{asset}"));
 
     if cache_path.exists() {
-        return cache_path;
+        return Ok(cache_path);
     }
 
-    fs::create_dir_all(&cache_root).expect("create cache dir");
+    fs::create_dir_all(&cache_root).map_err(|error| {
+        format!(
+            "failed to create Tailwind cache {}: {error}",
+            cache_root.display()
+        )
+    })?;
 
     let url = format!(
         "https://github.com/tailwindlabs/tailwindcss/releases/download/v{TAILWIND_VERSION}/{asset}"
@@ -98,31 +131,54 @@ fn ensure_binary() -> PathBuf {
         .arg(&tmp)
         .arg(&url)
         .status()
-        .expect("curl failed to start (is curl installed?)");
+        .map_err(|error| format!("failed to start curl while downloading {url}: {error}"))?;
     if !status.success() {
         let _ = fs::remove_file(&tmp);
-        panic!("curl download of {url} failed (exit {:?})", status.code());
+        return Err(format!(
+            "curl download of {url} failed (exit {:?})",
+            status.code()
+        ));
     }
 
     #[cfg(unix)]
     {
         use std::os::unix::fs::PermissionsExt;
-        let mut perms = fs::metadata(&tmp).unwrap().permissions();
+        let mut perms = fs::metadata(&tmp)
+            .map_err(|error| {
+                format!(
+                    "failed to read downloaded Tailwind metadata {}: {error}",
+                    tmp.display()
+                )
+            })?
+            .permissions();
         perms.set_mode(0o755);
-        fs::set_permissions(&tmp, perms).unwrap();
+        fs::set_permissions(&tmp, perms).map_err(|error| {
+            format!(
+                "failed to make downloaded Tailwind executable {}: {error}",
+                tmp.display()
+            )
+        })?;
     }
 
-    fs::rename(&tmp, &cache_path).expect("rename downloaded binary");
-    cache_path
+    fs::rename(&tmp, &cache_path).map_err(|error| {
+        format!(
+            "failed to install downloaded Tailwind {} as {}: {error}",
+            tmp.display(),
+            cache_path.display()
+        )
+    })?;
+    Ok(cache_path)
 }
 
 /// Asset filename for the current build host. Matches the naming
 /// pattern from <https://github.com/tailwindlabs/tailwindcss/releases>.
-fn host_asset_name() -> &'static str {
-    let os = env::var("CARGO_CFG_TARGET_OS").unwrap();
-    let arch = env::var("CARGO_CFG_TARGET_ARCH").unwrap();
+fn host_asset_name() -> Result<&'static str, String> {
+    let os = env::var("CARGO_CFG_TARGET_OS")
+        .map_err(|error| format!("Cargo did not set CARGO_CFG_TARGET_OS: {error}"))?;
+    let arch = env::var("CARGO_CFG_TARGET_ARCH")
+        .map_err(|error| format!("Cargo did not set CARGO_CFG_TARGET_ARCH: {error}"))?;
     let env_abi = env::var("CARGO_CFG_TARGET_ENV").unwrap_or_default();
-    match (os.as_str(), arch.as_str(), env_abi.as_str()) {
+    let asset = match (os.as_str(), arch.as_str(), env_abi.as_str()) {
         ("macos", "aarch64", _) => "tailwindcss-macos-arm64",
         ("macos", "x86_64", _) => "tailwindcss-macos-x64",
         ("linux", "aarch64", "musl") => "tailwindcss-linux-arm64-musl",
@@ -130,14 +186,20 @@ fn host_asset_name() -> &'static str {
         ("linux", "x86_64", "musl") => "tailwindcss-linux-x64-musl",
         ("linux", "x86_64", _) => "tailwindcss-linux-x64",
         // No Windows in scope (PLAN.md §6.1 lists it as out-of-scope).
-        (o, a, e) => panic!("no Tailwind 4 standalone binary for {o}/{a}/{e}; set TAILWIND_BIN"),
-    }
+        (o, a, e) => {
+            return Err(format!(
+                "no Tailwind 4 standalone binary for {o}/{a}/{e}"
+            ));
+        }
+    };
+    Ok(asset)
 }
 
-fn cache_dir() -> PathBuf {
+fn cache_dir() -> Result<PathBuf, String> {
     if let Ok(p) = env::var("XDG_CACHE_HOME") {
-        return PathBuf::from(p);
+        return Ok(PathBuf::from(p));
     }
-    let home = env::var("HOME").expect("HOME env var must be set");
-    Path::new(&home).join(".cache")
+    let home = env::var("HOME")
+        .map_err(|error| format!("HOME is unset and XDG_CACHE_HOME is unavailable: {error}"))?;
+    Ok(Path::new(&home).join(".cache"))
 }


### PR DESCRIPTION
Closes #931.

## Summary
- replace build-script panics and unchecked filesystem/process operations with contextual errors
- print explicit offline recovery instructions when Tailwind cannot be downloaded or invoked
- keep `TAILWIND_BIN` as the production-safe offline path and document `TAILWIND_SKIP=1` as an unstyled backend/test-only mode
- document offline source builds in the README and troubleshooting guide

## User impact
Offline and air-gapped builds now fail with a concise actionable message instead of a Rust panic. Operators can supply a cached Tailwind executable, while backend-only test environments can explicitly opt into placeholder CSS.

## Root cause
The admin build script used `panic!`, `expect`, and `unwrap` for environment, process, and filesystem failures. A missing network connection or `curl` therefore surfaced as an opaque custom-build panic even though an opt-in skip path already existed.

## Verification
- simulated missing `curl`/network with an empty `PATH`: exit 1, actionable error, no panic
- simulated missing `TAILWIND_BIN` through a real Cargo build: actionable error, no panic
- `TAILWIND_SKIP=1 DOCKER_REGISTRY_PASSWORD=test cargo build --locked -p ruscker-admin`
- `DOCKER_REGISTRY_PASSWORD=test cargo build --locked -p ruscker-admin`
- `DOCKER_REGISTRY_PASSWORD=test cargo test --locked`
- `DOCKER_REGISTRY_PASSWORD=test cargo clippy --locked --all-targets -- -D warnings`
- `mdbook build book`
- `./scripts/i18n-check.sh`
- `git diff --check`
