### PR TITLE
docs: the four-layer config model (#978, closes the #926 epic)

### DIFF
--- a/README.md
+++ b/README.md
@@ -162,10 +162,10 @@ Linux pulls the prebuilt musl binary; macOS builds from source.
 
 ```bash
 docker run --rm -p 8080:8080 \
-  -v "$PWD/application.yml:/etc/ruscker/application.yml:ro" \
+  -v "$PWD/ruscker.yml:/etc/ruscker/ruscker.yml:ro" \
   -v /var/run/docker.sock:/var/run/docker.sock \
   ghcr.io/strategicprojects/ruscker:latest \
-  serve --config /etc/ruscker/application.yml --bind 0.0.0.0:8080 --docker
+  serve --config /etc/ruscker/ruscker.yml --bind 0.0.0.0:8080 --docker
 ```
 
 ### Debian / Ubuntu

--- a/book/src/configuration.md
+++ b/book/src/configuration.md
@@ -1,26 +1,31 @@
 # Configuration
 
-Ruscker has **two layers** of configuration, and it helps to keep them
-apart:
+Ruscker's configuration lives in **four places**, each with its own
+job — keeping them apart answers most "where do I set X?" questions:
 
-- **Portal content** — your apps (specs), the landing page, users,
-  credentials, and media. This lives in the **database** and is managed
-  from the [admin panel](./admin.md); you don't write any YAML for it.
-  On a fresh `--db` the portal even seeds a set of showcase apps for you.
-- **Runtime / deployment** — *how and where* Ruscker runs: the address it
-  binds, whether it sits at the site root or under a subpath, the Docker
-  backend, the database, secrets, and HA. These are **CLI flags and
-  environment variables**, set once at startup.
+- **`ruscker.yml`** — how the **service** runs: bind address and port,
+  the subpath (`server.context-path`), forwarded-header trust, proxy
+  timeouts, metrics. The `.deb` installs a fully self-documented file
+  at `/etc/ruscker/ruscker.yml`; a few of these also have CLI-flag
+  overrides for one-off runs.
+- **`ruscker.env`** — **secrets** and environment: the admin token,
+  the master/cookie keys, registry passwords. Secrets are never
+  written in YAML — reference them as `${VAR}` and define them here.
+- **The database** (`--db`) — your **portal**: apps (specs), the
+  landing appearance, users, credentials, media. Managed from the
+  [admin panel](./admin.md); on a fresh `--db` it even seeds a set of
+  showcase apps for you.
+- **`application.yml`** — the **ShinyProxy import format**:
+  `ruscker import application.yml --db …` brings an existing config
+  into the database. It parses with the same schema as `ruscker.yml`,
+  so an existing file also still works as `--config` — but the
+  canonical service file is `ruscker.yml` (`serve` without `--config`
+  finds `ruscker.yml` first and falls back to `application.yml`).
 
-The `application.yml` file is the **bootstrap + migration format**: it
-must exist (it can be two lines), it carries the runtime `proxy:`
-settings that aren't flags, and it's how you **import an existing
-ShinyProxy config**. If you prefer to drive everything from YAML
-(GitOps), you still can — but for a normal install the admin panel is
-where you manage apps, and the YAML stays small.
-
-> Secrets are never written in the YAML — use `${VAR}` interpolation and
-> set the variables in the environment (or `/etc/ruscker/ruscker.env`).
+If you prefer to drive everything from YAML (GitOps), you still can —
+spec entries are accepted in the service file too. For a normal
+install the admin panel is where you manage apps, and the YAML stays
+small.
 
 ## Where each setting lives
 
@@ -30,8 +35,8 @@ where you manage apps, and the YAML stays small.
 | Customise the landing (title, colours, logos, SEO, blocks) | **Admin panel → Portal** |
 | Manage users, roles, group membership | **Admin panel → Users** |
 | Store registry credentials | **Admin panel → Credentials** |
-| Bind address / port | `--bind` (or `proxy.bind-address` / `proxy.port`) |
-| Serve at the root or a subpath | `--base-path` (or `proxy.server.context-path`) |
+| Bind address / port | `ruscker.yml` (`proxy.bind-address` / `proxy.port`); `--bind` overrides |
+| Serve at the root or a subpath | `ruscker.yml` (`server.context-path`); `--base-path` / `RUSCKER_BASE_PATH` override |
 | Enable / disable the Docker backend | auto · `--docker` · `--no-docker` |
 | Database (catalog, users, sessions) | `--db <file>` · `--config-db-url` (Postgres/HA) |
 | Admin token + crypto keys | `RUSCKER_ADMIN_TOKEN`, `RUSCKER_MASTER_KEY`, `RUSCKER_COOKIE_KEY` |
@@ -50,13 +55,14 @@ at the **site root** (`https://apps.example.org/`). If you can't dedicate
 a subdomain and need it under a path (`https://example.org/apps/`), set a
 base path:
 
-```sh
-ruscker serve --config application.yml --bind 127.0.0.1:8080 --db ruscker.db \
-  --base-path /apps
+```yaml
+# ruscker.yml
+server:
+  context-path: /apps
 ```
 
-(Equivalently `proxy.server.context-path: /apps` in the YAML, or the
-`RUSCKER_BASE_PATH` env var.) Ruscker then emits every URL — landing,
+(Equivalently the `--base-path /apps` flag or the `RUSCKER_BASE_PATH`
+env var — precedence: flag > env > file.) Ruscker then emits every URL — landing,
 admin, assets, and the `/app` proxy — under `/apps`, and rewrites app
 responses so unmodified Shiny / Streamlit / Jupyter apps work behind the
 prefix. Point your reverse proxy's `/apps/` location at Ruscker. Full
@@ -138,10 +144,11 @@ proxy:
 
 ## The full YAML reference
 
-Everything below is the complete `application.yml` schema (the same
-`docs/YAML_SCHEMA.md` shipped in the repo). Reach for it to **migrate an
-existing ShinyProxy config**, or to drive specs and landing from YAML
-instead of the admin panel — not for a normal, admin-panel-managed
-install.
+Everything below is the complete YAML schema (the same
+`docs/YAML_SCHEMA.md` shipped in the repo) — `ruscker.yml` and the
+ShinyProxy-compatible `application.yml` both parse with it. Reach for
+it to **migrate an existing ShinyProxy config**, or to drive specs and
+landing from YAML instead of the admin panel — not for a normal,
+admin-panel-managed install.
 
 {{#include ../../docs/YAML_SCHEMA.md}}

--- a/book/src/deploying.md
+++ b/book/src/deploying.md
@@ -12,8 +12,9 @@ sudo apt install ./ruscker_<version>-1_amd64.deb
 
 Manage your **apps, landing page and users in the admin panel** at
 `/admin` — the unit runs with `--db`, so the catalog is live out of the
-box. `application.yml` only carries **deployment** settings; put your
-**secrets** in `/etc/ruscker/ruscker.env` (read by the unit):
+box. `/etc/ruscker/ruscker.yml` only carries **service** settings (every
+option is documented inline in the shipped file); put your **secrets** in
+`/etc/ruscker/ruscker.env` (read by the unit):
 
 ```ini
 RUSCKER_ADMIN_TOKEN=...        # openssl rand -hex 32
@@ -42,8 +43,8 @@ sudo systemctl edit ruscker
 [Service]
 SupplementaryGroups=docker
 ExecStart=
-ExecStart=/usr/bin/ruscker serve --config /etc/ruscker/application.yml \
-  --bind 127.0.0.1:8090 --docker --db /var/lib/ruscker/ruscker.db
+ExecStart=/usr/bin/ruscker serve --config /etc/ruscker/ruscker.yml \
+  --docker --db /var/lib/ruscker/ruscker.db
 ```
 
 ```sh
@@ -371,7 +372,7 @@ services:
   ruscker:
     image: ghcr.io/strategicprojects/ruscker:latest
     command: >
-      serve --config /etc/ruscker/application.yml
+      serve --config /etc/ruscker/ruscker.yml
       --bind 0.0.0.0:8080 --docker --db /var/lib/ruscker/ruscker.db
     ports: ["127.0.0.1:8090:8080"]
     environment:
@@ -379,7 +380,7 @@ services:
       RUSCKER_MASTER_KEY:  ${RUSCKER_MASTER_KEY}
       RUSCKER_COOKIE_KEY:  ${RUSCKER_COOKIE_KEY}
     volumes:
-      - ./application.yml:/etc/ruscker/application.yml:ro
+      - ./ruscker.yml:/etc/ruscker/ruscker.yml:ro
       - /var/run/docker.sock:/var/run/docker.sock
       - ruscker-data:/var/lib/ruscker
     restart: unless-stopped
@@ -395,7 +396,7 @@ trade-off as the `docker` group with the `.deb`.
 
 State lives in two places:
 
-- **`/etc/ruscker/`** — `application.yml` and `ruscker.env` (your
+- **`/etc/ruscker/`** — `ruscker.yml` and `ruscker.env` (your
   tokens). Back these up with the rest of `/etc`.
 - **The SQLite DB** (`/var/lib/ruscker/ruscker.db`) — specs, the image
   library, encrypted credentials, landing customization and the audit

--- a/book/src/migrating.md
+++ b/book/src/migrating.md
@@ -2,6 +2,9 @@
 
 Ruscker reads the **same `application.yml` schema** as ShinyProxy, so
 in most cases you point it at your existing config and it just works.
+(Your file keeps working as `--config` too — Ruscker's canonical
+service config is `ruscker.yml`, same schema; see
+[Configuration](./configuration.md) for how the pieces fit.)
 
 ## 1. Pre-flight check
 

--- a/book/src/quickstart.md
+++ b/book/src/quickstart.md
@@ -8,7 +8,7 @@ shown below).
 ## 1. Run it (the portal seeds itself)
 
 Ruscker reads a config file, but it can be almost empty — the **database
-seeds the demos**. Save this two-line `application.yml`:
+seeds the demos**. Save this two-line `ruscker.yml`:
 
 ```yaml
 proxy:
@@ -19,7 +19,7 @@ Then start it with an admin token and `--db` (the admin database):
 
 ```sh
 RUSCKER_ADMIN_TOKEN=$(openssl rand -hex 32) \
-ruscker serve --config application.yml --bind 127.0.0.1:8080 --db ruscker.db
+ruscker serve --bind 127.0.0.1:8080 --db ruscker.db
 ```
 
 - Ruscker **auto-connects to Docker** when the daemon socket is
@@ -41,11 +41,11 @@ DB (the image is cosign-signed; `:latest` tracks the current release):
 ```sh
 docker run --rm -p 8080:8080 \
   -e RUSCKER_ADMIN_TOKEN=$(openssl rand -hex 32) \
-  -v "$PWD/application.yml:/etc/ruscker/application.yml:ro" \
+  -v "$PWD/ruscker.yml:/etc/ruscker/ruscker.yml:ro" \
   -v "$PWD/ruscker.db:/data/ruscker.db" \
   -v /var/run/docker.sock:/var/run/docker.sock \
   ghcr.io/strategicprojects/ruscker:latest \
-  serve --config /etc/ruscker/application.yml --bind 0.0.0.0:8080 \
+  serve --config /etc/ruscker/ruscker.yml --bind 0.0.0.0:8080 \
         --docker --db /data/ruscker.db
 ```
 
@@ -90,7 +90,7 @@ Two ways, neither of which needs a restart for the admin route:
   features:
 
   ```sh
-  ruscker validate application.yml
+  ruscker validate ruscker.yml
   # add --strict-compat to flag any ShinyProxy feature Ruscker would ignore
   ```
 

--- a/book/src/shinyproxy-fieldmap.md
+++ b/book/src/shinyproxy-fieldmap.md
@@ -5,6 +5,11 @@ A field-by-field reference for migrating a ShinyProxy 3.x
 [Migrating from ShinyProxy](./migrating.md); this page answers the
 narrower question *"what happens to each key in my config?"*
 
+> Context: in Ruscker your `application.yml` is the **import format**
+> (`ruscker import` brings the specs into the database); the service's
+> own config is `ruscker.yml` — same schema. See
+> [Configuration](./configuration.md) for the four-layer model.
+
 Statuses:
 
 | | Meaning |

--- a/docs/YAML_SCHEMA.md
+++ b/docs/YAML_SCHEMA.md
@@ -1,6 +1,8 @@
 # YAML schema reference
 
-Reference for every field Ruscker understands in `application.yml`.
+Reference for every field Ruscker understands in its YAML config —
+`ruscker.yml` (the canonical **service** config) and `application.yml`
+(kept as the **ShinyProxy import** format) parse with this same schema.
 
 For ShinyProxy users: this document marks which ShinyProxy features
 are **supported**, **extended** by Ruscker, **deferred** to later


### PR DESCRIPTION
Closes #978. Closes #926 (the epic — all four slices land with this: #975 title fix, #979 ruscker.yml canonical, #980 base-path first-class, and this docs pass).

## What

The docs now teach one coherent config story — the **four-layer model**:

| Layer | Where | What |
|---|---|---|
| Service | `ruscker.yml` | bind/port, subpath, forward-headers, timeouts, metrics — self-documented file shipped by the `.deb` |
| Secrets | `ruscker.env` | admin token, master/cookie keys, registry passwords (`${VAR}` interpolation) |
| Portal | database / admin panel | apps, appearance, users, credentials, media |
| Import | `application.yml` | the ShinyProxy migration format (`ruscker import`); same schema, still accepted as `--config` |

Touched: `configuration.md` (intro rewritten, table + subpath section lead with the file, schema preamble names both files), `quickstart.md` (two-line `ruscker.yml`, `serve` without `--config` — the resolution finds it), `deploying.md` (unit/compose/backup snippets; drop-in example matches the `--bind`-less unit from #980), `migrating.md` + `shinyproxy-fieldmap.md` (context notes), `README.md` (Docker example), `docs/YAML_SCHEMA.md` (intro).

ShinyProxy-compat references intentionally kept where they ARE about the import format (README positioning, `examples/application.yml`, the migration pre-flight).

## Note

Merge **after #980** — the deploying.md drop-in snippet describes the unit without `--bind`.

## Verification

- `mdbook build` clean; `cargo test -p ruscker-cli -p ruscker-config` green (111) — the docs don't touch runtime code.
- Docs policy respected: no hardcoded current-version strings.

🤖 Generated with [Claude Code](https://claude.com/claude-code)