### PR TITLE
feat: server-side pagination + search on the users admin page (#999)

### DIFF
--- a/crates/ruscker-admin/assets/i18n/en/landing.ftl
+++ b/crates/ruscker-admin/assets/i18n/en/landing.ftl
@@ -123,6 +123,16 @@ admin-users-col-role = Role
 admin-users-col-created = Created
 admin-users-col-actions = Actions
 admin-users-you = you
+# Server-side search + pagination on the users table (#999)
+admin-users-search = Search
+admin-users-search-clear = Clear search
+admin-users-search-none = No users match the search.
+admin-users-pager-status = Page { $page } of { $pages } · { $total } { $total ->
+        [one] user
+       *[other] users
+    }
+admin-users-prev = Previous
+admin-users-next = Next
 admin-users-must-change = Still using the initial password
 admin-users-save-role = Save role
 admin-users-groups = Groups

--- a/crates/ruscker-admin/assets/i18n/es/landing.ftl
+++ b/crates/ruscker-admin/assets/i18n/es/landing.ftl
@@ -123,6 +123,16 @@ admin-users-col-role = Nivel
 admin-users-col-created = Creado
 admin-users-col-actions = Acciones
 admin-users-you = tú
+# Búsqueda + paginación en el servidor en la tabla de usuarios (#999)
+admin-users-search = Buscar
+admin-users-search-clear = Limpiar búsqueda
+admin-users-search-none = Ningún usuario coincide con la búsqueda.
+admin-users-pager-status = Página { $page } de { $pages } · { $total } { $total ->
+        [one] usuario
+       *[other] usuarios
+    }
+admin-users-prev = Anterior
+admin-users-next = Siguiente
 admin-users-must-change = Aún usa la contraseña inicial
 admin-users-save-role = Guardar nivel
 admin-users-groups = Grupos

--- a/crates/ruscker-admin/assets/i18n/fr/landing.ftl
+++ b/crates/ruscker-admin/assets/i18n/fr/landing.ftl
@@ -123,6 +123,16 @@ admin-users-col-role = Niveau
 admin-users-col-created = Créé le
 admin-users-col-actions = Actions
 admin-users-you = vous
+# Recherche + pagination côté serveur dans le tableau des utilisateurs (#999)
+admin-users-search = Rechercher
+admin-users-search-clear = Effacer la recherche
+admin-users-search-none = Aucun utilisateur ne correspond à la recherche.
+admin-users-pager-status = Page { $page } sur { $pages } · { $total } { $total ->
+        [one] utilisateur
+       *[other] utilisateurs
+    }
+admin-users-prev = Précédente
+admin-users-next = Suivante
 admin-users-must-change = Utilise encore le mot de passe initial
 admin-users-save-role = Enregistrer le niveau
 admin-users-groups = Groupes

--- a/crates/ruscker-admin/assets/i18n/pt/landing.ftl
+++ b/crates/ruscker-admin/assets/i18n/pt/landing.ftl
@@ -127,6 +127,16 @@ admin-users-col-role = Nível
 admin-users-col-created = Criado em
 admin-users-col-actions = Ações
 admin-users-you = você
+# Busca + paginação server-side na tabela de usuários (#999)
+admin-users-search = Buscar
+admin-users-search-clear = Limpar busca
+admin-users-search-none = Nenhum usuário corresponde à busca.
+admin-users-pager-status = Página { $page } de { $pages } · { $total } { $total ->
+        [one] usuário
+       *[other] usuários
+    }
+admin-users-prev = Anterior
+admin-users-next = Próxima
 admin-users-must-change = Ainda usa a senha inicial
 admin-users-save-role = Salvar nível
 admin-users-groups = Grupos

--- a/crates/ruscker-admin/src/db/users.rs
+++ b/crates/ruscker-admin/src/db/users.rs
@@ -195,6 +195,171 @@ pub async fn list_all(db: &ConfigDb) -> Result<Vec<UserRow>> {
         .collect())
 }
 
