### PR TITLE
perf: aggregate access counts in memory, flush in batches (#944)

### DIFF
--- a/crates/ruscker-admin/src/access_counter.rs
+++ b/crates/ruscker-admin/src/access_counter.rs
@@ -1,0 +1,263 @@
+//! In-memory aggregation for the per-spec access counter (#944).
+//!
+//! The counter (#549) is aggregate analytics — nobody needs each hit
+//! durably persisted the instant it happens. The first cut awaited an
+//! UPSERT inline (a DB round-trip on every API response, serializing on
+//! SQLite's single writer); #744 moved it to a detached `tokio::spawn`
+//! per request, which only relocated the cost: task rate and write rate
+//! still equaled the request rate, now without backpressure or
+//! supervision.
+//!
+//! This module completes the fix. The hot path is a plain in-memory
+//! increment on a `(spec_id, day)` bucket — no await, no task, no DB.
+//! One supervised task per process drains the buffer every
+//! [`FLUSH_INTERVAL`], writing a single `count = count + delta` UPSERT
+//! per touched bucket. Ten thousand API calls in a window become one
+//! write, and a DB hiccup merges the deltas back into the buffer to
+//! retry with exponential backoff — nothing is silently lost while the
+//! process lives.
+//!
+//! Memory stays bounded structurally: keys are `(spec, day)` pairs, so
+//! the buffer grows with the catalog and the outage length in days, not
+//! with traffic. [`MAX_PENDING_KEYS`] is a backstop far above any real
+//! catalog; increments past it on *new* buckets are counted in
+//! [`AccessCounter::dropped`] rather than growing the map.
+
+use crate::db::{self, ConfigDb};
+use std::collections::HashMap;
+use std::sync::atomic::{AtomicU64, Ordering};
+use std::sync::{Arc, Mutex, PoisonError};
+use std::time::Duration;
+
+/// How often the drain task writes pending deltas to the DB. Counts
+/// surface in the admin at most this much later — fine for analytics.
+pub const FLUSH_INTERVAL: Duration = Duration::from_secs(2);
+
+/// Ceiling for the failure backoff: 2 s → 4 s → … → capped here.
+const MAX_BACKOFF: Duration = Duration::from_secs(60);
+
+/// Backstop on distinct `(spec, day)` buckets held in memory. Real
+/// deployments count dozens of specs, so hitting this means something
+/// is very wrong; we prefer dropping *new* buckets (counted in
+/// `dropped`) over unbounded growth during a long DB outage.
+pub const MAX_PENDING_KEYS: usize = 4096;
+
+/// Shared in-memory buffer of not-yet-persisted access counts.
+/// Cheap to clone via `Arc` in [`crate::AppState`].
+#[derive(Debug, Default)]
+pub struct AccessCounter {
+    /// Pending deltas keyed by `(spec_id, day)`. A std `Mutex` (not
+    /// tokio): the critical sections are a map insert or a `mem::take`,
+    /// never an await.
+    pending: Mutex<HashMap<(String, String), i64>>,
+    /// Increments discarded because the buffer was at
+    /// [`MAX_PENDING_KEYS`] — observability for the backstop.
+    dropped: AtomicU64,
+    /// Failed flush attempts since boot — observability for retries.
+    flush_failures: AtomicU64,
+}
+
+impl AccessCounter {
+    /// Record one access for `spec_id` in today's bucket. This is the
+    /// hot path: synchronous, allocation-light, no DB. A poisoned lock
+    /// is recovered rather than propagated — losing one increment to a
+    /// panicking peer thread beats poisoning the counter forever.
+    pub fn bump(&self, spec_id: &str) {
+        let key = (spec_id.to_string(), db::spec_access::today());
+        let mut pending = self
+            .pending
+            .lock()
+            .unwrap_or_else(PoisonError::into_inner);
+        if pending.len() >= MAX_PENDING_KEYS && !pending.contains_key(&key) {
+            self.dropped.fetch_add(1, Ordering::Relaxed);
+            return;
+        }
+        *pending.entry(key).or_insert(0) += 1;
+    }
+
+    /// Persist every pending delta with one UPSERT per bucket. Returns
+    /// how many buckets were written. On a write error the failed
+    /// bucket *and* everything not yet attempted are merged back into
+    /// the buffer (increments that arrived meanwhile are preserved),
+    /// so a retry later re-flushes the full amount.
+    pub async fn flush(&self, db: &ConfigDb) -> anyhow::Result<usize> {
+        let pending = std::mem::take(
+            &mut *self
+                .pending
+                .lock()
+                .unwrap_or_else(PoisonError::into_inner),
+        );
+        if pending.is_empty() {
+            return Ok(0);
+        }
+        let total = pending.len();
+        let mut entries = pending.into_iter();
+        while let Some(((spec_id, day), delta)) = entries.next() {
+            if let Err(e) = db::spec_access::record_delta(db, &spec_id, &day, delta).await {
+                let mut rest: HashMap<_, _> = entries.collect();
+                rest.insert((spec_id, day), delta);
+                self.merge_back(rest);
+                self.flush_failures.fetch_add(1, Ordering::Relaxed);
+                return Err(e);
+            }
+        }
+        Ok(total)
+    }
+
+    /// Re-add deltas that failed to persist, folding them into any
+    /// increments that arrived while the flush was in flight.
+    fn merge_back(&self, deltas: HashMap<(String, String), i64>) {
+        let mut pending = self
+            .pending
+            .lock()
+            .unwrap_or_else(PoisonError::into_inner);
+        for (key, delta) in deltas {
+            *pending.entry(key).or_insert(0) += delta;
+        }
+    }
+
+    /// Distinct `(spec, day)` buckets waiting to be flushed.
+    pub fn backlog(&self) -> usize {
+        self.pending
+            .lock()
+            .unwrap_or_else(PoisonError::into_inner)
+            .len()
+    }
+
+    /// Increments lost to the [`MAX_PENDING_KEYS`] backstop since boot.
+    pub fn dropped(&self) -> u64 {
+        self.dropped.load(Ordering::Relaxed)
+    }
+
+    /// Failed flush attempts since boot.
+    pub fn flush_failures(&self) -> u64 {
+        self.flush_failures.load(Ordering::Relaxed)
+    }
+}
+
+/// Start the single per-process drain task. Flushes every
+/// [`FLUSH_INTERVAL`]; on a DB error the deltas are already back in the
+/// buffer (see [`AccessCounter::flush`]) and the next attempt waits
+/// with exponential backoff up to [`MAX_BACKOFF`], logging the backlog
+/// so an outage is visible instead of silent.
+pub fn spawn(counter: Arc<AccessCounter>, db: ConfigDb) -> tokio::task::JoinHandle<()> {
+    tokio::spawn(async move {
+        let mut wait = FLUSH_INTERVAL;
+        loop {
+            tokio::time::sleep(wait).await;
+            match counter.flush(&db).await {
+                Ok(n) => {
+                    if n > 0 {
+                        tracing::debug!(buckets = n, "access counters flushed");
+                    }
+                    wait = FLUSH_INTERVAL;
+                }
+                Err(e) => {
+                    wait = (wait * 2).min(MAX_BACKOFF);
+                    tracing::warn!(
+                        error = ?e,
+                        backlog = counter.backlog(),
+                        dropped = counter.dropped(),
+                        retry_in_s = wait.as_secs(),
+                        "access-counter flush failed; deltas kept for retry"
+                    );
+                }
+            }
+        }
+    })
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    async fn mem_db() -> ConfigDb {
+        ConfigDb::Sqlite(crate::db::open_memory().await.expect("open in-memory"))
+    }
+
+    #[tokio::test]
+    async fn concurrent_bumps_flush_to_the_exact_total() {
+        let counter = Arc::new(AccessCounter::default());
+        let db = mem_db().await;
+
+        // 10 000 increments across 20 concurrent tasks, two specs.
+        let mut handles = Vec::new();
+        for t in 0..20 {
+            let c = counter.clone();
+            handles.push(tokio::spawn(async move {
+                let spec = if t % 2 == 0 { "a" } else { "b" };
+                for _ in 0..500 {
+                    c.bump(spec);
+                }
+            }));
+        }
+        for h in handles {
+            h.await.unwrap();
+        }
+
+        // Whatever the interleaving, the buffer holds 2 buckets and the
+        // flush lands the exact totals.
+        assert_eq!(counter.backlog(), 2);
+        assert_eq!(counter.flush(&db).await.unwrap(), 2);
+        assert_eq!(counter.backlog(), 0, "flush empties the buffer");
+        let totals = db::spec_access::totals(&db).await.unwrap();
+        assert_eq!(totals.get("a"), Some(&5000));
+        assert_eq!(totals.get("b"), Some(&5000));
+        assert_eq!(counter.dropped(), 0);
+    }
+
+    #[tokio::test]
+    async fn flush_failure_keeps_deltas_for_retry() {
+        let counter = AccessCounter::default();
+        counter.bump("a");
+        counter.bump("a");
+        counter.bump("b");
+
+        // A closed pool makes every write fail — the outage case.
+        let db = mem_db().await;
+        if let ConfigDb::Sqlite(pool) = &db {
+            pool.close().await;
+        }
+        assert!(counter.flush(&db).await.is_err());
+        assert_eq!(
+            counter.backlog(),
+            2,
+            "failed flush merges both buckets back"
+        );
+        assert_eq!(counter.flush_failures(), 1);
+
+        // Increments arriving after the failure fold into the same
+        // buckets — a later successful flush writes the full amount.
+        counter.bump("a");
+        let db = mem_db().await;
+        assert_eq!(counter.flush(&db).await.unwrap(), 2);
+        let totals = db::spec_access::totals(&db).await.unwrap();
+        assert_eq!(totals.get("a"), Some(&3));
+        assert_eq!(totals.get("b"), Some(&1));
+    }
+
+    #[tokio::test]
+    async fn backstop_drops_new_buckets_but_keeps_counting_existing() {
+        let counter = AccessCounter::default();
+        // Fill the buffer to the cap with distinct synthetic specs.
+        for i in 0..MAX_PENDING_KEYS {
+            counter.bump(&format!("spec-{i}"));
+        }
+        assert_eq!(counter.backlog(), MAX_PENDING_KEYS);
+
+        // A new bucket is dropped (and counted)…
+        counter.bump("one-too-many");
+        assert_eq!(counter.backlog(), MAX_PENDING_KEYS);
+        assert_eq!(counter.dropped(), 1);
+
+        // …but an existing bucket still increments.
+        counter.bump("spec-0");
+        assert_eq!(counter.backlog(), MAX_PENDING_KEYS);
+
+        let db = mem_db().await;
+        counter.flush(&db).await.unwrap();
+        let totals = db::spec_access::totals(&db).await.unwrap();
+        assert_eq!(totals.get("spec-0"), Some(&2));
+        assert_eq!(totals.get("one-too-many"), None);
+    }
+}

--- a/crates/ruscker-admin/src/db/spec_access.rs
+++ b/crates/ruscker-admin/src/db/spec_access.rs
@@ -11,38 +11,52 @@ use super::ConfigDb;
 use anyhow::{Context, Result};
 use std::collections::HashMap;
 
-/// Today's bucket key in UTC, `YYYY-MM-DD`.
-fn today() -> String {
+/// Today's bucket key in UTC, `YYYY-MM-DD`. `pub(crate)` so the
+/// in-memory aggregator ([`crate::access_counter`]) buckets increments
+/// with the same key it will later flush under.
+pub(crate) fn today() -> String {
     chrono::Utc::now().format("%Y-%m-%d").to_string()
 }
 
-/// Record one access for `spec_id` (today's bucket, +1). Atomic via
-/// `ON CONFLICT`. Callers treat this as best-effort — a counter hiccup
-/// must never break the request being served.
+/// Record one access for `spec_id` (today's bucket, +1). Callers treat
+/// this as best-effort — a counter hiccup must never break the request
+/// being served. The proxy hot path doesn't call this directly anymore
+/// (#944) — it buffers in [`crate::access_counter`], which flushes here
+/// via [`record_delta`].
 pub async fn record(db: &ConfigDb, spec_id: &str) -> Result<()> {
-    let day = today();
+    record_delta(db, spec_id, &today(), 1).await
+}
+
+/// Add `delta` accesses to the `(spec_id, day)` bucket in one atomic
+/// UPSERT (#944). The flush task calls this once per touched bucket per
+/// window, so the write rate tracks specs × flush windows — not the
+/// request rate.
+pub async fn record_delta(db: &ConfigDb, spec_id: &str, day: &str, delta: i64) -> Result<()> {
     match db {
         ConfigDb::Sqlite(pool) => {
             sqlx::query(
-                "INSERT INTO spec_access (spec_id, day, count) VALUES (?, ?, 1)
-                 ON CONFLICT(spec_id, day) DO UPDATE SET count = count + 1",
+                "INSERT INTO spec_access (spec_id, day, count) VALUES (?, ?, ?)
+                 ON CONFLICT(spec_id, day) DO UPDATE SET count = count + excluded.count",
             )
             .bind(spec_id)
-            .bind(&day)
+            .bind(day)
+            .bind(delta)
             .execute(pool)
             .await
-            .context("record spec access (sqlite)")?;
+            .context("record spec access delta (sqlite)")?;
         }
         ConfigDb::Postgres(pool) => {
             sqlx::query(
-                "INSERT INTO spec_access (spec_id, day, count) VALUES ($1, $2, 1)
-                 ON CONFLICT (spec_id, day) DO UPDATE SET count = spec_access.count + 1",
+                "INSERT INTO spec_access (spec_id, day, count) VALUES ($1, $2, $3)
+                 ON CONFLICT (spec_id, day) DO UPDATE
+                     SET count = spec_access.count + EXCLUDED.count",
             )
             .bind(spec_id)
-            .bind(&day)
+            .bind(day)
+            .bind(delta)
             .execute(pool)
             .await
-            .context("record spec access (postgres)")?;
+            .context("record spec access delta (postgres)")?;
         }
     }
     Ok(())
@@ -189,5 +203,38 @@ mod tests {
         assert_eq!(sparkline_svg(&[]), "");
         assert_eq!(sparkline_svg(&[0, 0, 0]), "");
         assert!(sparkline_svg(&[0, 1, 3, 2]).contains("<polyline"));
+    }
+
+    #[tokio::test]
+    async fn record_delta_upserts_and_accumulates() {
+        let db = mem_db().await;
+        record_delta(&db, "a", "2026-07-12", 41).await.unwrap();
+        record_delta(&db, "a", "2026-07-12", 1).await.unwrap();
+        record_delta(&db, "a", "2026-07-13", 8).await.unwrap();
+        let totals = totals(&db).await.expect("totals");
+        assert_eq!(totals.get("a"), Some(&50));
+    }
+
+    // The delta UPSERT against a real Postgres (its `EXCLUDED`-qualified
+    // conflict arm differs from SQLite's). Gated on `postgres-it`.
+    #[cfg(feature = "postgres-it")]
+    #[tokio::test]
+    async fn record_delta_against_real_postgres() {
+        let _guard = crate::db::pg_test_lock().lock().await;
+        let url = std::env::var("RUSCKER_TEST_PG_URL")
+            .expect("set RUSCKER_TEST_PG_URL to a reachable postgres:// DSN");
+        let pg = crate::db::open_pg(&url).await.unwrap();
+        sqlx::query("DELETE FROM spec_access")
+            .execute(&pg)
+            .await
+            .unwrap();
+        let db = ConfigDb::Postgres(pg);
+
+        record_delta(&db, "a", "2026-07-12", 41).await.unwrap();
+        record_delta(&db, "a", "2026-07-12", 1).await.unwrap();
+        record_delta(&db, "b", "2026-07-12", 7).await.unwrap();
+        let totals = totals(&db).await.expect("totals");
+        assert_eq!(totals.get("a"), Some(&42));
+        assert_eq!(totals.get("b"), Some(&7));
     }
 }

--- a/crates/ruscker-admin/src/lib.rs
+++ b/crates/ruscker-admin/src/lib.rs
@@ -21,6 +21,7 @@ use tokio::net::TcpListener;
 use tower_cookies::CookieManagerLayer;
 use tracing::info;
 
+pub mod access_counter;
 pub mod auth;
 pub mod catalog;
 pub mod crypto;
@@ -192,6 +193,14 @@ pub struct AppState {
     /// any node changes the signature every reader observes). `Arc` so all
     /// cloned `AppState`s share it in-process while each test gets its own.
     pub catalog_cache: catalog::CatalogCache,
+
+    /// In-memory buffer for the per-spec access counter (#944). The
+    /// proxy hot path bumps it synchronously; a single drain task
+    /// (started from `AdminServer::run`) batches the deltas into the DB
+    /// every couple of seconds, so writes track specs × flush windows —
+    /// not the request rate. Shared so every cloned `AppState` and the
+    /// drain task see the same buffer.
+    pub access_counter: Arc<access_counter::AccessCounter>,
 }
 
 impl AppState {
@@ -249,6 +258,7 @@ impl AdminServer {
             draining: Arc::new(std::sync::atomic::AtomicBool::new(false)),
             spec_cache: Arc::new(dashmap::DashMap::new()),
             catalog_cache: Arc::new(tokio::sync::RwLock::new(None)),
+            access_counter: Arc::new(access_counter::AccessCounter::default()),
         };
         Ok(Self {
             addr,
@@ -455,6 +465,17 @@ impl AdminServer {
             );
         }
 
+        // Access-counter drain (#944): the proxy hot path only bumps an
+        // in-memory buffer; this single supervised task batches the
+        // deltas into the DB. Needs only the DB, not a backend (external
+        // specs count clicks even in landing-only mode). Detached like
+        // the loops above — every flush is idempotent-by-delta, and the
+        // final flush on shutdown runs explicitly below.
+        if let Some(db) = self.state.db.clone() {
+            #[allow(clippy::let_underscore_future)]
+            let _ = access_counter::spawn(self.state.access_counter.clone(), db);
+        }
+
         let app = router_with_images(self.state.clone(), self.images_dir.as_deref());
         let listener = TcpListener::bind(self.addr)
             .await
@@ -495,6 +516,24 @@ impl AdminServer {
             .with_graceful_shutdown(shutdown_signal(self.state.clone()))
             .await
             .context("axum serve")?;
+        // Final access-counter flush (#944): in-flight requests have
+        // finished, so their bumps are in the buffer. Bounded — a dead
+        // DB must not hold up shutdown past the watchdog.
+        if let Some(db) = self.state.db.as_ref() {
+            let flush = self.state.access_counter.flush(db);
+            match tokio::time::timeout(std::time::Duration::from_secs(5), flush).await {
+                Ok(Ok(_)) => {}
+                Ok(Err(e)) => tracing::warn!(
+                    error = ?e,
+                    lost = self.state.access_counter.backlog(),
+                    "final access-counter flush failed; pending counts lost"
+                ),
+                Err(_) => tracing::warn!(
+                    lost = self.state.access_counter.backlog(),
+                    "final access-counter flush timed out; pending counts lost"
+                ),
+            }
+        }
         info!("shutdown complete");
         Ok(())
     }

--- a/crates/ruscker-admin/src/routes/admin.rs
+++ b/crates/ruscker-admin/src/routes/admin.rs
@@ -826,6 +826,7 @@ mod tests {
             draining: Arc::new(std::sync::atomic::AtomicBool::new(false)),
             spec_cache: Arc::new(dashmap::DashMap::new()),
             catalog_cache: Arc::new(tokio::sync::RwLock::new(None)),
+            access_counter: Arc::new(crate::access_counter::AccessCounter::default()),
         }
     }
 

--- a/crates/ruscker-admin/src/routes/proxy.rs
+++ b/crates/ruscker-admin/src/routes/proxy.rs
@@ -261,7 +261,7 @@ async fn forward(
             // Count the external-card click (#549). The landing routes
             // external cards through `/app/{id}` precisely so this click
             // is visible to Ruscker. Best-effort — never blocks the bounce.
-            record_access(&state, &spec.id).await;
+            record_access(&state, &spec.id);
             return Redirect::to(target).into_response();
         }
         return (
@@ -725,7 +725,7 @@ async fn forward(
         // A new sticky session = a new app visit (#549). Counting here
         // (not per request) means assets/WebSocket/polling don't inflate
         // it, and direct `/app/{id}` URLs (no landing) still count.
-        record_access(&state, &spec.id).await;
+        record_access(&state, &spec.id);
         let session = StickySession {
             session_id,
             spec_id: spec.id.clone(),
@@ -745,13 +745,12 @@ async fn forward(
 
     // API specs aren't sticky, so count each forwarded call here (#549
     // follow-up). One per request — for an API, each call *is* the
-    // access. Spawned, not awaited (#744): the write is best-effort by
-    // contract, and awaiting it inline added a DB round-trip to every
-    // API response (serializing on SQLite's single writer under load).
+    // access. A synchronous in-memory bump (#944): the per-request
+    // `tokio::spawn` from #744 kept the task and write rate equal to
+    // the request rate; now the drain task batches everything into one
+    // UPSERT per flush window.
     if spec.kind() == SpecKind::Api {
-        let st = state.clone();
-        let id = spec.id.clone();
-        tokio::spawn(async move { record_access(&st, &id).await });
+        record_access(&state, &spec.id);
     }
 
     let resp = with_cors(resp, cors_on);
@@ -782,14 +781,15 @@ fn spec_kind_needs_sticky(kind: SpecKind) -> bool {
     matches!(kind, SpecKind::Shiny | SpecKind::InteractiveApp)
 }
 
-/// Best-effort per-spec access count (#549). A counter write must never
-/// break the request being served, so a missing DB or a write error is
-/// ignored (logged at debug).
-async fn record_access(state: &AppState, spec_id: &str) {
-    if let Some(db) = state.db.as_ref() {
-        if let Err(e) = crate::db::spec_access::record(db, spec_id).await {
-            tracing::debug!(spec = spec_id, error = ?e, "spec access count failed");
-        }
+/// Best-effort per-spec access count (#549). Since #944 this is a plain
+/// in-memory bump — no task, no DB round-trip, nothing that could break
+/// the request being served. A single drain task (started in
+/// `AdminServer::run`) batches the deltas into the DB; without a DB
+/// there's no drain task, so skip the bump instead of buffering counts
+/// that would never land anywhere.
+fn record_access(state: &AppState, spec_id: &str) {
+    if state.db.is_some() {
+        state.access_counter.bump(spec_id);
     }
 }
 
@@ -2221,6 +2221,7 @@ mod tests {
             draining: StdArc::new(std::sync::atomic::AtomicBool::new(false)),
             spec_cache: StdArc::new(dashmap::DashMap::new()),
             catalog_cache: StdArc::new(tokio::sync::RwLock::new(None)),
+            access_counter: StdArc::new(crate::access_counter::AccessCounter::default()),
         }
     }
 

--- a/crates/ruscker-admin/src/scaler.rs
+++ b/crates/ruscker-admin/src/scaler.rs
@@ -1252,6 +1252,7 @@ mod tests {
             draining: Arc::new(std::sync::atomic::AtomicBool::new(false)),
             spec_cache: Arc::new(dashmap::DashMap::new()),
             catalog_cache: Arc::new(tokio::sync::RwLock::new(None)),
+            access_counter: Arc::new(crate::access_counter::AccessCounter::default()),
         }
     }
 

--- a/crates/ruscker-admin/tests/admin_landing_picker.rs
+++ b/crates/ruscker-admin/tests/admin_landing_picker.rs
@@ -45,6 +45,7 @@ async fn state_with_db() -> AppState {
         draining: Arc::new(std::sync::atomic::AtomicBool::new(false)),
         spec_cache: std::sync::Arc::new(dashmap::DashMap::new()),
         catalog_cache: std::sync::Arc::new(tokio::sync::RwLock::new(None)),
+        access_counter: std::sync::Arc::new(ruscker_admin::access_counter::AccessCounter::default()),
     }
 }
 

--- a/crates/ruscker-admin/tests/api_policies.rs
+++ b/crates/ruscker-admin/tests/api_policies.rs
@@ -62,6 +62,7 @@ fn state() -> AppState {
         draining: Arc::new(std::sync::atomic::AtomicBool::new(false)),
         spec_cache: std::sync::Arc::new(dashmap::DashMap::new()),
         catalog_cache: std::sync::Arc::new(tokio::sync::RwLock::new(None)),
+        access_counter: std::sync::Arc::new(ruscker_admin::access_counter::AccessCounter::default()),
     }
 }
 

--- a/crates/ruscker-admin/tests/health_probes.rs
+++ b/crates/ruscker-admin/tests/health_probes.rs
@@ -46,6 +46,7 @@ fn base_state() -> AppState {
         draining: Arc::new(std::sync::atomic::AtomicBool::new(false)),
         spec_cache: std::sync::Arc::new(dashmap::DashMap::new()),
         catalog_cache: std::sync::Arc::new(tokio::sync::RwLock::new(None)),
+        access_counter: std::sync::Arc::new(ruscker_admin::access_counter::AccessCounter::default()),
     }
 }
 

--- a/crates/ruscker-admin/tests/landing_access.rs
+++ b/crates/ruscker-admin/tests/landing_access.rs
@@ -84,6 +84,7 @@ async fn app_state(db: ConfigDb) -> AppState {
         draining: Arc::new(std::sync::atomic::AtomicBool::new(false)),
         spec_cache: std::sync::Arc::new(dashmap::DashMap::new()),
         catalog_cache: std::sync::Arc::new(tokio::sync::RwLock::new(None)),
+        access_counter: std::sync::Arc::new(ruscker_admin::access_counter::AccessCounter::default()),
     }
 }
 

--- a/crates/ruscker-admin/tests/landing_render.rs
+++ b/crates/ruscker-admin/tests/landing_render.rs
@@ -51,6 +51,7 @@ fn state_from_yaml(yaml: &str) -> AppState {
         draining: std::sync::Arc::new(std::sync::atomic::AtomicBool::new(false)),
         spec_cache: std::sync::Arc::new(dashmap::DashMap::new()),
         catalog_cache: std::sync::Arc::new(tokio::sync::RwLock::new(None)),
+        access_counter: std::sync::Arc::new(ruscker_admin::access_counter::AccessCounter::default()),
     }
 }
 

--- a/crates/ruscker-admin/tests/max_body_size.rs
+++ b/crates/ruscker-admin/tests/max_body_size.rs
@@ -61,6 +61,7 @@ fn state() -> AppState {
         draining: Arc::new(std::sync::atomic::AtomicBool::new(false)),
         spec_cache: std::sync::Arc::new(dashmap::DashMap::new()),
         catalog_cache: std::sync::Arc::new(tokio::sync::RwLock::new(None)),
+        access_counter: std::sync::Arc::new(ruscker_admin::access_counter::AccessCounter::default()),
     }
 }
 

--- a/crates/ruscker-admin/tests/metrics.rs
+++ b/crates/ruscker-admin/tests/metrics.rs
@@ -34,6 +34,7 @@ fn state(yaml: &str) -> AppState {
         draining: Arc::new(std::sync::atomic::AtomicBool::new(false)),
         spec_cache: std::sync::Arc::new(dashmap::DashMap::new()),
         catalog_cache: std::sync::Arc::new(tokio::sync::RwLock::new(None)),
+        access_counter: std::sync::Arc::new(ruscker_admin::access_counter::AccessCounter::default()),
     }
 }
 

