### PR TITLE
fix: harden media image processing

### DIFF
--- a/crates/ruscker-admin/src/db/builtin_logos.rs
+++ b/crates/ruscker-admin/src/db/builtin_logos.rs
@@ -28,14 +28,19 @@ pub async fn seed_if_unseeded(db: &ConfigDb) -> Result<()> {
         {
             continue;
         }
-        let processed =
-            match crate::images::process_upload(filename, Some("image/svg+xml"), bytes.to_vec()) {
-                Ok(p) => p,
-                Err(err) => {
-                    tracing::warn!(error = ?err, filename, "skip built-in logo seed");
-                    continue;
-                }
-            };
+        let processed = match crate::images::process_upload_async(
+            filename.to_string(),
+            Some("image/svg+xml".to_string()),
+            bytes.to_vec(),
+        )
+        .await
+        {
+            Ok(p) => p,
+            Err(err) => {
+                tracing::warn!(error = ?err, filename, "skip built-in logo seed");
+                continue;
+            }
+        };
         super::images::insert(db, processed, None)
             .await
             .with_context(|| format!("seed built-in logo {filename}"))?;

--- a/crates/ruscker-admin/src/db/images.rs
+++ b/crates/ruscker-admin/src/db/images.rs
@@ -568,7 +568,9 @@ pub async fn import_dir(db: &ConfigDb, dir: &std::path::Path) -> Result<ImportIm
             }
         };
         let name = path.file_name().and_then(|s| s.to_str()).unwrap_or_default();