+/// Escape `%`, `_` and `\` in a user-typed search term so each matches
+/// literally under SQL `LIKE`, then wrap it in `%…%` for a substring
+/// match. Both dialects use `\` as the escape character (Postgres by
+/// default; SQLite via an explicit `ESCAPE '\'` clause).
+fn like_pattern(term: &str) -> String {
+    let mut pat = String::with_capacity(term.len() + 2);
+    pat.push('%');
+    for c in term.chars() {
+        if matches!(c, '%' | '_' | '\\') {
+            pat.push('\\');
+        }
+        pat.push(c);
+    }
+    pat.push('%');
+    pat
+}
+
+/// Count the users matching a search term — the total behind
+/// [`list_page`]'s pagination (#999). A blank `search` counts every
+/// account; otherwise it's the same case-insensitive substring filter
+/// over username, groups and the profile fields.
+pub async fn count_filtered(db: &ConfigDb, search: &str) -> Result<i64> {
+    let search = search.trim();
+    let (n,): (i64,) = match db {
+        ConfigDb::Sqlite(pool) => {
+            if search.is_empty() {
+                sqlx::query_as("SELECT COUNT(*) FROM users")
+                    .fetch_one(pool)
+                    .await
+            } else {
+                // SQLite's LIKE is already case-insensitive for ASCII.
+                sqlx::query_as(
+                    "SELECT COUNT(*) FROM users
+                      WHERE username LIKE ?1 ESCAPE '\\'
+                         OR groups LIKE ?1 ESCAPE '\\'
+                         OR COALESCE(setor, '') LIKE ?1 ESCAPE '\\'
+                         OR COALESCE(email, '') LIKE ?1 ESCAPE '\\'
+                         OR COALESCE(celular, '') LIKE ?1 ESCAPE '\\'",
+                )
+                .bind(like_pattern(search))
+                .fetch_one(pool)
+                .await
+            }
+        }
+        ConfigDb::Postgres(pool) => {
+            if search.is_empty() {
+                sqlx::query_as("SELECT COUNT(*) FROM users")
+                    .fetch_one(pool)
+                    .await
+            } else {
+                // ILIKE for case-insensitivity; `\` is pg's default escape.
+                sqlx::query_as(
+                    "SELECT COUNT(*) FROM users
+                      WHERE username ILIKE $1
+                         OR groups ILIKE $1
+                         OR COALESCE(setor, '') ILIKE $1
+                         OR COALESCE(email, '') ILIKE $1
+                         OR COALESCE(celular, '') ILIKE $1",
+                )
+                .bind(like_pattern(search))
+                .fetch_one(pool)
+                .await
+            }
+        }
+    }
+    .context("count users (filtered)")?;
+    Ok(n)
+}
+
+/// One page of users (no hashes), most-recent first — the paginated
+/// sibling of [`list_all`] (#999), so the users admin page stays fast
+/// with thousands of accounts. `search` filters by a case-insensitive
+/// substring over username, groups, setor, email and celular; blank
+/// means no filter. The caller derives `limit`/`offset` from its page
+/// number.
+pub async fn list_page(
+    db: &ConfigDb,
+    search: &str,
+    limit: i64,
+    offset: i64,
+) -> Result<Vec<UserRow>> {
+    type Row = (
+        String,
+        String,
+        String,
+        bool,
+        String,
+        DateTime<Utc>,
+        Option<String>,
+        Option<String>,
+        Option<String>,
+        Option<String>,
+    );
+    let search = search.trim();
+    let rows: Vec<Row> = match db {
+        ConfigDb::Sqlite(pool) => {
+            if search.is_empty() {
+                sqlx::query_as(
+                    "SELECT id, username, role, must_change_password, groups, created_at, created_by, setor, email, celular
+                       FROM users
+                      ORDER BY created_at DESC, username ASC
+                      LIMIT ?1 OFFSET ?2",
+                )
+                .bind(limit)
+                .bind(offset)
+                .fetch_all(pool)
+                .await
+            } else {
+                sqlx::query_as(
+                    "SELECT id, username, role, must_change_password, groups, created_at, created_by, setor, email, celular
+                       FROM users
+                      WHERE username LIKE ?1 ESCAPE '\\'
+                         OR groups LIKE ?1 ESCAPE '\\'
+                         OR COALESCE(setor, '') LIKE ?1 ESCAPE '\\'
+                         OR COALESCE(email, '') LIKE ?1 ESCAPE '\\'
+                         OR COALESCE(celular, '') LIKE ?1 ESCAPE '\\'
+                      ORDER BY created_at DESC, username ASC
+                      LIMIT ?2 OFFSET ?3",
+                )
+                .bind(like_pattern(search))
+                .bind(limit)
+                .bind(offset)
+                .fetch_all(pool)
+                .await
+            }
+        }
+        ConfigDb::Postgres(pool) => {
+            if search.is_empty() {
+                sqlx::query_as(
+                    "SELECT id, username, role, must_change_password, groups, created_at, created_by, setor, email, celular
+                       FROM users
+                      ORDER BY created_at DESC, username ASC
+                      LIMIT $1 OFFSET $2",
+                )
+                .bind(limit)
+                .bind(offset)
+                .fetch_all(pool)
+                .await
+            } else {
+                sqlx::query_as(
+                    "SELECT id, username, role, must_change_password, groups, created_at, created_by, setor, email, celular
+                       FROM users
+                      WHERE username ILIKE $1
+                         OR groups ILIKE $1
+                         OR COALESCE(setor, '') ILIKE $1
+                         OR COALESCE(email, '') ILIKE $1
+                         OR COALESCE(celular, '') ILIKE $1
+                      ORDER BY created_at DESC, username ASC
+                      LIMIT $2 OFFSET $3",
+                )
+                .bind(like_pattern(search))
+                .bind(limit)
+                .bind(offset)
+                .fetch_all(pool)
+                .await
+            }
+        }
+    }
+    .context("list users (page)")?;
+    Ok(rows
+        .into_iter()
+        .map(|(id, u, r, m, g, c, by, se, em, ce)| row_from(id, u, r, m, g, c, by, se, em, ce))
+        .collect())
+}
+
 /// Fetch one user by (normalized) username, without the hash.
 pub async fn fetch(db: &ConfigDb, username: &str) -> Result<Option<UserRow>> {
     type Row = (
@@ -1218,6 +1383,55 @@ mod tests {
         assert!(verify_login(&p, "bob", "init-pw").await.unwrap().is_none());
     }
 
+    #[tokio::test]
+    async fn list_page_and_count_filtered() {
+        let p = pool().await;
+        create(&p, "alice", "pw-a", Role::Admin, false, &[], None)
+            .await
+            .unwrap();
+        create(&p, "bob", "pw-b", Role::Viewer, false, &["ops".to_string()], None)
+            .await
+            .unwrap();
+        create(&p, "carol", "pw-c", Role::Viewer, false, &[], None)
+            .await
+            .unwrap();
+        update_profile(&p, "carol", None, Some("carol@example.com"), None, None)
+            .await
+            .unwrap();
+
+        // Unfiltered: pages partition the full set with no overlap.
+        assert_eq!(count_filtered(&p, "").await.unwrap(), 3);
+        let first = list_page(&p, "", 2, 0).await.unwrap();
+        let rest = list_page(&p, "", 2, 2).await.unwrap();
+        assert_eq!(first.len(), 2);
+        assert_eq!(rest.len(), 1);
+        let mut all: Vec<String> = first
+            .iter()
+            .chain(rest.iter())
+            .map(|u| u.username.clone())
+            .collect();
+        all.sort();
+        assert_eq!(all, vec!["alice", "bob", "carol"]);
+        // Past the end ⇒ empty page, not an error.
+        assert!(list_page(&p, "", 2, 4).await.unwrap().is_empty());
+
+        // Search is a case-insensitive substring over username, groups
+        // and profile fields.
+        assert_eq!(count_filtered(&p, "ALI").await.unwrap(), 1);
+        let hit = list_page(&p, "ALI", 50, 0).await.unwrap();
+        assert_eq!(hit.len(), 1);
+        assert_eq!(hit[0].username, "alice");
+        assert_eq!(list_page(&p, "ops", 50, 0).await.unwrap()[0].username, "bob");
+        assert_eq!(
+            list_page(&p, "@example", 50, 0).await.unwrap()[0].username,
+            "carol"
+        );
+        // LIKE wildcards in the term match literally, not as patterns.
+        assert_eq!(count_filtered(&p, "%").await.unwrap(), 0);
+        assert_eq!(count_filtered(&p, "a_i").await.unwrap(), 0);
+        assert_eq!(count_filtered(&p, "nobody").await.unwrap(), 0);
+    }
+
     // Full user lifecycle through the `ConfigDb::Postgres` arm against a
     // real daemon (BOOLEAN `must_change_password`, argon2 verify, audit,
     // last-admin count). Gated on `postgres-it`.
@@ -1244,6 +1458,15 @@ mod tests {
         assert_eq!(count_admins(&db).await.unwrap(), 1);
         assert!(any_user_exists(&db).await.unwrap());
         assert_eq!(list_all(&db).await.unwrap().len(), 2);
+
+        // Pagination + ILIKE search through the Postgres arm (#999).
+        assert_eq!(count_filtered(&db, "").await.unwrap(), 2);
+        assert_eq!(list_page(&db, "", 1, 0).await.unwrap().len(), 1);
+        assert_eq!(list_page(&db, "", 10, 2).await.unwrap().len(), 0);
+        let hit = list_page(&db, "ED", 10, 0).await.unwrap();
+        assert_eq!(hit.len(), 1);
+        assert_eq!(hit[0].username, "ed");
+        assert_eq!(count_filtered(&db, "%").await.unwrap(), 0);
 
         // Case-insensitive login + must_change BOOLEAN round-trip.
         let u = verify_login(&db, "ed", "edpw1234")

--- a/crates/ruscker-admin/src/db/users.rs
+++ b/crates/ruscker-admin/src/db/users.rs
@@ -212,6 +212,23 @@ fn like_pattern(term: &str) -> String {
     pat
 }
 
+/// The two case variants of a search pattern for the SQLite arm.
+///
+/// SQLite's `LIKE` only case-folds ASCII, so `JOÃO` would not match a
+/// stored `João` (the `Ã`/`ã` pair doesn't fold) while Postgres'
+/// `ILIKE` folds full Unicode. Rust's `to_lowercase`/`to_uppercase`
+/// ARE Unicode-aware, so matching against both variants covers an
+/// accented query in either case against stored text in the usual
+/// forms (lowercase, Capitalized, ALL CAPS). Text with mixed-case
+/// accents mid-word (`GesTÃo`) can still evade — acceptable for a
+/// search box, and impossible to fix in stock SQLite without ICU.
+fn like_patterns_sqlite(term: &str) -> (String, String) {
+    (
+        like_pattern(&term.to_lowercase()),
+        like_pattern(&term.to_uppercase()),
+    )
+}
+
 /// Count the users matching a search term — the total behind
 /// [`list_page`]'s pagination (#999). A blank `search` counts every
 /// account; otherwise it's the same case-insensitive substring filter
@@ -225,16 +242,18 @@ pub async fn count_filtered(db: &ConfigDb, search: &str) -> Result<i64> {
                     .fetch_one(pool)
                     .await
             } else {
-                // SQLite's LIKE is already case-insensitive for ASCII.
+                // Two case variants per column — see [`like_patterns_sqlite`].
+                let (lo, up) = like_patterns_sqlite(search);
                 sqlx::query_as(
                     "SELECT COUNT(*) FROM users
-                      WHERE username LIKE ?1 ESCAPE '\\'
-                         OR groups LIKE ?1 ESCAPE '\\'
-                         OR COALESCE(setor, '') LIKE ?1 ESCAPE '\\'
-                         OR COALESCE(email, '') LIKE ?1 ESCAPE '\\'
-                         OR COALESCE(celular, '') LIKE ?1 ESCAPE '\\'",
+                      WHERE username LIKE ?1 ESCAPE '\\' OR username LIKE ?2 ESCAPE '\\'
+                         OR groups LIKE ?1 ESCAPE '\\' OR groups LIKE ?2 ESCAPE '\\'
+                         OR COALESCE(setor, '') LIKE ?1 ESCAPE '\\' OR COALESCE(setor, '') LIKE ?2 ESCAPE '\\'
+                         OR COALESCE(email, '') LIKE ?1 ESCAPE '\\' OR COALESCE(email, '') LIKE ?2 ESCAPE '\\'
+                         OR COALESCE(celular, '') LIKE ?1 ESCAPE '\\' OR COALESCE(celular, '') LIKE ?2 ESCAPE '\\'",
                 )
-                .bind(like_pattern(search))
+                .bind(lo)
+                .bind(up)
                 .fetch_one(pool)
                 .await
             }
@@ -303,18 +322,21 @@ pub async fn list_page(
                 .fetch_all(pool)
                 .await
             } else {
+                // Two case variants per column — see [`like_patterns_sqlite`].
+                let (lo, up) = like_patterns_sqlite(search);
                 sqlx::query_as(
                     "SELECT id, username, role, must_change_password, groups, created_at, created_by, setor, email, celular
                        FROM users
-                      WHERE username LIKE ?1 ESCAPE '\\'
-                         OR groups LIKE ?1 ESCAPE '\\'
-                         OR COALESCE(setor, '') LIKE ?1 ESCAPE '\\'
-                         OR COALESCE(email, '') LIKE ?1 ESCAPE '\\'
-                         OR COALESCE(celular, '') LIKE ?1 ESCAPE '\\'
+                      WHERE username LIKE ?1 ESCAPE '\\' OR username LIKE ?2 ESCAPE '\\'
+                         OR groups LIKE ?1 ESCAPE '\\' OR groups LIKE ?2 ESCAPE '\\'
+                         OR COALESCE(setor, '') LIKE ?1 ESCAPE '\\' OR COALESCE(setor, '') LIKE ?2 ESCAPE '\\'
+                         OR COALESCE(email, '') LIKE ?1 ESCAPE '\\' OR COALESCE(email, '') LIKE ?2 ESCAPE '\\'
+                         OR COALESCE(celular, '') LIKE ?1 ESCAPE '\\' OR COALESCE(celular, '') LIKE ?2 ESCAPE '\\'
                       ORDER BY created_at DESC, username ASC
-                      LIMIT ?2 OFFSET ?3",
+                      LIMIT ?3 OFFSET ?4",
                 )
-                .bind(like_pattern(search))
+                .bind(lo)
+                .bind(up)
                 .bind(limit)
                 .bind(offset)
                 .fetch_all(pool)
@@ -1430,6 +1452,24 @@ mod tests {
         assert_eq!(count_filtered(&p, "%").await.unwrap(), 0);
         assert_eq!(count_filtered(&p, "a_i").await.unwrap(), 0);
         assert_eq!(count_filtered(&p, "nobody").await.unwrap(), 0);
+
+        // Accented text: SQLite's LIKE only folds ASCII, so the sqlite
+        // arm matches both Rust-cased variants of the term (codex
+        // review, PR #1000). `GESTÃO` must find a stored `Gestão` and
+        // vice-versa.
+        update_profile(&p, "bob", Some("Gestão"), None, None, None)
+            .await
+            .unwrap();
+        assert_eq!(count_filtered(&p, "GESTÃO").await.unwrap(), 1);
+        assert_eq!(count_filtered(&p, "gestão").await.unwrap(), 1);
+        assert_eq!(
+            list_page(&p, "GESTÃO", 50, 0).await.unwrap()[0].username,
+            "bob"
+        );
+        update_profile(&p, "bob", Some("GESTÃO"), None, None, None)
+            .await
+            .unwrap();
+        assert_eq!(count_filtered(&p, "gestão").await.unwrap(), 1);
     }
 
     // Full user lifecycle through the `ConfigDb::Postgres` arm against a

--- a/crates/ruscker-admin/src/routes/admin/users.rs
+++ b/crates/ruscker-admin/src/routes/admin/users.rs
@@ -47,6 +47,14 @@ struct UsersPage<'a> {
     nav_section: &'static str,
     role: Role,
     users: Vec<db::users::UserRow>,
+    /// Server-side pagination state (#999): 1-based current page,
+    /// total page count, and how many users match the search.
+    page: i64,
+    pages: i64,
+    total: i64,
+    /// The active search term, echoed back into the search box and
+    /// carried on the pager links; `""` when unfiltered.
+    q: String,
     /// Username of the logged-in admin — flags the "you" row.
     me: String,
     /// "" | "saved" | "created" | "deleted" | "last-admin" | "bad-input"
@@ -60,6 +68,17 @@ struct UsersPage<'a> {
 impl UsersPage<'_> {
     fn t(&self, key: &str) -> String {
         self.locales.t(self.locale, key, None)
+    }
+
+    /// Localized "Page X of Y · N users" line under the table (#999).
+    fn pager_status(&self) -> String {
+        use fluent_bundle::FluentArgs;
+        let mut args = FluentArgs::new();
+        args.set("page", self.page);
+        args.set("pages", self.pages);
+        args.set("total", self.total);
+        self.locales
+            .t(self.locale, "admin-users-pager-status", Some(&args))
     }
 
     /// Human label for a role (Fluent).
@@ -103,6 +122,11 @@ impl UserEditPage<'_> {
     }
 }
 
+/// Rows per page on the users table (#999). The page paginates
+/// server-side so a large user base (e.g. a big CSV import) doesn't
+/// fetch and render thousands of rows per view.
+const USERS_PER_PAGE: i64 = 50;
+
 #[derive(Debug, Deserialize)]
 pub struct UsersQuery {
     pub flash: Option<String>,
@@ -111,6 +135,13 @@ pub struct UsersQuery {
     pub n: Option<usize>,
     #[serde(default)]
     pub skipped: Option<usize>,
+    /// 1-based page of the users table (#999); out-of-range clamps.
+    #[serde(default)]
+    pub page: Option<i64>,
+    /// Server-side search term (#999) — substring over username,
+    /// groups and the profile fields.
+    #[serde(default)]
+    pub q: Option<String>,
 }
 
 fn redirect_flash(flash: &str) -> Response {
@@ -135,7 +166,22 @@ async fn index(
         )
             .into_response();
     };
-    let users = match db::users::list_all(pool).await {
+    // Server-side pagination + search (#999): count first, clamp the
+    // requested page into range, then fetch only that page's rows.
+    let search = q.q.as_deref().unwrap_or("").trim().to_string();
+    let total = match db::users::count_filtered(pool, &search).await {
+        Ok(n) => n,
+        Err(e) => {
+            tracing::error!(error = ?e, "count users failed");
+            return (StatusCode::INTERNAL_SERVER_ERROR, "db error").into_response();
+        }
+    };
+    // Ceiling division (i64::div_ceil is still unstable on our floor).
+    let pages = ((total + USERS_PER_PAGE - 1) / USERS_PER_PAGE).max(1);
+    let page = q.page.unwrap_or(1).clamp(1, pages);
+    let users = match db::users::list_page(pool, &search, USERS_PER_PAGE, (page - 1) * USERS_PER_PAGE)
+        .await
+    {
         Ok(u) => u,
         Err(e) => {
             tracing::error!(error = ?e, "list users failed");
@@ -164,6 +210,10 @@ async fn index(
         nav_section: "users",
         role: admin.role,
         users,
+        page,
+        pages,
+        total,
+        q: search,
         me: admin.actor().to_string(),
         flash,
         import_summary,

--- a/crates/ruscker-admin/templates/admin/users.html
+++ b/crates/ruscker-admin/templates/admin/users.html
@@ -166,7 +166,24 @@
 </script>
 
 {# ── Existing users ────────────────────────────────────────────── #}
-<table class="admin-table" data-enhance>
+{# Search + pagination are SERVER-side (#999): with a large user base
+   only one page of rows is fetched and rendered, so the shared table
+   enhancer's client-side search would only see the current page —
+   `data-no-search` disables it and this form queries the DB instead.
+   Column sort (still client-side) stays and sorts the visible page. #}
+<form method="get" action="{{ base }}/admin/users" class="admin-table-toolbar"
+      style="display:flex;gap:8px;align-items:center;flex-wrap:wrap">
+  <input type="search" name="q" value="{{ q }}" autocapitalize="none"
+         placeholder="{{ self.t("admin-table-search") }}"
+         class="admin-table-search" style="max-width:280px">
+  <button type="submit" class="admin-nav-link" style="width:auto;cursor:pointer">
+    <i class="ti ti-search" aria-hidden="true"></i> {{ self.t("admin-users-search") }}
+  </button>
+  {% if !q.is_empty() %}
+    <a href="{{ base }}/admin/users" class="text-xs text-[color:var(--text-faint)] underline">{{ self.t("admin-users-search-clear") }}</a>
+  {% endif %}
+</form>
+<table class="admin-table" data-enhance data-no-search>
   <thead>
     <tr>
       <th>{{ self.t("admin-users-col-user") }}</th>
@@ -223,6 +240,27 @@
     {% endfor %}
   </tbody>
 </table>
+
+{% if users.is_empty() && !q.is_empty() %}
+  <p class="text-sm text-[color:var(--text-muted)] mt-3">{{ self.t("admin-users-search-none") }}</p>
+{% endif %}
+
+{# ── Pager (#999) — links preserve the search term. #}
+<div class="flex items-center gap-3 mt-3 text-xs text-[color:var(--text-muted)]" style="flex-wrap:wrap">
+  {% if page > 1 %}
+    <a class="admin-nav-link" style="width:auto"
+       href="{{ base }}/admin/users?page={{ page - 1 }}{% if !q.is_empty() %}&q={{ q|urlencode }}{% endif %}">
+      <i class="ti ti-chevron-left" aria-hidden="true"></i> {{ self.t("admin-users-prev") }}
+    </a>
+  {% endif %}
+  <span>{{ self.pager_status() }}</span>
+  {% if page < pages %}
+    <a class="admin-nav-link" style="width:auto"
+       href="{{ base }}/admin/users?page={{ page + 1 }}{% if !q.is_empty() %}&q={{ q|urlencode }}{% endif %}">
+      {{ self.t("admin-users-next") }} <i class="ti ti-chevron-right" aria-hidden="true"></i>
+    </a>
+  {% endif %}
+</div>
 
 <script>
   // Reveal/hide toggle for the admin user password inputs (#430). One

--- a/crates/ruscker-admin/tests/user_accounts.rs
+++ b/crates/ruscker-admin/tests/user_accounts.rs
@@ -821,3 +821,70 @@ async fn password_policy_enforced_on_create_and_reset() {
         .unwrap()
         .is_some());
 }
+
+/// The users list paginates + searches server-side (#999): `?q=` filters
+/// against the DB (not the rendered DOM) and an out-of-range `?page=`
+/// clamps instead of 404ing or rendering an empty table.
+#[tokio::test]
+async fn users_list_server_side_search_and_page_clamp() {
+    let (state, _pool) = state_with_db().await;
+    let db = state.db.clone().unwrap();
+    for (name, pw) in [
+        ("root", "Root!pass1"),
+        ("alice", "Alice!pass1"),
+        ("bob", "Bob!pass12"),
+    ] {
+        ruscker_admin::db::users::create(
+            &db,
+            name,
+            pw,
+            if name == "root" { Role::Admin } else { Role::Viewer },
+            false,
+            &[],
+            None,
+        )
+        .await
+        .unwrap();
+    }
+    let sid = state
+        .admin_sessions
+        .create(Role::Admin, Some("root".into()))
+        .await;
+    let cookie = format!("{COOKIE_NAME}={sid}");
+
+    let get_body = |uri: String| {
+        let state = state.clone();
+        let cookie = cookie.clone();
+        async move {
+            let resp = router(state)
+                .oneshot(
+                    Request::builder()
+                        .uri(uri)
+                        .header("cookie", cookie)
+                        .body(Body::empty())
+                        .unwrap(),
+                )
+                .await
+                .unwrap();
+            assert_eq!(resp.status(), StatusCode::OK);
+            let body = axum::body::to_bytes(resp.into_body(), 1 << 20).await.unwrap();
+            String::from_utf8(body.to_vec()).unwrap()
+        }
+    };
+
+    // The search hits the DB, so it filters rows before they render.
+    let body = get_body("/admin/users?q=alice".to_string()).await;
+    assert!(body.contains(r#"href="/admin/users/alice/edit""#));
+    assert!(!body.contains(r#"href="/admin/users/bob/edit""#));
+    // The term is echoed back into the search box (HTML-escaped by Askama).
+    assert!(body.contains(r#"value="alice""#));
+
+    // No match ⇒ empty table, no user rows.
+    let body = get_body("/admin/users?q=zzz-no-such-user".to_string()).await;
+    assert!(!body.contains("/edit\""));
+
+    // An out-of-range page clamps back into range (all 3 fit on page 1).
+    let body = get_body("/admin/users?page=999".to_string()).await;
+    assert!(body.contains(r#"href="/admin/users/alice/edit""#));
+    assert!(body.contains(r#"href="/admin/users/bob/edit""#));
+}


### PR DESCRIPTION
Closes #999.

`/admin/users` fetched and rendered **every** account per view (`db::users::list_all`, no `LIMIT`), so a large user base (e.g. a big CSV import) made the page slow at three layers: DB fetch → Askama render → giant table in the browser. This slice makes both the row fetch and the search server-side.

## What changed

- **`db::users::list_page` / `count_filtered`** — dual-dialect (sqlite `?N` / pg `$n`) `LIMIT/OFFSET` page + matching `COUNT`. The optional search term is a case-insensitive substring (`LIKE` sqlite / `ILIKE` pg) over username, groups, setor, email and celular; `%`, `_` and `\` are escaped so they match literally. `list_all` stays — the groups page and the spec form still use it.
- **Route** — `USERS_PER_PAGE = 50`; `?page=` clamps into range (no 404/empty page), `?q=` is trimmed and echoed back into the box. Order: count → clamp → fetch one page.
- **Template** — the shared table enhancer's client-side search would only see the current page now, so the table is `data-no-search` and a GET form queries the DB instead (placeholder reuses `admin-table-search`). Pager links preserve `q` via `|urlencode`; a no-match search gets an empty-state line. Client-side column sort stays (sorts the visible page).
- **i18n** — 6 new keys ×4 locales (pt/en/es/fr), incl. a Fluent plural selector on the "Page X of Y · N users" line. `i18n-check.sh` green.

## Tests

- sqlite unit test: paging partitions with no overlap, past-the-end page is empty, search by username/group/email is case-insensitive, LIKE wildcards match literally.
- pg arm: assertions added to the `postgres-it` lifecycle test — **run green against a real `postgres:16-alpine`** (ILIKE + `$n` binds).
- Route-level test: `?q=` filters against the DB (not the DOM), `?page=999` clamps.

## Real smoke

Live binary + temp sqlite seeded with 120 users:

| request | result |
|---|---|
| `/admin/users` | 50 rows · "Página 1 de 3 · 120 usuários" |
| `?page=3` | 20 rows |
| `?page=99` | clamps to page 3 |
| `?q=user111` / `?q=ops` (group) | 1 row · "1 usuário" (singular) |
| `?q=zzz` | 0 rows + empty-state message |
| pager links on `?page=2&q=user` | `?page=1&q=user` / `?page=3&q=user` |

Gate: `cargo test` (full, incl. after the `.ftl` edits) + `cargo clippy --all-targets -- -D warnings` + `./scripts/i18n-check.sh` — all green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)