### PR TITLE
fix: wire proxy.container-wait-time to the readiness wait (#970)

### DIFF
--- a/book/src/shinyproxy-fieldmap.md
+++ b/book/src/shinyproxy-fieldmap.md
@@ -47,7 +47,7 @@ Statuses:
 | `proxy.port` | ✅ | Same key |
 | `proxy.bind-address` | ✅ | Same key |
 | `proxy.heartbeat-timeout` | ✅ | Same key (ms; `-1` = never); per-spec override supported |
-| `proxy.container-wait-time` | 🚧 | Parses, but **not consumed today** — the readiness wait is fixed at 60 s and no startup warning fires yet. Wiring it (or warning) is tracked in issue #970 |
+| `proxy.container-wait-time` | ✅ | Same key (ms) — max wait for a spawned container to become ready. Note the default differs: ShinyProxy 20 s, Ruscker 60 s |
 | `proxy.template-path` | ✅ | Read for one purpose: auto-discovering card logos in `<template-path>/assets/img/` next to the config. Thymeleaf templates themselves don't apply — the portal UI is Ruscker's own, themed in the admin **Appearance** tab |
 | `proxy.specs` | ✅ | Same key — see the per-spec table below |
 | `proxy.authentication` | ✅/🚧 | Parsed; **only `none` is implemented today** (apps that do their own auth are the common case). `openid` / `saml` are the Phase 8 roadmap (issue #934). Anything non-`none` is flagged by `--strict-compat` and warned at boot |

--- a/crates/ruscker-cli/src/main.rs
+++ b/crates/ruscker-cli/src/main.rs
@@ -548,6 +548,10 @@ fn cmd_serve(args: ServeArgs) -> Result<()> {
         None => config.server.effective_base_path(),
     };
 
+    // Captured before `config` moves into the server (#970): how long
+    // a spawned container gets to become ready before the spawn fails.
+    let container_wait = std::time::Duration::from_millis(config.proxy.container_wait_time);
+
     let rt = tokio::runtime::Builder::new_multi_thread()
         .enable_all()
         .build()?;
@@ -576,12 +580,17 @@ fn cmd_serve(args: ServeArgs) -> Result<()> {
             // hosts); `connect` validates them and fails only on zero.
             tracing::info!(count = hosts.len(), "multi-host backend");
             let backend = ruscker_docker::MultiHostDockerBackend::connect(&hosts)
-                .context("connect to Docker hosts")?;
+                .context("connect to Docker hosts")?
+                // `proxy.container-wait-time` (#970): how long a spawned
+                // container gets to become ready before the spawn fails.
+                .with_readiness_timeout(container_wait);
             server = server.with_backend(std::sync::Arc::new(backend));
         } else if docker || is_local_docker_reachable() {
             // `docker` ⇒ forced on; otherwise auto (the socket file exists).
             match ruscker_docker::LocalDockerBackend::local() {
                 Ok(b) => {
+                    // `proxy.container-wait-time` (#970), as above.
+                    let b = b.with_readiness_timeout(container_wait);
                     let backend: std::sync::Arc<dyn ruscker_core::ContainerBackend> =
                         std::sync::Arc::new(b);
                     // The socket file can be present while the service user

--- a/crates/ruscker-docker/src/lib.rs
+++ b/crates/ruscker-docker/src/lib.rs
@@ -49,9 +49,12 @@ pub const LABEL_INNER_PORT: &str = "ruscker.inner_port";
 /// argument to [`LocalDockerBackend::spawn_with_port`].
 pub const DEFAULT_INNER_PORT: u16 = 3838;
 
-/// How long to wait for a freshly-started container to accept a
-/// TCP connection on its bound port. Mirrors the ShinyProxy
-/// `container-wait-time` default of 60 s.
+/// Default wait for a freshly-started container to accept a TCP
+/// connection on its bound port. Overridden per backend by
+/// `proxy.container-wait-time` via
+/// [`LocalDockerBackend::with_readiness_timeout`] (#970); this const
+/// is only the fallback (and mirrors ShinyProxy's spirit — their
+/// default is 20 s, ours is a more forgiving 60 s).
 pub const READINESS_TIMEOUT: Duration = Duration::from_secs(60);
 
 /// How often to retry the TCP connect during readiness polling.
@@ -85,6 +88,11 @@ pub struct LocalDockerBackend {
     /// (returning 0% only on the very first observation of a
     /// given container, until the next refresh fills the cache).
     prev_stats: DashMap<String, PrevReading>,
+    /// How long a freshly-started container gets to become ready
+    /// before the spawn fails. Defaults to [`READINESS_TIMEOUT`];
+    /// the operator's `proxy.container-wait-time` overrides it via
+    /// [`Self::with_readiness_timeout`] (#970).
+    readiness_timeout: Duration,
 }
 
 /// Cumulative CPU counters from a previous `stats` read,
@@ -132,7 +140,19 @@ impl LocalDockerBackend {
             publish_ip: publish_ip.into(),
             upstream_host: upstream_host.into(),
             prev_stats: DashMap::new(),
+            readiness_timeout: READINESS_TIMEOUT,
         }
+    }
+
+    /// Override how long a spawned container may take to become ready
+    /// (`proxy.container-wait-time`, #970). Zero keeps the default —
+    /// a 0 ms budget would fail every spawn instantly, which no
+    /// operator ever means.
+    pub fn with_readiness_timeout(mut self, timeout: Duration) -> Self {
+        if !timeout.is_zero() {
+            self.readiness_timeout = timeout;
+        }
+        self
     }
 
     /// Spawn a container for `spec_id` with the explicit inner
@@ -1271,7 +1291,8 @@ async fn wait_for_ready(
     container_id: &str,
     addr: SocketAddr,
 ) -> CoreResult<()> {
-    let deadline = std::time::Instant::now() + READINESS_TIMEOUT;
+    let budget = backend.readiness_timeout;
+    let deadline = std::time::Instant::now() + budget;
 
     // Phase 1: TCP connect.
     loop {
@@ -1295,7 +1316,7 @@ async fn wait_for_ready(
                     return Err(readiness_failure(
                         backend,
                         container_id,
-                        format!("container at {addr} never accepted TCP within {:?}: {e}", READINESS_TIMEOUT),
+                        format!("container at {addr} never accepted TCP within {budget:?}: {e}"),
                     )
                     .await);
                 }
@@ -1337,7 +1358,7 @@ async fn wait_for_ready(
                     return Err(readiness_failure(
                         backend,
                         container_id,
-                        format!("container at {addr} accepted TCP but never answered HTTP within {:?}", READINESS_TIMEOUT),
+                        format!("container at {addr} accepted TCP but never answered HTTP within {budget:?}"),
                     )
                     .await);
                 }
@@ -1525,6 +1546,42 @@ fn apply_limits(host_config: &mut HostConfig, limits: &ruscker_core::ResourceLim
 #[cfg(test)]
 mod tests {
     use super::*;
+
+    /// `proxy.container-wait-time` reaches the readiness wait (#970):
+    /// a 300 ms budget against a port nobody listens on must fail in
+    /// well under the 60 s default, and the error names the budget.
+    /// Needs no running daemon — the connect refuses immediately and
+    /// the crash-detection inspect is best-effort (`.ok()?`).
+    #[tokio::test]
+    async fn readiness_wait_honours_configured_timeout() {
+        let Ok(backend) = LocalDockerBackend::local() else {
+            return; // no way to even construct a client handle here
+        };
+        let backend = backend.with_readiness_timeout(Duration::from_millis(300));
+        let addr: SocketAddr = "127.0.0.1:1".parse().unwrap();
+        let started = std::time::Instant::now();
+        let err = wait_for_ready(&backend, "no-such-container", addr)
+            .await
+            .expect_err("nothing listens on port 1");
+        assert!(
+            started.elapsed() < Duration::from_secs(5),
+            "must give up near the 300 ms budget, not the 60 s default"
+        );
+        assert!(
+            err.to_string().contains("300ms"),
+            "error names the configured budget: {err}"
+        );
+    }
+
+    /// Zero keeps the default — a 0 ms budget would fail every spawn.
+    #[test]
+    fn zero_wait_time_keeps_the_default() {
+        let Ok(backend) = LocalDockerBackend::local() else {
+            return;
+        };
+        let backend = backend.with_readiness_timeout(Duration::ZERO);
+        assert_eq!(backend.readiness_timeout, READINESS_TIMEOUT);
+    }
 
     #[test]
     fn hub_aliases_normalize_to_the_v1_index(){

--- a/crates/ruscker-docker/src/multihost.rs
+++ b/crates/ruscker-docker/src/multihost.rs
@@ -282,6 +282,21 @@ impl MultiHostDockerBackend {
     /// cluster can start degraded from whoever is reachable; boot fails
     /// only if *no* host connects (#160 D4). This mirrors `list`'s
     /// degraded philosophy.
+    /// Override the readiness budget (`proxy.container-wait-time`,
+    /// #970) on every connected host's backend. Zero keeps the
+    /// default, matching [`LocalDockerBackend::with_readiness_timeout`].
+    pub fn with_readiness_timeout(mut self, timeout: std::time::Duration) -> Self {
+        self.hosts = self
+            .hosts
+            .into_iter()
+            .map(|mut h| {
+                h.backend = h.backend.with_readiness_timeout(timeout);
+                h
+            })
+            .collect();
+        self
+    }
+
     pub fn connect(hosts: &[Host]) -> CoreResult<Self> {
         if hosts.is_empty() {
             return Err(CoreError::Backend("no docker hosts configured".into()));

--- a/docs/YAML_SCHEMA.md
+++ b/docs/YAML_SCHEMA.md
@@ -98,7 +98,7 @@ ignored by Ruscker.
 | `authentication` | enum | `none` | `none` (only `none` is implemented today) / `openid` / `ldap` / `saml` / `simple` |
 | `landing-customization` | block | `{}` | Branding, SEO/social meta, analytics, custom HTML blocks, sign-in visibility — see [§ `proxy.landing-customization`](#proxylanding-customization). Ruscker extension |
 | `specs` | array | `[]` | List of apps/links/APIs |
-| `container-wait-time` | ms | `60000` | **Not consumed today** — the spawn readiness wait is a fixed 60 s; wiring the field is tracked in issue #970 |
+| `container-wait-time` | ms | `60000` | Max wait for a spawned container to become ready (TCP + HTTP probe) before the spawn fails; `0` keeps the default (#970) |
 | `shutdown-grace-ms` | ms | `30000` | Drain window on SIGTERM/Ctrl-C before forced exit; `/readyz` reports `draining` during it. Ruscker extension |
 | `max-body-size` | size | none | Global cap on proxied request bodies (`"10m"`, `"1g"`, bytes); over → `413`. Per-spec `max-body-size` overrides. Ruscker extension |
 | `metrics-enabled` | bool | `false` | Expose a Prometheus `/metrics` endpoint (**unauthenticated** when on — firewall it). Ruscker extension |


### PR DESCRIPTION
Closes #970

## What

`proxy.container-wait-time` parsed since day one but was never consumed — the spawn readiness wait was the hardcoded `READINESS_TIMEOUT` (60 s). Operators setting it (ShinyProxy's default is 20 000 ms, so migrated configs often carry the field) were silently ignored. Found during the #940 field-map verification.

## How

- `LocalDockerBackend` gains a `readiness_timeout` (default: the old const) via `with_readiness_timeout`; `wait_for_ready` uses it for the deadline and **names it in both failure messages** (TCP and HTTP phases).
- `MultiHostDockerBackend::with_readiness_timeout` forwards the override to every connected host's backend.
- `serve` wires it from `config.proxy.container_wait_time` on both the local and multi-host paths (captured before `config` moves into the server).
- `0` keeps the default — a 0 ms budget would fail every spawn instantly, which no operator ever means.
- Docs: the `YAML_SCHEMA.md` row and the ShinyProxy field-map row move back to ✅ supported, noting the default difference (ShinyProxy 20 s vs Ruscker 60 s).

## Verification

- Full gate green: **636 tests** (+2), clippy `-D warnings` clean.
- **`docker-it` green (42 tests)** against the real daemon.
- New unit tests: a 300 ms budget gives up in well under the 60 s default and the error names the budget; zero keeps the default.
- **E2E with the real binary + Docker**: `container-wait-time: 2000` + an alpine spec running `sleep` (never listens) — the visit failed after **2 s** (not 60) and the log reads `container … accepted TCP but never answered HTTP within 2s`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)