### PR TITLE
chore: enforce dead code linting

### DIFF
--- a/crates/ruscker-admin/src/lib.rs
+++ b/crates/ruscker-admin/src/lib.rs
@@ -11,8 +11,6 @@
 //! Admin CRUD (Phase 2), proxy (Phase 3), dashboard (Phase 4) come
 //! later.
 
-#![allow(dead_code)]
-
 use anyhow::{Context, Result};
 use axum::Router;
 use ruscker_config::Config;

--- a/crates/ruscker-admin/src/routes/admin/dashboard.rs
+++ b/crates/ruscker-admin/src/routes/admin/dashboard.rs
@@ -264,9 +264,7 @@ struct DashboardPage<'a> {
     total_sessions: u32,
     spec_count: usize,
     tracker_sessions: usize,
-    total_memory_bytes: u64,
     total_memory_display: String,
-    rows: Vec<ReplicaRow>,
     /// The same replicas grouped by app for the accordion render (#623).
     groups: Vec<AppGroup>,
     /// JSON of the same snapshot, embedded in a `<script
@@ -381,10 +379,8 @@ async fn index(
         total_sessions: snap.total_sessions,
         spec_count: snap.spec_count,
         tracker_sessions: snap.tracker_sessions,
-        total_memory_bytes: snap.total_memory_bytes,
         total_memory_display: snap.total_memory_display.clone(),
         groups: group_rows(&snap.rows),
-        rows: snap.rows.clone(),
         snapshot_json,
     };
     super::render(&page)
@@ -992,10 +988,8 @@ mod tests {
                 .collect::<std::collections::HashSet<_>>()
                 .len(),
             tracker_sessions: 0,
-            total_memory_bytes: 0,
             total_memory_display: "—".to_string(),
             groups: group_rows(&rows),
-            rows,
             snapshot_json: "{}".to_string(),
         };
         page.render().expect("render dashboard")

--- a/crates/ruscker-admin/src/routes/landing.rs
+++ b/crates/ruscker-admin/src/routes/landing.rs
@@ -18,7 +18,7 @@ use crate::auth::{MaybeSession, Role};
 use crate::i18n::{Locale, Locales};
 use crate::theme::Theme;
 use crate::view_model::{
-    build_type_chips, sort_by_recent, unique_subjects, CardCounts, CardCtx, DisplayType, TypeChip,
+    build_type_chips, sort_by_recent, unique_subjects, CardCtx, DisplayType, TypeChip,
 };
 use crate::AppState;
 
@@ -67,7 +67,6 @@ struct LandingPage<'a> {
     /// Unique themes present in this config, alphabetically. Drives
     /// the `<select>` filter at the top of the landing.
     subjects: Vec<&'a str>,
-    counts: CardCounts,
     /// Resolved per-locale intro, rendered through the inline-Markdown
     /// subset (#812: **bold**, *italic*, [links] — escape-first, see
     /// `crate::markdown`). Empty string when no intro is configured;