-        let Some(processed) = crate::images::process_for_import(name, raw) else {
+        let Some(processed) =
+            crate::images::process_for_import_async(name.to_string(), raw).await
+        else {
             report.skipped += 1;
             continue;
         };

--- a/crates/ruscker-admin/src/images.rs
+++ b/crates/ruscker-admin/src/images.rs
@@ -8,16 +8,37 @@
 //!
 //! Returned [`Processed`] carries everything `db::images::insert`
 //! needs to write a row. No DB code lives here so this module
-//! stays pure / unit-testable.
+//! stays isolated and unit-testable. Runtime entry points move the
+//! CPU-bound work to a shared, concurrency-limited blocking pool.
 
 use anyhow::{anyhow, Context, Result};
-use image::ImageReader;
+use image::{ImageReader, Limits};
 use std::io::Cursor;
+use std::sync::{Arc, LazyLock};
+use tokio::sync::Semaphore;
 
 /// Maximum source upload size accepted. Anything bigger is
 /// rejected before decoding — protects against
 /// decompression-bomb-style memory attacks.
 pub const MAX_UPLOAD_BYTES: usize = 10 * 1024 * 1024;
+
+/// Maximum width or height accepted for a raster image. A compressed-byte
+/// cap alone cannot bound the decoded allocation of an image bomb.
+pub const MAX_IMAGE_DIMENSION: u32 = 8192;
+
+/// Maximum decoded pixel count. This independently rejects wide-but-legal
+/// dimensions whose product would still require excessive memory.
+pub const MAX_IMAGE_PIXELS: u64 = 16_000_000;
+
+/// Decoder allocation budget, below `image`'s generic 512 MiB default.
+pub const MAX_DECODE_ALLOC_BYTES: u64 = 64 * 1024 * 1024;
+
+/// Image decoders and WebP encoders are CPU- and memory-heavy. Keep one
+/// shared process-wide budget across uploads, imports, and thumbnails.
+pub const MAX_CONCURRENT_IMAGE_JOBS: usize = 2;
+
+static IMAGE_JOB_SLOTS: LazyLock<Arc<Semaphore>> =
+    LazyLock::new(|| Arc::new(Semaphore::new(MAX_CONCURRENT_IMAGE_JOBS)));
 
 /// Soft target after re-encoding. Larger uploads still go through
 /// but produce a `tracing::warn`. Used by callers to surface a UI
@@ -26,12 +47,72 @@ pub const SOFT_TARGET_BYTES: usize = 500 * 1024;
 
 /// Output of [`process_upload`] — everything `db::images::insert`
 /// needs and nothing it doesn't.
+#[derive(Debug)]
 pub struct Processed {
     pub filename: String,
     pub mime_type: String,
     pub bytes: Vec<u8>,
     pub width: Option<u32>,
     pub height: Option<u32>,
+}
+
+/// Run image CPU work away from Tokio workers while bounding the number of
+/// simultaneous decodes/transcodes. The owned permit moves into the blocking
+/// closure so cancelling the request cannot release capacity while its
+/// non-cancellable `spawn_blocking` job is still running.
+async fn run_blocking_image_job<T, F>(slots: Arc<Semaphore>, job: F) -> Result<T>
+where
+    T: Send + 'static,
+    F: FnOnce() -> T + Send + 'static,
+{
+    let permit = slots
+        .acquire_owned()
+        .await
+        .map_err(|_| anyhow!("image processor unavailable"))?;
+    tokio::task::spawn_blocking(move || {
+        let _permit = permit;
+        job()
+    })
+    .await
+    .context("image processing task failed")
+}
+
+/// Async entry point for HTTP uploads and other runtime callers.
+pub async fn process_upload_async(
+    raw_filename: String,
+    supplied_mime: Option<String>,
+    bytes: Vec<u8>,
+) -> Result<Processed> {
+    run_blocking_image_job(IMAGE_JOB_SLOTS.clone(), move || {
+        process_upload(&raw_filename, supplied_mime.as_deref(), bytes)
+    })
+    .await?
+}
+
+/// Async migration-import entry point using the same resource budget.
+pub async fn process_for_import_async(
+    raw_filename: String,
+    bytes: Vec<u8>,
+) -> Option<Processed> {
+    match run_blocking_image_job(IMAGE_JOB_SLOTS.clone(), move || {
+        process_for_import(&raw_filename, bytes)
+    })
+    .await
+    {
+        Ok(processed) => processed,
+        Err(err) => {
+            tracing::warn!(error = ?err, "image import processing task failed");
+            None
+        }
+    }
+}
+
+/// Async thumbnail entry point using the same resource budget.
+pub async fn thumbnail_webp_async(bytes: Vec<u8>, max_dim: u32) -> Result<Vec<u8>> {
+    run_blocking_image_job(IMAGE_JOB_SLOTS.clone(), move || {
+        thumbnail_webp(&bytes, max_dim)
+    })
+    .await?
 }
 
 /// Accepted MIME categories.
@@ -109,7 +190,7 @@ pub fn process_upload(
 
     match kind {
         SourceKind::Png | SourceKind::Jpeg => {
-            let (webp_bytes, w, h) = encode_to_webp(&bytes).context("convert to WebP")?;
+            let (webp_bytes, w, h) = encode_to_webp(&bytes)?;
             let filename = rewrite_extension(&base, "webp");
             if webp_bytes.len() > SOFT_TARGET_BYTES {
                 tracing::warn!(
@@ -128,13 +209,17 @@ pub fn process_upload(
             })
         }
         SourceKind::Webp => {
-            let dims = decode_dimensions(&bytes).ok();
+            // Pass the original WebP bytes through, but still fully decode
+            // once under the product limits so corrupt/truncated files are
+            // never committed to the Media library.
+            let img = decode_raster(&bytes)?;
+            let (w, h) = (img.width(), img.height());
             Ok(Processed {
                 filename: rewrite_extension(&base, "webp"),
                 mime_type: "image/webp".into(),
                 bytes,
-                width: dims.map(|(w, _)| w),
-                height: dims.map(|(_, h)| h),
+                width: Some(w),
+                height: Some(h),
             })
         }
         SourceKind::Svg => Ok(Processed {
@@ -174,17 +259,17 @@ pub fn process_for_import(raw_filename: &str, bytes: Vec<u8>) -> Option<Processe
         return None;
     }
     let (mime, dims) = match kind {
-        SourceKind::Png => ("image/png", decode_dimensions(&bytes).ok()),
-        SourceKind::Jpeg => ("image/jpeg", decode_dimensions(&bytes).ok()),
-        SourceKind::Webp => ("image/webp", decode_dimensions(&bytes).ok()),
+        SourceKind::Png => ("image/png", Some(decode_raster(&bytes).ok()?)),
+        SourceKind::Jpeg => ("image/jpeg", Some(decode_raster(&bytes).ok()?)),
+        SourceKind::Webp => ("image/webp", Some(decode_raster(&bytes).ok()?)),
         SourceKind::Svg => ("image/svg+xml", None),
     };
     Some(Processed {
         filename,
         mime_type: mime.into(),
         bytes,
-        width: dims.map(|(w, _)| w),
-        height: dims.map(|(_, h)| h),
+        width: dims.as_ref().map(image::DynamicImage::width),
+        height: dims.as_ref().map(image::DynamicImage::height),
     })
 }
 
@@ -208,12 +293,82 @@ pub(crate) fn rewrite_extension(name: &str, new_ext: &str) -> String {
     format!("{stem}.{new_ext}")
 }
 
-fn encode_to_webp(bytes: &[u8]) -> Result<(Vec<u8>, u32, u32)> {
-    let img = ImageReader::new(Cursor::new(bytes))
+fn decode_limits() -> Limits {
+    let mut limits = Limits::default();
+    limits.max_image_width = Some(MAX_IMAGE_DIMENSION);
+    limits.max_image_height = Some(MAX_IMAGE_DIMENSION);
+    limits.max_alloc = Some(MAX_DECODE_ALLOC_BYTES);
+    limits
+}
+
+fn metadata_limits() -> Limits {
+    let mut limits = Limits::default();
+    // Leave width/height unset here so `validate_dimensions` can return the
+    // product-specific limit in the operator-facing error. The allocation
+    // budget still constrains any decoder work needed to inspect metadata.
+    limits.max_alloc = Some(MAX_DECODE_ALLOC_BYTES);
+    limits
+}
+
+fn image_reader(bytes: &[u8], limits: Limits) -> Result<ImageReader<Cursor<&[u8]>>> {
+    let mut reader = ImageReader::new(Cursor::new(bytes))
         .with_guessed_format()
-        .context("guess format")?
+        .context("guess format")?;
+    reader.limits(limits);
+    Ok(reader)
+}
+
+fn validate_dimensions(width: u32, height: u32) -> Result<u64> {
+    if width == 0 || height == 0 {
+        return Err(anyhow!("image dimensions must be non-zero"));
+    }
+    if width > MAX_IMAGE_DIMENSION || height > MAX_IMAGE_DIMENSION {
+        return Err(anyhow!(
+            "image dimensions {width}x{height} exceed {MAX_IMAGE_DIMENSION}x{MAX_IMAGE_DIMENSION} limit"
+        ));
+    }
+    let pixels = u64::from(width)
+        .checked_mul(u64::from(height))
+        .ok_or_else(|| anyhow!("image pixel count overflow"))?;
+    if pixels > MAX_IMAGE_PIXELS {
+        return Err(anyhow!(
+            "image has {pixels} pixels; limit is {MAX_IMAGE_PIXELS}"
+        ));
+    }
+    let rgba_bytes = pixels
+        .checked_mul(4)
+        .ok_or_else(|| anyhow!("image allocation size overflow"))?;
+    if rgba_bytes > MAX_DECODE_ALLOC_BYTES {
+        return Err(anyhow!(
+            "decoded image needs at least {rgba_bytes} bytes; limit is {MAX_DECODE_ALLOC_BYTES}"
+        ));
+    }
+    Ok(pixels)
+}
+
+/// Read only decoder metadata first, validate the product with checked
+/// arithmetic, then let full decode happen under strict decoder limits.
+fn decode_dimensions(bytes: &[u8]) -> Result<(u32, u32)> {
+    let dims = image_reader(bytes, metadata_limits())?
+        .into_dimensions()
+        .context("read image dimensions")?;
+    validate_dimensions(dims.0, dims.1)?;
+    Ok(dims)
+}
+
+fn decode_raster(bytes: &[u8]) -> Result<image::DynamicImage> {
+    let expected = decode_dimensions(bytes)?;
+    let img = image_reader(bytes, decode_limits())?
         .decode()
         .context("decode source image")?;
+    if (img.width(), img.height()) != expected {
+        return Err(anyhow!("image dimensions changed while decoding"));
+    }
+    Ok(img)
+}
+
+fn encode_to_webp(bytes: &[u8]) -> Result<(Vec<u8>, u32, u32)> {
+    let img = decode_raster(bytes)?;
 
     let (w, h) = (img.width(), img.height());
     let mut out: Vec<u8> = Vec::with_capacity(bytes.len() / 2);
@@ -228,11 +383,7 @@ fn encode_to_webp(bytes: &[u8]) -> Result<(Vec<u8>, u32, u32)> {
 /// full-size blob per `<img>` (#283). Raster formats only — the caller
 /// skips SVG (vector, already tiny).
 pub fn thumbnail_webp(bytes: &[u8], max_dim: u32) -> Result<Vec<u8>> {
-    let img = ImageReader::new(Cursor::new(bytes))
-        .with_guessed_format()
-        .context("guess format")?
-        .decode()
-        .context("decode source image")?;
+    let img = decode_raster(bytes)?;
     // `thumbnail` preserves aspect ratio and never upscales, using a
     // fast filter — fine for a small tile.
     let thumb = img.thumbnail(max_dim, max_dim);
@@ -243,16 +394,11 @@ pub fn thumbnail_webp(bytes: &[u8], max_dim: u32) -> Result<Vec<u8>> {
     Ok(out)
 }
 
-fn decode_dimensions(bytes: &[u8]) -> Result<(u32, u32)> {
-    let img = ImageReader::new(Cursor::new(bytes))
-        .with_guessed_format()?
-        .decode()?;
-    Ok((img.width(), img.height()))
-}
-
 #[cfg(test)]
 mod tests {
     use super::*;
+    use std::sync::atomic::{AtomicUsize, Ordering};
+    use std::time::Duration;
 
     #[test]
     fn thumbnail_webp_scales_within_max_dim_preserving_aspect() {
@@ -299,6 +445,45 @@ mod tests {
         assert!(process_upload("x.png", Some("image/png"), bytes).is_err());
     }
 
+    fn overwide_png() -> Vec<u8> {
+        let img = image::DynamicImage::ImageRgba8(image::RgbaImage::from_pixel(
+            MAX_IMAGE_DIMENSION + 1,
+            1,
+            image::Rgba([1, 2, 3, 255]),
+        ));
+        let mut png = Vec::new();
+        img.write_to(&mut Cursor::new(&mut png), image::ImageFormat::Png)
+            .unwrap();
+        png
+    }
+
+    #[test]
+    fn rejects_extreme_dimensions_before_full_decode() {
+        // One row keeps the fixture tiny while exceeding the product's
+        // strict width budget. The metadata pass rejects it before the
+        // decoder allocates an RGBA output buffer.
+        let err = process_upload("wide.png", Some("image/png"), overwide_png()).unwrap_err();
+        assert!(
+            err.to_string().contains("exceed"),
+            "operator-facing error should name the limit: {err:#}"
+        );
+    }
+
+    #[test]
+    fn imports_and_thumbnails_apply_the_same_dimension_budget() {
+        let png = overwide_png();
+        assert!(process_for_import("wide.png", png.clone()).is_none());
+        assert!(thumbnail_webp(&png, 96).is_err());
+    }
+
+    #[test]
+    fn dimension_budget_uses_checked_wide_arithmetic() {
+        assert_eq!(validate_dimensions(4_000, 4_000).unwrap(), MAX_IMAGE_PIXELS);
+        assert!(validate_dimensions(4_000, 4_001).is_err());
+        assert!(validate_dimensions(u32::MAX, u32::MAX).is_err());
+        assert!(validate_dimensions(0, 1).is_err());
+    }
+
     fn tiny_png() -> Vec<u8> {
         let img = image::DynamicImage::ImageRgba8(image::RgbaImage::from_pixel(
             2,
@@ -309,6 +494,58 @@ mod tests {
         img.write_to(&mut std::io::Cursor::new(&mut png), image::ImageFormat::Png)
             .unwrap();
         png
+    }
+
+    fn tiny_raster(format: image::ImageFormat) -> Vec<u8> {
+        let img = image::DynamicImage::ImageRgb8(image::RgbImage::from_pixel(
+            3,
+            2,
+            image::Rgb([1, 2, 3]),
+        ));
+        let mut bytes = Vec::new();
+        img.write_to(&mut Cursor::new(&mut bytes), format).unwrap();
+        bytes
+    }
+
+    #[test]
+    fn accepts_valid_png_jpeg_and_webp_with_dimensions() {
+        for (name, mime, format) in [
+            ("ok.png", "image/png", image::ImageFormat::Png),
+            ("ok.jpg", "image/jpeg", image::ImageFormat::Jpeg),
+            ("ok.webp", "image/webp", image::ImageFormat::WebP),
+        ] {
+            let processed = process_upload(name, Some(mime), tiny_raster(format)).unwrap();
+            assert_eq!(processed.mime_type, "image/webp");
+            assert_eq!((processed.width, processed.height), (Some(3), Some(2)));
+        }
+    }
+
+    #[tokio::test(flavor = "multi_thread", worker_threads = 4)]
+    async fn blocking_jobs_never_exceed_the_shared_slot_budget() {
+        let slots = Arc::new(Semaphore::new(MAX_CONCURRENT_IMAGE_JOBS));
+        let active = Arc::new(AtomicUsize::new(0));
+        let peak = Arc::new(AtomicUsize::new(0));
+        let mut tasks = Vec::new();
+
+        for _ in 0..6 {
+            let slots = slots.clone();
+            let active = active.clone();
+            let peak = peak.clone();
+            tasks.push(tokio::spawn(async move {
+                run_blocking_image_job(slots, move || {
+                    let now = active.fetch_add(1, Ordering::SeqCst) + 1;
+                    peak.fetch_max(now, Ordering::SeqCst);
+                    std::thread::sleep(Duration::from_millis(30));
+                    active.fetch_sub(1, Ordering::SeqCst);
+                })
+                .await
+                .unwrap();
+            }));
+        }
+        for task in tasks {
+            task.await.unwrap();
+        }
+        assert_eq!(peak.load(Ordering::SeqCst), MAX_CONCURRENT_IMAGE_JOBS);
     }
 
     #[test]

--- a/crates/ruscker-admin/src/routes/admin/images.rs
+++ b/crates/ruscker-admin/src/routes/admin/images.rs
@@ -2,7 +2,7 @@
 //!
 //! Upload pipeline:
 //!   1. axum::Multipart streams the form field
-//!   2. `images::process_upload` sniffs MIME, decodes,
+//!   2. `images::process_upload_async` sniffs MIME and runs bounded decode,
 //!      re-encodes PNG/JPEG to WebP (SVG passes through)
 //!   3. `db::images::insert` writes the BLOB + audit row
 //!   4. Redirect back to /admin/images
@@ -264,14 +264,15 @@ async fn upload(
             continue; // empty file input — nothing chosen
         }
 
-        let mut processed = match images::process_upload(&filename, mime.as_deref(), bytes) {
-            Ok(p) => p,
-            Err(err) => {
-                tracing::warn!(error = ?err, filename, "rejecting upload");
-                last_error = Some(err.to_string());
-                continue;
-            }
-        };
+        let mut processed =
+            match images::process_upload_async(filename.clone(), mime, bytes).await {
+                Ok(p) => p,
+                Err(err) => {
+                    tracing::warn!(error = ?err, filename, "rejecting upload");
+                    last_error = Some(err.to_string());
+                    continue;
+                }
+            };
         // Don't silently overwrite a same-named image: pick a free name
         // (`logo.webp` → `logo-2.webp`) so both are kept, and tell the
         // operator it was renamed. The import path keeps exact names.
@@ -367,7 +368,7 @@ async fn upload_inline(
         if bytes.is_empty() {
             continue;
         }
-        let mut processed = match images::process_upload(&filename, mime.as_deref(), bytes) {
+        let mut processed = match images::process_upload_async(filename, mime, bytes).await {
             Ok(p) => p,
             Err(err) => return inline_err(StatusCode::UNPROCESSABLE_ENTITY, err.to_string()),
         };

--- a/crates/ruscker-admin/src/routes/admin/specs.rs
+++ b/crates/ruscker-admin/src/routes/admin/specs.rs
@@ -896,7 +896,7 @@ async fn import_referenced_logos(
             Ok(b) => b,
             Err(_) => continue, // not on disk → nothing to copy
         };
-        match crate::images::process_upload(&filename, None, bytes) {
+        match crate::images::process_upload_async(filename.clone(), None, bytes).await {
             Ok(processed) => {
                 if crate::db::images::insert(db, processed, Some(actor))
                     .await

--- a/crates/ruscker-admin/src/routes/assets.rs
+++ b/crates/ruscker-admin/src/routes/assets.rs
@@ -444,21 +444,13 @@ async fn serve_card_image(
         if let Some(cached) = THUMB_CACHE.get(&key) {
             return serve_thumbnail_bytes(&req_headers, cached.clone());
         }
-        let src = bytes.clone();
-        match tokio::task::spawn_blocking(move || {
-            crate::images::thumbnail_webp(&src, THUMB_MAX_DIM)
-        })
-        .await
-        {
-            Ok(Ok(thumb)) => {
+        match crate::images::thumbnail_webp_async(bytes.clone(), THUMB_MAX_DIM).await {
+            Ok(thumb) => {
                 THUMB_CACHE.insert(key, thumb.clone());
                 return serve_thumbnail_bytes(&req_headers, thumb);
             }
-            Ok(Err(err)) => {
-                tracing::warn!(error = ?err, filename, "thumbnail generation failed; serving full image");
-            }
             Err(err) => {
-                tracing::warn!(error = ?err, filename, "thumbnail task join failed; serving full image");
+                tracing::warn!(error = ?err, filename, "thumbnail generation failed; serving full image");
             }
         }
     }


### PR DESCRIPTION
Closes #941.

## What changed

- caps raster inputs at 8192 px per dimension, 16 million pixels, and 64 MiB of decoder allocation
- reads and validates image metadata before allocating the full decoded buffer
- fully validates PNG, JPEG, and WebP before any Media database write
- moves uploads, migration imports, logo imports, and thumbnails to `spawn_blocking`
- shares a two-slot process-wide semaphore across every image-processing path
- keeps the permit inside the blocking closure so request cancellation cannot overbook CPU or memory
- adds regressions for valid formats, extreme dimensions, checked pixel budgets, import/thumbnail enforcement, and concurrency

## Why

The existing compressed-byte limit did not bound decoded image memory, and synchronous decode/transcode work ran on Tokio workers. Concurrent or decompression-bomb-style uploads could therefore cause global latency spikes or excessive memory use.

## User impact

The inline picker receives a clear 422 error for invalid or oversized raster dimensions, while the full Media form shows the same validation message. Valid uploads keep the existing filename/transcode behavior, and imports continue preserving their original bytes and names.

## Validation

- `DOCKER_REGISTRY_PASSWORD=test cargo test --locked`
- `DOCKER_REGISTRY_PASSWORD=test cargo clippy --locked --all-targets -- -D warnings`
- `./scripts/i18n-check.sh`
- `bash scripts/migration-parity-check.sh`
- `git diff --check`
