### PR TITLE
feat: standardize admin module titles/subtitles per the design doc (#989)

### DIFF
--- a/crates/ruscker-admin/assets/i18n/en/landing.ftl
+++ b/crates/ruscker-admin/assets/i18n/en/landing.ftl
@@ -26,7 +26,7 @@ type-api-abbr = API
 type-link-abbr = LNK
 
 # Admin shell
-admin-nav-dashboard = Dashboard
+admin-nav-dashboard = Containers
 admin-nav-apps = Apps
 admin-nav-images = Media
 admin-nav-credentials = Credentials
@@ -66,7 +66,7 @@ admin-blocks-pos-top = Top
 admin-blocks-pos-bottom = Bottom
 admin-blocks-done = Done
 admin-blocks-delete-block = Delete block
-admin-nav-audit = Audit log
+admin-nav-audit = Activity
 admin-nav-portal = Portal
 admin-nav-logout = Sign out
 role-current = Your access level
@@ -103,8 +103,8 @@ admin-pw-submit = Save password
 admin-pw-reveal = Show/hide password
 # — User management (admin)
 admin-nav-users = Users
-admin-users-title = Users
-admin-users-subtitle = Create and manage who can sign in, and at which level.
+admin-users-title = User Management
+admin-users-subtitle = User creation and editing.
 admin-users-edit = Edit user
 admin-users-edit-title = Edit user
 admin-users-edit-subtitle = Update access and profile in one save.
@@ -145,7 +145,7 @@ admin-users-save-profile = Save profile
 admin-users-import-review = Review import
 admin-users-import-change = Change file
 admin-users-import-choose = Choose CSV file
-admin-users-import-help = Columns: username, role, password, groups, setor, email, celular. First row is the header.
+admin-users-import-help = Columns: username, role, password, groups, setor, email, celular. First row is the header. Separator: comma (,); on Windows, save the CSV as Unix-style UTF-8. Roles are in English: viewer, editor, admin.
 admin-users-import-title = Import users
 admin-users-import-preview-title = Import preview
 admin-users-import-col-status = Status
@@ -178,7 +178,7 @@ admin-users-generate-password = Generate random password
 admin-users-flash-exists = A user with that name already exists.
 
 # Admin dashboard
-admin-dashboard-title = Monitoring dashboard
+admin-dashboard-title = Container Management
 admin-dashboard-subtitle = Live container and session state
 admin-dashboard-live = Live
 admin-dashboard-filter-search = Filter app…
@@ -218,9 +218,9 @@ admin-login-error-wrong = Wrong token. Please try again.
 admin-login-back-portal = ← public portal
 
 # Apps list
-admin-specs-title = Apps
+admin-specs-title = Application Management
 admin-specs-refresh = Refresh
-admin-specs-subtitle = Spec catalog stored in the database
+admin-specs-subtitle = Information and specifications for the application images
 admin-specs-empty = No apps yet. Use { $cmd } to import from a YAML.
 admin-specs-add = Add app
 admin-specs-col-id = ID
@@ -334,7 +334,8 @@ spec-form-error-stale = Someone else saved this app while you were editing. Revi
 
 # Admin image library
 admin-images-title = Media library
-admin-images-subtitle = PNG, JPEG and WebP are converted to WebP. SVG passes through.
+admin-images-subtitle = Images used across the portal
+admin-images-formats-help = PNG, JPEG and WebP are converted to WebP. SVG passes through.
 admin-images-drop-here = Click to pick a file
 admin-images-formats = PNG · JPEG · WebP · SVG · up to 10 MB
 admin-images-upload = Upload
@@ -358,8 +359,8 @@ admin-images-type-all = All types
 admin-images-no-match = No images match your search.
 
 # Admin credentials
-admin-creds-title = Registry credentials
-admin-creds-subtitle = Passwords are encrypted at rest with AES-256-GCM. They never appear in the YAML or in the panel after saving.
+admin-creds-title = Credential Management
+admin-creds-subtitle = Create credentials. They are encrypted at rest with AES-256-GCM and never appear in the YAML or in the panel after saving.
 admin-creds-form-title = Add / update credential
 admin-creds-name = Name
 admin-creds-name-help = Unique identifier. Use the same name in your specs.
@@ -380,9 +381,9 @@ admin-creds-key-missing-title = RUSCKER_MASTER_KEY is not configured
 admin-creds-key-missing-help = The credentials store needs a 32-byte key as hex (64 chars) or base64 (44 chars). Generate one with:
 
 # Admin landing editor
-admin-landing-title = Portal appearance
+admin-landing-title = Portal Appearance
 admin-landing-crumb = Settings · Landing page
-admin-landing-subtitle = Configure how the public portal looks to visitors.
+admin-landing-subtitle = Logo, header bars, footer and other display settings.
 admin-landing-scope-help = These options (colors, intro texts, SEO, custom blocks) apply to the public landing live — saved here, shown on the next view, no restart. It's a fixed set of settings, not an arbitrary-CSS editor.
 admin-landing-open-portal = Open portal
 admin-landing-save = Save
@@ -428,8 +429,8 @@ admin-landing-analytics-key-help = GA4 measurement id (G-XXXX), Plausible domain
 
 
 # Admin audit log
-admin-audit-title = Audit log
-admin-audit-subtitle = Every admin change, newest first. Capped at 100 events per query.
+admin-audit-title = Administrative Activity History
+admin-audit-subtitle = Administrative activity, newest first. Capped at 100 events per query.
 admin-audit-family = Family
 admin-audit-family-all = All actions
 admin-audit-family-spec = Apps
@@ -591,8 +592,8 @@ spec-form-error-volume = Each volume must be /host:/container (optionally :ro).
 spec-form-error-network = Invalid Docker network name (must start with a letter or digit, then letters/digits/_/./-).
 spec-form-error-env = Each environment variable must be NAME=value, with a valid NAME (letters, digits, _; starting with a letter or _). Fix or remove the invalid line.
 admin-nav-logs = Logs
-admin-proclog-title = Logs
-admin-proclog-subtitle = Event stream from the balancer and replicas
+admin-proclog-title = Log Audit
+admin-proclog-subtitle = Event logs from the balancer and replicas.
 admin-proclog-unavailable = Log buffer not wired (the server started without the logging layer).
 admin-proclog-empty = No logs captured yet at this level. New events show up here as they happen; run the server with -v to include info-level logs.
 
@@ -737,8 +738,8 @@ admin-landing-logo-add = Add logo
 
 # — Disk management (admin) #453
 admin-nav-disk = Disk
-admin-disk-title = Disk
-admin-disk-subtitle = Reclaim space from stopped containers and unused images.
+admin-disk-title = Disk Management
+admin-disk-subtitle = Disk monitoring and reclaiming idle space from stopped containers and unused images.
 admin-disk-backend-missing = The Docker backend isn't connected — start the server with `--docker` to manage disk.
 admin-disk-containers-heading = Ruscker containers
 admin-disk-prune = Remove stopped
@@ -866,8 +867,8 @@ admin-landing-show-highlights-help = Shows the carousel of featured apps above t
 
 # Groups page (#503, read-only)
 admin-nav-groups = Groups
-admin-groups-title = Groups
-admin-groups-subtitle = Groups derived from apps (access-groups) and users — read-only. Edit on the user or the app.
+admin-groups-title = Group Management
+admin-groups-subtitle = Create and edit the groups derived from apps and users.
 admin-groups-members = Members
 admin-groups-apps = Apps
 admin-groups-public-title = Public apps

--- a/crates/ruscker-admin/assets/i18n/es/landing.ftl
+++ b/crates/ruscker-admin/assets/i18n/es/landing.ftl
@@ -26,7 +26,7 @@ type-api-abbr = API
 type-link-abbr = LNK
 
 # Admin shell
-admin-nav-dashboard = Panel
+admin-nav-dashboard = Contenedores
 admin-nav-apps = Aplicaciones
 admin-nav-images = Multimedia
 admin-nav-credentials = Credenciales
@@ -66,7 +66,7 @@ admin-blocks-pos-top = Superior
 admin-blocks-pos-bottom = Base
 admin-blocks-done = Listo
 admin-blocks-delete-block = Eliminar bloque
-admin-nav-audit = Auditoría
+admin-nav-audit = Actividades
 admin-nav-portal = Portal
 admin-nav-logout = Salir
 role-current = Tu nivel de acceso
@@ -103,8 +103,8 @@ admin-pw-submit = Guardar contraseña
 admin-pw-reveal = Mostrar/ocultar contraseña
 # — Gestión de usuarios (admin)
 admin-nav-users = Usuarios
-admin-users-title = Usuarios
-admin-users-subtitle = Crea y gestiona quién accede al panel y con qué nivel.
+admin-users-title = Gestión de Usuarios
+admin-users-subtitle = Creación y edición de usuarios.
 admin-users-edit = Editar usuario
 admin-users-edit-title = Editar usuario
 admin-users-edit-subtitle = Actualiza el acceso y el perfil con un único guardado.
@@ -145,7 +145,7 @@ admin-users-save-profile = Guardar perfil
 admin-users-import-review = Revisar importación
 admin-users-import-change = Cambiar archivo
 admin-users-import-choose = Elegir archivo CSV
-admin-users-import-help = Columnas: username, role, password, groups, setor, email, celular. La primera fila es el encabezado.
+admin-users-import-help = Columnas: username, role, password, groups, setor, email, celular. La primera fila es el encabezado. Separador: coma (,); en Windows, guarda el CSV en formato Unix con encoding UTF-8. Los roles van en inglés: viewer, editor, admin.
 admin-users-import-title = Importar usuarios
 admin-users-import-preview-title = Vista previa de importación
 admin-users-import-col-status = Estado
@@ -178,7 +178,7 @@ admin-users-generate-password = Generar contraseña aleatoria
 admin-users-flash-exists = Ya existe un usuario con ese nombre.
 
 # Admin dashboard
-admin-dashboard-title = Panel de monitoreo
+admin-dashboard-title = Gestión de Contenedores
 admin-dashboard-subtitle = Estado de contenedores y sesiones en tiempo real
 admin-dashboard-live = En vivo
 admin-dashboard-filter-search = Filtrar app…
@@ -218,9 +218,9 @@ admin-login-error-wrong = Token incorrecto. Intente de nuevo.
 admin-login-back-portal = ← portal público
 
 # Apps list
-admin-specs-title = Aplicaciones
+admin-specs-title = Gestión de Aplicaciones
 admin-specs-refresh = Recargar
-admin-specs-subtitle = Catálogo de specs en la base de datos
+admin-specs-subtitle = Información y especificaciones de las imágenes de las aplicaciones
 admin-specs-empty = Aún no hay aplicaciones. Use { $cmd } para importar desde YAML.
 admin-specs-add = Añadir aplicación
 admin-specs-col-id = ID
@@ -334,7 +334,8 @@ spec-form-error-stale = Otra persona guardó esta app mientras editabas. Revisa 
 
 # Admin image library
 admin-images-title = Biblioteca multimedia
-admin-images-subtitle = PNG, JPEG y WebP se convierten a WebP. SVG pasa directo.
+admin-images-subtitle = Imágenes utilizadas por el portal
+admin-images-formats-help = PNG, JPEG y WebP se convierten a WebP. SVG pasa directo.
 admin-images-drop-here = Haga clic para elegir un archivo
 admin-images-formats = PNG · JPEG · WebP · SVG · hasta 10 MB
 admin-images-upload = Subir
@@ -358,8 +359,8 @@ admin-images-type-all = Todos los tipos
 admin-images-no-match = Ninguna imagen coincide con la búsqueda.
 
 # Admin credentials
-admin-creds-title = Credenciales del registry
-admin-creds-subtitle = Las contraseñas se cifran en reposo con AES-256-GCM. Nunca aparecen en el YAML ni en el panel después de guardarlas.
+admin-creds-title = Gestión de Credenciales
+admin-creds-subtitle = Creación de credenciales. Se cifran en reposo con AES-256-GCM y nunca aparecen en el YAML ni en el panel después de guardarlas.
 admin-creds-form-title = Añadir / actualizar credencial
 admin-creds-name = Nombre
 admin-creds-name-help = Identificador único. Use el mismo nombre en sus specs.
@@ -380,9 +381,9 @@ admin-creds-key-missing-title = RUSCKER_MASTER_KEY no está configurada
 admin-creds-key-missing-help = El store de credenciales necesita una clave de 32 bytes en hex (64 chars) o base64 (44 chars). Genere una con:
 
 # Admin landing editor
-admin-landing-title = Apariencia del portal
+admin-landing-title = Apariencia del Portal
 admin-landing-crumb = Ajustes · Landing page
-admin-landing-subtitle = Configure cómo se ve el portal público para los visitantes.
+admin-landing-subtitle = Configuración de logo, barras, pies de página, etc.
 admin-landing-scope-help = Estas opciones (colores, textos de introducción, SEO, bloques personalizados) se aplican a la portada pública en vivo — guardadas aquí, mostradas en la próxima visita, sin reinicio. Es un conjunto fijo de ajustes, no un editor de CSS arbitrario.
 admin-landing-open-portal = Abrir portal
 admin-landing-save = Guardar
@@ -428,8 +429,8 @@ admin-landing-analytics-key-help = ID de medición de GA4 (G-XXXX), dominio de P
 
 
 # Admin audit log
-admin-audit-title = Auditoría
-admin-audit-subtitle = Todos los cambios del admin, del más reciente al más antiguo. Tope de 100 eventos por consulta.
+admin-audit-title = Historial de Actividades Administrativas
+admin-audit-subtitle = Visualización de actividades administrativas, de la más reciente a la más antigua. Tope de 100 eventos por consulta.
 admin-audit-family = Familia
 admin-audit-family-all = Todas las acciones
 admin-audit-family-spec = Aplicaciones
@@ -591,8 +592,8 @@ spec-form-error-volume = Cada volumen debe ser /host:/contenedor (opcional :ro).
 spec-form-error-network = Nombre de red Docker inválido (debe empezar con letra o número, luego letras/números/_/./-).
 spec-form-error-env = Cada variable de entorno debe ser NOMBRE=valor, con un NOMBRE válido (letras, números, _; empezando por letra o _). Corrige o elimina la línea inválida.
 admin-nav-logs = Registros
-admin-proclog-title = Registros
-admin-proclog-subtitle = Flujo de eventos del balanceador y las réplicas
+admin-proclog-title = Auditoría de Logs
+admin-proclog-subtitle = Visualización de los logs de eventos del balanceador y las réplicas.
 admin-proclog-unavailable = Búfer de registro no disponible (el servidor inició sin la capa de logging).
 admin-proclog-empty = Aún no se ha capturado ningún registro en este nivel. Los nuevos eventos aparecen aquí a medida que ocurren; ejecuta el servidor con -v para incluir registros de nivel info.
 
@@ -737,8 +738,8 @@ admin-landing-logo-add = Añadir logo
 
 # — Gestión de disco (admin) #453
 admin-nav-disk = Disco
-admin-disk-title = Disco
-admin-disk-subtitle = Recupera espacio de contenedores detenidos e imágenes sin usar.
+admin-disk-title = Gestión del Disco
+admin-disk-subtitle = Monitoreo del disco y recuperación de espacio ocioso de contenedores detenidos e imágenes sin usar.
 admin-disk-backend-missing = El backend de Docker no está conectado — inicia el servidor con `--docker` para gestionar el disco.
 admin-disk-containers-heading = Contenedores de Ruscker
 admin-disk-prune = Eliminar detenidos
@@ -866,8 +867,8 @@ admin-landing-show-highlights-help = Muestra el carrusel de apps destacadas enci
 
 # Groups page (#503, read-only)
 admin-nav-groups = Grupos
-admin-groups-title = Grupos
-admin-groups-subtitle = Grupos derivados de los apps (access-groups) y usuarios — solo lectura. Edita en el usuario o el app.
+admin-groups-title = Gestión de Grupos
+admin-groups-subtitle = Creación y edición de los grupos derivados de los apps y usuarios.
 admin-groups-members = Miembros
 admin-groups-apps = Apps
 admin-groups-public-title = Apps públicas

--- a/crates/ruscker-admin/assets/i18n/fr/landing.ftl
+++ b/crates/ruscker-admin/assets/i18n/fr/landing.ftl
@@ -26,7 +26,7 @@ type-api-abbr = API
 type-link-abbr = LNK
 
 # Admin shell
-admin-nav-dashboard = Tableau de bord
+admin-nav-dashboard = Conteneurs
 admin-nav-apps = Applications
 admin-nav-images = Médias
 admin-nav-credentials = Identifiants
@@ -66,7 +66,7 @@ admin-blocks-pos-top = Haut
 admin-blocks-pos-bottom = Bas
 admin-blocks-done = Terminer
 admin-blocks-delete-block = Supprimer le bloc
-admin-nav-audit = Journal
+admin-nav-audit = Activités
 admin-nav-portal = Portail
 admin-nav-logout = Déconnexion
 role-current = Votre niveau d'accès
@@ -103,8 +103,8 @@ admin-pw-submit = Enregistrer le mot de passe
 admin-pw-reveal = Afficher/masquer le mot de passe
 # — Gestion des utilisateurs (admin)
 admin-nav-users = Utilisateurs
-admin-users-title = Utilisateurs
-admin-users-subtitle = Créez et gérez qui peut se connecter, et à quel niveau.
+admin-users-title = Gestion des Utilisateurs
+admin-users-subtitle = Création et édition des utilisateurs.
 admin-users-edit = Modifier l’utilisateur
 admin-users-edit-title = Modifier l’utilisateur
 admin-users-edit-subtitle = Mettez à jour l’accès et le profil en un seul enregistrement.
@@ -145,7 +145,7 @@ admin-users-save-profile = Enregistrer le profil
 admin-users-import-review = Vérifier l'import
 admin-users-import-change = Changer de fichier
 admin-users-import-choose = Choisir un fichier CSV
-admin-users-import-help = Colonnes : username, role, password, groups, setor, email, celular. La première ligne est l'en-tête.
+admin-users-import-help = Colonnes : username, role, password, groups, setor, email, celular. La première ligne est l'en-tête. Séparateur : virgule (,) ; sous Windows, enregistrez le CSV au format Unix en UTF-8. Les rôles sont en anglais : viewer, editor, admin.
 admin-users-import-title = Importer des utilisateurs
 admin-users-import-preview-title = Aperçu de l'import
 admin-users-import-col-status = Statut
@@ -178,7 +178,7 @@ admin-users-generate-password = Générer un mot de passe aléatoire
 admin-users-flash-exists = Un utilisateur portant ce nom existe déjà.
 
 # Admin dashboard
-admin-dashboard-title = Tableau de bord
+admin-dashboard-title = Gestion des Conteneurs
 admin-dashboard-subtitle = État des conteneurs et des sessions en temps réel
 admin-dashboard-live = En direct
 admin-dashboard-filter-search = Filtrer une app…
@@ -218,9 +218,9 @@ admin-login-error-wrong = Jeton incorrect. Réessayez.
 admin-login-back-portal = ← portail public
 
 # Apps list
-admin-specs-title = Applications
+admin-specs-title = Gestion des Applications
 admin-specs-refresh = Actualiser
-admin-specs-subtitle = Catalogue de specs dans la base
+admin-specs-subtitle = Informations et spécifications des images des applications
 admin-specs-empty = Aucune application. Utilisez { $cmd } pour importer un YAML.
 admin-specs-add = Ajouter une application
 admin-specs-col-id = ID
@@ -334,7 +334,8 @@ spec-form-error-stale = Une autre personne a enregistré cette app pendant votre
 
 # Admin image library
 admin-images-title = Bibliothèque de médias
-admin-images-subtitle = PNG, JPEG et WebP sont convertis en WebP. Le SVG passe tel quel.
+admin-images-subtitle = Images utilisées par le portail
+admin-images-formats-help = PNG, JPEG et WebP sont convertis en WebP. Le SVG passe tel quel.
 admin-images-drop-here = Cliquez pour choisir un fichier
 admin-images-formats = PNG · JPEG · WebP · SVG · jusqu'à 10 Mo
 admin-images-upload = Envoyer
@@ -358,8 +359,8 @@ admin-images-type-all = Tous les types
 admin-images-no-match = Aucune image ne correspond à la recherche.
 
 # Admin credentials
-admin-creds-title = Identifiants registry
-admin-creds-subtitle = Les mots de passe sont chiffrés au repos avec AES-256-GCM. Ils n'apparaissent jamais dans le YAML ni dans le panneau après sauvegarde.
+admin-creds-title = Gestion des Identifiants
+admin-creds-subtitle = Création d'identifiants. Ils sont chiffrés au repos avec AES-256-GCM et n'apparaissent jamais dans le YAML ni dans le panneau après sauvegarde.
 admin-creds-form-title = Ajouter / mettre à jour
 admin-creds-name = Nom
 admin-creds-name-help = Identifiant unique. Utilisez le même nom dans vos specs.
@@ -380,9 +381,9 @@ admin-creds-key-missing-title = RUSCKER_MASTER_KEY n'est pas configurée
 admin-creds-key-missing-help = Le store d'identifiants a besoin d'une clé de 32 octets en hex (64 chars) ou base64 (44 chars). Générez-en une avec :
 
 # Admin landing editor
-admin-landing-title = Apparence du portail
+admin-landing-title = Apparence du Portail
 admin-landing-crumb = Paramètres · Page d'accueil
-admin-landing-subtitle = Configurez l'apparence du portail public pour les visiteurs.
+admin-landing-subtitle = Configuration du logo, des barres, du pied de page, etc.
 admin-landing-scope-help = Ces options (couleurs, textes d'intro, SEO, blocs personnalisés) s'appliquent à la page d'accueil publique en direct — enregistrées ici, affichées à la prochaine visite, sans redémarrage. C'est un ensemble fixe de réglages, pas un éditeur de CSS arbitraire.
 admin-landing-open-portal = Ouvrir le portail
 admin-landing-save = Enregistrer
@@ -428,8 +429,8 @@ admin-landing-analytics-key-help = ID de mesure GA4 (G-XXXX), domaine Plausible,
 
 
 # Admin audit log
-admin-audit-title = Journal d'audit
-admin-audit-subtitle = Tous les changements admin, du plus récent au plus ancien. Limité à 100 événements par requête.
+admin-audit-title = Historique des Activités Administratives
+admin-audit-subtitle = Visualisation des activités administratives, de la plus récente à la plus ancienne. Limité à 100 événements par requête.
 admin-audit-family = Famille
 admin-audit-family-all = Toutes les actions
 admin-audit-family-spec = Applications
@@ -591,8 +592,8 @@ spec-form-error-volume = Chaque volume doit être /hôte:/conteneur (optionnel :
 spec-form-error-network = Nom de réseau Docker invalide (doit commencer par une lettre ou un chiffre, puis lettres/chiffres/_/./-).
 spec-form-error-env = Chaque variable d'environnement doit être NOM=valeur, avec un NOM valide (lettres, chiffres, _ ; commençant par une lettre ou _). Corrigez ou supprimez la ligne invalide.
 admin-nav-logs = Journaux
-admin-proclog-title = Journaux
-admin-proclog-subtitle = Flux d'événements de l'équilibreur et des répliques
+admin-proclog-title = Audit des Journaux
+admin-proclog-subtitle = Visualisation des journaux d'événements de l'équilibreur et des répliques.
 admin-proclog-unavailable = Tampon de journal indisponible (le serveur a démarré sans la couche de journalisation).
 admin-proclog-empty = Aucun journal capturé pour l'instant à ce niveau. Les nouveaux événements apparaissent ici au fur et à mesure ; lancez le serveur avec -v pour inclure les journaux de niveau info.
 
@@ -737,8 +738,8 @@ admin-landing-logo-add = Ajouter un logo
 
 # — Gestion du disque (admin) #453
 admin-nav-disk = Disque
-admin-disk-title = Disque
-admin-disk-subtitle = Récupérez de l'espace des conteneurs arrêtés et des images inutilisées.
+admin-disk-title = Gestion du Disque
+admin-disk-subtitle = Surveillance du disque et récupération de l'espace des conteneurs arrêtés et des images inutilisées.
 admin-disk-backend-missing = Le backend Docker n'est pas connecté — lancez le serveur avec `--docker` pour gérer le disque.
 admin-disk-containers-heading = Conteneurs Ruscker
 admin-disk-prune = Supprimer les arrêtés
@@ -866,8 +867,8 @@ admin-landing-show-highlights-help = Affiche le carrousel des apps en avant au-d
 
 # Groups page (#503, read-only)
 admin-nav-groups = Groupes
-admin-groups-title = Groupes
-admin-groups-subtitle = Groupes dérivés des apps (access-groups) et des utilisateurs — lecture seule. Modifiez sur l'utilisateur ou l'app.
+admin-groups-title = Gestion des Groupes
+admin-groups-subtitle = Création et édition des groupes dérivés des apps et des utilisateurs.
 admin-groups-members = Membres
 admin-groups-apps = Apps
 admin-groups-public-title = Apps publiques

--- a/crates/ruscker-admin/assets/i18n/pt/landing.ftl
+++ b/crates/ruscker-admin/assets/i18n/pt/landing.ftl
@@ -30,7 +30,7 @@ type-api-abbr = API
 type-link-abbr = LNK
 
 # Admin shell
-admin-nav-dashboard = Painel
+admin-nav-dashboard = Containers
 admin-nav-apps = Aplicações
 admin-nav-images = Mídia
 admin-nav-credentials = Credenciais
@@ -70,7 +70,7 @@ admin-blocks-pos-top = Topo
 admin-blocks-pos-bottom = Base
 admin-blocks-done = Concluir
 admin-blocks-delete-block = Excluir bloco
-admin-nav-audit = Auditoria
+admin-nav-audit = Atividades
 admin-nav-portal = Portal
 admin-nav-logout = Sair
 role-current = Seu nível de acesso
@@ -107,8 +107,8 @@ admin-pw-submit = Salvar senha
 admin-pw-reveal = Mostrar/ocultar senha
 # — Gestão de usuários (admin)
 admin-nav-users = Usuários
-admin-users-title = Usuários
-admin-users-subtitle = Crie e gerencie quem acessa o painel e com qual nível.
+admin-users-title = Gestão de Usuários
+admin-users-subtitle = Criação e edição de usuários.
 admin-users-edit = Editar usuário
 admin-users-edit-title = Editar usuário
 admin-users-edit-subtitle = Atualize acesso e perfil em um único salvamento.
@@ -149,7 +149,7 @@ admin-users-save-profile = Salvar perfil
 admin-users-import-review = Revisar import
 admin-users-import-change = Trocar arquivo
 admin-users-import-choose = Escolher arquivo CSV
-admin-users-import-help = Colunas: username, role, password, groups, setor, email, celular. A primeira linha é o cabeçalho.
+admin-users-import-help = Colunas: username, role, password, groups, setor, email, celular. A primeira linha é o cabeçalho. Separador: vírgula (,); no Windows, salve o CSV no padrão Unix com encoding UTF-8. Papéis (role) em inglês: viewer, editor, admin.
 admin-users-import-title = Importar usuários
 admin-users-import-preview-title = Prévia da importação
 admin-users-import-col-status = Status
@@ -182,7 +182,7 @@ admin-users-generate-password = Gerar senha aleatória
 admin-users-flash-exists = Já existe um usuário com esse nome.
 
 # Admin dashboard
-admin-dashboard-title = Painel de monitoramento
+admin-dashboard-title = Gestão dos Containers
 admin-dashboard-subtitle = Estado dos containers e sessões em tempo real
 admin-dashboard-live = Ao vivo
 admin-dashboard-filter-search = Filtrar app…
@@ -222,9 +222,9 @@ admin-login-error-wrong = Token incorreto. Tente de novo.
 admin-login-back-portal = ← portal público
 
 # Apps list
-admin-specs-title = Aplicações
+admin-specs-title = Gestão das Aplicações
 admin-specs-refresh = Recarregar
-admin-specs-subtitle = Catálogo de specs no banco
+admin-specs-subtitle = Informações e especificações das imagens das aplicações
 admin-specs-empty = Nenhuma aplicação ainda. Use { $cmd } para importar de um YAML.
 admin-specs-add = Adicionar aplicação
 admin-specs-col-id = ID
@@ -338,7 +338,8 @@ spec-form-error-stale = Outra pessoa salvou este app enquanto você editava. Rev
 
 # Admin image library
 admin-images-title = Biblioteca de mídia
-admin-images-subtitle = PNG, JPEG e WebP são convertidos para WebP. SVG passa direto.
+admin-images-subtitle = Imagens utilizadas pelo portal
+admin-images-formats-help = PNG, JPEG e WebP são convertidos para WebP. SVG passa direto.
 admin-images-drop-here = Clique para escolher um arquivo
 admin-images-formats = PNG · JPEG · WebP · SVG · até 10 MB
 admin-images-upload = Enviar
@@ -362,8 +363,8 @@ admin-images-type-all = Todos os tipos
 admin-images-no-match = Nenhuma imagem corresponde à busca.
 
 # Admin credentials
-admin-creds-title = Credenciais do registry
-admin-creds-subtitle = Senhas criptografadas em repouso com AES-256-GCM. Nunca aparecem no YAML nem no painel depois de salvas.
+admin-creds-title = Gestão de Credenciais
+admin-creds-subtitle = Criação de credenciais. As credenciais são criptografadas em repouso com AES-256-GCM. Nunca aparecem no YAML nem no painel depois de salvas.
 admin-creds-form-title = Adicionar / atualizar credencial
 admin-creds-name = Nome
 admin-creds-name-help = Identificador único. Use o mesmo nome nas specs.
@@ -384,9 +385,9 @@ admin-creds-key-missing-title = RUSCKER_MASTER_KEY não está configurada
 admin-creds-key-missing-help = O store de credenciais precisa de uma chave de 32 bytes em hex (64 chars) ou base64 (44 chars). Gere uma assim:
 
 # Admin landing editor
-admin-landing-title = Aparência do portal
+admin-landing-title = Aparência do Portal
 admin-landing-crumb = Configurações · Landing page
-admin-landing-subtitle = Configure como o portal público aparece para os visitantes.
+admin-landing-subtitle = Configurações de logo, barras, rodapés etc.
 admin-landing-scope-help = Estas opções (cores, textos de introdução, SEO, blocos customizados) se aplicam à landing pública ao vivo — salvas aqui, exibidas na próxima visita, sem restart. É um conjunto fixo de configurações, não um editor de CSS arbitrário.
 admin-landing-open-portal = Abrir portal
 admin-landing-save = Salvar
@@ -432,8 +433,8 @@ admin-landing-analytics-key-help = ID de medição do GA4 (G-XXXX), domínio do 
 
 
 # Admin audit log
-admin-audit-title = Auditoria
-admin-audit-subtitle = Todas as alterações administrativas, do mais recente para o mais antigo. Limite de 100 eventos por consulta.
+admin-audit-title = Histórico de Atividades Administrativas
+admin-audit-subtitle = Visualização de atividades administrativas, do mais recente para o mais antigo. Limite de 100 eventos por consulta.
 admin-audit-family = Família
 admin-audit-family-all = Todas as ações
 admin-audit-family-spec = Aplicações
@@ -595,8 +596,8 @@ spec-form-error-volume = Cada volume deve ser /host:/container (opcional :ro).
 spec-form-error-network = Nome de rede Docker inválido (precisa começar com letra ou número, depois letras/números/_/./-).
 spec-form-error-env = Cada variável de ambiente deve ser NOME=valor, com NOME válido (letras, números, _; começando por letra ou _). Corrija ou remova a linha inválida.
 admin-nav-logs = Logs
-admin-proclog-title = Logs
-admin-proclog-subtitle = Fluxo de eventos do balanceador e das réplicas
+admin-proclog-title = Auditoria de Logs
+admin-proclog-subtitle = Visualização dos logs de eventos do balanceador e das réplicas.
 admin-proclog-unavailable = Buffer de log não disponível (o servidor iniciou sem a camada de logging).
 admin-proclog-empty = Nenhum log capturado ainda neste nível. Novos eventos aparecem aqui conforme acontecem; rode o servidor com -v para incluir logs de nível info.
 
@@ -741,8 +742,8 @@ admin-landing-logo-add = Adicionar logo
 
 # — Gestão de disco (admin) #453
 admin-nav-disk = Disco
-admin-disk-title = Disco
-admin-disk-subtitle = Recupere espaço de containers parados e imagens não usadas.
+admin-disk-title = Gestão do Disco
+admin-disk-subtitle = Monitoramento do disco e recuperação de espaço ocioso de containers parados e imagens não usadas.
 admin-disk-backend-missing = O backend Docker não está conectado — inicie o servidor com `--docker` para gerenciar disco.
 admin-disk-containers-heading = Containers do Ruscker
 admin-disk-prune = Remover parados
@@ -870,8 +871,8 @@ admin-landing-show-highlights-help = Exibe o carrossel de apps em destaque acima
 
 # Groups page (#503, read-only)
 admin-nav-groups = Grupos
-admin-groups-title = Grupos
-admin-groups-subtitle = Grupos derivados dos apps (access-groups) e usuários — somente leitura. Edite no usuário ou no app.
+admin-groups-title = Gestão de Grupos
+admin-groups-subtitle = Criação e edição dos grupos derivados dos apps e usuários.
 admin-groups-members = Membros
 admin-groups-apps = Apps
 admin-groups-public-title = Apps públicos

--- a/crates/ruscker-admin/templates/admin/images.html
+++ b/crates/ruscker-admin/templates/admin/images.html
@@ -52,6 +52,9 @@
     {{ self.t("admin-images-choose") }}
   </label>
   <span class="image-upload-hint">{{ self.t("admin-images-drop-here") }} · {{ self.t("admin-images-formats") }}</span>
+  {# Conversion note (#989): moved out of the page subtitle — it's upload
+     detail, not the module's purpose. #}
+  <span class="image-upload-hint">{{ self.t("admin-images-formats-help") }}</span>
 </form>
 
 {# ── Gallery grid ─────────────────────────────────────────── #}


### PR DESCRIPTION
Closes #989.

Applies the boneca texts (posted by the lead, 2026-07-17) across all four locales — the "Gestão de X" title pattern + purpose-stating subtitles, with technical detail demoted to in-context helpers.

## Changes by screen (pt)

| Tela | Título | Subtítulo |
|---|---|---|
| **Containers** (nav renomeada, ex-Painel) | Gestão dos Containers | Estado dos containers e sessões em tempo real |
| Aplicações | Gestão das Aplicações | Informações e especificações das imagens das aplicações |
| Aparência | Aparência do Portal | Configurações de logo, barras, rodapés etc. (helper de escopo já existia e bate com a boneca) |
| Mídia | Biblioteca de mídia | Imagens utilizadas pelo portal — a nota de conversão WebP desceu para o dropzone |
| Credenciais | Gestão de Credenciais | Criação de credenciais. Criptografadas em repouso com AES-256-GCM… |
| Usuários | Gestão de Usuários | Criação e edição de usuários. + helper do CSV (separador vírgula, Windows→Unix/UTF-8, roles em inglês) |
| Grupos | Gestão de Grupos | Criação e edição dos grupos derivados dos apps e usuários. |
| Logs | Auditoria de Logs | Visualização dos logs de eventos do balanceador e das réplicas. |
| Disco | Gestão do Disco | Monitoramento do disco e recuperação de espaço ocioso… |
| **Atividades** (nav renomeada, ex-Auditoria) | Histórico de Atividades Administrativas | Visualização de atividades administrativas… Limite de 100 eventos por consulta. |
| Sistema | (inalterado) | (inalterado) |

Duas normalizações editoriais sobre a boneca (gritar se discordar): "Histórico de Atividades Administrativa**s**" (concordância) e "**C**riação e edição de usuários." (maiúscula inicial, consistência).

Bonus: o subtítulo de Grupos dizia "somente leitura" — **desatualizado desde o #540** (grupos editáveis na v0.1.68); o texto novo corrige.

## Validação
- Gate completo verde (incl. `cargo test` cheio após editar os `.ftl` — regra da casa) + `i18n-check.sh`.
- Smoke real: serve vivo, as 12 telas admin renderizadas via curl — todos os H1/subtítulos novos conferidos, nav mostrando Containers/Atividades, helper de formatos presente na Mídia.

🤖 Generated with [Claude Code](https://claude.com/claude-code)