### PR TITLE
docs: explicit data-plane section (proxy → containers, TLS story) (#991)

### DIFF
--- a/book/src/deploying.md
+++ b/book/src/deploying.md
@@ -101,7 +101,13 @@ Put Ruscker and the hosts on a private network and open that range
 between them; **do not expose those ports to the public** — they're
 unauthenticated app backends. (For SSH hosts, the SSH connection is
 only the Docker *control* plane; the *data* plane is still this direct
-TCP path.)
+TCP path.) This inter-host traffic is plain HTTP by design — if the
+link between the machines isn't trusted, encrypt it at the network
+layer (WireGuard or an encrypted overlay), which covers every
+published port at once. On a **single host** none of this applies:
+containers publish on `127.0.0.1` and the proxy connects over
+loopback, so the traffic never leaves the machine — see the *Data
+plane* section of [Security](./security.md).
 
 **Placement.** `spread` (default) distributes replicas (weighted by
 `weight`) for fault isolation; `bin-pack` fills one host before the

--- a/docs/SECURITY.md
+++ b/docs/SECURITY.md
@@ -376,6 +376,32 @@ deliberate feature, not a config flip.
   slot is client-controlled whenever a proxy appends). Off on
   plain-HTTP dev so the browser doesn't drop the cookie.
 
+### Data plane: proxy → app containers
+
+Where the traffic between Ruscker and the containers it spawns
+actually flows, and why it is **deliberately not TLS**:
+
+- **Single host (the default and every current deployment):** each
+  container publishes its port on **`127.0.0.1`** and the proxy
+  connects over loopback — the bytes never leave the machine, so
+  there is no network path for an eavesdropper that doesn't already
+  own the host. End-to-end encryption with the *user* is complete:
+  browser —TLS→ reverse proxy —loopback→ Ruscker —loopback→ container.
+- **Multi host (`proxy.hosts`):** the data plane crosses the network
+  (`host:published-port`), so the deployment requirement is a
+  **private network between the Ruscker box and the app hosts**, with
+  the ephemeral published-port range opened only between them and
+  **never exposed publicly** (the backends are unauthenticated). If
+  the link between hosts isn't trusted, encrypt at the network layer
+  (WireGuard / an encrypted overlay) — that protects every port at
+  once and needs no per-container certificates.
+- **[accepted limitation / by design]** Ruscker does not do TLS or
+  mTLS *to* the app containers: apps (Shiny, Streamlit, Jupyter,
+  Plumber) serve plain HTTP by default, and per-container certificate
+  issuance/rotation would add real complexity against a threat the
+  loopback / private-network requirement already removes. This
+  mirrors ShinyProxy and the rest of this class of tool.
+
 ### Forwarded-header trust model
 
 One switch — `server.useForwardHeaders: true` (or a


### PR DESCRIPTION
Closes #991 (lead request: *"deixar claro na documentação"* the proxy→container encryption story)

New **Data plane** subsection in `SECURITY.md` § 7 (TLS, headers & network), stating explicitly:

- **Single host**: containers publish on `127.0.0.1`, the proxy connects over loopback — the bytes never leave the machine; the user's end-to-end TLS chain is complete (`browser —TLS→ nginx —loopback→ Ruscker —loopback→ container`).
- **Multi host**: the data plane crosses the network → private network required, published-port range never public, and **WireGuard/encrypted overlay** is the recommended mitigation for untrusted links (covers every port at once, no per-container certs).
- **Accepted limitation / by design**: no TLS/mTLS *to* app containers — apps serve plain HTTP by default and per-container cert rotation adds real complexity against a threat the loopback/private-network requirement already removes (mirrors ShinyProxy and the class).

`deploying.md` § multi-host now cross-references the section and states the single-host loopback fact.

Docs-only; `mdbook build` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)