### PR TITLE
feat: trusted identity headers for proxied apps (#1001 slice A)

### DIFF
--- a/book/src/shinyproxy-fieldmap.md
+++ b/book/src/shinyproxy-fieldmap.md
@@ -118,7 +118,8 @@ Statuses:
 | `max-instances`, `max-total-instances`, `always-show-switch-instance`, `allow-container-re-use` | ❌ | Per-user-instance model — see the concurrency note in the proxy table above |
 | `scale-down-delay` | ✅ | Equivalents: `scale-down-grace` (idle grace before retiring a replica) and `scale-down-cooldown-secs` (anti-flap) |
 | `websocket-reconnection-mode`, `shiny-force-full-reload`, `track-app-url` | ❌ | WebSockets are pumped transparently; reconnection/reload is the app framework's business |
-| `add-default-http-headers`, `http-headers` | ❌ | No `X-SP-*` identity headers today; Ruscker forwards the standard `X-Forwarded-*` family and its sub-path context headers |
+| `add-default-http-headers` | ⚠️ | Supported for `X-SP-UserId` / `X-SP-UserGroups`, but Ruscker defaults it **off** (ShinyProxy defaults it on). Enable it explicitly per trusted spec |
+| `http-headers` | ❌ | Static custom headers remain unsupported; Ruscker forwards the standard `X-Forwarded-*` family and its sub-path context headers |
 | `cache-headers-mode` | ❌ | App responses pass through untouched |
 | `logo-url`, `logo-height/-width/-classes/-style`, `favicon-path` | ❌ | Card art comes from `template-properties.logo` (the `/assets/img/<file>` convention — `ruscker import --images-dir` ingests the files) or the admin **Media** picker; sizing is the card design's |
 | `template-group` | ❌ | The catalog groups cards by app **type** automatically (`template-properties.type`) |

--- a/crates/ruscker-admin/assets/i18n/en/landing.ftl
+++ b/crates/ruscker-admin/assets/i18n/en/landing.ftl
@@ -640,6 +640,8 @@ spec-help-access-groups = Groups that may see and reach the app (comma-separated
 spec-form-access-users = Allowed users
 spec-help-access-users = Usernames that may see and reach the app (comma-separated).
 spec-form-access-help = Both blank = card is open to everyone (including anonymous). With any value, only matching logged-in users — and admins always.
+spec-form-identity-headers = Send identity headers to the app
+spec-form-identity-headers-hint = Adds X-SP-UserId and X-SP-UserGroups for signed-in users. Off by default; enable only for apps that need and trust this identity.
 spec-form-access-public = Public
 spec-form-access-add-group = + add group
 spec-form-access-public-hint = empty = visible to everyone

--- a/crates/ruscker-admin/assets/i18n/es/landing.ftl
+++ b/crates/ruscker-admin/assets/i18n/es/landing.ftl
@@ -640,6 +640,8 @@ spec-help-access-groups = Grupos que pueden ver y acceder a la app (separados po
 spec-form-access-users = Usuarios permitidos
 spec-help-access-users = Usuarios que pueden ver y acceder a la app (separados por comas).
 spec-form-access-help = Ambos vacíos = tarjeta abierta a todos (incluido anónimo). Con algún valor, solo usuarios conectados que coincidan — y los admins siempre.
+spec-form-identity-headers = Enviar cabeceras de identidad a la app
+spec-form-identity-headers-hint = Añade X-SP-UserId y X-SP-UserGroups para usuarios autenticados. Desactivado por defecto; actívalo solo para apps que necesiten y confíen en esta identidad.
 spec-form-access-public = Público
 spec-form-access-add-group = + añadir grupo
 spec-form-access-public-hint = vacío = visible para todos

--- a/crates/ruscker-admin/assets/i18n/fr/landing.ftl
+++ b/crates/ruscker-admin/assets/i18n/fr/landing.ftl
@@ -640,6 +640,8 @@ spec-help-access-groups = Groupes qui peuvent voir et atteindre l'app (séparés
 spec-form-access-users = Utilisateurs autorisés
 spec-help-access-users = Utilisateurs qui peuvent voir et atteindre l'app (séparés par des virgules).
 spec-form-access-help = Les deux vides = carte ouverte à tous (y compris anonyme). Avec une valeur, seuls les utilisateurs connectés correspondants — et toujours les admins.
+spec-form-identity-headers = Envoyer les en-têtes d’identité à l’app
+spec-form-identity-headers-hint = Ajoute X-SP-UserId et X-SP-UserGroups pour les utilisateurs connectés. Désactivé par défaut ; activez uniquement pour les apps qui ont besoin de cette identité et lui font confiance.
 spec-form-access-public = Public
 spec-form-access-add-group = + ajouter
 spec-form-access-public-hint = vide = visible par tous

--- a/crates/ruscker-admin/assets/i18n/pt/landing.ftl
+++ b/crates/ruscker-admin/assets/i18n/pt/landing.ftl
@@ -644,6 +644,8 @@ spec-help-access-groups = Grupos que podem ver e acessar o app (separados por v�
 spec-form-access-users = Usuários permitidos
 spec-help-access-users = Usuários que podem ver e acessar o app (separados por vírgula).
 spec-form-access-help = Ambos em branco = card aberto a todos (inclusive anônimos). Com algum valor, só usuários logados que combinam — e admins sempre.
+spec-form-identity-headers = Enviar cabeçalhos de identidade ao app
+spec-form-identity-headers-hint = Adiciona X-SP-UserId e X-SP-UserGroups para usuários autenticados. Desativado por padrão; ative apenas para apps que precisam e confiam nessa identidade.
 spec-form-access-public = Público
 spec-form-access-add-group = + add. grupo
 spec-form-access-public-hint = vazio = visível a todos

--- a/crates/ruscker-admin/src/lib.rs
+++ b/crates/ruscker-admin/src/lib.rs
@@ -61,9 +61,58 @@ pub const APP_VERSION: &str = env!("CARGO_PKG_VERSION");
 /// in `ruscker-cli`'s `init_tracing`.
 pub const STARTUP_LOG_TARGET: &str = "ruscker_startup";
 
-/// Shared short-TTL cache of user group memberships for the proxy hot path.
-pub type IdentityCache =
-    Arc<dashmap::DashMap<String, (std::time::Instant, Arc<Vec<String>>)>>;
+/// Shared short-TTL cache of user group memberships for the proxy hot
+/// path (#1001).
+///
+/// The generation counter closes an invalidation race (codex review):
+/// a proxied request that read the DB *before* an admin mutation must
+/// not repopulate the cache *after* that mutation cleared it — else a
+/// revoked membership could survive locally for the full TTL. A fill
+/// therefore snapshots [`IdentityCache::generation`] before its DB
+/// read and hands it to [`IdentityCache::store`], which only accepts
+/// still-current fills (double-checked after the insert, so a clear
+/// that lands mid-store can't leave the stale entry behind either).
+#[derive(Default)]
+pub struct IdentityCache {
+    map: dashmap::DashMap<String, (std::time::Instant, Arc<Vec<String>>)>,
+    generation: std::sync::atomic::AtomicU64,
+}
+
+impl IdentityCache {
+    /// Cached groups for `username`, if fresher than `ttl`.
+    pub fn get(&self, username: &str, ttl: std::time::Duration) -> Option<Arc<Vec<String>>> {
+        let entry = self.map.get(username)?;
+        (entry.0.elapsed() < ttl).then(|| entry.1.clone())
+    }
+
+    /// Snapshot to take BEFORE the DB read that will feed [`Self::store`].
+    pub fn generation(&self) -> u64 {
+        self.generation.load(std::sync::atomic::Ordering::Acquire)
+    }
+
+    /// Cache a resolved membership, unless an invalidation happened
+    /// since `generation` was snapshotted (the fill is then stale).
+    pub fn store(&self, generation: u64, username: &str, groups: Arc<Vec<String>>) {
+        use std::sync::atomic::Ordering;
+        if self.generation.load(Ordering::Acquire) != generation {
+            return;
+        }
+        self.map
+            .insert(username.to_string(), (std::time::Instant::now(), groups));
+        // An invalidation may have interleaved between the check and the
+        // insert; re-check and undo so the clear always wins.
+        if self.generation.load(Ordering::Acquire) != generation {
+            self.map.remove(username);
+        }
+    }
+
+    /// Drop everything and refuse in-flight fills (generation bump).
+    pub fn invalidate(&self) {
+        self.generation
+            .fetch_add(1, std::sync::atomic::Ordering::AcqRel);
+        self.map.clear();
+    }
+}
 
 /// Shared state injected into every request.
 #[derive(Clone)]
@@ -195,7 +244,7 @@ pub struct AppState {
     /// admin handlers that mutate membership call
     /// [`AppState::invalidate_identity_cache`] so revocations apply on
     /// the very next proxied request, matching the pre-cache semantics.
-    pub identity_cache: IdentityCache,
+    pub identity_cache: Arc<IdentityCache>,
 
     /// Short-circuit cache of the **effective spec catalog** for admin
     /// pages (#902). The admin tabs (Apps/Disk/Media/Groups/System +
@@ -240,7 +289,7 @@ impl AppState {
     /// next proxied request — the 30s TTL is only a backstop for edits
     /// made outside this process (e.g. another HA node).
     pub fn invalidate_identity_cache(&self) {
-        self.identity_cache.clear();
+        self.identity_cache.invalidate();
     }
 }
 
@@ -289,7 +338,7 @@ impl AdminServer {
             metrics: metrics_cache::MetricsCache::new(),
             draining: Arc::new(std::sync::atomic::AtomicBool::new(false)),
             spec_cache: Arc::new(dashmap::DashMap::new()),
-            identity_cache: Arc::new(dashmap::DashMap::new()),
+            identity_cache: Default::default(),
             catalog_cache: Arc::new(tokio::sync::RwLock::new(None)),
             access_counter: Arc::new(access_counter::AccessCounter::default()),
             alerts: alerts::AlertSink::default(),

--- a/crates/ruscker-admin/src/lib.rs
+++ b/crates/ruscker-admin/src/lib.rs
@@ -61,6 +61,10 @@ pub const APP_VERSION: &str = env!("CARGO_PKG_VERSION");
 /// in `ruscker-cli`'s `init_tracing`.
 pub const STARTUP_LOG_TARGET: &str = "ruscker_startup";
 
+/// Shared short-TTL cache of user group memberships for the proxy hot path.
+pub type IdentityCache =
+    Arc<dashmap::DashMap<String, (std::time::Instant, Arc<Vec<String>>)>>;
+
 /// Shared state injected into every request.
 #[derive(Clone)]
 pub struct AppState {
@@ -184,6 +188,15 @@ pub struct AppState {
     /// sees the same cache.
     pub spec_cache: Arc<dashmap::DashMap<String, (Arc<ruscker_config::Spec>, std::time::Instant)>>,
 
+    /// Short-lived username → group-membership cache for the proxy hot
+    /// path (#1001). Identity-enabled pages fetch many assets; resolving
+    /// the same signed-in user from the DB for each one would turn a page
+    /// load into a burst of identical SELECTs. The TTL is a backstop —
+    /// admin handlers that mutate membership call
+    /// [`AppState::invalidate_identity_cache`] so revocations apply on
+    /// the very next proxied request, matching the pre-cache semantics.
+    pub identity_cache: IdentityCache,
+
     /// Short-circuit cache of the **effective spec catalog** for admin
     /// pages (#902). The admin tabs (Apps/Disk/Media/Groups/System +
     /// landing) each rebuilt the full catalog — `list_all` + a
@@ -218,6 +231,16 @@ impl AppState {
     /// mode they get `None` and 503. See [`db::ConfigDb`].
     pub fn sqlite(&self) -> Option<&SqlitePool> {
         self.db.as_ref().and_then(db::ConfigDb::as_sqlite)
+    }
+
+    /// Drop every cached identity resolution (#1001). Admin handlers
+    /// call this after any mutation that can change group membership or
+    /// remove an account (user edit/delete, group rename/membership,
+    /// CSV import), so a revoked group loses app access on the very
+    /// next proxied request — the 30s TTL is only a backstop for edits
+    /// made outside this process (e.g. another HA node).
+    pub fn invalidate_identity_cache(&self) {
+        self.identity_cache.clear();
     }
 }
 
@@ -266,6 +289,7 @@ impl AdminServer {
             metrics: metrics_cache::MetricsCache::new(),
             draining: Arc::new(std::sync::atomic::AtomicBool::new(false)),
             spec_cache: Arc::new(dashmap::DashMap::new()),
+            identity_cache: Arc::new(dashmap::DashMap::new()),
             catalog_cache: Arc::new(tokio::sync::RwLock::new(None)),
             access_counter: Arc::new(access_counter::AccessCounter::default()),
             alerts: alerts::AlertSink::default(),

--- a/crates/ruscker-admin/src/lib.rs
+++ b/crates/ruscker-admin/src/lib.rs
@@ -66,23 +66,27 @@ pub const STARTUP_LOG_TARGET: &str = "ruscker_startup";
 ///
 /// The generation counter closes an invalidation race (codex review):
 /// a proxied request that read the DB *before* an admin mutation must
-/// not repopulate the cache *after* that mutation cleared it — else a
-/// revoked membership could survive locally for the full TTL. A fill
-/// therefore snapshots [`IdentityCache::generation`] before its DB
-/// read and hands it to [`IdentityCache::store`], which only accepts
-/// still-current fills (double-checked after the insert, so a clear
-/// that lands mid-store can't leave the stale entry behind either).
+/// not repopulate the cache *after* that mutation invalidated it —
+/// else a revoked membership could survive locally for the full TTL.
+/// Every entry records the generation that was current when its fill
+/// STARTED (snapshotted before the DB read), and [`IdentityCache::get`]
+/// rejects entries from an older generation. A stale fill may thus
+/// physically land in the map after an invalidation, but it is
+/// unreadable — no check-then-insert window exists by construction.
 #[derive(Default)]
 pub struct IdentityCache {
-    map: dashmap::DashMap<String, (std::time::Instant, Arc<Vec<String>>)>,
+    map: dashmap::DashMap<String, (u64, std::time::Instant, Arc<Vec<String>>)>,
     generation: std::sync::atomic::AtomicU64,
 }
 
 impl IdentityCache {
-    /// Cached groups for `username`, if fresher than `ttl`.
+    /// Cached groups for `username`, if fresher than `ttl` AND filled
+    /// under the current generation (i.e. not invalidated since).
     pub fn get(&self, username: &str, ttl: std::time::Duration) -> Option<Arc<Vec<String>>> {
         let entry = self.map.get(username)?;
-        (entry.0.elapsed() < ttl).then(|| entry.1.clone())
+        let (generation, filled_at, groups) = entry.value();
+        (*generation == self.generation() && filled_at.elapsed() < ttl)
+            .then(|| groups.clone())
     }
 
     /// Snapshot to take BEFORE the DB read that will feed [`Self::store`].
@@ -90,23 +94,18 @@ impl IdentityCache {
         self.generation.load(std::sync::atomic::Ordering::Acquire)
     }
 
-    /// Cache a resolved membership, unless an invalidation happened
-    /// since `generation` was snapshotted (the fill is then stale).
+    /// Cache a resolved membership, tagged with the generation that was
+    /// current when the fill began — if an invalidation raced this fill,
+    /// the entry lands already-expired and `get` never serves it.
     pub fn store(&self, generation: u64, username: &str, groups: Arc<Vec<String>>) {
-        use std::sync::atomic::Ordering;
-        if self.generation.load(Ordering::Acquire) != generation {
-            return;
-        }
-        self.map
-            .insert(username.to_string(), (std::time::Instant::now(), groups));
-        // An invalidation may have interleaved between the check and the
-        // insert; re-check and undo so the clear always wins.
-        if self.generation.load(Ordering::Acquire) != generation {
-            self.map.remove(username);
-        }
+        self.map.insert(
+            username.to_string(),
+            (generation, std::time::Instant::now(), groups),
+        );
     }
 
-    /// Drop everything and refuse in-flight fills (generation bump).
+    /// Expire every entry — current AND in-flight (generation bump);
+    /// the clear just reclaims memory early.
     pub fn invalidate(&self) {
         self.generation
             .fetch_add(1, std::sync::atomic::Ordering::AcqRel);

--- a/crates/ruscker-admin/src/routes/admin.rs
+++ b/crates/ruscker-admin/src/routes/admin.rs
@@ -826,6 +826,7 @@ mod tests {
             metrics: crate::metrics_cache::MetricsCache::new(),
             draining: Arc::new(std::sync::atomic::AtomicBool::new(false)),
             spec_cache: Arc::new(dashmap::DashMap::new()),
+            identity_cache: Arc::new(dashmap::DashMap::new()),
             catalog_cache: Arc::new(tokio::sync::RwLock::new(None)),
             access_counter: Arc::new(crate::access_counter::AccessCounter::default()),
             alerts: crate::alerts::AlertSink::default(),

--- a/crates/ruscker-admin/src/routes/admin.rs
+++ b/crates/ruscker-admin/src/routes/admin.rs
@@ -826,7 +826,7 @@ mod tests {
             metrics: crate::metrics_cache::MetricsCache::new(),
             draining: Arc::new(std::sync::atomic::AtomicBool::new(false)),
             spec_cache: Arc::new(dashmap::DashMap::new()),
-            identity_cache: Arc::new(dashmap::DashMap::new()),
+            identity_cache: Default::default(),
             catalog_cache: Arc::new(tokio::sync::RwLock::new(None)),
             access_counter: Arc::new(crate::access_counter::AccessCounter::default()),
             alerts: crate::alerts::AlertSink::default(),

--- a/crates/ruscker-admin/src/routes/admin/groups.rs
+++ b/crates/ruscker-admin/src/routes/admin/groups.rs
@@ -214,6 +214,8 @@ async fn rewrite_group(state: &AppState, old: &str, new: Option<&str>, actor: &s
                 tracing::warn!(user = %u.username, error = ?e, "group rewrite (user) failed");
             }
         }
+        // A rename/delete touches many memberships at once (#1001).
+        state.invalidate_identity_cache();
     }
 
     if let Ok(specs) = crate::db::specs::list_all(db).await {
@@ -295,6 +297,7 @@ async fn add_member(
                 groups.push(group);
             }
             let _ = crate::db::users::set_groups(db, &u.username, &groups, Some(admin.actor())).await;
+            state.invalidate_identity_cache();
             redirect_flash("member-added")
         }
         _ => redirect_flash("bad-input"),
@@ -312,6 +315,7 @@ async fn remove_member(
     if let Ok(Some(u)) = crate::db::users::fetch(db, &f.username).await {
         let groups: Vec<String> = u.groups.into_iter().filter(|g| g != &f.group).collect();
         let _ = crate::db::users::set_groups(db, &u.username, &groups, Some(admin.actor())).await;
+        state.invalidate_identity_cache();
     }
     redirect_flash("member-removed")
 }

--- a/crates/ruscker-admin/src/routes/admin/spec_form.rs
+++ b/crates/ruscker-admin/src/routes/admin/spec_form.rs
@@ -500,6 +500,9 @@ pub struct SpecForm {
     pub access_groups: String,
     /// Usernames allowed to see + reach this app — comma/newline list.
     pub access_users: String,
+    /// Checkbox ("on") ⇒ forward the signed-in user's ShinyProxy-compatible
+    /// identity headers to this app. Off by default (data minimization).
+    pub add_default_http_headers: String,
 
     // ── Advanced · Resources (requests + body cap) ──────────────
     /// Soft CPU reservation in fractional cores (`container-cpu-request`).
@@ -637,6 +640,7 @@ impl SpecForm {
             docker_registry_credential: spec.docker_registry_credential.clone().unwrap_or_default(),
             access_groups: spec.access_groups.as_ref().map(|v| v.join(", ")).unwrap_or_default(),
             access_users: spec.access_users.as_ref().map(|v| v.join(", ")).unwrap_or_default(),
+            add_default_http_headers: checkbox(spec.effective_add_default_http_headers()),
             container_cpu_request: spec
                 .container_cpu_request
                 .map(|n| n.to_string())
@@ -816,6 +820,7 @@ impl SpecForm {
             docker_registry_credential: empty_to_none(&self.docker_registry_credential),
             access_groups: list_to_vec(&self.access_groups),
             access_users: list_to_vec(&self.access_users),
+            add_default_http_headers: checkbox_opt(&self.add_default_http_headers),
             container_cpu_request: parse_opt(&self.container_cpu_request),
             container_memory_request: empty_to_none(&self.container_memory_request),
             max_body_size: empty_to_none(&self.max_body_size),
@@ -2029,6 +2034,7 @@ proxy:
         - --ServerApp.base_url=/
       access-groups: [staff, ops]
       access-users: [alice]
+      add-default-http-headers: true
       placement: bin-pack
       anti-affinity: true
       routing-strategy: round-robin
@@ -2056,6 +2062,7 @@ proxy:
         );
         assert_eq!(merged.access_groups.as_deref(), Some(&["staff".into(), "ops".into()][..]));
         assert_eq!(merged.access_users.as_deref(), Some(&["alice".into()][..]));
+        assert!(merged.effective_add_default_http_headers());
         assert_eq!(merged.placement, Some(Placement::BinPack));
         assert_eq!(merged.anti_affinity, Some(true));
         assert_eq!(merged.routing_strategy, Some(RoutingStrategy::RoundRobin));

--- a/crates/ruscker-admin/src/routes/admin/users.rs
+++ b/crates/ruscker-admin/src/routes/admin/users.rs
@@ -396,6 +396,9 @@ async fn save_edit(
                 // Role changes take effect immediately, including self-demotion.
                 state.admin_sessions.revoke_by_actor(&username).await;
             }
+            // Group edits must reach the proxy's access checks and
+            // identity headers now, not at cache expiry (#1001).
+            state.invalidate_identity_cache();
             redirect_flash("saved")
         }
         Err(e) => {
@@ -464,7 +467,10 @@ async fn set_groups(
     };
     let groups = db::users::parse_groups(&form.groups);
     match db::users::set_groups(pool, &username, &groups, Some(admin.actor())).await {
-        Ok(()) => redirect_flash("saved"),
+        Ok(()) => {
+            state.invalidate_identity_cache();
+            redirect_flash("saved")
+        }
         Err(e) => {
             tracing::warn!(error = ?e, %username, "set groups failed");
             redirect_flash("bad-input")
@@ -555,6 +561,7 @@ async fn delete(
         Ok(()) => {
             // A deleted user must lose access now, not at session expiry (#544).
             state.admin_sessions.revoke_by_actor(&username).await;
+            state.invalidate_identity_cache();
             redirect_flash("deleted")
         }
         Err(e) => {
@@ -859,6 +866,8 @@ async fn import_confirm(
             Err(_) => skipped += 1,
         }
     }
+    // Imported rows may re-create a recently-deleted username (#1001).
+    state.invalidate_identity_cache();
     Redirect::to(&format!(
         "/admin/users?flash=imported&n={imported}&skipped={skipped}"
     ))

--- a/crates/ruscker-admin/src/routes/proxy.rs
+++ b/crates/ruscker-admin/src/routes/proxy.rs
@@ -1010,12 +1010,14 @@ pub(crate) const IDENTITY_CACHE_TTL: std::time::Duration =
     std::time::Duration::from_secs(30);
 
 async fn find_user_groups(state: &AppState, username: &str) -> Arc<Vec<String>> {
-    if let Some(entry) = state.identity_cache.get(username) {
-        if entry.0.elapsed() < IDENTITY_CACHE_TTL {
-            return entry.1.clone();
-        }
+    if let Some(groups) = state.identity_cache.get(username, IDENTITY_CACHE_TTL) {
+        return groups;
     }
 
+    // Snapshot BEFORE the read: `store` rejects this fill if an admin
+    // mutation invalidated the cache while we were at the DB, so a
+    // pre-revocation read can never repopulate the cache (#1001).
+    let generation = state.identity_cache.generation();
     let groups = match state.db.as_ref() {
         Some(db) => match crate::db::users::fetch(db, username).await {
             Ok(row) => Arc::new(row.map(|user| user.groups).unwrap_or_default()),
@@ -1026,10 +1028,7 @@ async fn find_user_groups(state: &AppState, username: &str) -> Arc<Vec<String>> 
         },
         None => Arc::new(Vec::new()),
     };
-    state.identity_cache.insert(
-        username.to_string(),
-        (std::time::Instant::now(), groups.clone()),
-    );
+    state.identity_cache.store(generation, username, groups.clone());
     groups
 }
 
@@ -1982,15 +1981,18 @@ fn strip_ruscker_cookies(headers: &mut HeaderMap) {
 }
 
 /// Remove client-supplied identity claims before a request crosses the
-/// trust boundary into an app container. `HeaderName` is normalized to
+/// trust boundary into an app container. The WHOLE `X-SP-*` and
+/// `X-Ruscker-User-*` namespaces are reserved (codex review, #1001):
+/// stripping only the exact names we inject would let an anonymous
+/// client forge any *other* identity-looking attribute an app might
+/// trust (e.g. `X-SP-UserEmail`). `HeaderName` is normalized to
 /// lowercase, so the comparisons are case-insensitive by construction.
 fn strip_reserved_identity_headers(headers: &mut HeaderMap) {
     let names: Vec<_> = headers
         .keys()
         .filter(|name| {
             let name = name.as_str();
-            matches!(name, "x-sp-userid" | "x-sp-usergroups")
-                || name.starts_with("x-ruscker-user-")
+            name.starts_with("x-sp-") || name.starts_with("x-ruscker-user-")
         })
         .cloned()
         .collect();
@@ -2063,6 +2065,9 @@ mod tests {
         let mut headers = HeaderMap::new();
         headers.insert("x-sp-userid", HeaderValue::from_static("mallory"));
         headers.insert("x-sp-usergroups", HeaderValue::from_static("attackers"));
+        // The whole namespace is reserved, not just the injected pair —
+        // an app could trust any X-SP-* attribute (codex review, #1001).
+        headers.insert("x-sp-useremail", HeaderValue::from_static("m@evil.test"));
         headers.insert(
             "x-ruscker-user-email",
             HeaderValue::from_static("mallory@example.test"),
@@ -2073,6 +2078,7 @@ mod tests {
 
         assert!(!headers.contains_key("x-sp-userid"));
         assert!(!headers.contains_key("x-sp-usergroups"));
+        assert!(!headers.contains_key("x-sp-useremail"));
         assert!(!headers.contains_key("x-ruscker-user-email"));
         assert_eq!(headers.get("x-app-header").unwrap(), "keep");
     }
@@ -2344,7 +2350,7 @@ mod tests {
             metrics: crate::metrics_cache::MetricsCache::new(),
             draining: StdArc::new(std::sync::atomic::AtomicBool::new(false)),
             spec_cache: StdArc::new(dashmap::DashMap::new()),
-            identity_cache: StdArc::new(dashmap::DashMap::new()),
+            identity_cache: Default::default(),
             catalog_cache: StdArc::new(tokio::sync::RwLock::new(None)),
             access_counter: StdArc::new(crate::access_counter::AccessCounter::default()),
             alerts: crate::alerts::AlertSink::default(),

--- a/crates/ruscker-admin/src/routes/proxy.rs
+++ b/crates/ruscker-admin/src/routes/proxy.rs
@@ -1813,11 +1813,21 @@ async fn do_forward(
 
     if let Some(identity) = identity {
         for (name, value) in identity.header_pairs() {
-            if let (Ok(name), Ok(value)) = (
+            // `from_bytes`, not `from_str`: group names are free-form
+            // UTF-8 (`gestão`) and `from_str` only accepts visible
+            // ASCII — it would silently drop X-SP-UserGroups (codex
+            // review, #1001). The raw UTF-8 bytes are what ShinyProxy
+            // (Spring) sends too. A value that still fails (embedded
+            // control chars can't reach here via parse_groups) is
+            // logged, never silently omitted.
+            match (
                 name.parse::<header::HeaderName>(),
-                HeaderValue::from_str(&value),
+                HeaderValue::from_bytes(value.as_bytes()),
             ) {
-                req.headers_mut().insert(name, value);
+                (Ok(name), Ok(value)) => {
+                    req.headers_mut().insert(name, value);
+                }
+                _ => tracing::warn!(header = %name, "identity header value not encodable; omitted"),
             }
         }
     }

--- a/crates/ruscker-admin/src/routes/proxy.rs
+++ b/crates/ruscker-admin/src/routes/proxy.rs
@@ -43,7 +43,7 @@ use ruscker_core::{Replica, ReplicaState};
 use ruscker_proxy::sticky::{self, CookieKey, StickySession, COOKIE_NAME};
 use ruscker_proxy::ws;
 use std::net::SocketAddr;
-use std::sync::OnceLock;
+use std::sync::{Arc, OnceLock};
 use tower_cookies::cookie::time::Duration;
 use tower_cookies::{Cookie, Cookies};
 
@@ -74,6 +74,23 @@ impl<S: Send + Sync> FromRequestParts<S> for MaybeWs {
 /// — we provide our own infallible wrapper that yields `None`
 /// instead of rejecting.
 struct MaybePeer(Option<SocketAddr>);
+
+/// Authenticated identity resolved once for this proxied request. Group
+/// membership is an `Arc` because cache hits should not clone the vector
+/// for every asset in a page load (#1001).
+struct Identity {
+    username: String,
+    groups: Arc<Vec<String>>,
+}
+
+impl Identity {
+    fn header_pairs(&self) -> Vec<(String, String)> {
+        vec![
+            ("X-SP-UserId".into(), self.username.clone()),
+            ("X-SP-UserGroups".into(), self.groups.join(",")),
+        ]
+    }
+}
 
 impl<S: Send + Sync> FromRequestParts<S> for MaybePeer {
     type Rejection = std::convert::Infallible;
@@ -350,34 +367,40 @@ async fn forward(
     //     match; an Admin role (incl. the break-glass token) passes
     //     everything. This is the *enforcement* that the landing's card
     //     filtering only hints at — hiding a card never stopped a direct
-    //     hit on `/app/{spec}`. We resolve groups per request (only for
-    //     restricted specs) from the same `users` store the landing uses.
+    //     hit on `/app/{spec}`. Group membership comes from the same users
+    //     store as the landing, through the identity hot-path cache (#1001).
+    //
+    // Resolve identity once when either access control or upstream header
+    // disclosure needs it. Open specs with disclosure disabled do no user
+    // lookup at all.
+    let identity = match acting_user.as_ref() {
+        Some(username) if !spec.is_open() || spec.effective_add_default_http_headers() => {
+            Some(Identity {
+                username: username.clone(),
+                groups: find_user_groups(&state, username).await,
+            })
+        }
+        _ => None,
+    };
     if !spec.is_open() {
-        let session = session.0;
         let is_admin = session
+            .0
             .as_ref()
             .map(|s| s.role == crate::auth::Role::Admin)
             .unwrap_or(false);
-        let username = session.as_ref().and_then(|s| s.actor.clone());
-        let groups: Vec<String> = match (username.as_deref(), state.db.as_ref()) {
-            (Some(user), Some(db)) => crate::db::users::fetch(db, user)
-                .await
-                .ok()
-                .flatten()
-                .map(|row| row.groups)
-                .unwrap_or_default(),
-            _ => Vec::new(),
-        };
-        if !spec.access_allows(is_admin, username.as_deref(), &groups) {
+        let groups = identity
+            .as_ref()
+            .map_or(&[][..], |identity| identity.groups.as_slice());
+        if !spec.access_allows(is_admin, acting_user.as_deref(), groups) {
             tracing::info!(
                 spec = %spec.id,
-                user = username.as_deref().unwrap_or("-"),
+                user = acting_user.as_deref().unwrap_or("-"),
                 "access denied to restricted spec"
             );
             // An anonymous visitor hitting a restricted interactive app
             // is sent to log in; everyone else (and all API clients) get
             // a flat 403 (CORS-wrapped for the `/api/` family).
-            if route_prefix == APP_PREFIX && session.is_none() {
+            if route_prefix == APP_PREFIX && session.0.is_none() {
                 // Proxy routes are not wrapped by the chrome's
                 // `prefix_base_path` Location-rewriter, so build the
                 // base-prefixed login URL ourselves (#294) — otherwise a
@@ -549,6 +572,10 @@ async fn forward(
         // this the admin session id (a bearer) leaks to the app container
         // over the WS handshake — the most-used transport for Shiny/
         // Jupyter/RStudio.
+        // The WS connector only forwards explicitly selected headers, but
+        // still scrub the inbound map before building that handshake so the
+        // reserved namespace has one unconditional rule across transports.
+        strip_reserved_identity_headers(req.headers_mut());
         let cookie = req
             .headers()
             .get(header::COOKIE)
@@ -569,10 +596,19 @@ async fn forward(
         // selected can be echoed on our 101 — a browser that offered
         // subprotocols and receives a 101 without one selected must fail
         // the connection (RFC 6455 §4.1).
-        let handshake = match ws::connect(
+        let identity_headers = if spec.effective_add_default_http_headers() {
+            identity
+                .as_ref()
+                .map(Identity::header_pairs)
+                .unwrap_or_default()
+        } else {
+            Vec::new()
+        };
+        let handshake = match ws::connect_with_headers(
             &upstream_ws_url,
             cookie.as_deref(),
             subprotocols.as_deref(),
+            &identity_headers,
         )
         .await
         {
@@ -680,6 +716,11 @@ async fn forward(
         is_https,
         req,
         body_cap,
+        if spec.effective_add_default_http_headers() {
+            identity.as_ref()
+        } else {
+            None
+        },
     )
     .await
     {
@@ -961,6 +1002,36 @@ pub(crate) fn apply_public_path(env: &mut [String], cmd: &mut Option<Vec<String>
 /// enough that one page load's burst of subresource requests all hit the
 /// cache instead of the DB.
 pub(crate) const SPEC_CACHE_TTL: std::time::Duration = std::time::Duration::from_secs(1);
+
+/// Group memberships change far less often than proxy requests. A 30s TTL
+/// prevents one SELECT per asset while bounding how long an admin edit can
+/// take to reach access checks and injected identity headers (#1001).
+pub(crate) const IDENTITY_CACHE_TTL: std::time::Duration =
+    std::time::Duration::from_secs(30);
+
+async fn find_user_groups(state: &AppState, username: &str) -> Arc<Vec<String>> {
+    if let Some(entry) = state.identity_cache.get(username) {
+        if entry.0.elapsed() < IDENTITY_CACHE_TTL {
+            return entry.1.clone();
+        }
+    }
+
+    let groups = match state.db.as_ref() {
+        Some(db) => match crate::db::users::fetch(db, username).await {
+            Ok(row) => Arc::new(row.map(|user| user.groups).unwrap_or_default()),
+            Err(error) => {
+                tracing::warn!(user = username, error = ?error, "identity lookup failed");
+                return Arc::new(Vec::new());
+            }
+        },
+        None => Arc::new(Vec::new()),
+    };
+    state.identity_cache.insert(
+        username.to_string(),
+        (std::time::Instant::now(), groups.clone()),
+    );
+    groups
+}
 
 pub(crate) async fn find_spec(state: &AppState, id: &str) -> Option<Spec> {
     // Hot path: `find_spec` runs on every proxied request. Serve a recent
@@ -1716,6 +1787,7 @@ async fn do_forward(
     is_https: bool,
     mut req: Request,
     max_body: Option<usize>,
+    identity: Option<&Identity>,
 ) -> anyhow::Result<Response> {
     let query = req.uri().query().map(|q| format!("?{q}")).unwrap_or_default();
     let new_uri: Uri = format!("http://{}{}{}", replica.upstream, upstream_path, query)
@@ -1731,10 +1803,25 @@ async fn do_forward(
     let fwd_host = req.headers().get(header::HOST).cloned();
 
     strip_hop_headers(req.headers_mut());
+    // These namespaces are reserved for Ruscker-authenticated identity.
+    // Strip them for every request — anonymous, feature-off, and feature-on
+    // alike — before optionally adding authoritative values (#1001).
+    strip_reserved_identity_headers(req.headers_mut());
     // Never forward Ruscker's own cookies (admin session, sticky,
     // prefs) to the app container — the admin session id is a bearer
     // (#258).
     strip_ruscker_cookies(req.headers_mut());
+
+    if let Some(identity) = identity {
+        for (name, value) in identity.header_pairs() {
+            if let (Ok(name), Ok(value)) = (
+                name.parse::<header::HeaderName>(),
+                HeaderValue::from_str(&value),
+            ) {
+                req.headers_mut().insert(name, value);
+            }
+        }
+    }
 
     // Smart-routing headers — tell the upstream what public prefix,
     // scheme, and host it's mounted behind so it can self-route. Set
@@ -1894,6 +1981,24 @@ fn strip_ruscker_cookies(headers: &mut HeaderMap) {
     }
 }
 
+/// Remove client-supplied identity claims before a request crosses the
+/// trust boundary into an app container. `HeaderName` is normalized to
+/// lowercase, so the comparisons are case-insensitive by construction.
+fn strip_reserved_identity_headers(headers: &mut HeaderMap) {
+    let names: Vec<_> = headers
+        .keys()
+        .filter(|name| {
+            let name = name.as_str();
+            matches!(name, "x-sp-userid" | "x-sp-usergroups")
+                || name.starts_with("x-ruscker-user-")
+        })
+        .cloned()
+        .collect();
+    for name in names {
+        headers.remove(name);
+    }
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
@@ -1951,6 +2056,25 @@ mod tests {
         );
         strip_ruscker_cookies(&mut h);
         assert!(!h.contains_key(header::COOKIE), "empty Cookie header should be removed");
+    }
+
+    #[test]
+    fn strip_reserved_identity_headers_drops_sp_and_ruscker_claims() {
+        let mut headers = HeaderMap::new();
+        headers.insert("x-sp-userid", HeaderValue::from_static("mallory"));
+        headers.insert("x-sp-usergroups", HeaderValue::from_static("attackers"));
+        headers.insert(
+            "x-ruscker-user-email",
+            HeaderValue::from_static("mallory@example.test"),
+        );
+        headers.insert("x-app-header", HeaderValue::from_static("keep"));
+
+        strip_reserved_identity_headers(&mut headers);
+
+        assert!(!headers.contains_key("x-sp-userid"));
+        assert!(!headers.contains_key("x-sp-usergroups"));
+        assert!(!headers.contains_key("x-ruscker-user-email"));
+        assert_eq!(headers.get("x-app-header").unwrap(), "keep");
     }
 
     #[test]
@@ -2220,6 +2344,7 @@ mod tests {
             metrics: crate::metrics_cache::MetricsCache::new(),
             draining: StdArc::new(std::sync::atomic::AtomicBool::new(false)),
             spec_cache: StdArc::new(dashmap::DashMap::new()),
+            identity_cache: StdArc::new(dashmap::DashMap::new()),
             catalog_cache: StdArc::new(tokio::sync::RwLock::new(None)),
             access_counter: StdArc::new(crate::access_counter::AccessCounter::default()),
             alerts: crate::alerts::AlertSink::default(),
@@ -2717,9 +2842,17 @@ docker-registry-password: hunter2
             .body(Body::empty())
             .unwrap();
 
-        let resp = do_forward(&replica, "/".to_string(), "/app/rstudio", false, req, None)
-            .await
-            .expect("the dead-connection GET should be retried, not surfaced as an error");
+        let resp = do_forward(
+            &replica,
+            "/".to_string(),
+            "/app/rstudio",
+            false,
+            req,
+            None,
+            None,
+        )
+        .await
+        .expect("the dead-connection GET should be retried, not surfaced as an error");
         assert_eq!(resp.status(), StatusCode::OK);
         server.await.unwrap();
     }

--- a/crates/ruscker-admin/src/scaler.rs
+++ b/crates/ruscker-admin/src/scaler.rs
@@ -1302,7 +1302,7 @@ mod tests {
             metrics: crate::metrics_cache::MetricsCache::new(),
             draining: Arc::new(std::sync::atomic::AtomicBool::new(false)),
             spec_cache: Arc::new(dashmap::DashMap::new()),
-            identity_cache: Arc::new(dashmap::DashMap::new()),
+            identity_cache: Default::default(),
             catalog_cache: Arc::new(tokio::sync::RwLock::new(None)),
             access_counter: Arc::new(crate::access_counter::AccessCounter::default()),
             alerts: crate::alerts::AlertSink::default(),

--- a/crates/ruscker-admin/src/scaler.rs
+++ b/crates/ruscker-admin/src/scaler.rs
@@ -1302,6 +1302,7 @@ mod tests {
             metrics: crate::metrics_cache::MetricsCache::new(),
             draining: Arc::new(std::sync::atomic::AtomicBool::new(false)),
             spec_cache: Arc::new(dashmap::DashMap::new()),
+            identity_cache: Arc::new(dashmap::DashMap::new()),
             catalog_cache: Arc::new(tokio::sync::RwLock::new(None)),
             access_counter: Arc::new(crate::access_counter::AccessCounter::default()),
             alerts: crate::alerts::AlertSink::default(),

--- a/crates/ruscker-admin/templates/admin/spec_form.html
+++ b/crates/ruscker-admin/templates/admin/spec_form.html
@@ -573,6 +573,19 @@
       <div class="spec-form-help">{{ self.t("spec-form-access-help") }}</div>
       </div>{# /x-show restricted #}
 
+      {# Identity disclosure is an explicit per-app opt-in (#1001). #}
+      <label class="toggle-row">
+        <div>
+          <div class="toggle-row__label">{{ self.t("spec-form-identity-headers") }}</div>
+          <div class="toggle-row__hint">{{ self.t("spec-form-identity-headers-hint") }}</div>
+        </div>
+        <span class="switch">
+          <input type="checkbox" name="add_default_http_headers" value="on"
+                 {% if !form.add_default_http_headers.is_empty() %}checked{% endif %}>
+          <span class="switch__track"><span class="switch__dot"></span></span>
+        </span>
+      </label>
+
       {# Initial replicas (#701) — the always-on pool floor (min_replicas),
          surfaced here as part of "scale". Container-backed kinds only; the
          autoscaling ceiling + thresholds stay in Advanced. #}

--- a/crates/ruscker-admin/tests/admin_landing_picker.rs
+++ b/crates/ruscker-admin/tests/admin_landing_picker.rs
@@ -44,7 +44,7 @@ async fn state_with_db() -> AppState {
         metrics: ruscker_admin::metrics_cache::MetricsCache::new(),
         draining: Arc::new(std::sync::atomic::AtomicBool::new(false)),
         spec_cache: std::sync::Arc::new(dashmap::DashMap::new()),
-        identity_cache: std::sync::Arc::new(dashmap::DashMap::new()),
+        identity_cache: Default::default(),
         catalog_cache: std::sync::Arc::new(tokio::sync::RwLock::new(None)),
         access_counter: std::sync::Arc::new(ruscker_admin::access_counter::AccessCounter::default()),
         alerts: ruscker_admin::alerts::AlertSink::default(),

--- a/crates/ruscker-admin/tests/admin_landing_picker.rs
+++ b/crates/ruscker-admin/tests/admin_landing_picker.rs
@@ -44,6 +44,7 @@ async fn state_with_db() -> AppState {
         metrics: ruscker_admin::metrics_cache::MetricsCache::new(),
         draining: Arc::new(std::sync::atomic::AtomicBool::new(false)),
         spec_cache: std::sync::Arc::new(dashmap::DashMap::new()),
+        identity_cache: std::sync::Arc::new(dashmap::DashMap::new()),
         catalog_cache: std::sync::Arc::new(tokio::sync::RwLock::new(None)),
         access_counter: std::sync::Arc::new(ruscker_admin::access_counter::AccessCounter::default()),
         alerts: ruscker_admin::alerts::AlertSink::default(),

--- a/crates/ruscker-admin/tests/api_policies.rs
+++ b/crates/ruscker-admin/tests/api_policies.rs
@@ -61,6 +61,7 @@ fn state() -> AppState {
         metrics: ruscker_admin::metrics_cache::MetricsCache::new(),
         draining: Arc::new(std::sync::atomic::AtomicBool::new(false)),
         spec_cache: std::sync::Arc::new(dashmap::DashMap::new()),
+        identity_cache: std::sync::Arc::new(dashmap::DashMap::new()),
         catalog_cache: std::sync::Arc::new(tokio::sync::RwLock::new(None)),
         access_counter: std::sync::Arc::new(ruscker_admin::access_counter::AccessCounter::default()),
         alerts: ruscker_admin::alerts::AlertSink::default(),

--- a/crates/ruscker-admin/tests/api_policies.rs
+++ b/crates/ruscker-admin/tests/api_policies.rs
@@ -61,7 +61,7 @@ fn state() -> AppState {
         metrics: ruscker_admin::metrics_cache::MetricsCache::new(),
         draining: Arc::new(std::sync::atomic::AtomicBool::new(false)),
         spec_cache: std::sync::Arc::new(dashmap::DashMap::new()),
-        identity_cache: std::sync::Arc::new(dashmap::DashMap::new()),
+        identity_cache: Default::default(),
         catalog_cache: std::sync::Arc::new(tokio::sync::RwLock::new(None)),
         access_counter: std::sync::Arc::new(ruscker_admin::access_counter::AccessCounter::default()),
         alerts: ruscker_admin::alerts::AlertSink::default(),

--- a/crates/ruscker-admin/tests/health_probes.rs
+++ b/crates/ruscker-admin/tests/health_probes.rs
@@ -45,7 +45,7 @@ fn base_state() -> AppState {
         metrics: ruscker_admin::metrics_cache::MetricsCache::new(),
         draining: Arc::new(std::sync::atomic::AtomicBool::new(false)),
         spec_cache: std::sync::Arc::new(dashmap::DashMap::new()),
-        identity_cache: std::sync::Arc::new(dashmap::DashMap::new()),
+        identity_cache: Default::default(),
         catalog_cache: std::sync::Arc::new(tokio::sync::RwLock::new(None)),
         access_counter: std::sync::Arc::new(ruscker_admin::access_counter::AccessCounter::default()),
         alerts: ruscker_admin::alerts::AlertSink::default(),

--- a/crates/ruscker-admin/tests/health_probes.rs
+++ b/crates/ruscker-admin/tests/health_probes.rs
@@ -45,6 +45,7 @@ fn base_state() -> AppState {
         metrics: ruscker_admin::metrics_cache::MetricsCache::new(),
         draining: Arc::new(std::sync::atomic::AtomicBool::new(false)),
         spec_cache: std::sync::Arc::new(dashmap::DashMap::new()),
+        identity_cache: std::sync::Arc::new(dashmap::DashMap::new()),
         catalog_cache: std::sync::Arc::new(tokio::sync::RwLock::new(None)),
         access_counter: std::sync::Arc::new(ruscker_admin::access_counter::AccessCounter::default()),
         alerts: ruscker_admin::alerts::AlertSink::default(),

--- a/crates/ruscker-admin/tests/identity_headers.rs
+++ b/crates/ruscker-admin/tests/identity_headers.rs
@@ -232,6 +232,44 @@ async fn enabled_app_gets_authoritative_user_and_db_groups() {
     assert!(!headers.contains_key("x-ruscker-user-email"));
 }
 
+/// Group names are free-form UTF-8 (`gestão` is a perfectly normal
+/// pt-BR group) — the header value must go out as raw UTF-8 bytes, not
+/// be silently dropped by an ASCII-only conversion (codex review, #1001).
+#[tokio::test]
+async fn accented_group_names_reach_the_upstream() {
+    let db = open_db().await;
+    ruscker_admin::db::users::create(
+        &db,
+        "joana",
+        "joanapass1",
+        Role::Viewer,
+        false,
+        &["gestão".into()],
+        Some("admin"),
+    )
+    .await
+    .unwrap();
+    let (upstream, capture) = echo_upstream().await;
+    let state = state(db, "identity-on", upstream).await;
+    let sid = state
+        .admin_sessions
+        .create(Role::Viewer, Some("joana".into()))
+        .await;
+    let cookie = format!("{COOKIE_NAME}={sid}");
+    send(state, "/api/identity-on/data", Some(&cookie), false).await;
+    let headers = capture.await.unwrap();
+
+    assert_eq!(
+        headers.get("x-sp-userid").map(String::as_str),
+        Some("joana")
+    );
+    assert_eq!(
+        headers.get("x-sp-usergroups").map(String::as_str),
+        Some("gestão"),
+        "captured headers: {headers:?}"
+    );
+}
+
 #[tokio::test]
 async fn anonymous_api_request_cannot_forge_reserved_identity() {
     let db = open_db().await;

--- a/crates/ruscker-admin/tests/identity_headers.rs
+++ b/crates/ruscker-admin/tests/identity_headers.rs
@@ -151,7 +151,7 @@ async fn state(db: ConfigDb, spec_id: &str, upstream: SocketAddr) -> AppState {
         metrics: ruscker_admin::metrics_cache::MetricsCache::new(),
         draining: Arc::new(std::sync::atomic::AtomicBool::new(false)),
         spec_cache: Arc::new(dashmap::DashMap::new()),
-        identity_cache: Arc::new(dashmap::DashMap::new()),
+        identity_cache: Default::default(),
         catalog_cache: Arc::new(tokio::sync::RwLock::new(None)),
         access_counter: Arc::new(ruscker_admin::access_counter::AccessCounter::default()),
         alerts: ruscker_admin::alerts::AlertSink::default(),

--- a/crates/ruscker-admin/tests/identity_headers.rs
+++ b/crates/ruscker-admin/tests/identity_headers.rs
@@ -1,0 +1,270 @@
+//! Trusted identity-header forwarding for proxied HTTP requests (#1001).
+//!
+//! Each test puts a ready replica in the registry and points it at a tiny
+//! local TCP upstream that captures the request head. This exercises the
+//! real `/app` and `/api` forwarding path without Docker.
+
+use async_trait::async_trait;
+use axum::body::Body;
+use axum::http::{header, Request, StatusCode};
+use ruscker_admin::auth::{Role, COOKIE_NAME};
+use ruscker_admin::db::ConfigDb;
+use ruscker_admin::{router, AppState};
+use ruscker_config::Config;
+use ruscker_core::{
+    ContainerBackend, CoreError, CoreResult, Replica, ReplicaId, ReplicaMetrics,
+    ReplicaRegistry, ReplicaState,
+};
+use std::collections::HashMap;
+use std::net::SocketAddr;
+use std::sync::Arc;
+use tokio::io::{AsyncReadExt, AsyncWriteExt};
+use tokio::net::TcpListener;
+use tower::ServiceExt;
+
+const CONFIG: &str = r#"
+proxy:
+  specs:
+    - id: identity-on
+      display-name: Identity on
+      type: api
+      container-image: test/api
+      add-default-http-headers: true
+    - id: identity-off
+      display-name: Identity off
+      type: api
+      container-image: test/api
+"#;
+
+struct ReadyBackend;
+
+#[async_trait]
+impl ContainerBackend for ReadyBackend {
+    async fn spawn(&self, _spec_id: &str, _image: &str) -> CoreResult<Replica> {
+        Err(CoreError::Backend("unexpected spawn".into()))
+    }
+
+    async fn stop(&self, _replica_id: &ReplicaId) -> CoreResult<()> {
+        Ok(())
+    }
+
+    async fn list(&self) -> CoreResult<Vec<Replica>> {
+        Ok(Vec::new())
+    }
+
+    async fn metrics(&self, _replica_id: &ReplicaId) -> CoreResult<ReplicaMetrics> {
+        Ok(ReplicaMetrics {
+            cpu_percent: 0.0,
+            memory_bytes: 0,
+            network_rx_bytes: 0,
+            network_tx_bytes: 0,
+        })
+    }
+}
+
+async fn open_db() -> ConfigDb {
+    use std::sync::atomic::{AtomicU64, Ordering};
+    static N: AtomicU64 = AtomicU64::new(0);
+    let path = std::env::temp_dir().join(format!(
+        "ruscker-identity-headers-{}-{}.db",
+        std::process::id(),
+        N.fetch_add(1, Ordering::Relaxed)
+    ));
+    let _ = std::fs::remove_file(&path);
+    ConfigDb::Sqlite(ruscker_admin::db::open(&path).await.expect("open test DB"))
+}
+
+/// Accept one HTTP request, capture its headers, and answer `200 OK`.
+async fn echo_upstream() -> (
+    SocketAddr,
+    tokio::task::JoinHandle<HashMap<String, String>>,
+) {
+    let listener = TcpListener::bind("127.0.0.1:0").await.unwrap();
+    let addr = listener.local_addr().unwrap();
+    let task = tokio::spawn(async move {
+        let (mut stream, _) = listener.accept().await.unwrap();
+        let mut raw = Vec::new();
+        let mut chunk = [0_u8; 4096];
+        loop {
+            let n = stream.read(&mut chunk).await.unwrap();
+            if n == 0 {
+                break;
+            }
+            raw.extend_from_slice(&chunk[..n]);
+            if raw.windows(4).any(|window| window == b"\r\n\r\n") {
+                break;
+            }
+        }
+
+        let mut headers = HashMap::new();
+        for line in String::from_utf8_lossy(&raw).split("\r\n").skip(1) {
+            let Some((name, value)) = line.split_once(':') else {
+                continue;
+            };
+            headers.insert(name.to_ascii_lowercase(), value.trim().to_string());
+        }
+        stream
+            .write_all(b"HTTP/1.1 200 OK\r\nContent-Length: 2\r\nConnection: close\r\n\r\nok")
+            .await
+            .unwrap();
+        headers
+    });
+    (addr, task)
+}
+
+async fn state(db: ConfigDb, spec_id: &str, upstream: SocketAddr) -> AppState {
+    let config = Config::from_yaml(CONFIG).expect("parse test config");
+    let mut replicas = ReplicaRegistry::new();
+    replicas.add(Replica {
+        id: ReplicaId(uuid::Uuid::new_v4()),
+        spec_id: spec_id.to_string(),
+        container_id: "identity-test".into(),
+        upstream,
+        state: ReplicaState::Ready,
+        started_at: chrono::Utc::now(),
+        sessions_active: 0,
+        sessions_max: 100,
+        host: None,
+    });
+
+    AppState {
+        config: Arc::new(config),
+        base_path: Arc::from(""),
+        locales: Arc::new(ruscker_admin::i18n::Locales::load().expect("load locales")),
+        admin_auth: ruscker_admin::auth::AdminAuth::with_token("test-token"),
+        admin_sessions: Arc::new(
+            ruscker_admin::auth::InMemoryAdminSessionStore::default(),
+        ),
+        log_buffer: None,
+        login_limiter: Arc::new(ruscker_admin::auth::LoginRateLimiter::default_policy()),
+        api_limiter: Arc::new(ruscker_admin::ratelimit::ApiRateLimiter::new()),
+        db: Some(db),
+        images_dir: None,
+        master_key: Default::default(),
+        backend: Some(Arc::new(ReadyBackend)),
+        replicas: Arc::new(tokio::sync::RwLock::new(replicas)),
+        cookie_key: ruscker_proxy::sticky::CookieKey::random(),
+        spawn_locks: Arc::new(dashmap::DashMap::new()),
+        sessions: Arc::new(ruscker_admin::sessions::InMemorySessionStore::new()),
+        logout_index: Arc::new(dashmap::DashMap::new()),
+        leader: Arc::new(ruscker_admin::leader::AlwaysLeader),
+        metrics: ruscker_admin::metrics_cache::MetricsCache::new(),
+        draining: Arc::new(std::sync::atomic::AtomicBool::new(false)),
+        spec_cache: Arc::new(dashmap::DashMap::new()),
+        identity_cache: Arc::new(dashmap::DashMap::new()),
+        catalog_cache: Arc::new(tokio::sync::RwLock::new(None)),
+        access_counter: Arc::new(ruscker_admin::access_counter::AccessCounter::default()),
+        alerts: ruscker_admin::alerts::AlertSink::default(),
+    }
+}
+
+async fn send(
+    state: AppState,
+    path: &str,
+    cookie: Option<&str>,
+    forged: bool,
+) {
+    let mut request = Request::builder().method("GET").uri(path);
+    if let Some(cookie) = cookie {
+        request = request.header(header::COOKIE, cookie);
+    }
+    if forged {
+        request = request
+            .header("X-SP-UserId", "mallory")
+            .header("X-SP-UserGroups", "attackers")
+            .header("X-Ruscker-User-Email", "mallory@example.test");
+    }
+    let response = router(state)
+        .oneshot(request.body(Body::empty()).unwrap())
+        .await
+        .unwrap();
+    assert_eq!(response.status(), StatusCode::OK);
+    // The response body owns the upstream connection; consume it so every
+    // test completes the full forwarding lifecycle before joining capture.
+    let _ = axum::body::to_bytes(response.into_body(), 1024)
+        .await
+        .unwrap();
+}
+
+async fn logged_in_state(
+    spec_id: &str,
+) -> (
+    AppState,
+    String,
+    tokio::task::JoinHandle<HashMap<String, String>>,
+) {
+    let db = open_db().await;
+    ruscker_admin::db::users::create(
+        &db,
+        "alice",
+        "alicepass1",
+        Role::Viewer,
+        false,
+        &["analysts".into(), "ops".into()],
+        Some("admin"),
+    )
+    .await
+    .unwrap();
+    let (upstream, capture) = echo_upstream().await;
+    let state = state(db, spec_id, upstream).await;
+    let sid = state
+        .admin_sessions
+        .create(Role::Viewer, Some("alice".into()))
+        .await;
+    (state, format!("{COOKIE_NAME}={sid}"), capture)
+}
+
+#[tokio::test]
+async fn enabled_app_gets_authoritative_user_and_db_groups() {
+    let (state, cookie, capture) = logged_in_state("identity-on").await;
+    send(state, "/app/identity-on/data", Some(&cookie), true).await;
+    let headers = capture.await.unwrap();
+
+    assert_eq!(
+        headers.get("x-sp-userid").map(String::as_str),
+        Some("alice"),
+        "captured headers: {headers:?}"
+    );
+    assert_eq!(
+        headers.get("x-sp-usergroups").map(String::as_str),
+        Some("analysts,ops")
+    );
+    assert!(!headers.contains_key("x-ruscker-user-email"));
+}
+
+#[tokio::test]
+async fn anonymous_api_request_cannot_forge_reserved_identity() {
+    let db = open_db().await;
+    let (upstream, capture) = echo_upstream().await;
+    let state = state(db, "identity-on", upstream).await;
+    send(state, "/api/identity-on/data", None, true).await;
+    let headers = capture.await.unwrap();
+
+    assert!(!headers.contains_key("x-sp-userid"));
+    assert!(!headers.contains_key("x-sp-usergroups"));
+    assert!(!headers.contains_key("x-ruscker-user-email"));
+}
+
+#[tokio::test]
+async fn feature_off_sends_no_identity_for_logged_in_user() {
+    let (state, cookie, capture) = logged_in_state("identity-off").await;
+    send(state, "/api/identity-off/data", Some(&cookie), false).await;
+    let headers = capture.await.unwrap();
+
+    assert!(!headers.contains_key("x-sp-userid"));
+    assert!(!headers.contains_key("x-sp-usergroups"));
+}
+
+#[tokio::test]
+async fn break_glass_session_has_no_identity_headers() {
+    let db = open_db().await;
+    let (upstream, capture) = echo_upstream().await;
+    let state = state(db, "identity-on", upstream).await;
+    let sid = state.admin_sessions.create(Role::Admin, None).await;
+    let cookie = format!("{COOKIE_NAME}={sid}");
+    send(state, "/api/identity-on/data", Some(&cookie), false).await;
+    let headers = capture.await.unwrap();
+
+    assert!(!headers.contains_key("x-sp-userid"));
+    assert!(!headers.contains_key("x-sp-usergroups"));
+}

--- a/crates/ruscker-admin/tests/landing_access.rs
+++ b/crates/ruscker-admin/tests/landing_access.rs
@@ -83,6 +83,7 @@ async fn app_state(db: ConfigDb) -> AppState {
         metrics: ruscker_admin::metrics_cache::MetricsCache::new(),
         draining: Arc::new(std::sync::atomic::AtomicBool::new(false)),
         spec_cache: std::sync::Arc::new(dashmap::DashMap::new()),
+        identity_cache: std::sync::Arc::new(dashmap::DashMap::new()),
         catalog_cache: std::sync::Arc::new(tokio::sync::RwLock::new(None)),
         access_counter: std::sync::Arc::new(ruscker_admin::access_counter::AccessCounter::default()),
         alerts: ruscker_admin::alerts::AlertSink::default(),

--- a/crates/ruscker-admin/tests/landing_access.rs
+++ b/crates/ruscker-admin/tests/landing_access.rs
@@ -83,7 +83,7 @@ async fn app_state(db: ConfigDb) -> AppState {
         metrics: ruscker_admin::metrics_cache::MetricsCache::new(),
         draining: Arc::new(std::sync::atomic::AtomicBool::new(false)),
         spec_cache: std::sync::Arc::new(dashmap::DashMap::new()),
-        identity_cache: std::sync::Arc::new(dashmap::DashMap::new()),
+        identity_cache: Default::default(),
         catalog_cache: std::sync::Arc::new(tokio::sync::RwLock::new(None)),
         access_counter: std::sync::Arc::new(ruscker_admin::access_counter::AccessCounter::default()),
         alerts: ruscker_admin::alerts::AlertSink::default(),

--- a/crates/ruscker-admin/tests/landing_render.rs
+++ b/crates/ruscker-admin/tests/landing_render.rs
@@ -50,7 +50,7 @@ fn state_from_yaml(yaml: &str) -> AppState {
         metrics: ruscker_admin::metrics_cache::MetricsCache::new(),
         draining: std::sync::Arc::new(std::sync::atomic::AtomicBool::new(false)),
         spec_cache: std::sync::Arc::new(dashmap::DashMap::new()),
-        identity_cache: std::sync::Arc::new(dashmap::DashMap::new()),
+        identity_cache: Default::default(),
         catalog_cache: std::sync::Arc::new(tokio::sync::RwLock::new(None)),
         access_counter: std::sync::Arc::new(ruscker_admin::access_counter::AccessCounter::default()),
         alerts: ruscker_admin::alerts::AlertSink::default(),

--- a/crates/ruscker-admin/tests/landing_render.rs
+++ b/crates/ruscker-admin/tests/landing_render.rs
@@ -50,6 +50,7 @@ fn state_from_yaml(yaml: &str) -> AppState {
         metrics: ruscker_admin::metrics_cache::MetricsCache::new(),
         draining: std::sync::Arc::new(std::sync::atomic::AtomicBool::new(false)),
         spec_cache: std::sync::Arc::new(dashmap::DashMap::new()),
+        identity_cache: std::sync::Arc::new(dashmap::DashMap::new()),
         catalog_cache: std::sync::Arc::new(tokio::sync::RwLock::new(None)),
         access_counter: std::sync::Arc::new(ruscker_admin::access_counter::AccessCounter::default()),
         alerts: ruscker_admin::alerts::AlertSink::default(),

--- a/crates/ruscker-admin/tests/max_body_size.rs
+++ b/crates/ruscker-admin/tests/max_body_size.rs
@@ -60,7 +60,7 @@ fn state() -> AppState {
         metrics: ruscker_admin::metrics_cache::MetricsCache::new(),
         draining: Arc::new(std::sync::atomic::AtomicBool::new(false)),
         spec_cache: std::sync::Arc::new(dashmap::DashMap::new()),
-        identity_cache: std::sync::Arc::new(dashmap::DashMap::new()),
+        identity_cache: Default::default(),
         catalog_cache: std::sync::Arc::new(tokio::sync::RwLock::new(None)),
         access_counter: std::sync::Arc::new(ruscker_admin::access_counter::AccessCounter::default()),
         alerts: ruscker_admin::alerts::AlertSink::default(),

--- a/crates/ruscker-admin/tests/max_body_size.rs
+++ b/crates/ruscker-admin/tests/max_body_size.rs
@@ -60,6 +60,7 @@ fn state() -> AppState {
         metrics: ruscker_admin::metrics_cache::MetricsCache::new(),
         draining: Arc::new(std::sync::atomic::AtomicBool::new(false)),
         spec_cache: std::sync::Arc::new(dashmap::DashMap::new()),
+        identity_cache: std::sync::Arc::new(dashmap::DashMap::new()),
         catalog_cache: std::sync::Arc::new(tokio::sync::RwLock::new(None)),
         access_counter: std::sync::Arc::new(ruscker_admin::access_counter::AccessCounter::default()),
         alerts: ruscker_admin::alerts::AlertSink::default(),

--- a/crates/ruscker-admin/tests/metrics.rs
+++ b/crates/ruscker-admin/tests/metrics.rs
@@ -33,7 +33,7 @@ fn state(yaml: &str) -> AppState {
         metrics: ruscker_admin::metrics_cache::MetricsCache::new(),
         draining: Arc::new(std::sync::atomic::AtomicBool::new(false)),
         spec_cache: std::sync::Arc::new(dashmap::DashMap::new()),
-        identity_cache: std::sync::Arc::new(dashmap::DashMap::new()),
+        identity_cache: Default::default(),
         catalog_cache: std::sync::Arc::new(tokio::sync::RwLock::new(None)),
         access_counter: std::sync::Arc::new(ruscker_admin::access_counter::AccessCounter::default()),
         alerts: ruscker_admin::alerts::AlertSink::default(),

--- a/crates/ruscker-admin/tests/metrics.rs
+++ b/crates/ruscker-admin/tests/metrics.rs
@@ -33,6 +33,7 @@ fn state(yaml: &str) -> AppState {
         metrics: ruscker_admin::metrics_cache::MetricsCache::new(),
         draining: Arc::new(std::sync::atomic::AtomicBool::new(false)),
         spec_cache: std::sync::Arc::new(dashmap::DashMap::new()),
+        identity_cache: std::sync::Arc::new(dashmap::DashMap::new()),
         catalog_cache: std::sync::Arc::new(tokio::sync::RwLock::new(None)),
         access_counter: std::sync::Arc::new(ruscker_admin::access_counter::AccessCounter::default()),
         alerts: ruscker_admin::alerts::AlertSink::default(),

--- a/crates/ruscker-admin/tests/proxy_access.rs
+++ b/crates/ruscker-admin/tests/proxy_access.rs
@@ -81,6 +81,7 @@ async fn app_state(db: ConfigDb) -> AppState {
         metrics: ruscker_admin::metrics_cache::MetricsCache::new(),
         draining: Arc::new(std::sync::atomic::AtomicBool::new(false)),
         spec_cache: std::sync::Arc::new(dashmap::DashMap::new()),
+        identity_cache: std::sync::Arc::new(dashmap::DashMap::new()),
         catalog_cache: std::sync::Arc::new(tokio::sync::RwLock::new(None)),
         access_counter: Arc::new(ruscker_admin::access_counter::AccessCounter::default()),
         alerts: ruscker_admin::alerts::AlertSink::default(),

--- a/crates/ruscker-admin/tests/proxy_access.rs
+++ b/crates/ruscker-admin/tests/proxy_access.rs
@@ -81,7 +81,7 @@ async fn app_state(db: ConfigDb) -> AppState {
         metrics: ruscker_admin::metrics_cache::MetricsCache::new(),
         draining: Arc::new(std::sync::atomic::AtomicBool::new(false)),
         spec_cache: std::sync::Arc::new(dashmap::DashMap::new()),
-        identity_cache: std::sync::Arc::new(dashmap::DashMap::new()),
+        identity_cache: Default::default(),
         catalog_cache: std::sync::Arc::new(tokio::sync::RwLock::new(None)),
         access_counter: Arc::new(ruscker_admin::access_counter::AccessCounter::default()),
         alerts: ruscker_admin::alerts::AlertSink::default(),

--- a/crates/ruscker-admin/tests/rbac.rs
+++ b/crates/ruscker-admin/tests/rbac.rs
@@ -57,6 +57,7 @@ fn state() -> AppState {
         metrics: ruscker_admin::metrics_cache::MetricsCache::new(),
         draining: Arc::new(std::sync::atomic::AtomicBool::new(false)),
         spec_cache: std::sync::Arc::new(dashmap::DashMap::new()),
+        identity_cache: std::sync::Arc::new(dashmap::DashMap::new()),
         catalog_cache: std::sync::Arc::new(tokio::sync::RwLock::new(None)),
         access_counter: std::sync::Arc::new(ruscker_admin::access_counter::AccessCounter::default()),
         alerts: ruscker_admin::alerts::AlertSink::default(),

--- a/crates/ruscker-admin/tests/rbac.rs
+++ b/crates/ruscker-admin/tests/rbac.rs
@@ -57,7 +57,7 @@ fn state() -> AppState {
         metrics: ruscker_admin::metrics_cache::MetricsCache::new(),
         draining: Arc::new(std::sync::atomic::AtomicBool::new(false)),
         spec_cache: std::sync::Arc::new(dashmap::DashMap::new()),
-        identity_cache: std::sync::Arc::new(dashmap::DashMap::new()),
+        identity_cache: Default::default(),
         catalog_cache: std::sync::Arc::new(tokio::sync::RwLock::new(None)),
         access_counter: std::sync::Arc::new(ruscker_admin::access_counter::AccessCounter::default()),
         alerts: ruscker_admin::alerts::AlertSink::default(),

--- a/crates/ruscker-admin/tests/schedules_ui.rs
+++ b/crates/ruscker-admin/tests/schedules_ui.rs
@@ -65,6 +65,7 @@ async fn app_state(db: ConfigDb) -> AppState {
         metrics: ruscker_admin::metrics_cache::MetricsCache::new(),
         draining: Arc::new(std::sync::atomic::AtomicBool::new(false)),
         spec_cache: std::sync::Arc::new(dashmap::DashMap::new()),
+        identity_cache: std::sync::Arc::new(dashmap::DashMap::new()),
         catalog_cache: std::sync::Arc::new(tokio::sync::RwLock::new(None)),
         access_counter: Arc::new(ruscker_admin::access_counter::AccessCounter::default()),
         alerts: ruscker_admin::alerts::AlertSink::default(),

--- a/crates/ruscker-admin/tests/schedules_ui.rs
+++ b/crates/ruscker-admin/tests/schedules_ui.rs
@@ -65,7 +65,7 @@ async fn app_state(db: ConfigDb) -> AppState {
         metrics: ruscker_admin::metrics_cache::MetricsCache::new(),
         draining: Arc::new(std::sync::atomic::AtomicBool::new(false)),
         spec_cache: std::sync::Arc::new(dashmap::DashMap::new()),
-        identity_cache: std::sync::Arc::new(dashmap::DashMap::new()),
+        identity_cache: Default::default(),
         catalog_cache: std::sync::Arc::new(tokio::sync::RwLock::new(None)),
         access_counter: Arc::new(ruscker_admin::access_counter::AccessCounter::default()),
         alerts: ruscker_admin::alerts::AlertSink::default(),

--- a/crates/ruscker-admin/tests/user_accounts.rs
+++ b/crates/ruscker-admin/tests/user_accounts.rs
@@ -44,6 +44,7 @@ async fn state_with_db() -> (AppState, sqlx::SqlitePool) {
         metrics: ruscker_admin::metrics_cache::MetricsCache::new(),
         draining: Arc::new(std::sync::atomic::AtomicBool::new(false)),
         spec_cache: std::sync::Arc::new(dashmap::DashMap::new()),
+        identity_cache: std::sync::Arc::new(dashmap::DashMap::new()),
         catalog_cache: std::sync::Arc::new(tokio::sync::RwLock::new(None)),
         access_counter: std::sync::Arc::new(ruscker_admin::access_counter::AccessCounter::default()),
         alerts: ruscker_admin::alerts::AlertSink::default(),

--- a/crates/ruscker-admin/tests/user_accounts.rs
+++ b/crates/ruscker-admin/tests/user_accounts.rs
@@ -44,7 +44,7 @@ async fn state_with_db() -> (AppState, sqlx::SqlitePool) {
         metrics: ruscker_admin::metrics_cache::MetricsCache::new(),
         draining: Arc::new(std::sync::atomic::AtomicBool::new(false)),
         spec_cache: std::sync::Arc::new(dashmap::DashMap::new()),
-        identity_cache: std::sync::Arc::new(dashmap::DashMap::new()),
+        identity_cache: Default::default(),
         catalog_cache: std::sync::Arc::new(tokio::sync::RwLock::new(None)),
         access_counter: std::sync::Arc::new(ruscker_admin::access_counter::AccessCounter::default()),
         alerts: ruscker_admin::alerts::AlertSink::default(),

--- a/crates/ruscker-admin/tests/ws_e2e.rs
+++ b/crates/ruscker-admin/tests/ws_e2e.rs
@@ -132,6 +132,7 @@ async fn serve() -> (AppState, SocketAddr) {
         metrics: ruscker_admin::metrics_cache::MetricsCache::new(),
         draining: Arc::new(std::sync::atomic::AtomicBool::new(false)),
         spec_cache: Arc::new(dashmap::DashMap::new()),
+        identity_cache: Arc::new(dashmap::DashMap::new()),
         catalog_cache: Arc::new(tokio::sync::RwLock::new(None)),
         access_counter: Arc::new(ruscker_admin::access_counter::AccessCounter::default()),
         alerts: ruscker_admin::alerts::AlertSink::default(),

--- a/crates/ruscker-admin/tests/ws_e2e.rs
+++ b/crates/ruscker-admin/tests/ws_e2e.rs
@@ -132,7 +132,7 @@ async fn serve() -> (AppState, SocketAddr) {
         metrics: ruscker_admin::metrics_cache::MetricsCache::new(),
         draining: Arc::new(std::sync::atomic::AtomicBool::new(false)),
         spec_cache: Arc::new(dashmap::DashMap::new()),
-        identity_cache: Arc::new(dashmap::DashMap::new()),
+        identity_cache: Default::default(),
         catalog_cache: Arc::new(tokio::sync::RwLock::new(None)),
         access_counter: Arc::new(ruscker_admin::access_counter::AccessCounter::default()),
         alerts: ruscker_admin::alerts::AlertSink::default(),

--- a/crates/ruscker-config/src/schema.rs
+++ b/crates/ruscker-config/src/schema.rs
@@ -924,6 +924,13 @@ pub struct Spec {
     #[serde(rename = "access-users", default)]
     pub access_users: Option<Vec<String>>,
 
+    /// Forward the authenticated user's ShinyProxy-compatible identity
+    /// headers to this app. Deliberately defaults to `false`, unlike
+    /// ShinyProxy: existing apps must opt in before Ruscker discloses a
+    /// username or group membership (#1001).
+    #[serde(rename = "add-default-http-headers")]
+    pub add_default_http_headers: Option<bool>,
+
     /// Free-form properties consumed by the landing page template.
     /// Common keys: `logo`, `icon`, `type`, `updated`, `state`, `link`.
     #[serde(rename = "template-properties", default)]
@@ -1191,6 +1198,15 @@ impl Spec {
     pub fn is_open(&self) -> bool {
         self.access_groups.as_deref().is_none_or(<[String]>::is_empty)
             && self.access_users.as_deref().is_none_or(<[String]>::is_empty)
+    }
+
+    /// Whether authenticated identity headers are disclosed to this app.
+    ///
+    /// ShinyProxy defaults this field to `true`; Ruscker defaults it to
+    /// `false` so an existing registered app never starts receiving user
+    /// identity merely because the server was upgraded (#1001).
+    pub fn effective_add_default_http_headers(&self) -> bool {
+        self.add_default_http_headers.unwrap_or(false)
     }
 
     /// Decorative "requires login" padlock (#839). Purely informational:
@@ -2026,6 +2042,7 @@ proxy:
             labels: None,
             access_groups: None,
             access_users: None,
+            add_default_http_headers: None,
             template_properties: TemplateProperties::default(),
             kind_override: None,
             api: None,
@@ -2077,6 +2094,7 @@ proxy:
             labels: None,
             access_groups: None,
             access_users: None,
+            add_default_http_headers: None,
             template_properties: TemplateProperties::default(),
             kind_override: None,
             api: None,
@@ -2128,6 +2146,7 @@ proxy:
             labels: None,
             access_groups: None,
             access_users: None,
+            add_default_http_headers: None,
             template_properties: TemplateProperties::default(),
             kind_override: Some(SpecKindOverride::Api),
             api: None,
@@ -2262,6 +2281,19 @@ proxy:
         // empty lists are also "open".
         let e = parse_spec("id: a\ncontainer-image: x\naccess-groups: []");
         assert!(e.is_open());
+    }
+
+    #[test]
+    fn parses_identity_header_opt_in_and_defaults_off() {
+        let default = parse_spec("id: a\ncontainer-image: x");
+        assert_eq!(default.add_default_http_headers, None);
+        assert!(!default.effective_add_default_http_headers());
+
+        let enabled = parse_spec(
+            "id: a\ncontainer-image: x\nadd-default-http-headers: true",
+        );
+        assert_eq!(enabled.add_default_http_headers, Some(true));
+        assert!(enabled.effective_add_default_http_headers());
     }
 
     #[test]

--- a/crates/ruscker-proxy/src/ws.rs
+++ b/crates/ruscker-proxy/src/ws.rs
@@ -166,9 +166,13 @@ pub async fn connect_with_headers(
             .insert(header::SEC_WEBSOCKET_PROTOCOL, v);
     }
     for (name, value) in extra_headers {
+        // `from_bytes`, not `from_str`: identity values may carry
+        // non-ASCII UTF-8 (a group named `gestão`) which `from_str`
+        // rejects — the bytes go out raw, as ShinyProxy/Spring do,
+        // and a UTF-8-reading app gets the original string (#1001).
         if let (Ok(name), Ok(value)) = (
             name.parse::<header::HeaderName>(),
-            HeaderValue::from_str(value),
+            HeaderValue::from_bytes(value.as_bytes()),
         ) {
             request.headers_mut().insert(name, value);
         }

--- a/crates/ruscker-proxy/src/ws.rs
+++ b/crates/ruscker-proxy/src/ws.rs
@@ -142,6 +142,19 @@ pub async fn connect(
     cookie: Option<&str>,
     subprotocols: Option<&str>,
 ) -> Result<UpstreamHandshake, tokio_tungstenite::tungstenite::Error> {
+    connect_with_headers(upstream_ws_url, cookie, subprotocols, &[]).await
+}
+
+/// Like [`connect`], with additional authoritative headers supplied by
+/// the proxy. Keeping the original three-argument helper as a wrapper
+/// preserves existing callers while identity-aware proxies can add the
+/// trusted handshake headers they resolved themselves (#1001).
+pub async fn connect_with_headers(
+    upstream_ws_url: &str,
+    cookie: Option<&str>,
+    subprotocols: Option<&str>,
+    extra_headers: &[(String, String)],
+) -> Result<UpstreamHandshake, tokio_tungstenite::tungstenite::Error> {
     let mut request = upstream_ws_url.into_client_request()?;
     // Forward the client's session cookie and requested subprotocol.
     if let Some(v) = cookie.and_then(|s| HeaderValue::from_str(s).ok()) {
@@ -151,6 +164,14 @@ pub async fn connect(
         request
             .headers_mut()
             .insert(header::SEC_WEBSOCKET_PROTOCOL, v);
+    }
+    for (name, value) in extra_headers {
+        if let (Ok(name), Ok(value)) = (
+            name.parse::<header::HeaderName>(),
+            HeaderValue::from_str(value),
+        ) {
+            request.headers_mut().insert(name, value);
+        }
     }
 
     let (stream, resp) = tokio_tungstenite::connect_async(request).await?;

--- a/crates/ruscker-proxy/tests/ws_pump.rs
+++ b/crates/ruscker-proxy/tests/ws_pump.rs
@@ -55,6 +55,44 @@ async fn spawn_closing_upstream() -> String {
     format!("ws://{addr}/")
 }
 
+/// Spawn one upstream handshake that reports the identity headers it saw.
+#[allow(clippy::result_large_err)] // tungstenite's callback error is a full HTTP response
+async fn spawn_header_capture_upstream(
+) -> (String, tokio::sync::oneshot::Receiver<(String, String)>) {
+    let listener = TcpListener::bind("127.0.0.1:0").await.unwrap();
+    let addr = listener.local_addr().unwrap();
+    let (tx, rx) = tokio::sync::oneshot::channel();
+    tokio::spawn(async move {
+        let (stream, _) = listener.accept().await.unwrap();
+        let mut ws = tokio_tungstenite::accept_hdr_async(
+            stream,
+            move |request: &tokio_tungstenite::tungstenite::handshake::server::Request,
+                  response| {
+                let user = request
+                    .headers()
+                    .get("x-sp-userid")
+                    .unwrap()
+                    .to_str()
+                    .unwrap()
+                    .to_string();
+                let groups = request
+                    .headers()
+                    .get("x-sp-usergroups")
+                    .unwrap()
+                    .to_str()
+                    .unwrap()
+                    .to_string();
+                let _ = tx.send((user, groups));
+                Ok(response)
+            },
+        )
+        .await
+        .unwrap();
+        let _ = ws.close(None).await;
+    });
+    (format!("ws://{addr}/"), rx)
+}
+
 /// Spawn the axum proxy app (one `/ws` route → `ws::connect` +
 /// `ws::pump`, the #730 two-step shape). Returns its bound address.
 async fn spawn_proxy(upstream_url: String) -> std::net::SocketAddr {
@@ -124,6 +162,23 @@ async fn pump_forwards_both_ways_and_closes_cleanly() {
     })
     .await;
     assert!(drained.is_ok(), "pump tore down without hanging");
+}
+
+#[tokio::test]
+async fn upstream_handshake_includes_extra_headers() {
+    let (url, captured) = spawn_header_capture_upstream().await;
+    let headers = vec![
+        ("X-SP-UserId".to_string(), "alice".to_string()),
+        ("X-SP-UserGroups".to_string(), "analysts,ops".to_string()),
+    ];
+    let handshake = ruscker_proxy::ws::connect_with_headers(&url, None, None, &headers)
+        .await
+        .expect("upstream handshake");
+    assert_eq!(
+        captured.await.unwrap(),
+        ("alice".to_string(), "analysts,ops".to_string())
+    );
+    drop(handshake);
 }
 
 #[tokio::test]

--- a/docs/SECURITY.md
+++ b/docs/SECURITY.md
@@ -401,6 +401,14 @@ actually flows, and why it is **deliberately not TLS**:
   issuance/rotation would add real complexity against a threat the
   loopback / private-network requirement already removes. This
   mirrors ShinyProxy and the rest of this class of tool.
+- **Identity-header trust boundary (#1001):** an app may trust the
+  `X-SP-*` / reserved `X-Ruscker-User-*` identity namespaces only when
+  its container port is reachable exclusively through Ruscker — loopback
+  on a single host, or the private app network in a multi-host deployment.
+  Exposing a container's published port lets a caller bypass the proxy and
+  forge those headers directly. Ruscker strips inbound claims and injects
+  authoritative `X-SP-UserId` / `X-SP-UserGroups` only on opted-in specs,
+  but it cannot protect a separate network path around the proxy.
 
 ### Forwarded-header trust model
 

--- a/docs/YAML_SCHEMA.md
+++ b/docs/YAML_SCHEMA.md
@@ -340,6 +340,7 @@ A spec describes one app, API, or external link. Every spec has an
     cost-center: GAPE
   access-groups: [staff, ops]         # who may see/reach this app
   access-users: [alice]               #   (ShinyProxy-compatible)
+  add-default-http-headers: true       # opt in to X-SP-UserId / X-SP-UserGroups
 ```
 
 `container-volumes` is a list of Docker bind specs (`/host:/container`,
@@ -387,6 +388,15 @@ visitors. Otherwise: a logged-in user sees it when their username is in
 always sees everything; an anonymous visitor sees only open apps. Group
 membership is set per user in the admin panel. Enforcement is real (not
 just hiding the card). See the [Roadmap](ROADMAP.md) Phase 8.
+
+`add-default-http-headers` is a ShinyProxy-compatible, per-spec opt-in
+that forwards `X-SP-UserId` and comma-separated `X-SP-UserGroups` on HTTP
+requests and WebSocket handshakes for signed-in users. Ruscker deliberately
+defaults it to **`false`** (ShinyProxy defaults it to `true`) so an upgrade
+does not silently disclose identity to an app that was not already trusted
+to receive it. Anonymous requests and break-glass token sessions carry no
+identity headers. Client-supplied `X-SP-*` identity headers and the reserved
+`X-Ruscker-User-*` namespace are always stripped before proxying.
 
 #### Registry credentials — inline vs. named (`docker-registry-credential`)
 


### PR DESCRIPTION
Slice A of #1001. Apps migrated from ShinyProxy lost the authenticated identity they relied on for data authorship — Ruscker authenticated and authorized but forwarded **nothing** to the container. This restores ShinyProxy-compatible identity headers, safely and opt-in.

## What changed

- **Schema** (`add-default-http-headers`, ShinyProxy-compatible name) + `effective_add_default_http_headers()`. **Defaults OFF** (ShinyProxy defaults it on) — an upgrade must never silently start disclosing a username/groups to an already-registered app (data minimization).
- **Proxy** (`do_forward` + the WS handshake branch):
  - The **whole `X-SP-*` and `X-Ruscker-User-*` namespaces are stripped unconditionally** from every inbound request — anonymous, feature-off, feature-on alike — before any authoritative value is injected. Anti-spoofing.
  - For an opted-in spec with a **named session**, authoritative `X-SP-UserId` / `X-SP-UserGroups` (comma-separated) are injected. Anonymous requests and break-glass token sessions carry no identity.
- **Identity resolution** once per request via a short-TTL (30s) username→groups cache on `AppState`; the existing restricted-access check reuses it (drops its former per-request `SELECT`). Admin handlers that mutate membership/accounts (user edit/delete, group rename/add/remove member, CSV import) invalidate the cache so revocations apply on the next proxied request; each entry is tagged with a generation so a fill racing an invalidation lands already-expired (never readable).
- **WS**: `ws::connect_with_headers` forwards the same pair on the upstream handshake; the original `connect` is kept as a wrapper. Both paths use `HeaderValue::from_bytes` so **UTF-8 group names** (`gestão`) survive.
- **Admin**: toggle in the spec form's Access section, localized pt/en/es/fr.
- **Docs**: `YAML_SCHEMA.md`, `SECURITY.md` (trust boundary — the headers are trustworthy only when the container is reachable **exclusively** through Ruscker; an exposed container port lets a caller bypass the proxy and forge them), fieldmap `add-default-http-headers` ❌→⚠️ (default-divergence noted).

## Out of scope (slice B / later)
Extra claims (`X-Ruscker-User-Email`/`-Setor` injection — only the *strip* of that namespace is here), static `http-headers` map, OIDC/SAML (#934), env-var identity.

## How it was built & validated
- **Implemented by a Codex agent** (`gpt-5.6`, reasoning high, sandbox workspace-write).
- **Reviewed by Codex** (`gpt-5.6` high) over 3 rounds — each finding fixed and re-reviewed to a clean pass:
  1. cache invalidation lagged revocations → invalidate on mutations;
  2. **P1** strip only covered the two injected names → strip the full reserved namespace; **P2** stale-fill race → per-entry generation;
  3. **P2** ASCII-only `from_str` dropped accented group names → `from_bytes`.
- **Full gate green**: `cargo test` + `cargo clippy --all-targets -D warnings` + `i18n-check.sh`; `--features ws-e2e` compiles.
- **Live smoke** against real echo containers (both `/api` specs, Docker backend), all 5 scenarios correct:

| scenario | X-SP-* at upstream |
|---|---|
| logged-in user + spec ON | `x-sp-userid: smokeuser`, `x-sp-usergroups: ops,data` ✅ |
| anonymous forging `X-SP-UserId`/`X-Ruscker-User-Email` | stripped, empty ✅ |
| logged-in user forging `X-SP-UserId: mallory` | replaced by authoritative `smokeuser` ✅ |
| logged-in user + spec OFF (default) | none ✅ |
| break-glass token session + spec ON | none (no actor) ✅ |

Integration tests cover the same matrix plus accented group names and the reserved-strip unit; a WS-handshake test covers the extra-headers plumbing.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
