### PR TITLE
feat: configure per-app scale-down cooldown

### DIFF
--- a/crates/ruscker-admin/assets/i18n/en/landing.ftl
+++ b/crates/ruscker-admin/assets/i18n/en/landing.ftl
@@ -636,6 +636,8 @@ spec-form-scale-down = Scale-down threshold
 spec-help-scale-down = Utilization fraction (0–1) below which a replica is reaped. Blank = scaler default.
 spec-form-scale-down-grace = Scale-down grace (s)
 spec-help-scale-down-grace = Seconds below the threshold before reaping the replica. Blank = default.
+spec-form-scale-down-cooldown = Post-scale-down cooldown (s)
+spec-help-scale-down-cooldown = Seconds to suppress saturation scale-up after a replica is retired. Blank = 60; 0 disables.
 spec-form-drain-timeout = Drain timeout (s)
 spec-help-drain-timeout = Seconds to drain a replica's sessions before stopping it. Blank = default.
 spec-form-routing-strategy = Routing strategy

--- a/crates/ruscker-admin/assets/i18n/es/landing.ftl
+++ b/crates/ruscker-admin/assets/i18n/es/landing.ftl
@@ -636,6 +636,8 @@ spec-form-scale-down = Umbral de scale-down
 spec-help-scale-down = Fracción de utilización (0–1) por debajo de la cual se retira una réplica. Vacío = predeterminado del scaler.
 spec-form-scale-down-grace = Gracia de scale-down (s)
 spec-help-scale-down-grace = Segundos por debajo del umbral antes de retirar la réplica. Vacío = predeterminado.
+spec-form-scale-down-cooldown = Cooldown tras scale-down (s)
+spec-help-scale-down-cooldown = Segundos sin scale-up por saturación tras retirar una réplica. Vacío = 60; 0 desactiva.
 spec-form-drain-timeout = Tiempo de drenaje (s)
 spec-help-drain-timeout = Segundos para drenar las sesiones de una réplica antes de detenerla. Vacío = predeterminado.
 spec-form-routing-strategy = Estrategia de enrutamiento

--- a/crates/ruscker-admin/assets/i18n/fr/landing.ftl
+++ b/crates/ruscker-admin/assets/i18n/fr/landing.ftl
@@ -636,6 +636,8 @@ spec-form-scale-down = Seuil de scale-down
 spec-help-scale-down = Fraction d'utilisation (0–1) sous laquelle une réplique est retirée. Vide = défaut du scaler.
 spec-form-scale-down-grace = Délai de scale-down (s)
 spec-help-scale-down-grace = Secondes sous le seuil avant de retirer la réplique. Vide = défaut.
+spec-form-scale-down-cooldown = Cooldown après scale-down (s)
+spec-help-scale-down-cooldown = Secondes sans scale-up par saturation après le retrait d’une réplique. Vide = 60 ; 0 désactive.
 spec-form-drain-timeout = Délai de drainage (s)
 spec-help-drain-timeout = Secondes pour drainer les sessions d'une réplique avant de l'arrêter. Vide = défaut.
 spec-form-routing-strategy = Stratégie de routage

--- a/crates/ruscker-admin/assets/i18n/pt/landing.ftl
+++ b/crates/ruscker-admin/assets/i18n/pt/landing.ftl
@@ -640,6 +640,8 @@ spec-form-scale-down = Limiar de scale-down
 spec-help-scale-down = Fração de utilização (0–1) abaixo da qual uma réplica é recolhida. Em branco = padrão do scaler.
 spec-form-scale-down-grace = Carência de scale-down (s)
 spec-help-scale-down-grace = Segundos abaixo do limiar antes de recolher a réplica. Em branco = padrão.
+spec-form-scale-down-cooldown = Cooldown pós-scale-down (s)
+spec-help-scale-down-cooldown = Segundos sem scale-up por saturação após recolher uma réplica. Em branco = 60; 0 desativa.
 spec-form-drain-timeout = Timeout de drenagem (s)
 spec-help-drain-timeout = Segundos para drenar as sessões de uma réplica antes de pará-la. Em branco = padrão.
 spec-form-routing-strategy = Estratégia de roteamento

