### PR TITLE
feat: reorder admin nav tabs by workflow

### DIFF
--- a/crates/ruscker-admin/templates/admin/_layout.html
+++ b/crates/ruscker-admin/templates/admin/_layout.html
@@ -45,16 +45,17 @@
       <i class="ti ti-arrow-back-up" aria-hidden="true"></i>
       <span>{{ self.t("admin-nav-portal") }}</span>
     </a>
+    {# Tab order is by workflow, not feature age: operate (Painel) →
+       the catalog and what feeds it (Aplicações → Mídia → Credenciais
+       → Aparência) → people (Usuários → Grupos) → diagnostics and
+       governance last (Logs → Disco → Auditoria → Sistema). Nice side
+       effect: an Editor's tabs (dashboard/specs/images) are one
+       contiguous block on the left — everything after Mídia is
+       admin-only, so the two roles share the same geography. #}
     {% if role.can_access_section("dashboard") %}
     <a href="{{ base }}/admin/dashboard" class="admin-nav-link {% if nav_section == "dashboard" %}is-active{% endif %}">
       <i class="ti ti-chart-line" aria-hidden="true"></i>
       <span>{{ self.t("admin-nav-dashboard") }}</span>
-    </a>
-    {% endif %}
-    {% if role.can_access_section("disk") %}
-    <a href="{{ base }}/admin/disk" class="admin-nav-link {% if nav_section == "disk" %}is-active{% endif %}">
-      <i class="ti ti-database" aria-hidden="true"></i>
-      <span>{{ self.t("admin-nav-disk") }}</span>
     </a>
     {% endif %}
     {% if role.can_access_section("specs") %}
@@ -81,18 +82,6 @@
       <span>{{ self.t("admin-nav-landing") }}</span>
     </a>
     {% endif %}
-    {% if role.can_access_section("audit") %}
-    <a href="{{ base }}/admin/audit" class="admin-nav-link {% if nav_section == "audit" %}is-active{% endif %}">
-      <i class="ti ti-history" aria-hidden="true"></i>
-      <span>{{ self.t("admin-nav-audit") }}</span>
-    </a>
-    {% endif %}
-    {% if role.can_access_section("system") %}
-    <a href="{{ base }}/admin/system" class="admin-nav-link {% if nav_section == "system" %}is-active{% endif %}">
-      <i class="ti ti-cpu" aria-hidden="true"></i>
-      <span>{{ self.t("admin-nav-system") }}</span>
-    </a>
-    {% endif %}
     {% if role.can_access_section("users") %}
     <a href="{{ base }}/admin/users" class="admin-nav-link {% if nav_section == "users" %}is-active{% endif %}">
       <i class="ti ti-users" aria-hidden="true"></i>
@@ -109,6 +98,24 @@
     <a href="{{ base }}/admin/logs" class="admin-nav-link {% if nav_section == "logs" %}is-active{% endif %}">
       <i class="ti ti-terminal-2" aria-hidden="true"></i>
       <span>{{ self.t("admin-nav-logs") }}</span>
+    </a>
+    {% endif %}
+    {% if role.can_access_section("disk") %}
+    <a href="{{ base }}/admin/disk" class="admin-nav-link {% if nav_section == "disk" %}is-active{% endif %}">
+      <i class="ti ti-database" aria-hidden="true"></i>
+      <span>{{ self.t("admin-nav-disk") }}</span>
+    </a>
+    {% endif %}
+    {% if role.can_access_section("audit") %}
+    <a href="{{ base }}/admin/audit" class="admin-nav-link {% if nav_section == "audit" %}is-active{% endif %}">
+      <i class="ti ti-history" aria-hidden="true"></i>
+      <span>{{ self.t("admin-nav-audit") }}</span>
+    </a>
+    {% endif %}
+    {% if role.can_access_section("system") %}
+    <a href="{{ base }}/admin/system" class="admin-nav-link {% if nav_section == "system" %}is-active{% endif %}">
+      <i class="ti ti-cpu" aria-hidden="true"></i>
+      <span>{{ self.t("admin-nav-system") }}</span>
     </a>
     {% endif %}
   </div>


### PR DESCRIPTION
## What

Reorders the admin nav from feature-age order to workflow order:

**Before:** Portal · Painel · **Disco** · Aplicações · Mídia · Credenciais · Aparência · Auditoria · Sistema · Usuários · Grupos · Logs

**After:** Portal · Painel · Aplicações · Mídia · Credenciais · Aparência · Usuários · Grupos · Logs · Disco · Auditoria · Sistema

Rationale (full analysis in the session):
- Disk (rare, Admin-only maintenance) no longer splits the two daily-driver tabs.
- Four clusters: operate → catalog + what feeds it → people → diagnostics/governance; System last per convention.
- An **Editor's tabs become one contiguous left block** (Painel/Aplicações/Mídia) — Editor and Admin now share the same nav geography, which today diverged because Disk (invisible to Editors) interrupted the block.
- On mobile the icons row is scrollable (#841), so frequency-first matters double there.

Pure template reorder — role guards untouched (`can_access_section`); no logic, no i18n changes.

## Verification

- 476 ruscker-admin tests green (forced template re-embed via touch, per the Askama staleness gotcha); clippy clean; template lint included in the suite. No test asserts nav order.

🤖 Generated with [Claude Code](https://claude.com/claude-code)