--- a/crates/ruscker-admin/tests/proxy_access.rs
+++ b/crates/ruscker-admin/tests/proxy_access.rs
@@ -82,6 +82,7 @@ async fn app_state(db: ConfigDb) -> AppState {
         draining: Arc::new(std::sync::atomic::AtomicBool::new(false)),
         spec_cache: std::sync::Arc::new(dashmap::DashMap::new()),
         catalog_cache: std::sync::Arc::new(tokio::sync::RwLock::new(None)),
+        access_counter: Arc::new(ruscker_admin::access_counter::AccessCounter::default()),
     }
 }
 

--- a/crates/ruscker-admin/tests/rbac.rs
+++ b/crates/ruscker-admin/tests/rbac.rs
@@ -58,6 +58,7 @@ fn state() -> AppState {
         draining: Arc::new(std::sync::atomic::AtomicBool::new(false)),
         spec_cache: std::sync::Arc::new(dashmap::DashMap::new()),
         catalog_cache: std::sync::Arc::new(tokio::sync::RwLock::new(None)),
+        access_counter: std::sync::Arc::new(ruscker_admin::access_counter::AccessCounter::default()),
     }
 }
 

--- a/crates/ruscker-admin/tests/user_accounts.rs
+++ b/crates/ruscker-admin/tests/user_accounts.rs
@@ -45,6 +45,7 @@ async fn state_with_db() -> (AppState, sqlx::SqlitePool) {
         draining: Arc::new(std::sync::atomic::AtomicBool::new(false)),
         spec_cache: std::sync::Arc::new(dashmap::DashMap::new()),
         catalog_cache: std::sync::Arc::new(tokio::sync::RwLock::new(None)),
+        access_counter: std::sync::Arc::new(ruscker_admin::access_counter::AccessCounter::default()),
     };
     (state, pool)
 }


