### PR TITLE
fix: browser-tab title honours the title chain (#926 pt. 1)

### DIFF
--- a/crates/ruscker-admin/src/routes/landing.rs
+++ b/crates/ruscker-admin/src/routes/landing.rs
@@ -420,8 +420,21 @@ async fn index(
             .filter(|t| !t.is_empty())
             .map(str::to_string)
     };
-    let page_title =
-        not_blank(&lc.seo_title).unwrap_or_else(|| state.locales.t(loc, "landing-title", None));
+    // Browser-tab `<title>` + `og:title` (#926 pt. 1): the explicit
+    // `seo-title` wins; otherwise the SAME chain the header uses —
+    // editor title → `proxy.title` → the localized default. This used
+    // to skip `proxy.title` entirely, so a YAML `title:` changed the
+    // header but never the tab, which read as "title doesn't work".
+    let page_title = not_blank(&lc.seo_title)
+        .or_else(|| not_blank(&lc.title))
+        .unwrap_or_else(|| {
+            let cfg = state.config.proxy.title.trim();
+            if cfg.is_empty() {
+                state.locales.t(loc, "landing-title", None)
+            } else {
+                cfg.to_string()
+            }
+        });
     // The meta-description fallback wants PLAIN text — strip the
     // Markdown markers instead of leaking `**` into the tag (#812).
     let seo_description = not_blank(&lc.seo_description)

--- a/crates/ruscker-admin/tests/landing_render.rs
+++ b/crates/ruscker-admin/tests/landing_render.rs
@@ -85,6 +85,78 @@ async fn landing_renders_default_locale() {
 }
 
 #[tokio::test]
+async fn page_title_falls_back_to_proxy_title() {
+    // #926 pt. 1: with no seo-title and no editor title, the browser
+    // tab (<title> + og:title) must show the configured `proxy.title`
+    // — it used to skip it and always show the localized default.
+    let yaml = r#"
+proxy:
+  title: Meu Portal
+  specs: []
+"#;
+    let app = router(state_from_yaml(yaml));
+    let response = app
+        .oneshot(Request::builder().uri("/").body(Body::empty()).unwrap())
+        .await
+        .unwrap();
+    assert_eq!(response.status(), StatusCode::OK);
+    let body = axum::body::to_bytes(response.into_body(), 1024 * 1024)
+        .await
+        .unwrap();
+    let body = String::from_utf8_lossy(&body);
+    assert!(
+        body.contains("<title>Meu Portal</title>"),
+        "tab title uses proxy.title"
+    );
+    assert!(
+        body.contains(r#"<meta property="og:title" content="Meu Portal">"#),
+        "og:title uses proxy.title"
+    );
+}
+
+#[tokio::test]
+async fn page_title_prefers_editor_title_then_seo_title() {
+    // The editor (landing-customization) title outranks proxy.title…
+    let yaml = r#"
+proxy:
+  title: YAML Title
+  landing-customization:
+    title: Editor Title
+  specs: []
+"#;
+    let app = router(state_from_yaml(yaml));
+    let response = app
+        .oneshot(Request::builder().uri("/").body(Body::empty()).unwrap())
+        .await
+        .unwrap();
+    let body = axum::body::to_bytes(response.into_body(), 1024 * 1024)
+        .await
+        .unwrap();
+    let body = String::from_utf8_lossy(&body);
+    assert!(body.contains("<title>Editor Title</title>"));
+
+    // …and an explicit seo-title outranks both.
+    let yaml = r#"
+proxy:
+  title: YAML Title
+  landing-customization:
+    title: Editor Title
+    seo-title: SEO Title
+  specs: []
+"#;
+    let app = router(state_from_yaml(yaml));
+    let response = app
+        .oneshot(Request::builder().uri("/").body(Body::empty()).unwrap())
+        .await
+        .unwrap();
+    let body = axum::body::to_bytes(response.into_body(), 1024 * 1024)
+        .await
+        .unwrap();
+    let body = String::from_utf8_lossy(&body);
+    assert!(body.contains("<title>SEO Title</title>"));
+}
+
+#[tokio::test]
 async fn sections_layout_groups_cards_by_type() {
     // `catalog-layout: sections` (#701) renders one labeled group per
     // app type, in canonical order, each heading carrying the Alpine


### PR DESCRIPTION
Refs #926 (point 1 — does not close the epic)

## What

The reported "YAML `title:` doesn't work" symptom, root-caused: the **header** already resolved correctly (#468: editor title → `proxy.title` → localized default), but the **page `<title>` + `og:title`** skipped `proxy.title` entirely (`seo-title` → localized default). So setting `title:` changed the header while the browser tab kept the default — which reads as "doesn't work".

`page_title` now chains: explicit `seo-title` → editor title → `proxy.title` → localized default, mirroring the header.

Also verified for the epic's point 1: the Appearance editor **does** expose the portal title (`landing.html` "Portal title" field, with `proxy.title` as its placeholder), so the DB-first official path already exists — the YAML value acts as the documented fallback/seed.

## Verification

- New regression tests: `page_title_falls_back_to_proxy_title` (tab + og:title show the YAML title on a virgin landing-customization) and `page_title_prefers_editor_title_then_seo_title` (rank order).
- Full gate green: **638 tests** (+2), clippy clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)