### PR TITLE
feat: run-to-completion jobs in the container backend (#986 slice A)

### DIFF
--- a/crates/ruscker-core/src/lib.rs
+++ b/crates/ruscker-core/src/lib.rs
@@ -428,6 +428,21 @@ pub trait ContainerBackend: Send + Sync {
         Ok(())
     }
 
+    /// Run a container to COMPLETION (#986 slice A) — the primitive
+    /// behind scheduled jobs (ETL, reports): same image/env/volumes/
+    /// creds model as a spawn (the request type is [`SpawnRequest`];
+    /// `inner_port`/`placement` are ignored — a job publishes nothing),
+    /// but the container runs, exits, has its exit code + log tail
+    /// captured, and is removed. A NON-ZERO exit is a valid
+    /// [`JobOutcome`], not an `Err` — errors mean the job could not be
+    /// run at all (pull/create/start failure, timeout). Defaults to an
+    /// error so backends without job support fail closed.
+    async fn run_job(&self, _req: &SpawnRequest) -> CoreResult<JobOutcome> {
+        Err(CoreError::Backend(
+            "run-to-completion jobs are not supported by this backend".into(),
+        ))
+    }
+
     /// Named Docker volumes on the host, with how many containers (ANY
     /// container, not just Ruscker's) reference each — the disk panel
     /// only offers to remove unreferenced ones (#987). Defaults to an
@@ -523,6 +538,20 @@ pub struct ManagedContainer {
     pub status: String,
     /// Whether the container is currently running.
     pub running: bool,
+}
+
+/// The result of a run-to-completion job (#986). A captured non-zero
+/// exit code is a *reported failure*, distinct from the backend being
+/// unable to run the job at all (which is a `CoreResult::Err`).
+#[derive(Debug, Clone, serde::Serialize, serde::Deserialize)]
+pub struct JobOutcome {
+    /// The container's exit code (0 = success).
+    pub exit_code: i64,
+    /// Trailing log lines (stdout+stderr interleaved), for the run
+    /// history and failure alerts.
+    pub log_tail: Vec<String>,
+    /// Wall-clock duration of the run, in milliseconds.
+    pub duration_ms: u64,
 }
 
 /// A named Docker volume, for the disk panel's volumes card (#987).

--- a/crates/ruscker-docker/src/lib.rs
+++ b/crates/ruscker-docker/src/lib.rs
@@ -42,6 +42,10 @@ use tokio::time::sleep;
 
 pub const LABEL_SPEC_ID: &str = "ruscker.spec_id";
 pub const LABEL_REPLICA_ID: &str = "ruscker.replica_id";
+/// Stamped on run-to-completion job containers (#986) instead of
+/// `LABEL_REPLICA_ID`, so the replica machinery (reconcile, registry,
+/// liveness prune, disk panel's managed list) never sees a job.
+pub const LABEL_JOB: &str = "ruscker.job";
 pub const LABEL_INNER_PORT: &str = "ruscker.inner_port";
 
 /// Default inner port if the spec doesn't tell us — matches the
@@ -989,6 +993,119 @@ impl ContainerBackend for LocalDockerBackend {
             .await
             .map_err(|e| backend_err("remove image", e))?;
         Ok(())
+    }
+
+    async fn run_job(&self, req: &ruscker_core::SpawnRequest) -> CoreResult<ruscker_core::JobOutcome> {
+        use futures_util::StreamExt;
+        let started = std::time::Instant::now();
+
+        // Same pull path as a spawn (idempotent, creds-aware).
+        self.ensure_image_pulled(&req.image, req.creds.as_ref(), req.platform.as_deref())
+            .await?;
+
+        // Create WITHOUT any port publishing: a job talks to nobody.
+        // `ruscker.job` (not `ruscker.replica_id`) keeps it invisible
+        // to the replica machinery; `ruscker.spec_id` still ties it to
+        // its spec for the disk panel / manual cleanup.
+        let mut labels = HashMap::new();
+        for (k, v) in &req.labels {
+            labels.insert(k.clone(), v.clone());
+        }
+        labels.insert(LABEL_SPEC_ID.to_string(), req.spec_id.clone());
+        labels.insert(LABEL_JOB.to_string(), "true".to_string());
+
+        let mut host_config = HostConfig {
+            binds: (!req.volumes.is_empty()).then(|| req.volumes.clone()),
+            ..Default::default()
+        };
+        apply_limits(&mut host_config, &req.limits);
+        if let Some(network) = req.network.as_deref() {
+            self.ensure_network(network).await?;
+            host_config.network_mode = Some(network.to_string());
+        }
+        let body = ContainerCreateBody {
+            image: Some(req.image.clone()),
+            labels: Some(labels),
+            host_config: Some(host_config),
+            env: (!req.env.is_empty()).then(|| req.env.clone()),
+            cmd: req.cmd.clone(),
+            ..Default::default()
+        };
+        let suffix = uuid::Uuid::new_v4().to_string();
+        let name = format!("ruscker-job-{}-{}", req.spec_id, &suffix[..8]);
+        let opts = CreateContainerOptions {
+            name: Some(name.clone()),
+            platform: req.platform.clone().unwrap_or_default(),
+        };
+        let container_id = self
+            .docker
+            .create_container(Some(opts), body)
+            .await
+            .map_err(|e| backend_err("create job container", e))?
+            .id;
+
+        // Best-effort removal on EVERY exit path below — a finished or
+        // failed job must never linger as a stopped container.
+        let cleanup = |docker: Docker, id: String| async move {
+            let opts = RemoveContainerOptions {
+                force: true,
+                ..Default::default()
+            };
+            let _ = docker.remove_container(&id, Some(opts)).await;
+        };
+
+        if let Err(e) = self
+            .docker
+            .start_container(&container_id, None::<StartContainerOptions>)
+            .await
+        {
+            cleanup(self.docker.clone(), container_id).await;
+            return Err(backend_err("start job container", e));
+        }
+
+        // Wait for the exit, bounded: a hung job must not pin the
+        // scheduler forever. The cap is generous — ETL runs are long —
+        // and slice B makes it per-schedule.
+        const JOB_TIMEOUT: Duration = Duration::from_secs(60 * 60);
+        let waited = tokio::time::timeout(JOB_TIMEOUT, async {
+            self.docker
+                .wait_container(&container_id, None::<bollard::query_parameters::WaitContainerOptions>)
+                .next()
+                .await
+        })
+        .await;
+        let exit_code = match waited {
+            Err(_) => {
+                cleanup(self.docker.clone(), container_id).await;
+                return Err(CoreError::Backend(format!(
+                    "job for `{}` still running after {JOB_TIMEOUT:?}; killed and removed",
+                    req.spec_id
+                )));
+            }
+            // Docker reports a non-zero exit as a stream *error* carrying
+            // the response — both arms below still mean "the job ran".
+            Ok(Some(Ok(w))) => w.status_code,
+            Ok(Some(Err(bollard::errors::Error::DockerContainerWaitError { code, .. }))) => code,
+            Ok(Some(Err(e))) => {
+                cleanup(self.docker.clone(), container_id).await;
+                return Err(backend_err("wait for job container", e));
+            }
+            Ok(None) => {
+                cleanup(self.docker.clone(), container_id).await;
+                return Err(CoreError::Backend("job wait stream ended without a status".into()));
+            }
+        };
+
+        let log_tail = self
+            .logs_for_container(&container_id, READINESS_LOG_TAIL)
+            .await
+            .unwrap_or_default();
+        cleanup(self.docker.clone(), container_id).await;
+        Ok(ruscker_core::JobOutcome {
+            exit_code,
+            log_tail,
+            duration_ms: started.elapsed().as_millis() as u64,
+        })
     }
 
     async fn list_volumes(&self) -> CoreResult<Vec<ruscker_core::VolumeInfo>> {
@@ -2202,6 +2319,49 @@ mod tests {
             !after.iter().any(|c| c.id == replica.container_id),
             "container should be gone after remove"
         );
+    }
+
+    /// #986 slice A: a run-to-completion job against the real daemon.
+    /// A succeeding job returns exit 0 + its stdout in the tail; a
+    /// FAILING job is a valid JobOutcome (exit code preserved), never
+    /// an Err; and in both cases the container is removed afterwards.
+    #[cfg(feature = "docker-it")]
+    #[tokio::test]
+    async fn run_job_captures_exit_and_logs_and_reaps() {
+        use ruscker_core::ContainerBackend as _;
+        let backend = LocalDockerBackend::local().expect("connect docker");
+
+        let mut req = ruscker_core::SpawnRequest::new("it-job", "busybox:latest");
+        req.cmd = Some(vec![
+            "sh".into(),
+            "-c".into(),
+            "echo etl-ok; exit 0".into(),
+        ]);
+        let out = backend.run_job(&req).await.expect("job ran");
+        assert_eq!(out.exit_code, 0);
+        assert!(
+            out.log_tail.iter().any(|l| l.contains("etl-ok")),
+            "stdout captured: {:?}",
+            out.log_tail
+        );
+
+        // Non-zero exit: reported, not an error.
+        req.cmd = Some(vec!["sh".into(), "-c".into(), "echo boom >&2; exit 3".into()]);
+        let out = backend.run_job(&req).await.expect("failing job still ran");
+        assert_eq!(out.exit_code, 3);
+        assert!(out.log_tail.iter().any(|l| l.contains("boom")));
+
+        // No stopped job containers linger.
+        let opts = ListContainersOptions {
+            all: true,
+            filters: Some(HashMap::from([(
+                "label".to_string(),
+                vec![format!("{LABEL_JOB}=true")],
+            )])),
+            ..Default::default()
+        };
+        let leftover = backend.docker.list_containers(Some(opts)).await.unwrap();
+        assert!(leftover.is_empty(), "job containers must be removed");
     }
 
     /// #987: named-volume roundtrip against the real daemon — create


### PR DESCRIPTION
Refs #986 (slice A of 3 — does not close the epic)

## What

The primitive the scheduled-jobs epic needs and the backend lacked: everything today spawns **servers** (published port + readiness probe). `ContainerBackend::run_job(&SpawnRequest) -> JobOutcome { exit_code, log_tail, duration_ms }`:

- **Request type is the existing `SpawnRequest`** (same image/env/cmd/volumes/limits/network/creds/platform model; `inner_port`/`placement` ignored — a job publishes nothing). No trait-type proliferation.
- Default impl is `Err` — backends without job support **fail closed** (same rule as volumes/#889).
- `LocalDockerBackend`: same pull path; create with **no port bindings**; labelled `ruscker.job` + `ruscker.spec_id` and **never** `ruscker.replica_id`, so reconcile/registry/liveness-prune/disk-managed-list never see a job; bounded wait (1 h cap — slice B makes it per-schedule); log tail captured; container force-removed on **every** exit path.
- Semantics: a **non-zero exit is a valid `JobOutcome`**, not an `Err` — "ran and failed" is a result; "could not run" (pull/create/start/timeout) is the error. Docker reports non-zero exits as a stream error carrying the code (`DockerContainerWaitError`) — mapped accordingly.

## Verification

- **docker-it 44/44** against the real daemon, including the new roundtrip: succeeding job (exit 0, stdout in tail), failing job (exit 3 preserved, stderr captured), zero leftover containers by job label. (Learned: a bare image name without tag makes the daemon pull *all* tags incl. v1-manifest ones — the test pins `busybox:latest`.)
- Default gate green: 646 tests, clippy `-D warnings` clean.

Slices B (migration `schedules`/`schedule_runs` + leader-only scheduler + `job-failed` alert) and C (admin UI + docs) follow — plan on the issue.

🤖 Generated with [Claude Code](https://claude.com/claude-code)