--- a/crates/ruscker-admin/src/routes/admin/spec_form.rs
+++ b/crates/ruscker-admin/src/routes/admin/spec_form.rs
@@ -516,6 +516,8 @@ pub struct SpecForm {
     pub scale_down_threshold: String,
     /// Seconds below `scale-down-threshold` before reaping.
     pub scale_down_grace: String,
+    /// Seconds to suppress saturation scale-up after a scale-down.
+    pub scale_down_cooldown_secs: String,
     /// Seconds to drain a replica's sessions before stopping it.
     pub drain_timeout: String,
 
@@ -647,6 +649,10 @@ impl SpecForm {
                 .map(|f| f.0.to_string())
                 .unwrap_or_default(),
             scale_down_grace: spec.scale_down_grace.map(|n| n.to_string()).unwrap_or_default(),
+            scale_down_cooldown_secs: spec
+                .scale_down_cooldown_secs
+                .map(|n| n.to_string())
+                .unwrap_or_default(),
             drain_timeout: spec.drain_timeout.map(|n| n.to_string()).unwrap_or_default(),
             routing_strategy: spec.routing_strategy.map(routing_to_key).unwrap_or_default(),
             placement: spec.placement.map(placement_to_key).unwrap_or_default(),
@@ -816,6 +822,7 @@ impl SpecForm {
             scale_up_threshold: parse_opt::<f64>(&self.scale_up_threshold).map(OrderedFloat),
             scale_down_threshold: parse_opt::<f64>(&self.scale_down_threshold).map(OrderedFloat),
             scale_down_grace: parse_opt(&self.scale_down_grace),
+            scale_down_cooldown_secs: parse_opt(&self.scale_down_cooldown_secs),
             drain_timeout: parse_opt(&self.drain_timeout),
             routing_strategy: routing_from_key(&self.routing_strategy),
             placement: placement_from_key(&self.placement),
@@ -854,6 +861,7 @@ impl SpecForm {
             &self.container_port,
             &self.container_lifetime,
             &self.scale_down_grace,
+            &self.scale_down_cooldown_secs,
             &self.drain_timeout,
         ];
         if int_fields
@@ -2027,6 +2035,7 @@ proxy:
       scale-up-threshold: 0.8
       scale-down-threshold: 0.2
       scale-down-grace: 45
+      scale-down-cooldown-secs: 90
       drain-timeout: 20
       template-properties:
         type: app
@@ -2052,6 +2061,7 @@ proxy:
         assert_eq!(merged.routing_strategy, Some(RoutingStrategy::RoundRobin));
         assert_eq!(merged.scale_up_threshold.map(|f| f.0), Some(0.8));
         assert_eq!(merged.scale_down_grace, Some(45));
+        assert_eq!(merged.scale_down_cooldown_secs, Some(90));
         assert_eq!(merged.drain_timeout, Some(20));
     }
 

--- a/crates/ruscker-admin/src/scaler.rs
+++ b/crates/ruscker-admin/src/scaler.rs
@@ -23,7 +23,7 @@
 //! - **Flap dampening**: the worst-case flap (one user, one
 //!   seat, long sticky session) is stretched by both the
 //!   hysteresis windows AND a post-drop cooldown
-//!   ([`DEFAULT_SCALE_DOWN_COOLDOWN_TICKS`]) that suppresses
+//!   ([`ruscker_config::DEFAULT_SCALE_DOWN_COOLDOWN_SECS`]) that suppresses
 //!   saturation scale-up of a spec right after it was scaled
 //!   down. A spec we just dropped a replica from is almost
 //!   certainly still saturated (the session that pinned it
@@ -72,22 +72,6 @@ pub const DEFAULT_IDLE_GRACE_TICKS: u32 = 3;
 /// Setting this to 1 (used in unit tests) restores the
 /// "spawn on first saturated observation" behavior.
 pub const DEFAULT_SATURATION_GRACE_TICKS: u32 = 2;
-
-/// After scale-down stops a replica for a spec, suppress
-/// saturation-driven scale-up of that spec for this many ticks.
-/// With the default 10s interval that's ~60s. This breaks the
-/// residual spawn↔drop flap that the two-counter hysteresis
-/// only dampens: with `seats-per-container: 1` and one
-/// long-lived sticky session, replica A is permanently
-/// saturated, so right after we drop the idle replica B the
-/// saturation branch would want to spawn B again. The cooldown
-/// holds that off, so the flap (if load truly stays this shape)
-/// happens at most once per `idle_grace + cooldown + saturation_grace`
-/// window instead of once per `idle_grace + saturation_grace`.
-///
-/// Below-min and genuinely-growing load are unaffected — the
-/// cooldown only gates the *saturation* scale-up path.
-pub const DEFAULT_SCALE_DOWN_COOLDOWN_TICKS: u32 = 6;
 
 /// A freshly-Ready replica is exempt from the idle counter (and so from
 /// idle scale-down) for this long, measured from `started_at` — which the
@@ -209,7 +193,7 @@ pub fn spawn(state: AppState, interval: Duration) -> JoinHandle<()> {
             ?interval,
             idle_grace_ticks = DEFAULT_IDLE_GRACE_TICKS,
             saturation_grace_ticks = DEFAULT_SATURATION_GRACE_TICKS,
-            scale_down_cooldown_ticks = DEFAULT_SCALE_DOWN_COOLDOWN_TICKS,
+            scale_down_cooldown_secs = ruscker_config::DEFAULT_SCALE_DOWN_COOLDOWN_SECS,
             "auto-scaler started"
         );
         // Per-replica idle-tick counter, per-spec saturated-tick
@@ -254,14 +238,15 @@ pub fn spawn(state: AppState, interval: Duration) -> JoinHandle<()> {
                 continue;
             }
 
-            tick(
+            tick_with_interval(
                 &state,
                 &mut idle_ticks,
                 &mut saturation_ticks,
                 &mut cooldown,
                 DEFAULT_IDLE_GRACE_TICKS,
                 DEFAULT_SATURATION_GRACE_TICKS,
-                DEFAULT_SCALE_DOWN_COOLDOWN_TICKS,
+                None,
+                interval,
             )
             .await;
         }
@@ -279,22 +264,25 @@ pub fn spawn(state: AppState, interval: Duration) -> JoinHandle<()> {
 /// - `spawn_after_saturated_ticks` — hysteresis threshold for
 ///   scale-up on saturation. Below-min spawns never use this;
 ///   they're baseline capacity, not load-driven.
-/// - `cooldown_ticks` — how long to suppress saturation
-///   scale-up after a scale-down (per spec).
+/// - `default_cooldown_ticks` — test-only fallback when the spec leaves
+///   `scale-down-cooldown-secs` unset. Production passes `None` and uses
+///   the schema default.
+/// - `interval` — scaler cadence used to convert per-spec seconds to ticks.
 ///
 /// Scale-up and scale-down are mutually exclusive for a single
 /// spec on a single tick: a saturated spec by definition has no
 /// idle replicas, and an over-min spec with idle replicas isn't
 /// saturated.
 #[allow(clippy::too_many_arguments)]
-async fn tick(
+async fn tick_with_interval(
     state: &AppState,
     idle_ticks: &mut HashMap<ReplicaId, u32>,
     saturation_ticks: &mut HashMap<String, u32>,
     cooldown: &mut HashMap<String, u32>,
     drop_after_ticks: u32,
     spawn_after_saturated_ticks: u32,
-    cooldown_ticks: u32,
+    default_cooldown_ticks: Option<u32>,
+    interval: Duration,
 ) {
     let Some(backend) = state.backend.clone() else {
         return;
@@ -377,6 +365,7 @@ async fn tick(
 
         let min = spec.effective_min_replicas() as usize;
         let max = spec.effective_max_replicas() as usize;
+        let cooldown_after_drop = cooldown_ticks_for_spec(spec, interval, default_cooldown_ticks);
 
         // Read the post-drop cooldown for this spec, then
         // decrement it (creating no entry if absent). `cooling`
@@ -567,9 +556,9 @@ async fn tick(
                 // Arm the post-drop cooldown so the next saturation
                 // spawn for this spec waits — breaks the flap.
                 // Set after this tick's decrement so it lasts the
-                // full window. `0` disables (tests).
-                if stopped_any && cooldown_ticks > 0 {
-                    cooldown.insert(spec.id.clone(), cooldown_ticks);
+                // full configured window. `0` disables per spec.
+                if stopped_any && cooldown_after_drop > 0 {
+                    cooldown.insert(spec.id.clone(), cooldown_after_drop);
                 }
             }
         }
@@ -640,7 +629,55 @@ fn scale_up_triggered(replicas: &[ruscker_core::Replica], up_threshold: Option<f
 /// `scale-down-grace` against the scaler's fixed tick cadence.
 fn grace_secs_to_ticks(secs: u64, interval: Duration) -> u32 {
     let iv = interval.as_secs().max(1);
-    secs.div_ceil(iv).max(1) as u32
+    secs.div_ceil(iv).max(1).min(u32::MAX as u64) as u32
+}
+
+/// Convert the per-spec post-drop cooldown to ticks. Unlike idle grace,
+/// zero is meaningful here: it explicitly disables suppression (#936).
+fn cooldown_secs_to_ticks(secs: u64, interval: Duration) -> u32 {
+    if secs == 0 {
+        0
+    } else {
+        grace_secs_to_ticks(secs, interval)
+    }
+}
+
+fn cooldown_ticks_for_spec(
+    spec: &Spec,
+    interval: Duration,
+    default_cooldown_ticks: Option<u32>,
+) -> u32 {
+    match spec.scale_down_cooldown_secs {
+        Some(secs) => cooldown_secs_to_ticks(secs, interval),
+        None => default_cooldown_ticks.unwrap_or_else(|| {
+            cooldown_secs_to_ticks(spec.effective_scale_down_cooldown_secs(), interval)
+        }),
+    }
+}
+
+/// Test wrapper that keeps the existing tick-level tuning surface. An
+/// explicit per-spec cooldown still wins over this fallback.
+#[cfg(test)]
+async fn tick(
+    state: &AppState,
+    idle_ticks: &mut HashMap<ReplicaId, u32>,
+    saturation_ticks: &mut HashMap<String, u32>,
+    cooldown: &mut HashMap<String, u32>,
+    drop_after_ticks: u32,
+    spawn_after_saturated_ticks: u32,
+    default_cooldown_ticks: u32,
+) {
+    tick_with_interval(
+        state,
+        idle_ticks,
+        saturation_ticks,
+        cooldown,
+        drop_after_ticks,
+        spawn_after_saturated_ticks,
+        Some(default_cooldown_ticks),
+        DEFAULT_INTERVAL,
+    )
+    .await;
 }
 
 /// For API specs, overlay request-based capacity onto the snapshot so the
@@ -1783,6 +1820,16 @@ proxy:
     }
 
     #[test]
+    fn cooldown_secs_to_ticks_allows_zero_and_rounds_up() {
+        let iv = Duration::from_secs(10);
+        assert_eq!(cooldown_secs_to_ticks(60, iv), 6);
+        assert_eq!(cooldown_secs_to_ticks(25, iv), 3);
+        assert_eq!(cooldown_secs_to_ticks(1, iv), 1);
+        assert_eq!(cooldown_secs_to_ticks(0, iv), 0);
+        assert_eq!(cooldown_secs_to_ticks(u64::MAX, iv), u32::MAX);
+    }
+
+    #[test]
     fn overlay_request_capacity_maps_inflight_for_api_only() {
         let api: Spec = serde_yaml_ng::from_str(
             "id: api1\ncontainer-image: a:1\ntype: api\nconcurrent-requests-per-replica: 50\n",
@@ -2073,6 +2120,7 @@ proxy:
     container-image: nginx:alpine
     min-replicas: 1
     max-replicas: 3
+    scale-down-cooldown-secs: 25
 "#,
             backend.clone(),
         );
@@ -2091,11 +2139,13 @@ proxy:
         let mut cooldown = HashMap::new();
         // idle grace = 1 (drop immediately), saturation grace = 1
         // (would respawn immediately if not for cooldown),
-        // cooldown = 3 ticks.
-        let (drop_after, sat_after, cd) = (1u32, 1u32, 3u32);
+        // The per-spec 25-second cooldown rounds up to 3 ticks and wins
+        // over the test fallback of 99 ticks.
+        let (drop_after, sat_after, fallback_cd) = (1u32, 1u32, 99u32);
 
         // Tick 1: B is idle past grace → drop B → count=1, cooldown armed.
-        tick(&state, &mut idle_ticks, &mut sat, &mut cooldown, drop_after, sat_after, cd).await;
+        tick(&state, &mut idle_ticks, &mut sat, &mut cooldown, drop_after, sat_after, fallback_cd)
+            .await;
         assert_eq!(state.replicas.read().await.replicas_of("flappy").len(), 1);
         assert_eq!(backend.spawns.load(Ordering::SeqCst), 0, "drop only, no spawn yet");
         assert!(cooldown.contains_key("flappy"), "cooldown armed after drop");
@@ -2103,7 +2153,8 @@ proxy:
         // Ticks 2-4: A still saturated (1/1), count=1<max, but
         // cooldown suppresses the saturation spawn.
         for t in 0..3 {
-            tick(&state, &mut idle_ticks, &mut sat, &mut cooldown, drop_after, sat_after, cd).await;
+            tick(&state, &mut idle_ticks, &mut sat, &mut cooldown, drop_after, sat_after, fallback_cd)
+                .await;
             assert_eq!(
                 backend.spawns.load(Ordering::SeqCst),
                 0,
@@ -2112,7 +2163,8 @@ proxy:
         }
 
         // Cooldown now expired → saturation spawn allowed again.
-        tick(&state, &mut idle_ticks, &mut sat, &mut cooldown, drop_after, sat_after, cd).await;
+        tick(&state, &mut idle_ticks, &mut sat, &mut cooldown, drop_after, sat_after, fallback_cd)
+            .await;
         assert_eq!(
             backend.spawns.load(Ordering::SeqCst),
             1,
@@ -2192,6 +2244,7 @@ proxy:
     container-image: nginx:alpine
     min-replicas: 1
     max-replicas: 3
+    scale-down-cooldown-secs: 0
 "#,
             backend.clone(),
         );
@@ -2206,11 +2259,12 @@ proxy:
         let mut sat = HashMap::new();
         let mut cooldown = HashMap::new();
 
-        // Tick 1: drop the idle one (count 2→1). cooldown=0 → not armed.
-        tick(&state, &mut idle_ticks, &mut sat, &mut cooldown, 1, 1, 0).await;
+        // Tick 1: the explicit per-spec zero wins over the six-tick test
+        // fallback, so dropping the idle replica does not arm cooldown.
+        tick(&state, &mut idle_ticks, &mut sat, &mut cooldown, 1, 1, 6).await;
         assert!(!cooldown.contains_key("nocd"));
         // Tick 2: A saturated, count=1<max → respawn immediately.
-        tick(&state, &mut idle_ticks, &mut sat, &mut cooldown, 1, 1, 0).await;
+        tick(&state, &mut idle_ticks, &mut sat, &mut cooldown, 1, 1, 6).await;
         assert_eq!(backend.spawns.load(Ordering::SeqCst), 1);
     }
 

--- a/crates/ruscker-admin/templates/admin/spec_form.html
+++ b/crates/ruscker-admin/templates/admin/spec_form.html
@@ -839,7 +839,7 @@
             </div>
             <span class="switch">
               <input type="checkbox" x-model="autoscaling"
-                     @change="if (!autoscaling) { form.scale_up_threshold = ''; form.scale_down_threshold = ''; form.scale_down_grace = ''; }">
+                     @change="if (!autoscaling) { form.scale_up_threshold = ''; form.scale_down_threshold = ''; form.scale_down_grace = ''; form.scale_down_cooldown_secs = ''; }">
               <span class="switch__track"><span class="switch__dot"></span></span>
             </span>
           </label>
@@ -879,6 +879,14 @@
               </div>
               <input id="f-scale-grace" type="number" name="scale_down_grace" min="0"
                      value="{{ form.scale_down_grace }}" placeholder="30" class="spec-form-input">
+            </div>
+            <div class="spec-form-field">
+              <div class="spec-form-label-row">
+                <label for="f-scale-cooldown" class="spec-form-label">{{ self.t("spec-form-scale-down-cooldown") }}</label>
+                {% call help(self.t("spec-help-scale-down-cooldown")) %}{% endcall %}
+              </div>
+              <input id="f-scale-cooldown" type="number" name="scale_down_cooldown_secs" min="0"
+                     value="{{ form.scale_down_cooldown_secs }}" placeholder="60" class="spec-form-input">
             </div>
             <div class="spec-form-field">
               <div class="spec-form-label-row">
@@ -1351,7 +1359,8 @@ window.ruscker.specForm = (initial, logoImages, availableGroups) => ({
   // toggle's signal (#854).
   autoscaling: !!((initial.scale_up_threshold || '').toString().trim()
     || (initial.scale_down_threshold || '').toString().trim()
-    || (initial.scale_down_grace || '').toString().trim()),
+    || (initial.scale_down_grace || '').toString().trim()
+    || (initial.scale_down_cooldown_secs || '').toString().trim()),
   // Card-cover editing mode: 'auto' (kind tint, empty cover),
   // 'solid' (color), 'gradient' (builder), or 'legacy' for a saved
   // image cover (`url(...)`) from before image covers were retired —

--- a/crates/ruscker-config/src/lib.rs
+++ b/crates/ruscker-config/src/lib.rs
@@ -49,6 +49,7 @@ pub use schema::{
     is_valid_memory_size, normalize_base_path, ApiSpec, Config, Host, HostTls, LandingBlock,
     LandingCustomization, LandingLogo, Logging, Placement, Proxy, RatePolicy, RoutingStrategy,
     Server, Spec, SpecKind, SpecKindOverride, TemplateProperties, ThemeColors, ThemePalette,
+    DEFAULT_SCALE_DOWN_COOLDOWN_SECS,
 };
 pub use validate::{
     is_reserved_label_key, is_valid_label_key, is_valid_network_name, is_valid_volume_bind,

--- a/crates/ruscker-config/src/schema.rs
+++ b/crates/ruscker-config/src/schema.rs
@@ -969,6 +969,13 @@ pub struct Spec {
     #[serde(rename = "scale-down-grace")]
     pub scale_down_grace: Option<u64>,
 
+    /// Seconds to suppress saturation-driven scale-up after this spec
+    /// scales down. Prevents an idle replica from being immediately
+    /// respawned while another long-lived session keeps the pool saturated.
+    /// Defaults to 60; `0` disables the cooldown.
+    #[serde(rename = "scale-down-cooldown-secs")]
+    pub scale_down_cooldown_secs: Option<u64>,
+
     /// Seconds to wait for in-flight sessions to drain before killing
     /// a replica being retired. Defaults to 60.
     #[serde(rename = "drain-timeout")]
@@ -1091,6 +1098,10 @@ pub enum SpecKind {
 /// container each — out of the box, rather than locking everyone out after
 /// the first. Override per spec with `max-replicas`.
 pub const DEFAULT_MAX_REPLICAS: u32 = 5;
+
+/// Default post-scale-down cooldown in seconds. With the scaler's default
+/// 10-second cadence this preserves the original six-tick window.
+pub const DEFAULT_SCALE_DOWN_COOLDOWN_SECS: u64 = 60;
 
 /// Default `seats-per-container` for web-framework specs (Shiny, Streamlit,
 /// Dash, Voilà — `SpecKind::Shiny`/`InteractiveApp`). These frameworks
@@ -1301,6 +1312,13 @@ impl Spec {
     /// pool is still moderately utilized.
     pub fn effective_scale_down_threshold(&self) -> Option<f64> {
         self.scale_down_threshold.map(|f| f.0)
+    }
+
+    /// Post-scale-down window during which saturation-driven scale-up is
+    /// suppressed for this spec. Default 60 seconds; `0` opts out (#936).
+    pub fn effective_scale_down_cooldown_secs(&self) -> u64 {
+        self.scale_down_cooldown_secs
+            .unwrap_or(DEFAULT_SCALE_DOWN_COOLDOWN_SECS)
     }
 
     /// Whether a signed-in user's sticky sessions on this spec should be
@@ -1906,6 +1924,31 @@ proxy:
     }
 
     #[test]
+    fn scale_down_cooldown_defaults_parses_and_allows_zero() {
+        let yaml = r#"
+proxy:
+  specs:
+    - id: default
+      container-image: nginx
+    - id: tuned
+      container-image: nginx
+      scale-down-cooldown-secs: 25
+    - id: disabled
+      container-image: nginx
+      scale-down-cooldown-secs: 0
+"#;
+        let config: Config = serde_yaml_ng::from_str(yaml).unwrap();
+        let specs = &config.proxy.specs;
+        assert_eq!(
+            specs[0].effective_scale_down_cooldown_secs(),
+            DEFAULT_SCALE_DOWN_COOLDOWN_SECS
+        );
+        assert_eq!(specs[1].scale_down_cooldown_secs, Some(25));
+        assert_eq!(specs[1].effective_scale_down_cooldown_secs(), 25);
+        assert_eq!(specs[2].effective_scale_down_cooldown_secs(), 0);
+    }
+
+    #[test]
     fn cold_start_spec_still_scales_to_one() {
         // A cold-start app sets `min-replicas: 0` (don't pre-spawn) and
         // usually leaves `max-replicas` unset. effective-max must NOT
@@ -1991,6 +2034,7 @@ proxy:
             scale_up_threshold: None,
             scale_down_threshold: None,
             scale_down_grace: None,
+            scale_down_cooldown_secs: None,
             drain_timeout: None,
             routing_strategy: None,
             inject_base_href: None,
@@ -2041,6 +2085,7 @@ proxy:
             scale_up_threshold: None,
             scale_down_threshold: None,
             scale_down_grace: None,
+            scale_down_cooldown_secs: None,
             drain_timeout: None,
             routing_strategy: None,
             inject_base_href: None,
@@ -2091,6 +2136,7 @@ proxy:
             scale_up_threshold: None,
             scale_down_threshold: None,
             scale_down_grace: None,
+            scale_down_cooldown_secs: None,
             drain_timeout: None,
             routing_strategy: None,
             inject_base_href: None,

--- a/docs/NEXT_STEPS.md
+++ b/docs/NEXT_STEPS.md
@@ -66,8 +66,9 @@ Known refinements that matter under sustained real load (see CLAUDE.md
 
 - **Scale-down hysteresis / post-drop cooldown.** ✅ *Shipped.* A
   `seats=1` spec with long sessions could flap; a post-drop cooldown
-  (`DEFAULT_SCALE_DOWN_COOLDOWN_TICKS`) now gates the saturation respawn
-  after a scale-down, on top of the existing hysteresis.
+  (`scale-down-cooldown-secs`, 60 s by default) now gates the saturation
+  respawn after a scale-down, on top of the existing hysteresis, and can
+  be tuned per app.
 - **Per-spec heartbeat-timeout override.** A single global timeout today;
   some apps need a longer idle window than others.
 - **Observability template.** The Prometheus endpoint already exists

--- a/docs/YAML_SCHEMA.md
+++ b/docs/YAML_SCHEMA.md
@@ -583,6 +583,7 @@ applied) and flagged by `ruscker validate`.
 | `scale-up-threshold` | float | unset | scale up when pool utilization exceeds this; unset ⇒ the built-in saturation rule (enforced, #333) |
 | `scale-down-threshold` | float | unset | only retire idle replicas while utilization is below this; unset ⇒ the built-in idle rule (enforced, #333) |
 | `scale-down-grace` | s | unset | idle-grace before retiring a replica; unset ⇒ the global ~30 s grace (enforced, #333) |
+| `scale-down-cooldown-secs` | s | `60` | suppress saturation-driven scale-up after this app scales down, preventing immediate respawn flaps; `0` disables. Ruscker extension (#936) |
 | `drain-timeout` | s | `60` | grace for in-flight sessions on a `max-lifetime` recycle (enforced, #335) |
 | `routing-strategy` | enum | varies | See below |
 | `concurrent-requests-per-replica` | u32 | `100` | API-only — per-replica in-flight cap the scaler scales on (enforced, #336) |


### PR DESCRIPTION
Closes #936.

## What changed

- adds `scale-down-cooldown-secs` to each app spec, defaulting to the previous 60-second behavior
- allows `0` to explicitly disable post-scale-down suppression
- converts seconds to scaler ticks using the active interval, rounding up and clamping safely
- exposes the setting in the Admin advanced autoscaling form in all four locales
- documents the YAML field and updates the scaling follow-up notes
- adds schema, form round-trip, conversion, precedence, and disabled-state regressions

## Why

The cooldown was a fixed six-tick constant for every app. Different workload shapes need independent tuning without changing the global scaler cadence.

## Validation

- `DOCKER_REGISTRY_PASSWORD=test cargo test --locked`
- `DOCKER_REGISTRY_PASSWORD=test cargo clippy --locked --all-targets -- -D warnings`
- `./scripts/i18n-check.sh`
- `bash scripts/migration-parity-check.sh`
- `git diff --check`

No database migration is required because specs remain stored as configuration JSON.