@@ -202,12 +201,6 @@ impl<'a> LandingPage<'a> {
     /// whether to render a slot's chrome insert (header-left replaces the
     /// Ruscker mark; header-right sits after the chrome cluster; the
     /// `center` bucket still renders as a separate bar). See #468.
-    /// Any card in the "Featured" section? Gates the carousel together
-    /// with `show_highlights` (#506/#858 — favorites ∪ admin-featured).
-    fn has_featured(&self) -> bool {
-        !self.highlights.is_empty()
-    }
-
     fn has_logos_at(&self, slot: &str, align: &str) -> bool {
         self.logos.iter().any(|l| l.slot == slot && l.align == align)
     }
@@ -382,9 +375,6 @@ async fn index(
 
     let type_chips = build_type_chips(&cards);
     let subjects = unique_subjects(&cards);
-    let counts = CardCounts {
-        total: cards.iter().filter(|c| c.active).count(),
-    };
 
     // Landing customization: read from DB when available
     // (admin-editable), fall back to the YAML-derived value
@@ -585,7 +575,6 @@ async fn index(
         cards,
         type_chips,
         subjects,
-        counts,
         intro: crate::markdown::render_inline(&intro),
         header_title,
         header_subtitle,

--- a/crates/ruscker-admin/src/view_model.rs
+++ b/crates/ruscker-admin/src/view_model.rs
@@ -440,12 +440,6 @@ pub struct TypeChip {
     pub count: usize,
 }
 
-/// Counts to display alongside filter chips.
-#[derive(Debug, Clone, Default)]
-pub struct CardCounts {
-    pub total: usize,
-}
-
 /// Sort cards by recency (newest first). Cards without a parseable
 /// `updated` date sink to the end, preserving their relative
 /// declaration order. This matches the "Recentes" sort the mockup

--- a/crates/ruscker-admin/templates/landing.html
+++ b/crates/ruscker-admin/templates/landing.html
@@ -189,6 +189,7 @@
 
   {# ── Sticky filter cluster (#623): search + filters + meta stay
      reachable while the catalog scrolls under them. ── #}
+  {% if show_search || show_filters %}
   <div class="portal-sticky">
   {# ── Filter row 1: search + theme select + sort + status ───── #}
   <div class="flex flex-wrap gap-2.5 items-center mb-3.5">
@@ -203,6 +204,7 @@
     </label>
     {% endif %}
 
+    {% if show_filters %}
     <div class="select-wrap" :class="subject !== 'all' ? 'is-active' : ''">
       <select x-model="subject"
               class="theme-select"
@@ -235,8 +237,10 @@
       </select>
       <i class="ti ti-chevron-down select-chevron" aria-hidden="true"></i>
     </div>
+    {% endif %}
   </div>
 
+  {% if show_filters %}
   {# ── Filter row 2: type chips with long labels ───── #}
   <div class="flex flex-wrap items-center gap-1.5 mb-2">
     <button class="chip"
@@ -255,6 +259,7 @@
     {% endfor %}
 
   </div>
+  {% endif %}
 
   {# ── Meta row: count + clear filters ───────────────────────── #}
   <div class="text-[11px] text-[color:var(--text-faint)] mb-3.5 flex items-center gap-1.5">
@@ -266,6 +271,7 @@
     </button>
   </div>
   </div>{# /portal-sticky #}
+  {% endif %}
 
   {# ── Card area (#701): one or more groups. `grid`/`list` renders a
      single unlabeled group with every card; `sections` renders one

--- a/crates/ruscker-admin/tests/landing_render.rs
+++ b/crates/ruscker-admin/tests/landing_render.rs
@@ -165,6 +165,39 @@ proxy:
 }
 
 #[tokio::test]
+async fn filters_toggle_hides_filters_without_hiding_search() {
+    // The crate-wide dead-code suppression hid that `show-filters` was
+    // carried into the page model but never consulted by the template
+    // (#935). Search and filters are independent appearance switches.
+    let yaml = r#"
+proxy:
+  title: Filter Toggle Test
+  landing-customization:
+    show-search: true
+    show-filters: false
+  specs:
+    - id: alpha
+      display-name: Alpha
+      container-image: img:1
+"#;
+    let app = router(state_from_yaml(yaml));
+    let response = app
+        .oneshot(Request::builder().uri("/").body(Body::empty()).unwrap())
+        .await
+        .unwrap();
+    assert_eq!(response.status(), StatusCode::OK);
+    let body = axum::body::to_bytes(response.into_body(), 1024 * 1024)
+        .await
+        .unwrap();
+    let body = String::from_utf8(body.to_vec()).unwrap();
+
+    assert!(body.contains(r#"type="search""#), "search remains visible");
+    assert!(!body.contains(r#"x-model="subject""#), "subject filter is hidden");
+    assert!(!body.contains(r#"x-model="status_""#), "status filter is hidden");
+    assert!(!body.contains(r#"class="chip""#), "type chips are hidden");
+}
+
+#[tokio::test]
 async fn landing_honors_locale_cookie() {
     // Distinctive substrings from the per-locale intro in the example's
     // landing-customization.intro-locales — proves the locale cookie

--- a/crates/ruscker-docker/src/lib.rs
+++ b/crates/ruscker-docker/src/lib.rs
@@ -14,8 +14,6 @@
 //! Ruscker can crash and resume without losing track of who's
 //! running.
 
-#![allow(dead_code)]
-
 use async_trait::async_trait;
 use bollard::models::{
     ContainerCreateBody, ContainerSummaryStateEnum, HostConfig, NetworkCreateRequest, PortBinding,
@@ -1232,8 +1230,8 @@ fn cpu_percent_from_delta(
 /// means ready".
 /// `Some(exit_code)` once the container has stopped/exited, `None` while
 /// it is still running (or inspect failed — treat as "keep waiting").
-/// Mirrors the string-matching style of `state_from_docker` so it's
-/// robust across bollard enum shapes (#550 A).
+/// Uses the formatted status defensively because the inspect response's
+/// nested status type differs from the container-summary enum (#550 A).
 async fn container_exit_code(docker: &Docker, container_id: &str) -> Option<i64> {
     let info = docker.inspect_container(container_id, None).await.ok()?;
     let state = info.state?;
@@ -1376,19 +1374,6 @@ fn state_from_enum(s: Option<&ContainerSummaryStateEnum>) -> ReplicaState {
         _ => ReplicaState::Starting,
     }
 }
-
-fn state_from_docker(s: Option<&str>) -> ReplicaState {
-    match s {
-        Some(s) if s.contains("running") => ReplicaState::Ready,
-        Some(s) if s.contains("created") || s.contains("restarting") => ReplicaState::Starting,
-        Some(s) if s.contains("paused") => ReplicaState::Draining,
-        Some(s) if s.contains("exited") || s.contains("dead") || s.contains("removing") => {
-            ReplicaState::Stopped
-        }
-        _ => ReplicaState::Starting,
-    }
-}
-
 
 const DOCKER_HUB_REGISTRY: &str = "https://index.docker.io/v1/";
 
@@ -1590,15 +1575,6 @@ mod tests {
         assert_eq!(registry_from_image("docker.io/acme/app"), DOCKER_HUB_REGISTRY);
         assert_eq!(registry_from_image("ghcr.io/acme/app"), "ghcr.io");
         assert_eq!(registry_from_image("localhost:5000/app"), "localhost:5000");
-    }
-
-    #[test]
-    fn state_from_docker_maps_common_values() {
-        assert_eq!(state_from_docker(Some("running")), ReplicaState::Ready);
-        assert_eq!(state_from_docker(Some("created")), ReplicaState::Starting);
-        assert_eq!(state_from_docker(Some("paused")), ReplicaState::Draining);
-        assert_eq!(state_from_docker(Some("exited")), ReplicaState::Stopped);
-        assert_eq!(state_from_docker(None), ReplicaState::Starting);
     }
 
     #[test]

--- a/crates/ruscker-proxy/src/lib.rs
+++ b/crates/ruscker-proxy/src/lib.rs
@@ -11,7 +11,5 @@
 //! reusable — every function here can be unit-tested without an
 //! axum server.
 
-#![allow(dead_code)]
-
 pub mod sticky;
 pub mod ws;


### PR DESCRIPTION
Closes #935.

## Summary
- remove crate-wide `#![allow(dead_code)]` from ruscker-admin, ruscker-docker, and ruscker-proxy
- delete the obsolete string-based Docker state mapper and its superseded test
- remove unused landing/dashboard view-model fields and the unused `CardCounts` type
- wire the existing `show-filters` setting into the landing template instead of deleting an intended feature
- add a rendering regression that keeps search visible while filters are disabled

## User and developer impact
Dead code warnings are enforced normally across all three crates, so future refactors cannot silently accumulate unused private code. The appearance editor's “show filters” switch also works as configured while remaining independent from the search switch.

## Root cause
Crate-wide suppressions hid both obsolete implementation leftovers and a page-model field that was populated but never consumed by Askama. Removing the suppressions exposed the stale code and the ineffective landing option.

## Verification
- `DOCKER_REGISTRY_PASSWORD=test cargo clippy --locked --all-targets -- -D warnings`
- `DOCKER_REGISTRY_PASSWORD=test cargo test --locked`
- `DOCKER_REGISTRY_PASSWORD=test cargo test --locked -p ruscker-admin --test landing_render filters_toggle_hides_filters_without_hiding_search`
- `DOCKER_REGISTRY_PASSWORD=test cargo test --locked -p ruscker-docker --lib`
- `DOCKER_REGISTRY_PASSWORD=test cargo test --locked -p ruscker-proxy`
- `./scripts/i18n-check.sh`
- `git diff --check`
