### PR TITLE
ci: enforce migration parity

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -1,0 +1,14 @@
+## Summary
+
+<!-- What changed, and why? -->
+
+## Verification
+
+<!-- List the commands or checks used to validate the change. -->
+
+## Migration checklist
+
+<!-- Choose one when this PR changes database migrations. -->
+
+- [ ] Not applicable: this PR does not add, rename, or remove a migration.
+- [ ] SQLite and Postgres twins use the same filename in `migrations/` and `migrations-pg/`, and `bash ./scripts/migration-parity-check.sh` passes.

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -19,6 +19,17 @@ concurrency:
   cancel-in-progress: true
 
 jobs:
+  migration-parity:
+    name: Migration parity
+    runs-on: ubuntu-24.04
+    steps:
+      - uses: actions/checkout@v6
+
+      # Keep this independent from the Rust build so a missing SQLite or
+      # Postgres migration twin fails quickly with a filename diff (#938).
+      - name: Check SQLite/Postgres migration parity
+        run: bash ./scripts/migration-parity-check.sh
+
   test:
     name: Tests
     runs-on: ubuntu-24.04

--- a/scripts/migration-parity-check.sh
+++ b/scripts/migration-parity-check.sh
@@ -1,0 +1,27 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+repo_root="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+sqlite_dir="$repo_root/crates/ruscker-admin/migrations"
+postgres_dir="$repo_root/crates/ruscker-admin/migrations-pg"
+
+for dir in "$sqlite_dir" "$postgres_dir"; do
+    if [[ ! -d "$dir" ]]; then
+        printf 'migration parity: directory not found: %s\n' "$dir" >&2
+        exit 1
+    fi
+done
+
+migration_names() {
+    find "$1" -maxdepth 1 -type f -name '*.sql' -exec basename {} \; | LC_ALL=C sort
+}
+
+if ! diff -u <(migration_names "$sqlite_dir") <(migration_names "$postgres_dir"); then
+    printf '%s\n' \
+        'migration parity failed: SQLite and Postgres must contain the same .sql filenames.' \
+        'Add, rename, or remove the matching migration in both directories.' >&2
+    exit 1
+fi
+
+count="$(migration_names "$sqlite_dir" | wc -l | tr -d '[:space:]')"
+printf 'migration parity ok: %s matching files\n' "$count"


### PR DESCRIPTION
Closes #938.

## Summary
- add a dedicated `Migration parity` CI job that runs before any Rust build
- compare the sorted SQLite and Postgres migration filenames with an actionable unified diff
- report the matching migration count on success
- add a pull-request checklist for migration twins

## User and developer impact
A missing, renamed, or removed migration twin now fails as a clearly named CI check without waiting for the Rust workspace to compile. Contributors also see the dual-dialect requirement while preparing a PR.

## Root cause
The repository already had a Rust unit test for filename parity, but the invariant was hidden inside the full test suite and absent from the pull-request workflow. That made an important HA schema rule easy to overlook and slower to diagnose.

## Verification
- `bash -n scripts/migration-parity-check.sh`
- `bash scripts/migration-parity-check.sh` (26 matching files)
- `DOCKER_REGISTRY_PASSWORD=test cargo test --locked -p ruscker-admin migration_parity`
- `DOCKER_REGISTRY_PASSWORD=test cargo test --locked`
- `DOCKER_REGISTRY_PASSWORD=test cargo clippy --locked --all-targets -- -D warnings`
- `./scripts/i18n-check.sh`
- `git diff --check`
