### PR TITLE
docs: ShinyProxy → Ruscker field map (#940)

### DIFF
--- a/book/src/SUMMARY.md
+++ b/book/src/SUMMARY.md
@@ -9,6 +9,7 @@
 - [Quickstart](./quickstart.md)
 - [Installation](./installation.md)
 - [Migrating from ShinyProxy](./migrating.md)
+  - [Field map (de-para)](./shinyproxy-fieldmap.md)
 - [Configuration](./configuration.md)
 - [The admin panel](./admin.md)
 - [Deploying in production](./deploying.md)

--- a/book/src/migrating.md
+++ b/book/src/migrating.md
@@ -151,17 +151,16 @@ source of truth for your specific config. For apps that handle their
 own auth (a common case), `none` is correct: Ruscker just routes
 traffic.
 
-The following ShinyProxy per-spec fields are accepted by the parser
-but currently ignored:
+For the full field-by-field picture — every ShinyProxy key with its
+status in Ruscker (supported / warned-and-ignored / planned / out of
+scope, and the Ruscker way to get the same outcome) — see the
+**[ShinyProxy → Ruscker field map](./shinyproxy-fieldmap.md)**.
 
-- `minimum-seats-available` — use `min-replicas` instead
-- `labels` — custom container labels (phase 3.5)
-- `network-connections` — container network wiring (phase 3.5)
-- `kubernetes-*` — Kubernetes backend
-
-Fields that **are** now fully supported (and no longer flagged by
-`--strict-compat`): `volumes`, `container-env`, `container-cmd`,
-`port` (maps to `container-port`), and the scaling and lifecycle knobs
-`scale-up-threshold`, `scale-down-threshold`, `scale-down-grace`,
-`max-lifetime`, `container-lifetime`, `drain-timeout`,
-`stop-on-logout`, and `concurrent-requests-per-replica`.
+The short version: the container keys (`container-env` / `-cmd` /
+`-volumes` / `-network`, `labels`, the CPU/memory requests and limits,
+`port`), the access lists, and the lifecycle knobs all map straight
+across; `minimum-seats-available` (use `min-replicas`),
+`network-connections` (use the single `container-network`) and
+`kubernetes-*` are flagged by `--strict-compat`; per-user-instance
+knobs (`max-instances` family) don't apply — Ruscker pools
+seats × replicas instead.

--- a/book/src/shinyproxy-fieldmap.md
+++ b/book/src/shinyproxy-fieldmap.md
@@ -1,0 +1,150 @@
+# ShinyProxy → Ruscker field map
+
+A field-by-field reference for migrating a ShinyProxy 3.x
+`application.yml` to Ruscker. For the step-by-step migration guide, see
+[Migrating from ShinyProxy](./migrating.md); this page answers the
+narrower question *"what happens to each key in my config?"*
+
+Statuses:
+
+| | Meaning |
+|---|---|
+| ✅ | **Supported** — Ruscker honours the key (same name unless noted) |
+| ⚠️ | **Accepted but ignored** — parses fine, does nothing; Ruscker **warns at startup** when it's set |
+| 🚧 | **Planned** — not implemented yet; tracked on the roadmap / an issue |
+| ❌ | **Not planned** — out of scope, with the reasoning and (where one exists) the Ruscker way to get the same outcome |
+
+> **How to check *your* config:** run
+> `ruscker validate application.yml --strict-compat`. It flags a
+> non-`none` `proxy.authentication`, the whole `proxy.docker.*` block,
+> and the per-spec `kubernetes-*` / `minimum-seats-available` /
+> `network-connections` keys, and exits non-zero if any are present.
+> The ⚠️ rows below additionally warn at every startup. **Any other
+> unknown key is dropped silently by the parser** — that's standard
+> serde behaviour, and it's exactly why this table exists.
+
+## `server.*` and Spring-level keys
+
+| ShinyProxy key | Status | In Ruscker |
+|---|---|---|
+| `server.servlet.context-path` | ✅ | Same key, or the flat `server.context-path`; the `--base-path` CLI flag overrides both. See [Configuration](./configuration.md) |
+| `server.forward-headers-strategy` | ✅ | Same key — any value other than `none` trusts `X-Forwarded-*`. The pre-3.x `server.useForwardHeaders: true` is also accepted. **Set one of them whenever a reverse proxy terminates TLS** |
+| `server.secure-cookies` | ⚠️ | Warned and ignored. The `Secure` cookie flag comes from the forwarded-headers trust above + your proxy's `X-Forwarded-Proto` |
+| `server.servlet.session.timeout` | ⚠️ | Warned and ignored — admin sessions have a fixed 24 h TTL |
+| `server.compression.*` | ❌ | Not needed: Ruscker always compresses responses (gzip/brotli built in) |
+| `server.tomcat.accesslog.*` | ❌ | Tomcat-specific. Use structured logging (`--log-format json`) and your process manager's log routing |
+| `logging.file` / `logging.file.name` | ⚠️ | `logging.file` is warned and ignored — Ruscker logs to stdout/stderr; let systemd/journald or Docker capture it |
+| `logging.level.*`, `logging.pattern.*`, `logging.logback.*`, `logging.json.*` | ❌ | Spring/Logback-specific. Use `-v`/`-vv` for verbosity and `--log-format json` for JSON logs |
+| `spring.session.store-type`, `spring.redis.*` | ❌ | Ruscker's HA story uses **Postgres**, not Redis: `--config-db-url`, `--session-store-url`, `--admin-session-store-url`. See [Deploying](./deploying.md) |
+| `management.prometheus.metrics.export.enabled` | ✅ | Equivalent: `proxy.metrics-enabled: true` exposes a Prometheus `/metrics` endpoint (unauthenticated — firewall it) |
+| `spring.application.name` | ❌ | Cosmetic; `proxy.title` names the portal |
+
+## `proxy.*` top-level keys
+
+| ShinyProxy key | Status | In Ruscker |
+|---|---|---|
+| `proxy.title` | ✅ | Same key (browser-tab / portal title) |
+| `proxy.port` | ✅ | Same key |
+| `proxy.bind-address` | ✅ | Same key |
+| `proxy.heartbeat-timeout` | ✅ | Same key (ms; `-1` = never); per-spec override supported |
+| `proxy.container-wait-time` | 🚧 | Parses, but **not consumed today** — the readiness wait is fixed at 60 s and no startup warning fires yet. Wiring it (or warning) is tracked in issue #970 |
+| `proxy.template-path` | ✅ | Read for one purpose: auto-discovering card logos in `<template-path>/assets/img/` next to the config. Thymeleaf templates themselves don't apply — the portal UI is Ruscker's own, themed in the admin **Appearance** tab |
+| `proxy.specs` | ✅ | Same key — see the per-spec table below |
+| `proxy.authentication` | ✅/🚧 | Parsed; **only `none` is implemented today** (apps that do their own auth are the common case). `openid` / `saml` are the Phase 8 roadmap (issue #934). Anything non-`none` is flagged by `--strict-compat` and warned at boot |
+| `proxy.admin-groups`, `proxy.admin-users`, `proxy.users` | ❌ | Ruscker has its own user store with roles (Admin / Editor / Viewer), managed in the admin **Users** tab (CSV import available) — not driven from YAML |
+| `proxy.heartbeat-rate` | ⚠️ | Warned and ignored — the landing's heartbeat is fixed |
+| `proxy.landing-page` | ⚠️ | Warned and ignored — the portal is always at the root / base path |
+| `proxy.hide-navbar` | ⚠️ | Warned and ignored |
+| `proxy.container-log-path` | ⚠️ | Warned and ignored — use `docker logs`, or the admin **Logs** tab |
+| `proxy.container-log-storage`, `proxy.s3-log-*` | ❌ | No app-log shipping; capture container logs with Docker's own log drivers |
+| `proxy.container-backend` | ❌ | Docker only (local daemon by default; several daemons via the `proxy.hosts` extension). Kubernetes/Swarm/ECS are out of scope |
+| `proxy.container-wait-timeout` | ❌ | Single readiness knob: `container-wait-time` |
+| `proxy.stop-proxies-on-shutdown` | ✅ | Built-in behaviour, not a flag: Ruscker **never stops app containers on shutdown** (equivalent to `false`) |
+| `proxy.recover-running-proxies` (+ `…-from-different-config`) | ✅ | Built-in: at boot Ruscker reconciles running containers it owns (label-scoped) back into the registry — no Redis, no flag |
+| `proxy.default-stop-proxy-on-logout` | ✅ | Per-spec `stop-on-logout` (no global default — set it on the specs that need it) |
+| `proxy.default-proxy-max-lifetime` | ✅ | Per-spec `max-lifetime` (no global default) |
+| `proxy.default-max-instances`, `proxy.max-total-instances`, per-spec `max-instances` | ❌ | Different concurrency model: ShinyProxy counts **instances per user**; Ruscker pools **seats × replicas** (`seats-per-container`, `min-replicas` / `max-replicas`). See [Configuration § load balancing](./configuration.md) |
+| `proxy.seat-wait-time` | ❌ | No seat queue — a cold-start visitor sees a splash while the replica spawns; a saturated pool scales up to `max-replicas` |
+| `proxy.default-webSocket-reconnection-mode` | ❌ | Ruscker pumps WebSockets transparently and leaves reconnection to the app framework |
+| `proxy.default-cache-headers-mode` | ❌ | App responses pass through untouched |
+| `proxy.default-max-session-time` | ❌ | Sessions expire by `heartbeat-timeout` (idle), not wall-clock |
+| `proxy.notification-message` | ✅ | Equivalent: the landing **intro text** and custom HTML blocks, edited in the admin **Appearance** tab |
+| `proxy.username-case-sensitive` | ❌ | Usernames are normalized (lowercase) throughout |
+| `proxy.secure-cookies`, `proxy.same-site-cookie` | ❌ | Cookie flags are managed by Ruscker (`Secure` via forwarded-header trust; sticky cookies are per-spec, `SameSite` set appropriately) |
+| `proxy.usage-stats-*`, `proxy.usage-stats` | ❌ | No InfluxDB/JDBC usage-stats pipeline. Built in instead: a per-spec **access counter** with sparklines in the admin Apps table, the live dashboard, and the optional Prometheus `/metrics` endpoint |
+| `proxy.monitoring.grafana-url` | ❌ | The monitoring dashboard is built in; scrape `/metrics` for Grafana |
+| `proxy.enable-app-persistence` | ❌ | Not needed: containers keep running across Ruscker restarts and are reconciled at boot |
+| `proxy.logo-url`, `proxy.favicon-path`, `proxy.template-groups`, `proxy.body-classes`, `proxy.my-apps-mode` | ❌ | Thymeleaf-template UI knobs. The equivalents live in the admin **Appearance** tab (header logos, presets, catalog layout); the catalog groups cards by app type automatically |
+| `proxy.ldap.*`, `proxy.openid.*`, `proxy.saml.*`, `proxy.ms-graph.*`, `proxy.webservice.*`, `proxy.custom-header.*` | 🚧/❌ | Provider config for the unimplemented auth schemes. OIDC/SAML config will come with Phase 8 (#934); LDAP / webservice / customHeader have no plans |
+| `proxy.docker.*` (url, cert-path, port-range, internal-networking, image-pull-policy, …) | ❌ | Flagged by `--strict-compat`. Ruscker talks to the daemon via the standard socket/env (`DOCKER_HOST`); published ports bind on `127.0.0.1` by design; re-pull is a button in the admin. Multiple daemons: the `proxy.hosts` extension |
+| `proxy.kubernetes.*`, `proxy.ecs.*` | ❌ | Kubernetes / ECS backends are out of scope |
+
+## Per-spec keys (`proxy.specs[]`)
+
+| ShinyProxy key | Status | In Ruscker |
+|---|---|---|
+| `id` | ✅ | Same key (also the `/app/{id}` URL segment) |
+| `display-name` | ✅ | Same key |
+| `description` | ✅ | Same key (inline HTML allowed) |
+| `container-image` | ✅ | Same key |
+| `port` | ✅ | Accepted as an alias of `container-port`. Unset, `type: streamlit\|dash\|voila` default to 8501 / 8050 / 8866; Shiny to 3838 |
+| `container-cmd` | ✅ | Same key (argv list overriding the image `CMD`) |
+| `container-env` | ✅ | Same key; `${VAR}` values resolve at spawn and never land in the DB |
+| `container-volumes` | ✅ | Same key (bare `volumes` also accepted). Bind mounts are admin-only — see `SECURITY.md` |
+| `container-network` | ✅ | Same key; Ruscker also **creates** the network if missing |
+| `labels` | ✅ | Same key; Ruscker's own `ruscker.*` labels win on collision |
+| `container-memory-request` / `container-memory-limit` | ✅ | Same keys |
+| `container-cpu-request` / `container-cpu-limit` | ✅ | Same keys |
+| `access-groups` / `access-users` | ✅ | Same keys — enforced at `/app`–`/api` and on landing visibility, against Ruscker's own user store |
+| `heartbeat-timeout` | ✅ | Same key (per-spec override, ms) |
+| `stop-on-logout` | ✅ | Same key |
+| `max-lifetime` | ✅ | Same key (minutes, hard recycle; in-flight sessions get `drain-timeout`) |
+| `seats-per-container` | ✅ | Same key — but **defaults differ**: ShinyProxy defaults to 1; Ruscker to 10 for web apps (Shiny/Streamlit/Dash/Voilà) and 100 for APIs. Single-user IDEs (RStudio, Jupyter) should set `1` explicitly |
+| `docker-registry-username` / `-password` / `-domain` | ✅ | Same keys. Use `${ENV_VAR}` for the password; or the named-credential extension `docker-registry-credential` |
+| `template-properties` | ✅ | Same key — Ruscker reads `logo`, `type`, `state`, `link`, and its own extensions (`locked`, `accent`, `monogram`) |
+| `minimum-seats-available` | 🚧 | Flagged by `--strict-compat`. Pre-warm pool not implemented — `min-replicas: 1` keeps an app warm today |
+| `container-network-connections` / `network-connections` | ❌ | Flagged by `--strict-compat`. Multi-network attach is deferred — map it to the single `container-network` |
+| `kubernetes-*` (pod-patches, manifests, probes, …) | ❌ | Flagged by `--strict-compat`. Kubernetes backend is out of scope |
+| `ecs-*` | ❌ | ECS backend is out of scope |
+| `container-privileged`, `docker-user`, `docker-ipc`, `docker-group-add`, `docker-runtime`, `docker-device-requests`, `resource-name`, `container-dns`, `additional-port-mappings` | ❌ | Host-level container knobs, deliberately not exposed (privileged containers are root-equivalent; see `SECURITY.md`) |
+| `container-env-file` | ❌ | Use `container-env` with `${VAR}` references instead — same secrecy, no file to mount |
+| `target-path` | ❌ | Ruscker mounts every app at `/app/{id}/` and rewrites URLs itself (see [Architecture](./architecture.md)); apps that self-route get the forwarded-prefix headers |
+| `access-expression`, `access-strict-expression` | ❌ | SpEL is JVM-specific; use `access-groups` / `access-users` |
+| `max-instances`, `max-total-instances`, `always-show-switch-instance`, `allow-container-re-use` | ❌ | Per-user-instance model — see the concurrency note in the proxy table above |
+| `scale-down-delay` | ✅ | Equivalents: `scale-down-grace` (idle grace before retiring a replica) and `scale-down-cooldown-secs` (anti-flap) |
+| `websocket-reconnection-mode`, `shiny-force-full-reload`, `track-app-url` | ❌ | WebSockets are pumped transparently; reconnection/reload is the app framework's business |
+| `add-default-http-headers`, `http-headers` | ❌ | No `X-SP-*` identity headers today; Ruscker forwards the standard `X-Forwarded-*` family and its sub-path context headers |
+| `cache-headers-mode` | ❌ | App responses pass through untouched |
+| `logo-url`, `logo-height/-width/-classes/-style`, `favicon-path` | ❌ | Card art comes from `template-properties.logo` (the `/assets/img/<file>` convention — `ruscker import --images-dir` ingests the files) or the admin **Media** picker; sizing is the card design's |
+| `template-group` | ❌ | The catalog groups cards by app **type** automatically (`template-properties.type`) |
+| `custom-app-details`, `hide-navbar-on-main-page-link`, `support-mail-to-address`, `support-mail-subject` | ❌ | Thymeleaf-template features with no Ruscker counterpart |
+| `parameters` (app parameters) | ❌ | No parameterized-launch form; make variants explicit as separate specs with different `container-env` |
+| `external-url` | ✅ | Equivalent: an **external link spec** — omit `container-image` and set `template-properties.link` |
+
+## Ruscker extensions (no ShinyProxy counterpart)
+
+These are additions, not compat concerns — listed so a reviewed config
+is fully accounted for. Details in the
+[YAML schema reference](./configuration.md): per-spec `type`,
+`min-replicas` / `max-replicas`, `scale-up-threshold` /
+`scale-down-threshold` / `scale-down-grace` / `scale-down-cooldown-secs`,
+`drain-timeout`, `routing-strategy`,
+`concurrent-requests-per-replica`, `container-lifetime`, `platform`,
+`inject-base-href`, `max-body-size` (global + per-spec),
+`docker-registry-credential`, `placement` / `anti-affinity`, the
+`api.*` block (`docs-path`, `health-path`, `rate-limit`, `cors`),
+`proxy.hosts` (multi-host), `proxy.landing-customization`,
+`proxy.metrics-enabled` / `metrics-interval`, `proxy.shutdown-grace-ms`
+and `proxy.csp-origins`.
+
+## Keeping this page honest
+
+This table is a living contract. When a field's status changes
+(a 🚧 ships, a ⚠️ gains a consumer), the PR that changes the behaviour
+should update this page, `docs/YAML_SCHEMA.md`, and — when the
+detection surface changes — the `--strict-compat` scan
+(`ruscker-config::validate`). The sources of truth, in order:
+`crates/ruscker-config/src/schema.rs` (what parses),
+`validate.rs`'s `check_ignored_compat_fields` (the ⚠️ set) and
+`compat_scan` (what `--strict-compat` flags), and
+`docs/YAML_SCHEMA.md` § *Not supported*.

--- a/docs/YAML_SCHEMA.md
+++ b/docs/YAML_SCHEMA.md
@@ -98,7 +98,7 @@ ignored by Ruscker.
 | `authentication` | enum | `none` | `none` (only `none` is implemented today) / `openid` / `ldap` / `saml` / `simple` |
 | `landing-customization` | block | `{}` | Branding, SEO/social meta, analytics, custom HTML blocks, sign-in visibility — see [§ `proxy.landing-customization`](#proxylanding-customization). Ruscker extension |
 | `specs` | array | `[]` | List of apps/links/APIs |
-| `container-wait-time` | ms | `60000` | Max wait for container Ready |
+| `container-wait-time` | ms | `60000` | **Not consumed today** — the spawn readiness wait is a fixed 60 s; wiring the field is tracked in issue #970 |
 | `shutdown-grace-ms` | ms | `30000` | Drain window on SIGTERM/Ctrl-C before forced exit; `/readyz` reports `draining` during it. Ruscker extension |
 | `max-body-size` | size | none | Global cap on proxied request bodies (`"10m"`, `"1g"`, bytes); over → `413`. Per-spec `max-body-size` overrides. Ruscker extension |
 | `metrics-enabled` | bool | `false` | Expose a Prometheus `/metrics` endpoint (**unauthenticated** when on — firewall it). Ruscker extension |
@@ -751,3 +751,9 @@ Run `ruscker validate --strict-compat <config>` to list every
 unsupported feature a config uses (and exit non-zero if any are
 found) — the recommended pre-flight check when migrating from
 ShinyProxy.
+
+For a field-by-field ShinyProxy → Ruscker reference — every documented
+ShinyProxy 3.x key with its status here (supported /
+warned-and-ignored / planned / out of scope) and the Ruscker
+equivalent where one exists — see the **ShinyProxy → Ruscker field
+map** page on the docs site (`book/src/shinyproxy-fieldmap.md`).


### PR DESCRIPTION
Closes #940

## What

New docs-site page **ShinyProxy → Ruscker field map** (`book/src/shinyproxy-fieldmap.md`, sidebar child of *Migrating from ShinyProxy*): a field-by-field table covering every configuration key documented by ShinyProxy 3.x — `server.*`/Spring, `proxy.*` top-level, auth families, per-spec, and the backend blocks — each with a status and the Ruscker equivalent:

- ✅ supported (same or mapped name)
- ⚠️ accepted but ignored, **warned at startup** (the `IgnoredCompatField` set)
- 🚧 planned (linked to the roadmap/issue, e.g. OIDC/SAML → #934)
- ❌ out of scope, with the reasoning and the Ruscker way to get the same outcome (e.g. `max-instances` family → seats × replicas; `usage-stats-*` → built-in access counter + `/metrics`)

Plus a *Ruscker extensions* section (so a reviewed config is fully accounted for) and a *keeping this page honest* note naming the sources of truth (`schema.rs`, `check_ignored_compat_fields`, `compat_scan`, `YAML_SCHEMA.md`).

Also:
- **`migrating.md`**: replaced the stale "Not supported (yet)" list — it still claimed `labels` and `network-connections` were ignored (both supported since #850/#851) — with a pointer to the map + an accurate short version.
- **`docs/YAML_SCHEMA.md`**: cross-reference in § *Not supported*.

## Found while verifying the table

`proxy.container-wait-time` **parses but is never consumed** — the spawn readiness wait is the hardcoded `READINESS_TIMEOUT` (60 s) in `ruscker-docker`, and the field isn't in `check_ignored_compat_fields`, so no warning fires. Filed **#970** (wire it, or add the warning); both tables now state this honestly instead of listing it as supported.

## Verification

- ShinyProxy side built from the official docs (configuration + security + usage-statistics + UI + app-parameters/recovery pages) via a research agent; Ruscker side verified claim-by-claim against `schema.rs`, `validate.rs` (`check_ignored_compat_fields` + `compat_scan` + `UNSUPPORTED_*` tables) and `YAML_SCHEMA.md`. Spot-checked runtime consumption by grep for the ✅ rows I wasn't sure of (`title`, `port`, `bind-address` confirmed; `container-wait-time` caught as NOT consumed → #970).
- `mdbook build` clean; page in the sidebar; escaped pipes render; `migrating.html` links to the new page.
- `cargo test -p ruscker-config` green (docs-only change; no runtime surface).
- Docs policy respected: no hardcoded current-version strings; no footprint claims.

🤖 Generated with [Claude Code](https://claude.com/claude-code)