### PR DESCRIPTION
Closes #944

## What

Replaces the per-request detached task + UPSERT for `Api` access counting with an in-memory aggregator flushed in batches. Sticky-session visits and external-card clicks route through the same component, unifying semantics.

## How

- **`access_counter::AccessCounter`** (new module, on `AppState`): the proxy hot path (`record_access`) is now a synchronous bump on a `(spec_id, day)` bucket — no await, no task, no DB. The `tokio::spawn` per API request is gone.
- **One supervised drain task** (started in `AdminServer::run` when a DB is wired) flushes every 2 s via the new **`db::spec_access::record_delta`** — one `count = count + delta` UPSERT per touched bucket, both dialects (`excluded.count` / `EXCLUDED.count`).
- **Failure policy**: a failed flush merges the deltas back into the buffer (folding into increments that arrived meanwhile) and retries with exponential backoff capped at 60 s, logging `backlog`/`dropped`/`retry_in_s`. Memory is bounded structurally (keys = specs × days) plus a `MAX_PENDING_KEYS=4096` backstop that drops only *new* buckets, counted in `dropped()`.
- **Shutdown**: after `axum::serve` returns (in-flight requests done, their bumps buffered), a final flush runs under a 5 s timeout so a dead DB can't hold the process past the watchdog.

## Acceptance criteria from the issue

- [x] Task count no longer grows with request count (zero spawns on the hot path).
- [x] 10 000 concurrent accesses flush to the exact total (`concurrent_bumps_flush_to_the_exact_total`).
- [x] Writes proportional to specs × flush windows (one UPSERT per bucket per window).
- [x] Explicit retry/loss policy for DB failure, memory bounded (`flush_failure_keeps_deltas_for_retry`, `backstop_drops_new_buckets_but_keeps_counting_existing`).
- [x] Bounded final flush on graceful shutdown.
- [x] Delta-UPSERT tests on SQLite and Postgres (`record_delta_upserts_and_accumulates`, `record_delta_against_real_postgres`).

## Verification

- Full gate green: **628 tests**, `clippy --all-targets -- -D warnings` clean.
- `postgres-it` suite green against a throwaway `postgres:16-alpine` (including the new delta test).
- **E2E with the real binary**: `serve --no-docker` + an external spec — 5 clicks landed `count=5` after one flush window; 3 more clicks followed by SIGTERM before the next window landed `count=8` via the shutdown flush; no flush failures logged.

🤖 Generated with [Claude Code](https://claude.com/claude-code)