### PR TITLE
feat: refresh button on the Apps list

### DIFF
--- a/crates/ruscker-admin/assets/i18n/en/landing.ftl
+++ b/crates/ruscker-admin/assets/i18n/en/landing.ftl
@@ -209,6 +209,7 @@ admin-login-back-portal = ← public portal
 
 # Apps list
 admin-specs-title = Apps
+admin-specs-refresh = Refresh
 admin-specs-subtitle = Spec catalog stored in the database
 admin-specs-empty = No apps yet. Use { $cmd } to import from a YAML.
 admin-specs-add = Add app

--- a/crates/ruscker-admin/assets/i18n/es/landing.ftl
+++ b/crates/ruscker-admin/assets/i18n/es/landing.ftl
@@ -209,6 +209,7 @@ admin-login-back-portal = ← portal público
 
 # Apps list
 admin-specs-title = Aplicaciones
+admin-specs-refresh = Recargar
 admin-specs-subtitle = Catálogo de specs en la base de datos
 admin-specs-empty = Aún no hay aplicaciones. Use { $cmd } para importar desde YAML.
 admin-specs-add = Añadir aplicación

--- a/crates/ruscker-admin/assets/i18n/fr/landing.ftl
+++ b/crates/ruscker-admin/assets/i18n/fr/landing.ftl
@@ -209,6 +209,7 @@ admin-login-back-portal = ← portail public
 
 # Apps list
 admin-specs-title = Applications
+admin-specs-refresh = Actualiser
 admin-specs-subtitle = Catalogue de specs dans la base
 admin-specs-empty = Aucune application. Utilisez { $cmd } pour importer un YAML.
 admin-specs-add = Ajouter une application

--- a/crates/ruscker-admin/assets/i18n/pt/landing.ftl
+++ b/crates/ruscker-admin/assets/i18n/pt/landing.ftl
@@ -213,6 +213,7 @@ admin-login-back-portal = ← portal público
 
 # Apps list
 admin-specs-title = Aplicações
+admin-specs-refresh = Recarregar
 admin-specs-subtitle = Catálogo de specs no banco
 admin-specs-empty = Nenhuma aplicação ainda. Use { $cmd } para importar de um YAML.
 admin-specs-add = Adicionar aplicação

--- a/crates/ruscker-admin/templates/admin/specs.html
+++ b/crates/ruscker-admin/templates/admin/specs.html
@@ -10,6 +10,14 @@
     <p class="text-xs text-[color:var(--text-muted)] mt-1">{{ self.t("admin-specs-subtitle") }}</p>
   </div>
   <div class="flex items-center gap-2">
+    {# Reload the list (lead request 2026-07): the page is server-
+       rendered, so a plain same-URL navigation IS the refresh — new
+       replica counts, states and rows appear without hunting for F5. #}
+    <a href="{{ base }}/admin/specs" class="btn"
+       title="{{ self.t("admin-specs-refresh") }}">
+      <i class="ti ti-refresh" aria-hidden="true"></i>
+      {{ self.t("admin-specs-refresh") }}
+    </a>
     <a href="{{ base }}/admin/specs/import" class="btn"
        title="{{ self.t("admin-import-title") }}">
       <i class="ti ti-file-upload" aria-hidden="true"></i>


### PR DESCRIPTION
Lead request (2026-07 list), intent confirmed as **reload the listing** (the per-app image re-pull already exists — #855's *Update image*).

The Apps page is server-rendered, so the refresh is a plain same-URL anchor (`ti-refresh` + label) in the header actions row next to Import/Add — fresh rows, states and counts with zero JS. Localized pt/en/es/fr.

## Verification
- E2E against the real binary: button renders with the right href and label on `/admin/specs`.
- Full gate green: 643 tests (forced template re-embed), clippy, i18n parity; `ti-refresh` already in the icon subset.

🤖 Generated with [Claude Code](https://claude.com/claude-code)