### PR TITLE
feat: per-spec opt-in identity claims — email + setor (#1001 slice B)

### DIFF
--- a/book/src/shinyproxy-fieldmap.md
+++ b/book/src/shinyproxy-fieldmap.md
@@ -129,6 +129,10 @@ Statuses:
 
 ## Ruscker extensions (no ShinyProxy counterpart)
 
+- `identity-claims` opts a trusted spec in to selected additional profile
+  headers (`email` and/or `setor`); it is independent of
+  `add-default-http-headers` and defaults to none.
+
 These are additions, not compat concerns — listed so a reviewed config
 is fully accounted for. Details in the
 [YAML schema reference](./configuration.md): per-spec `type`,

--- a/crates/ruscker-admin/assets/i18n/en/landing.ftl
+++ b/crates/ruscker-admin/assets/i18n/en/landing.ftl
@@ -642,6 +642,10 @@ spec-help-access-users = Usernames that may see and reach the app (comma-separat
 spec-form-access-help = Both blank = card is open to everyone (including anonymous). With any value, only matching logged-in users — and admins always.
 spec-form-identity-headers = Send identity headers to the app
 spec-form-identity-headers-hint = Adds X-SP-UserId and X-SP-UserGroups for signed-in users. Off by default; enable only for apps that need and trust this identity.
+spec-form-identity-claims = Additional identity claims
+spec-form-identity-claims-hint = Send only the selected profile data to this app. These claims are independent of the X-SP identity headers.
+spec-form-identity-claim-email = Email
+spec-form-identity-claim-setor = Department / unit
 spec-form-access-public = Public
 spec-form-access-add-group = + add group
 spec-form-access-public-hint = empty = visible to everyone

--- a/crates/ruscker-admin/assets/i18n/es/landing.ftl
+++ b/crates/ruscker-admin/assets/i18n/es/landing.ftl
@@ -642,6 +642,10 @@ spec-help-access-users = Usuarios que pueden ver y acceder a la app (separados p
 spec-form-access-help = Ambos vacíos = tarjeta abierta a todos (incluido anónimo). Con algún valor, solo usuarios conectados que coincidan — y los admins siempre.
 spec-form-identity-headers = Enviar cabeceras de identidad a la app
 spec-form-identity-headers-hint = Añade X-SP-UserId y X-SP-UserGroups para usuarios autenticados. Desactivado por defecto; actívalo solo para apps que necesiten y confíen en esta identidad.
+spec-form-identity-claims = Datos de identidad adicionales
+spec-form-identity-claims-hint = Envía solo los datos de perfil seleccionados a esta app. Estos datos son independientes de las cabeceras de identidad X-SP.
+spec-form-identity-claim-email = Correo electrónico
+spec-form-identity-claim-setor = Sector / unidad
 spec-form-access-public = Público
 spec-form-access-add-group = + añadir grupo
 spec-form-access-public-hint = vacío = visible para todos

--- a/crates/ruscker-admin/assets/i18n/fr/landing.ftl
+++ b/crates/ruscker-admin/assets/i18n/fr/landing.ftl
@@ -642,6 +642,10 @@ spec-help-access-users = Utilisateurs qui peuvent voir et atteindre l'app (sépa
 spec-form-access-help = Les deux vides = carte ouverte à tous (y compris anonyme). Avec une valeur, seuls les utilisateurs connectés correspondants — et toujours les admins.
 spec-form-identity-headers = Envoyer les en-têtes d’identité à l’app
 spec-form-identity-headers-hint = Ajoute X-SP-UserId et X-SP-UserGroups pour les utilisateurs connectés. Désactivé par défaut ; activez uniquement pour les apps qui ont besoin de cette identité et lui font confiance.
+spec-form-identity-claims = Attributs d’identité supplémentaires
+spec-form-identity-claims-hint = Envoie uniquement les données de profil sélectionnées à cette app. Ces attributs sont indépendants des en-têtes d’identité X-SP.
+spec-form-identity-claim-email = E-mail
+spec-form-identity-claim-setor = Service / unité
 spec-form-access-public = Public
 spec-form-access-add-group = + ajouter
 spec-form-access-public-hint = vide = visible par tous

--- a/crates/ruscker-admin/assets/i18n/pt/landing.ftl
+++ b/crates/ruscker-admin/assets/i18n/pt/landing.ftl
@@ -646,6 +646,10 @@ spec-help-access-users = Usuários que podem ver e acessar o app (separados por 
 spec-form-access-help = Ambos em branco = card aberto a todos (inclusive anônimos). Com algum valor, só usuários logados que combinam — e admins sempre.
 spec-form-identity-headers = Enviar cabeçalhos de identidade ao app
 spec-form-identity-headers-hint = Adiciona X-SP-UserId e X-SP-UserGroups para usuários autenticados. Desativado por padrão; ative apenas para apps que precisam e confiam nessa identidade.
+spec-form-identity-claims = Dados adicionais de identidade
+spec-form-identity-claims-hint = Envia somente os dados de perfil selecionados a este app. Estes dados são independentes dos cabeçalhos de identidade X-SP.
+spec-form-identity-claim-email = E-mail
+spec-form-identity-claim-setor = Setor / unidade
 spec-form-access-public = Público
 spec-form-access-add-group = + add. grupo
 spec-form-access-public-hint = vazio = visível a todos

--- a/crates/ruscker-admin/src/lib.rs
+++ b/crates/ruscker-admin/src/lib.rs
@@ -61,7 +61,17 @@ pub const APP_VERSION: &str = env!("CARGO_PKG_VERSION");
 /// in `ruscker-cli`'s `init_tracing`.
 pub const STARTUP_LOG_TARGET: &str = "ruscker_startup";
 
-/// Shared short-TTL cache of user group memberships for the proxy hot
+/// Identity attributes cached together for the proxy hot path (#1001).
+/// `celular`, roles, and authentication tokens are intentionally absent:
+/// they are not supported upstream identity claims.
+#[derive(Default)]
+pub struct CachedIdentity {
+    pub(crate) groups: Arc<Vec<String>>,
+    pub(crate) email: Option<String>,
+    pub(crate) setor: Option<String>,
+}
+
+/// Shared short-TTL cache of user identity attributes for the proxy hot
 /// path (#1001).
 ///
 /// The generation counter closes an invalidation race (codex review):
@@ -75,18 +85,18 @@ pub const STARTUP_LOG_TARGET: &str = "ruscker_startup";
 /// unreadable — no check-then-insert window exists by construction.
 #[derive(Default)]
 pub struct IdentityCache {
-    map: dashmap::DashMap<String, (u64, std::time::Instant, Arc<Vec<String>>)>,
+    map: dashmap::DashMap<String, (u64, std::time::Instant, Arc<CachedIdentity>)>,
     generation: std::sync::atomic::AtomicU64,
 }
 
 impl IdentityCache {
-    /// Cached groups for `username`, if fresher than `ttl` AND filled
+    /// Cached identity for `username`, if fresher than `ttl` AND filled
     /// under the current generation (i.e. not invalidated since).
-    pub fn get(&self, username: &str, ttl: std::time::Duration) -> Option<Arc<Vec<String>>> {
+    pub fn get(&self, username: &str, ttl: std::time::Duration) -> Option<Arc<CachedIdentity>> {
         let entry = self.map.get(username)?;
-        let (generation, filled_at, groups) = entry.value();
+        let (generation, filled_at, identity) = entry.value();
         (*generation == self.generation() && filled_at.elapsed() < ttl)
-            .then(|| groups.clone())
+            .then(|| identity.clone())
     }
 
     /// Snapshot to take BEFORE the DB read that will feed [`Self::store`].
@@ -94,13 +104,13 @@ impl IdentityCache {
         self.generation.load(std::sync::atomic::Ordering::Acquire)
     }
 
-    /// Cache a resolved membership, tagged with the generation that was
+    /// Cache a resolved identity, tagged with the generation that was
     /// current when the fill began — if an invalidation raced this fill,
     /// the entry lands already-expired and `get` never serves it.
-    pub fn store(&self, generation: u64, username: &str, groups: Arc<Vec<String>>) {
+    pub fn store(&self, generation: u64, username: &str, identity: Arc<CachedIdentity>) {
         self.map.insert(
             username.to_string(),
-            (generation, std::time::Instant::now(), groups),
+            (generation, std::time::Instant::now(), identity),
         );
     }
 

--- a/crates/ruscker-admin/src/routes/admin/spec_form.rs
+++ b/crates/ruscker-admin/src/routes/admin/spec_form.rs
@@ -20,7 +20,8 @@ use axum::{
 };
 use chrono::Utc;
 use ruscker_config::{
-    ApiSpec, OrderedFloat, Placement, RoutingStrategy, Spec, SpecKindOverride, TemplateProperties,
+    ApiSpec, IdentityClaim, OrderedFloat, Placement, RoutingStrategy, Spec, SpecKindOverride,
+    TemplateProperties,
 };
 use std::collections::BTreeMap;
 use serde::{Deserialize, Serialize};
@@ -503,6 +504,10 @@ pub struct SpecForm {
     /// Checkbox ("on") ⇒ forward the signed-in user's ShinyProxy-compatible
     /// identity headers to this app. Off by default (data minimization).
     pub add_default_http_headers: String,
+    /// Checkbox ("on") ⇒ disclose the user's e-mail to this app.
+    pub identity_claim_email: String,
+    /// Checkbox ("on") ⇒ disclose the user's setor/department to this app.
+    pub identity_claim_setor: String,
 
     // ── Advanced · Resources (requests + body cap) ──────────────
     /// Soft CPU reservation in fractional cores (`container-cpu-request`).
@@ -540,6 +545,7 @@ impl SpecForm {
     pub fn from_spec(spec: &Spec) -> Self {
         let tp = &spec.template_properties;
         let dt = DisplayType::from_spec(spec);
+        let identity_claims = spec.effective_identity_claims();
         Self {
             id: spec.id.clone(),
             base_version: String::new(),
@@ -641,6 +647,8 @@ impl SpecForm {
             access_groups: spec.access_groups.as_ref().map(|v| v.join(", ")).unwrap_or_default(),
             access_users: spec.access_users.as_ref().map(|v| v.join(", ")).unwrap_or_default(),
             add_default_http_headers: checkbox(spec.effective_add_default_http_headers()),
+            identity_claim_email: checkbox(identity_claims.contains(&IdentityClaim::Email)),
+            identity_claim_setor: checkbox(identity_claims.contains(&IdentityClaim::Setor)),
             container_cpu_request: spec
                 .container_cpu_request
                 .map(|n| n.to_string())
@@ -756,6 +764,23 @@ impl SpecForm {
             None
         };
 
+        // Preserve unknown/future claim names from the base spec while the
+        // two recognized checkboxes remain authoritative for email/setor.
+        let mut identity_claims: Vec<String> = base
+            .and_then(|spec| spec.identity_claims.as_ref())
+            .into_iter()
+            .flatten()
+            .filter(|name| !matches!(name.trim(), "email" | "setor"))
+            .cloned()
+            .collect();
+        if !self.identity_claim_email.trim().is_empty() {
+            identity_claims.push("email".into());
+        }
+        if !self.identity_claim_setor.trim().is_empty() {
+            identity_claims.push("setor".into());
+        }
+        let identity_claims = (!identity_claims.is_empty()).then_some(identity_claims);
+
         Ok(Spec {
             id: self.id.trim().to_string(),
             display_name: empty_to_none(&self.display_name),
@@ -821,6 +846,7 @@ impl SpecForm {
             access_groups: list_to_vec(&self.access_groups),
             access_users: list_to_vec(&self.access_users),
             add_default_http_headers: checkbox_opt(&self.add_default_http_headers),
+            identity_claims,
             container_cpu_request: parse_opt(&self.container_cpu_request),
             container_memory_request: empty_to_none(&self.container_memory_request),
             max_body_size: empty_to_none(&self.max_body_size),
@@ -2035,6 +2061,7 @@ proxy:
       access-groups: [staff, ops]
       access-users: [alice]
       add-default-http-headers: true
+      identity-claims: [email, future-claim, setor]
       placement: bin-pack
       anti-affinity: true
       routing-strategy: round-robin
@@ -2063,6 +2090,14 @@ proxy:
         assert_eq!(merged.access_groups.as_deref(), Some(&["staff".into(), "ops".into()][..]));
         assert_eq!(merged.access_users.as_deref(), Some(&["alice".into()][..]));
         assert!(merged.effective_add_default_http_headers());
+        assert_eq!(
+            merged.effective_identity_claims(),
+            vec![IdentityClaim::Email, IdentityClaim::Setor]
+        );
+        assert!(merged
+            .identity_claims
+            .as_deref()
+            .is_some_and(|claims| claims.iter().any(|claim| claim == "future-claim")));
         assert_eq!(merged.placement, Some(Placement::BinPack));
         assert_eq!(merged.anti_affinity, Some(true));
         assert_eq!(merged.routing_strategy, Some(RoutingStrategy::RoundRobin));

--- a/crates/ruscker-admin/src/routes/admin/users.rs
+++ b/crates/ruscker-admin/src/routes/admin/users.rs
@@ -441,7 +441,12 @@ async fn set_profile(
     )
     .await
     {
-        Ok(()) => redirect_flash("saved"),
+        Ok(()) => {
+            // email/setor are cached for identity claims (#1001 slice B) —
+            // a profile edit/clear must reach the proxy now, not at TTL.
+            state.invalidate_identity_cache();
+            redirect_flash("saved")
+        }
         Err(e) => {
             tracing::warn!(error = ?e, %username, "set profile failed");
             redirect_flash("bad-input")

--- a/crates/ruscker-admin/src/routes/proxy.rs
+++ b/crates/ruscker-admin/src/routes/proxy.rs
@@ -38,7 +38,7 @@ use http_body_util::BodyExt;
 use hyper_util::client::legacy::connect::HttpConnector;
 use hyper_util::client::legacy::Client;
 use hyper_util::rt::{TokioExecutor, TokioTimer};
-use ruscker_config::{RoutingStrategy, Spec, SpecKind};
+use ruscker_config::{IdentityClaim, RoutingStrategy, Spec, SpecKind};
 use ruscker_core::{Replica, ReplicaState};
 use ruscker_proxy::sticky::{self, CookieKey, StickySession, COOKIE_NAME};
 use ruscker_proxy::ws;
@@ -49,7 +49,7 @@ use tower_cookies::{Cookie, Cookies};
 
 use super::rewrite;
 use crate::ratelimit;
-use crate::AppState;
+use crate::{AppState, CachedIdentity};
 
 /// Wrapper extractor: `WebSocketUpgrade::FromRequestParts` returns
 /// an error for non-upgrade requests; axum 0.8 doesn't blanket-
@@ -81,14 +81,31 @@ struct MaybePeer(Option<SocketAddr>);
 struct Identity {
     username: String,
     groups: Arc<Vec<String>>,
+    email: Option<String>,
+    setor: Option<String>,
 }
 
 impl Identity {
-    fn header_pairs(&self) -> Vec<(String, String)> {
-        vec![
-            ("X-SP-UserId".into(), self.username.clone()),
-            ("X-SP-UserGroups".into(), self.groups.join(",")),
-        ]
+    fn header_pairs(
+        &self,
+        add_default_http_headers: bool,
+        claims: &[IdentityClaim],
+    ) -> Vec<(String, String)> {
+        let mut headers = Vec::new();
+        if add_default_http_headers {
+            headers.push(("X-SP-UserId".into(), self.username.clone()));
+            headers.push(("X-SP-UserGroups".into(), self.groups.join(",")));
+        }
+        for claim in claims {
+            let (name, value) = match claim {
+                IdentityClaim::Email => ("X-Ruscker-User-Email", self.email.as_deref()),
+                IdentityClaim::Setor => ("X-Ruscker-User-Setor", self.setor.as_deref()),
+            };
+            if let Some(value) = value.filter(|value| !value.trim().is_empty()) {
+                headers.push((name.into(), value.to_string()));
+            }
+        }
+        headers
     }
 }
 
@@ -373,15 +390,32 @@ async fn forward(
     // Resolve identity once when either access control or upstream header
     // disclosure needs it. Open specs with disclosure disabled do no user
     // lookup at all.
+    let identity_claims = spec.effective_identity_claims();
     let identity = match acting_user.as_ref() {
-        Some(username) if !spec.is_open() || spec.effective_add_default_http_headers() => {
+        Some(username)
+            if !spec.is_open()
+                || spec.effective_add_default_http_headers()
+                || !identity_claims.is_empty() =>
+        {
+            let cached = resolve_identity(&state, username).await;
             Some(Identity {
                 username: username.clone(),
-                groups: find_user_groups(&state, username).await,
+                groups: cached.groups.clone(),
+                email: cached.email.clone(),
+                setor: cached.setor.clone(),
             })
         }
         _ => None,
     };
+    let identity_headers = identity
+        .as_ref()
+        .map(|identity| {
+            identity.header_pairs(
+                spec.effective_add_default_http_headers(),
+                &identity_claims,
+            )
+        })
+        .unwrap_or_default();
     if !spec.is_open() {
         let is_admin = session
             .0
@@ -596,14 +630,6 @@ async fn forward(
         // selected can be echoed on our 101 — a browser that offered
         // subprotocols and receives a 101 without one selected must fail
         // the connection (RFC 6455 §4.1).
-        let identity_headers = if spec.effective_add_default_http_headers() {
-            identity
-                .as_ref()
-                .map(Identity::header_pairs)
-                .unwrap_or_default()
-        } else {
-            Vec::new()
-        };
         let handshake = match ws::connect_with_headers(
             &upstream_ws_url,
             cookie.as_deref(),
@@ -716,11 +742,7 @@ async fn forward(
         is_https,
         req,
         body_cap,
-        if spec.effective_add_default_http_headers() {
-            identity.as_ref()
-        } else {
-            None
-        },
+        &identity_headers,
     )
     .await
     {
@@ -1003,33 +1025,40 @@ pub(crate) fn apply_public_path(env: &mut [String], cmd: &mut Option<Vec<String>
 /// cache instead of the DB.
 pub(crate) const SPEC_CACHE_TTL: std::time::Duration = std::time::Duration::from_secs(1);
 
-/// Group memberships change far less often than proxy requests. A 30s TTL
+/// Identity attributes change far less often than proxy requests. A 30s TTL
 /// prevents one SELECT per asset while bounding how long an admin edit can
 /// take to reach access checks and injected identity headers (#1001).
 pub(crate) const IDENTITY_CACHE_TTL: std::time::Duration =
     std::time::Duration::from_secs(30);
 
-async fn find_user_groups(state: &AppState, username: &str) -> Arc<Vec<String>> {
-    if let Some(groups) = state.identity_cache.get(username, IDENTITY_CACHE_TTL) {
-        return groups;
+async fn resolve_identity(state: &AppState, username: &str) -> Arc<CachedIdentity> {
+    if let Some(identity) = state.identity_cache.get(username, IDENTITY_CACHE_TTL) {
+        return identity;
     }
 
-    // Snapshot BEFORE the read: `store` rejects this fill if an admin
-    // mutation invalidated the cache while we were at the DB, so a
-    // pre-revocation read can never repopulate the cache (#1001).
+    // Snapshot BEFORE the read: `get` rejects this fill after it lands if
+    // an admin mutation invalidated the cache while we were at the DB, so a
+    // pre-revocation read can never become readable again (#1001).
     let generation = state.identity_cache.generation();
-    let groups = match state.db.as_ref() {
+    let identity = match state.db.as_ref() {
         Some(db) => match crate::db::users::fetch(db, username).await {
-            Ok(row) => Arc::new(row.map(|user| user.groups).unwrap_or_default()),
+            Ok(Some(user)) => Arc::new(CachedIdentity {
+                groups: Arc::new(user.groups),
+                email: user.email,
+                setor: user.setor,
+            }),
+            Ok(None) => Arc::new(CachedIdentity::default()),
             Err(error) => {
                 tracing::warn!(user = username, error = ?error, "identity lookup failed");
-                return Arc::new(Vec::new());
+                return Arc::new(CachedIdentity::default());
             }
         },
-        None => Arc::new(Vec::new()),
+        None => Arc::new(CachedIdentity::default()),
     };
-    state.identity_cache.store(generation, username, groups.clone());
-    groups
+    state
+        .identity_cache
+        .store(generation, username, identity.clone());
+    identity
 }
 
 pub(crate) async fn find_spec(state: &AppState, id: &str) -> Option<Spec> {
@@ -1786,7 +1815,7 @@ async fn do_forward(
     is_https: bool,
     mut req: Request,
     max_body: Option<usize>,
-    identity: Option<&Identity>,
+    identity_headers: &[(String, String)],
 ) -> anyhow::Result<Response> {
     let query = req.uri().query().map(|q| format!("?{q}")).unwrap_or_default();
     let new_uri: Uri = format!("http://{}{}{}", replica.upstream, upstream_path, query)
@@ -1811,24 +1840,20 @@ async fn do_forward(
     // (#258).
     strip_ruscker_cookies(req.headers_mut());
 
-    if let Some(identity) = identity {
-        for (name, value) in identity.header_pairs() {
-            // `from_bytes`, not `from_str`: group names are free-form
-            // UTF-8 (`gestão`) and `from_str` only accepts visible
-            // ASCII — it would silently drop X-SP-UserGroups (codex
-            // review, #1001). The raw UTF-8 bytes are what ShinyProxy
-            // (Spring) sends too. A value that still fails (embedded
-            // control chars can't reach here via parse_groups) is
-            // logged, never silently omitted.
-            match (
-                name.parse::<header::HeaderName>(),
-                HeaderValue::from_bytes(value.as_bytes()),
-            ) {
-                (Ok(name), Ok(value)) => {
-                    req.headers_mut().insert(name, value);
-                }
-                _ => tracing::warn!(header = %name, "identity header value not encodable; omitted"),
+    for (name, value) in identity_headers {
+        // `from_bytes`, not `from_str`: group/claim values are free-form
+        // UTF-8 (`gestão`) and `from_str` only accepts visible ASCII — it
+        // would silently drop an accented value (codex review, #1001).
+        // A value that still fails (e.g. embedded control characters) is
+        // logged, never silently omitted.
+        match (
+            name.parse::<header::HeaderName>(),
+            HeaderValue::from_bytes(value.as_bytes()),
+        ) {
+            (Ok(name), Ok(value)) => {
+                req.headers_mut().insert(name, value);
             }
+            _ => tracing::warn!(header = %name, "identity header value not encodable; omitted"),
         }
     }
 
@@ -2091,6 +2116,34 @@ mod tests {
         assert!(!headers.contains_key("x-sp-useremail"));
         assert!(!headers.contains_key("x-ruscker-user-email"));
         assert_eq!(headers.get("x-app-header").unwrap(), "keep");
+    }
+
+    #[test]
+    fn identity_header_pairs_minimize_claims_and_omit_blank_values() {
+        let identity = Identity {
+            username: "alice".into(),
+            groups: Arc::new(vec!["staff".into()]),
+            email: Some("alice@example.test".into()),
+            setor: Some("  ".into()),
+        };
+
+        let headers = identity.header_pairs(false, &[IdentityClaim::Email, IdentityClaim::Setor]);
+        assert_eq!(
+            headers,
+            vec![(
+                "X-Ruscker-User-Email".to_string(),
+                "alice@example.test".to_string(),
+            )]
+        );
+
+        let defaults_only = identity.header_pairs(true, &[]);
+        assert_eq!(
+            defaults_only,
+            vec![
+                ("X-SP-UserId".to_string(), "alice".to_string()),
+                ("X-SP-UserGroups".to_string(), "staff".to_string()),
+            ]
+        );
     }
 
     #[test]
@@ -2865,7 +2918,7 @@ docker-registry-password: hunter2
             false,
             req,
             None,
-            None,
+            &[],
         )
         .await
         .expect("the dead-connection GET should be retried, not surfaced as an error");

--- a/crates/ruscker-admin/templates/admin/spec_form.html
+++ b/crates/ruscker-admin/templates/admin/spec_form.html
@@ -586,6 +586,23 @@
         </span>
       </label>
 
+      <fieldset class="spec-form-field">
+        <legend class="spec-form-label">{{ self.t("spec-form-identity-claims") }}</legend>
+        <div class="spec-form-help">{{ self.t("spec-form-identity-claims-hint") }}</div>
+        <div class="flex flex-wrap gap-4 mt-2">
+          <label class="spec-form-check">
+            <input type="checkbox" name="identity_claim_email" value="on"
+                   {% if !form.identity_claim_email.is_empty() %}checked{% endif %}>
+            <span>{{ self.t("spec-form-identity-claim-email") }}</span>
+          </label>
+          <label class="spec-form-check">
+            <input type="checkbox" name="identity_claim_setor" value="on"
+                   {% if !form.identity_claim_setor.is_empty() %}checked{% endif %}>
+            <span>{{ self.t("spec-form-identity-claim-setor") }}</span>
+          </label>
+        </div>
+      </fieldset>
+
       {# Initial replicas (#701) — the always-on pool floor (min_replicas),
          surfaced here as part of "scale". Container-backed kinds only; the
          autoscaling ceiling + thresholds stay in Advanced. #}

--- a/crates/ruscker-admin/tests/identity_headers.rs
+++ b/crates/ruscker-admin/tests/identity_headers.rs
@@ -34,6 +34,22 @@ proxy:
       display-name: Identity off
       type: api
       container-image: test/api
+    - id: claims-both
+      display-name: Both additional claims
+      type: api
+      container-image: test/api
+      identity-claims: [email, setor]
+    - id: claims-email
+      display-name: Email claim only
+      type: api
+      container-image: test/api
+      identity-claims: [email]
+    - id: identity-all
+      display-name: Default and additional identity
+      type: api
+      container-image: test/api
+      add-default-http-headers: true
+      identity-claims: [email, setor]
 "#;
 
 struct ReadyBackend;
@@ -172,7 +188,8 @@ async fn send(
         request = request
             .header("X-SP-UserId", "mallory")
             .header("X-SP-UserGroups", "attackers")
-            .header("X-Ruscker-User-Email", "mallory@example.test");
+            .header("X-Ruscker-User-Email", "mallory@example.test")
+            .header("X-Ruscker-User-Setor", "Attackers");
     }
     let response = router(state)
         .oneshot(request.body(Body::empty()).unwrap())
@@ -201,6 +218,16 @@ async fn logged_in_state(
         Role::Viewer,
         false,
         &["analysts".into(), "ops".into()],
+        Some("admin"),
+    )
+    .await
+    .unwrap();
+    ruscker_admin::db::users::update_profile(
+        &db,
+        "alice",
+        Some("Gestão"),
+        Some("alice@example.test"),
+        Some("+55 81 99999-9999"),
         Some("admin"),
     )
     .await
@@ -294,15 +321,100 @@ async fn feature_off_sends_no_identity_for_logged_in_user() {
 }
 
 #[tokio::test]
+async fn declared_email_and_setor_are_forwarded_without_x_sp_headers() {
+    let (state, cookie, capture) = logged_in_state("claims-both").await;
+    send(state, "/app/claims-both/data", Some(&cookie), false).await;
+    let headers = capture.await.unwrap();
+
+    assert_eq!(
+        headers.get("x-ruscker-user-email").map(String::as_str),
+        Some("alice@example.test")
+    );
+    assert_eq!(
+        headers.get("x-ruscker-user-setor").map(String::as_str),
+        Some("Gestão")
+    );
+    assert!(!headers.contains_key("x-sp-userid"));
+    assert!(!headers.contains_key("x-sp-usergroups"));
+    assert!(!headers.contains_key("x-ruscker-user-celular"));
+}
+
+#[tokio::test]
+async fn email_only_spec_does_not_receive_setor() {
+    let (state, cookie, capture) = logged_in_state("claims-email").await;
+    send(state, "/api/claims-email/data", Some(&cookie), false).await;
+    let headers = capture.await.unwrap();
+
+    assert_eq!(
+        headers.get("x-ruscker-user-email").map(String::as_str),
+        Some("alice@example.test")
+    );
+    assert!(!headers.contains_key("x-ruscker-user-setor"));
+}
+
+#[tokio::test]
+async fn missing_declared_email_is_omitted_instead_of_sent_empty() {
+    let db = open_db().await;
+    ruscker_admin::db::users::create(
+        &db,
+        "bruno",
+        "brunopass1",
+        Role::Viewer,
+        false,
+        &[],
+        Some("admin"),
+    )
+    .await
+    .unwrap();
+    ruscker_admin::db::users::update_profile(
+        &db,
+        "bruno",
+        Some("Financeiro"),
+        None,
+        None,
+        Some("admin"),
+    )
+    .await
+    .unwrap();
+    let (upstream, capture) = echo_upstream().await;
+    let state = state(db, "claims-email", upstream).await;
+    let sid = state
+        .admin_sessions
+        .create(Role::Viewer, Some("bruno".into()))
+        .await;
+    let cookie = format!("{COOKIE_NAME}={sid}");
+
+    send(state, "/api/claims-email/data", Some(&cookie), false).await;
+    let headers = capture.await.unwrap();
+    assert!(!headers.contains_key("x-ruscker-user-email"));
+    assert!(!headers.contains_key("x-ruscker-user-setor"));
+}
+
+#[tokio::test]
+async fn anonymous_request_cannot_forge_declared_claims() {
+    let db = open_db().await;
+    let (upstream, capture) = echo_upstream().await;
+    let state = state(db, "claims-both", upstream).await;
+    send(state, "/api/claims-both/data", None, true).await;
+    let headers = capture.await.unwrap();
+
+    assert!(!headers.contains_key("x-ruscker-user-email"));
+    assert!(!headers.contains_key("x-ruscker-user-setor"));
+    assert!(!headers.contains_key("x-sp-userid"));
+}
+
+#[tokio::test]
 async fn break_glass_session_has_no_identity_headers() {
     let db = open_db().await;
     let (upstream, capture) = echo_upstream().await;
-    let state = state(db, "identity-on", upstream).await;
+    let state = state(db, "identity-all", upstream).await;
     let sid = state.admin_sessions.create(Role::Admin, None).await;
     let cookie = format!("{COOKIE_NAME}={sid}");
-    send(state, "/api/identity-on/data", Some(&cookie), false).await;
+    send(state, "/api/identity-all/data", Some(&cookie), false).await;
     let headers = capture.await.unwrap();
 
     assert!(!headers.contains_key("x-sp-userid"));
     assert!(!headers.contains_key("x-sp-usergroups"));
+    assert!(!headers.contains_key("x-ruscker-user-email"));
+    assert!(!headers.contains_key("x-ruscker-user-setor"));
 }

--- a/crates/ruscker-config/src/lib.rs
+++ b/crates/ruscker-config/src/lib.rs
@@ -46,10 +46,10 @@ pub use error::{Error, Result};
 /// depending on `ordered-float` directly.
 pub use ordered_float::OrderedFloat;
 pub use schema::{
-    is_valid_memory_size, normalize_base_path, ApiSpec, Config, Host, HostTls, LandingBlock,
-    LandingCustomization, LandingLogo, Logging, Placement, Proxy, RatePolicy, RoutingStrategy,
-    Server, Spec, SpecKind, SpecKindOverride, TemplateProperties, ThemeColors, ThemePalette,
-    DEFAULT_SCALE_DOWN_COOLDOWN_SECS,
+    is_valid_memory_size, normalize_base_path, ApiSpec, Config, Host, HostTls, IdentityClaim,
+    LandingBlock, LandingCustomization, LandingLogo, Logging, Placement, Proxy, RatePolicy,
+    RoutingStrategy, Server, Spec, SpecKind, SpecKindOverride, TemplateProperties, ThemeColors,
+    ThemePalette, DEFAULT_SCALE_DOWN_COOLDOWN_SECS,
 };
 pub use validate::{
     is_reserved_label_key, is_valid_label_key, is_valid_network_name, is_valid_volume_bind,

--- a/crates/ruscker-config/src/schema.rs
+++ b/crates/ruscker-config/src/schema.rs
@@ -732,6 +732,17 @@ pub enum AuthScheme {
     Simple,
 }
 
+/// Additional authenticated user attributes a spec may opt in to receive.
+///
+/// The YAML stores claim names as strings so an older Ruscker can continue
+/// loading a config authored with future claim names. Runtime forwarding uses
+/// only the recognized variants returned by [`Spec::effective_identity_claims`].
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum IdentityClaim {
+    Email,
+    Setor,
+}
+
 /// A single spec — an app, API, or external link surfaced on the landing
 /// page and (if containerized) orchestrated by Ruscker.
 ///
@@ -930,6 +941,13 @@ pub struct Spec {
     /// username or group membership (#1001).
     #[serde(rename = "add-default-http-headers")]
     pub add_default_http_headers: Option<bool>,
+
+    /// Additional authenticated user attributes disclosed to this app.
+    /// Ruscker-native and deliberately empty by default. Unknown strings are
+    /// retained in the config but ignored by the runtime for forward
+    /// compatibility (#1001).
+    #[serde(rename = "identity-claims", default)]
+    pub identity_claims: Option<Vec<String>>,
 
     /// Free-form properties consumed by the landing page template.
     /// Common keys: `logo`, `icon`, `type`, `updated`, `state`, `link`.
@@ -1207,6 +1225,26 @@ impl Spec {
     /// identity merely because the server was upgraded (#1001).
     pub fn effective_add_default_http_headers(&self) -> bool {
         self.add_default_http_headers.unwrap_or(false)
+    }
+
+    /// Recognized additional identity claims this app opted in to receive.
+    ///
+    /// Unknown names are ignored instead of rejecting the whole config. This
+    /// lets hand-edited/imported configs carry claims introduced by a newer
+    /// Ruscker version without breaking startup.
+    pub fn effective_identity_claims(&self) -> Vec<IdentityClaim> {
+        let mut claims = Vec::new();
+        for name in self.identity_claims.as_deref().unwrap_or_default() {
+            let claim = match name.trim() {
+                "email" => IdentityClaim::Email,
+                "setor" => IdentityClaim::Setor,
+                _ => continue,
+            };
+            if !claims.contains(&claim) {
+                claims.push(claim);
+            }
+        }
+        claims
     }
 
     /// Decorative "requires login" padlock (#839). Purely informational:
@@ -2043,6 +2081,7 @@ proxy:
             access_groups: None,
             access_users: None,
             add_default_http_headers: None,
+            identity_claims: None,
             template_properties: TemplateProperties::default(),
             kind_override: None,
             api: None,
@@ -2095,6 +2134,7 @@ proxy:
             access_groups: None,
             access_users: None,
             add_default_http_headers: None,
+            identity_claims: None,
             template_properties: TemplateProperties::default(),
             kind_override: None,
             api: None,
@@ -2147,6 +2187,7 @@ proxy:
             access_groups: None,
             access_users: None,
             add_default_http_headers: None,
+            identity_claims: None,
             template_properties: TemplateProperties::default(),
             kind_override: Some(SpecKindOverride::Api),
             api: None,
@@ -2294,6 +2335,30 @@ proxy:
         );
         assert_eq!(enabled.add_default_http_headers, Some(true));
         assert!(enabled.effective_add_default_http_headers());
+    }
+
+    #[test]
+    fn identity_claims_parse_recognized_values_and_ignore_unknown_ones() {
+        let default = parse_spec("id: a\ncontainer-image: x");
+        assert_eq!(default.identity_claims, None);
+        assert!(default.effective_identity_claims().is_empty());
+
+        let spec = parse_spec(
+            "id: a\ncontainer-image: x\nidentity-claims: [email, future-claim, setor, email]",
+        );
+        assert_eq!(
+            spec.identity_claims.as_deref(),
+            Some(&[
+                "email".to_string(),
+                "future-claim".to_string(),
+                "setor".to_string(),
+                "email".to_string(),
+            ][..])
+        );
+        assert_eq!(
+            spec.effective_identity_claims(),
+            vec![IdentityClaim::Email, IdentityClaim::Setor]
+        );
     }
 
     #[test]

--- a/docs/SECURITY.md
+++ b/docs/SECURITY.md
@@ -407,8 +407,11 @@ actually flows, and why it is **deliberately not TLS**:
   on a single host, or the private app network in a multi-host deployment.
   Exposing a container's published port lets a caller bypass the proxy and
   forge those headers directly. Ruscker strips inbound claims and injects
-  authoritative `X-SP-UserId` / `X-SP-UserGroups` only on opted-in specs,
-  but it cannot protect a separate network path around the proxy.
+  authoritative `X-SP-UserId` / `X-SP-UserGroups` and explicitly selected
+  `X-Ruscker-User-Email` / `X-Ruscker-User-Setor` claims only on opted-in
+  specs, but it cannot protect a separate network path around the proxy.
+  E-mail and department/unit values are PII; operators should enable each
+  claim only for apps that need and are trusted to process it.
 
 ### Forwarded-header trust model
 

--- a/docs/YAML_SCHEMA.md
+++ b/docs/YAML_SCHEMA.md
@@ -341,6 +341,7 @@ A spec describes one app, API, or external link. Every spec has an
   access-groups: [staff, ops]         # who may see/reach this app
   access-users: [alice]               #   (ShinyProxy-compatible)
   add-default-http-headers: true       # opt in to X-SP-UserId / X-SP-UserGroups
+  identity-claims: [email, setor]      # opt in to selected profile claims
 ```
 
 `container-volumes` is a list of Docker bind specs (`/host:/container`,
@@ -397,6 +398,16 @@ does not silently disclose identity to an app that was not already trusted
 to receive it. Anonymous requests and break-glass token sessions carry no
 identity headers. Client-supplied `X-SP-*` identity headers and the reserved
 `X-Ruscker-User-*` namespace are always stripped before proxying.
+
+`identity-claims` is a Ruscker-native, per-spec list of additional profile
+attributes to disclose. Allowed values are `email` and `setor`, forwarded as
+`X-Ruscker-User-Email` and `X-Ruscker-User-Setor` respectively for signed-in
+users. It defaults to empty and is independent of `add-default-http-headers`,
+so a spec can request only an e-mail without receiving the username/group
+pair. A selected claim with no stored value is omitted, never sent as an empty
+header. Unknown claim names are retained by the schema but ignored by the
+runtime for forward compatibility. These values are PII; enable each one only
+for an app that needs and is trusted to receive it.
 
 #### Registry credentials — inline vs. named (`docker-registry-credential`)
 


### PR DESCRIPTION
Slice B of #1001. **Stacked on #1002 (slice A)** — base branch is `feat/1001-identity-headers`; review/merge that first.

Slice A restored the ShinyProxy-compatible `X-SP-UserId`/`X-SP-UserGroups` pair. Slice B adds **Ruscker-native additional claims, per spec, with data minimization**: an app receives only the claims it explicitly declared.

## What changed
- **Schema**: `identity-claims: Option<Vec<String>>` + `enum IdentityClaim { Email, Setor }` + `effective_identity_claims()` (recognized subset). Unknown claim names are **retained in the config but ignored at runtime** — a newer-Ruscker config still loads on an older binary. Default empty.
- **Cache**: slice A's username→groups cache now also carries `email` + `setor` (`CachedIdentity`), so claims add **no extra SELECT**; slice A's generation-tagged invalidation (closes the revocation race) is preserved. `resolve_identity` replaces `find_user_groups`.
- **Proxy**: `Identity::header_pairs(add_default_http_headers, claims)` builds the X-SP pair (when enabled) plus `X-Ruscker-User-Email` / `X-Ruscker-User-Setor` for declared claims — computed once, fed to **both** the HTTP path and the WS handshake. Key rules:
  - Claims are **independent** of `add-default-http-headers` (a spec can request email alone).
  - A declared claim with **no stored value is omitted**, never sent empty.
  - Anonymous requests and break-glass token sessions get nothing.
  - `HeaderValue::from_bytes` (UTF-8 `setor` like `Gestão` survives), behind slice A's unconditional `x-ruscker-user-*` strip (anti-spoof).
- **Cache invalidation**: extended to the profile-only handler (`POST /admin/users/{username}/profile`) — a profile edit/removal now drops cached email/setor immediately, not at TTL (caught in review; removed PII must not linger).
- **Admin**: Email/Setor checkboxes in the spec form's Access section; `to_spec` preserves unknown/future claim names set via YAML. Localized pt/en/es/fr.
- **Docs**: `YAML_SCHEMA.md` (values `email`/`setor`, default none, independence, PII note), `SECURITY.md`, fieldmap.

## Out of scope
Celular, admin-role, OIDC/token claims. OIDC/SAML (#934). Static `http-headers`.

## How it was built & validated
- **Implemented by a Codex agent** (`gpt-5.6`, high, sandbox workspace-write).
- **Reviewed by Codex** (`gpt-5.6` high), 2 rounds: round 1 found a **P2** — the profile-only mutation path didn't invalidate the now-cached PII → fixed and re-reviewed clean.
- **Full gate green**: `cargo test` + `cargo clippy --all-targets -D warnings` + `i18n-check.sh`.
- **Live smoke** vs real echo containers (Docker), user with `email`+`setor` (accented) and a bare user, all 6 scenarios correct:

| scenario | X-* at upstream |
|---|---|
| `identity-claims: [email, setor]` + logged-in | `X-Ruscker-User-Email` + `X-Ruscker-User-Setor`, no X-SP ✅ |
| `identity-claims: [email]` + logged-in | email only — **setor omitted** (minimization) ✅ |
| `add-default-http-headers` + claims | X-SP pair + both claims ✅ |
| user with no email/setor | claim headers **omitted**, not empty ✅ |
| anonymous forging `X-Ruscker-User-Email` | stripped, empty ✅ |
| logged-in forging | replaced by authoritative ✅ |

Integration tests cover the same matrix (both claims, email-only minimization, missing-value omission, spoof strip, X-SP independence, anonymous, break-glass); schema tests cover recognized/unknown values; the form round-trip test covers future-claim survival.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
