### PR TITLE
feat: per-app MFA policy fields — schema + form + validation (#1005 slice 1)

### DIFF
--- a/crates/ruscker-admin/assets/i18n/en/landing.ftl
+++ b/crates/ruscker-admin/assets/i18n/en/landing.ftl
@@ -326,6 +326,7 @@ spec-form-error-id-shape = ID must start with a letter and contain only letters,
 spec-form-error-id-duplicate = An app with that ID already exists.
 spec-form-error-name-required = Display name is required.
 spec-form-error-number = A numeric field has a non-numeric value.
+spec-form-error-mfa-days = “Ask again after N days” must be an integer between 0 and 30.
 spec-form-error-max-replicas-zero = Max containers must be at least 1 (0 means the app can never start).
 spec-form-error-cpu = CPU limit must be a positive number (e.g. 0.5).
 spec-form-error-memory = Memory limit must be a size like 512m or 1.5g.

--- a/crates/ruscker-admin/assets/i18n/en/landing.ftl
+++ b/crates/ruscker-admin/assets/i18n/en/landing.ftl
@@ -641,6 +641,11 @@ spec-help-access-groups = Groups that may see and reach the app (comma-separated
 spec-form-access-users = Allowed users
 spec-help-access-users = Usernames that may see and reach the app (comma-separated).
 spec-form-access-help = Both blank = card is open to everyone (including anonymous). With any value, only matching logged-in users — and admins always.
+spec-form-require-mfa = Require 2FA
+spec-form-require-mfa-hint = Users without a configured TOTP factor will be guided through enrollment on first access to a protected app.
+spec-form-mfa-validity = Ask again after N days
+spec-form-mfa-validity-hint = Blank = 7 days. Use 0 to require a new proof in every login session, with no remembered device.
+spec-form-mfa-staged-note = 2FA enforcement arrives in an upcoming release; for now, this app is not yet protected.
 spec-form-identity-headers = Send identity headers to the app
 spec-form-identity-headers-hint = Adds X-SP-UserId and X-SP-UserGroups for signed-in users. Off by default; enable only for apps that need and trust this identity.
 spec-form-identity-claims = Additional identity claims

--- a/crates/ruscker-admin/assets/i18n/es/landing.ftl
+++ b/crates/ruscker-admin/assets/i18n/es/landing.ftl
@@ -326,6 +326,7 @@ spec-form-error-id-shape = El ID debe empezar con una letra y contener solo letr
 spec-form-error-id-duplicate = Ya existe una aplicación con ese ID.
 spec-form-error-name-required = El nombre visible es obligatorio.
 spec-form-error-number = Un campo numérico tiene un valor no numérico.
+spec-form-error-mfa-days = “Solicitar de nuevo después de N días” debe ser un entero entre 0 y 30.
 spec-form-error-max-replicas-zero = Máx. de contenedores debe ser al menos 1 (0 hace que la app nunca inicie).
 spec-form-error-cpu = El límite de CPU debe ser un número positivo (ej.: 0.5).
 spec-form-error-memory = El límite de memoria debe ser un tamaño como 512m o 1.5g.

--- a/crates/ruscker-admin/assets/i18n/es/landing.ftl
+++ b/crates/ruscker-admin/assets/i18n/es/landing.ftl
@@ -641,6 +641,11 @@ spec-help-access-groups = Grupos que pueden ver y acceder a la app (separados po
 spec-form-access-users = Usuarios permitidos
 spec-help-access-users = Usuarios que pueden ver y acceder a la app (separados por comas).
 spec-form-access-help = Ambos vacíos = tarjeta abierta a todos (incluido anónimo). Con algún valor, solo usuarios conectados que coincidan — y los admins siempre.
+spec-form-require-mfa = Exigir 2FA
+spec-form-require-mfa-hint = Los usuarios sin un factor TOTP configurado recibirán instrucciones para registrarlo en el primer acceso a una app protegida.
+spec-form-mfa-validity = Volver a solicitar después de N días
+spec-form-mfa-validity-hint = Vacío = 7 días. Usa 0 para exigir una nueva prueba en cada sesión de inicio de sesión, sin dispositivo recordado.
+spec-form-mfa-staged-note = La aplicación de 2FA llegará en una próxima versión; por ahora, esta app aún no está protegida.
 spec-form-identity-headers = Enviar cabeceras de identidad a la app
 spec-form-identity-headers-hint = Añade X-SP-UserId y X-SP-UserGroups para usuarios autenticados. Desactivado por defecto; actívalo solo para apps que necesiten y confíen en esta identidad.
 spec-form-identity-claims = Datos de identidad adicionales

--- a/crates/ruscker-admin/assets/i18n/fr/landing.ftl
+++ b/crates/ruscker-admin/assets/i18n/fr/landing.ftl
@@ -326,6 +326,7 @@ spec-form-error-id-shape = L'ID doit commencer par une lettre et contenir unique
 spec-form-error-id-duplicate = Une application avec cet ID existe déjà.
 spec-form-error-name-required = Le nom d'affichage est obligatoire.
 spec-form-error-number = Un champ numérique a une valeur non numérique.
+spec-form-error-mfa-days = « Redemander après N jours » doit être un entier entre 0 et 30.
 spec-form-error-max-replicas-zero = Le nombre max. de conteneurs doit être au moins 1 (0 empêche l'app de démarrer).
 spec-form-error-cpu = La limite CPU doit être un nombre positif (ex. 0.5).
 spec-form-error-memory = La limite mémoire doit être une taille comme 512m ou 1.5g.

--- a/crates/ruscker-admin/assets/i18n/fr/landing.ftl
+++ b/crates/ruscker-admin/assets/i18n/fr/landing.ftl
@@ -641,6 +641,11 @@ spec-help-access-groups = Groupes qui peuvent voir et atteindre l'app (séparés
 spec-form-access-users = Utilisateurs autorisés
 spec-help-access-users = Utilisateurs qui peuvent voir et atteindre l'app (séparés par des virgules).
 spec-form-access-help = Les deux vides = carte ouverte à tous (y compris anonyme). Avec une valeur, seuls les utilisateurs connectés correspondants — et toujours les admins.
+spec-form-require-mfa = Exiger la 2FA
+spec-form-require-mfa-hint = Les utilisateurs sans facteur TOTP configuré seront guidés pour l’inscrire lors du premier accès à une app protégée.
+spec-form-mfa-validity = Redemander après N jours
+spec-form-mfa-validity-hint = Vide = 7 jours. Utilisez 0 pour exiger une nouvelle preuve à chaque session de connexion, sans appareil mémorisé.
+spec-form-mfa-staged-note = L’application de la 2FA arrivera dans une prochaine version ; pour l’instant, cette app n’est pas encore protégée.
 spec-form-identity-headers = Envoyer les en-têtes d’identité à l’app
 spec-form-identity-headers-hint = Ajoute X-SP-UserId et X-SP-UserGroups pour les utilisateurs connectés. Désactivé par défaut ; activez uniquement pour les apps qui ont besoin de cette identité et lui font confiance.
 spec-form-identity-claims = Attributs d’identité supplémentaires

--- a/crates/ruscker-admin/assets/i18n/pt/landing.ftl
+++ b/crates/ruscker-admin/assets/i18n/pt/landing.ftl
@@ -645,6 +645,11 @@ spec-help-access-groups = Grupos que podem ver e acessar o app (separados por v�
 spec-form-access-users = Usuários permitidos
 spec-help-access-users = Usuários que podem ver e acessar o app (separados por vírgula).
 spec-form-access-help = Ambos em branco = card aberto a todos (inclusive anônimos). Com algum valor, só usuários logados que combinam — e admins sempre.
+spec-form-require-mfa = Exigir 2FA
+spec-form-require-mfa-hint = Usuários sem um fator TOTP configurado serão orientados a cadastrá-lo no primeiro acesso a um app protegido.
+spec-form-mfa-validity = Solicitar novamente após N dias
+spec-form-mfa-validity-hint = Em branco = 7 dias. Use 0 para exigir nova prova em cada sessão de login, sem dispositivo lembrado.
+spec-form-mfa-staged-note = A exigência de 2FA chega em uma próxima versão; por enquanto, este app ainda não está protegido.
 spec-form-identity-headers = Enviar cabeçalhos de identidade ao app
 spec-form-identity-headers-hint = Adiciona X-SP-UserId e X-SP-UserGroups para usuários autenticados. Desativado por padrão; ative apenas para apps que precisam e confiam nessa identidade.
 spec-form-identity-claims = Dados adicionais de identidade

--- a/crates/ruscker-admin/assets/i18n/pt/landing.ftl
+++ b/crates/ruscker-admin/assets/i18n/pt/landing.ftl
@@ -330,6 +330,7 @@ spec-form-error-id-shape = ID deve começar com letra e conter apenas letras, n�
 spec-form-error-id-duplicate = Já existe uma aplicação com esse ID.
 spec-form-error-name-required = Nome de exibição é obrigatório.
 spec-form-error-number = Um campo numérico tem valor não numérico.
+spec-form-error-mfa-days = “Solicitar novamente após N dias” deve ser um inteiro entre 0 e 30.
 spec-form-error-max-replicas-zero = Máx. de containers deve ser ao menos 1 (0 faz o app nunca iniciar).
 spec-form-error-cpu = O limite de CPU deve ser um número positivo (ex.: 0.5).
 spec-form-error-memory = O limite de memória deve ser um tamanho como 512m ou 1.5g.

--- a/crates/ruscker-admin/src/routes/admin/spec_form.rs
+++ b/crates/ruscker-admin/src/routes/admin/spec_form.rs
@@ -652,9 +652,14 @@ impl SpecForm {
             access_groups: spec.access_groups.as_ref().map(|v| v.join(", ")).unwrap_or_default(),
             access_users: spec.access_users.as_ref().map(|v| v.join(", ")).unwrap_or_default(),
             require_mfa: checkbox(spec.effective_require_mfa()),
+            // Render the CLAMPED value: an imported `mfa-validity-days: 31`
+            // in the `max=30` number input would make the browser's
+            // constraint validation block the WHOLE form submit — silently,
+            // when the field is hidden by the require-mfa x-show (codex
+            // review, #1005). The clamp is what runtime applies anyway.
             mfa_validity_days: spec
                 .mfa_validity_days
-                .map(|days| days.to_string())
+                .map(|days| days.min(ruscker_config::MAX_MFA_VALIDITY_DAYS).to_string())
                 .unwrap_or_default(),
             add_default_http_headers: checkbox(spec.effective_add_default_http_headers()),
             identity_claim_email: checkbox(identity_claims.contains(&IdentityClaim::Email)),
@@ -2146,6 +2151,13 @@ proxy:
         let merged = form.into_spec(Some(&base), Role::Admin).expect("merge zero days");
         assert_eq!(merged.require_mfa, Some(true));
         assert_eq!(merged.mfa_validity_days, Some(0));
+
+        // An imported out-of-range value renders CLAMPED in the form —
+        // else the browser's max=30 constraint blocks the whole submit
+        // (silently when the field is hidden by x-show).
+        let mut over = base.clone();
+        over.mfa_validity_days = Some(31);
+        assert_eq!(SpecForm::from_spec(&over).mfa_validity_days, "30");
 
         let mut form = SpecForm::from_spec(&base);
         form.require_mfa.clear();

--- a/crates/ruscker-admin/src/routes/admin/spec_form.rs
+++ b/crates/ruscker-admin/src/routes/admin/spec_form.rs
@@ -919,6 +919,18 @@ impl SpecForm {
         {
             errs.push("spec-form-error-number");
         }
+        // The MFA validity window is a u16 clamped to 30. A crafted POST
+        // bypassing the HTML min/max (e.g. -1 or 65536) parses as i64 —
+        // passing the generic check above — but fails `parse_opt::<u16>`
+        // in into_spec and would silently become None = the 7-day default,
+        // changing the policy instead of rejecting the request (codex
+        // review; same class as #877).
+        if matches!(
+            self.mfa_validity_days.trim().parse::<i64>(),
+            Ok(n) if !(0..=i64::from(ruscker_config::MAX_MFA_VALIDITY_DAYS)).contains(&n)
+        ) {
+            errs.push("spec-form-error-mfa-days");
+        }
         // A max-containers ceiling of 0 refuses every spawn (`live >= max`),
         // so the app can never start. Reject it server-side, not just via
         // the HTML `min=1` a crafted POST can bypass (#877).
@@ -1891,6 +1903,25 @@ proxy:
         let mut f = valid_form();
         f.container_cpu_limit = "0,5".into(); // pt-BR comma
         assert!(f.validate(FormMode::New).contains(&"spec-form-error-cpu"));
+
+        // MFA validity: a crafted POST past the HTML min/max must be
+        // rejected, not silently become None → the 7-day default.
+        for bad in ["-1", "65536", "31"] {
+            let mut f = valid_form();
+            f.mfa_validity_days = bad.into();
+            assert!(
+                f.validate(FormMode::New).contains(&"spec-form-error-mfa-days"),
+                "{bad} must be rejected"
+            );
+        }
+        for ok in ["", "0", "7", "30"] {
+            let mut f = valid_form();
+            f.mfa_validity_days = ok.into();
+            assert!(
+                !f.validate(FormMode::New).contains(&"spec-form-error-mfa-days"),
+                "{ok} must pass"
+            );
+        }
 
         let mut f = valid_form();
         f.container_memory_limit = "512mb".into(); // typo

--- a/crates/ruscker-admin/src/routes/admin/spec_form.rs
+++ b/crates/ruscker-admin/src/routes/admin/spec_form.rs
@@ -501,6 +501,11 @@ pub struct SpecForm {
     pub access_groups: String,
     /// Usernames allowed to see + reach this app — comma/newline list.
     pub access_users: String,
+    /// Checkbox ("on") ⇒ this app requires a user-owned MFA proof (#1005).
+    pub require_mfa: String,
+    /// Maximum MFA-proof age in days. Blank ⇒ schema default; `0` is a
+    /// deliberate session-only window and must not collapse to blank.
+    pub mfa_validity_days: String,
     /// Checkbox ("on") ⇒ forward the signed-in user's ShinyProxy-compatible
     /// identity headers to this app. Off by default (data minimization).
     pub add_default_http_headers: String,
@@ -646,6 +651,11 @@ impl SpecForm {
             docker_registry_credential: spec.docker_registry_credential.clone().unwrap_or_default(),
             access_groups: spec.access_groups.as_ref().map(|v| v.join(", ")).unwrap_or_default(),
             access_users: spec.access_users.as_ref().map(|v| v.join(", ")).unwrap_or_default(),
+            require_mfa: checkbox(spec.effective_require_mfa()),
+            mfa_validity_days: spec
+                .mfa_validity_days
+                .map(|days| days.to_string())
+                .unwrap_or_default(),
             add_default_http_headers: checkbox(spec.effective_add_default_http_headers()),
             identity_claim_email: checkbox(identity_claims.contains(&IdentityClaim::Email)),
             identity_claim_setor: checkbox(identity_claims.contains(&IdentityClaim::Setor)),
@@ -845,6 +855,8 @@ impl SpecForm {
             docker_registry_credential: empty_to_none(&self.docker_registry_credential),
             access_groups: list_to_vec(&self.access_groups),
             access_users: list_to_vec(&self.access_users),
+            require_mfa: checkbox_opt(&self.require_mfa),
+            mfa_validity_days: parse_opt(&self.mfa_validity_days),
             add_default_http_headers: checkbox_opt(&self.add_default_http_headers),
             identity_claims,
             container_cpu_request: parse_opt(&self.container_cpu_request),
@@ -891,6 +903,7 @@ impl SpecForm {
             &self.api_port,
             &self.container_port,
             &self.container_lifetime,
+            &self.mfa_validity_days,
             &self.scale_down_grace,
             &self.scale_down_cooldown_secs,
             &self.drain_timeout,
@@ -2060,6 +2073,8 @@ proxy:
         - --ServerApp.base_url=/
       access-groups: [staff, ops]
       access-users: [alice]
+      require-mfa: true
+      mfa-validity-days: 12
       add-default-http-headers: true
       identity-claims: [email, future-claim, setor]
       placement: bin-pack
@@ -2089,6 +2104,8 @@ proxy:
         );
         assert_eq!(merged.access_groups.as_deref(), Some(&["staff".into(), "ops".into()][..]));
         assert_eq!(merged.access_users.as_deref(), Some(&["alice".into()][..]));
+        assert_eq!(merged.require_mfa, Some(true));
+        assert_eq!(merged.mfa_validity_days, Some(12));
         assert!(merged.effective_add_default_http_headers());
         assert_eq!(
             merged.effective_identity_claims(),
@@ -2105,6 +2122,36 @@ proxy:
         assert_eq!(merged.scale_down_grace, Some(45));
         assert_eq!(merged.scale_down_cooldown_secs, Some(90));
         assert_eq!(merged.drain_timeout, Some(20));
+    }
+
+    #[test]
+    fn mfa_form_preserves_blank_zero_and_checkbox_state() {
+        let base = Config::from_yaml(
+            "proxy:\n  specs:\n    - id: guarded\n      container-image: a:1\n      require-mfa: true\n",
+        )
+        .expect("parse fixture")
+        .proxy
+        .specs
+        .remove(0);
+
+        let form = SpecForm::from_spec(&base);
+        assert_eq!(form.require_mfa, "on");
+        assert_eq!(form.mfa_validity_days, "");
+        let merged = form.into_spec(Some(&base), Role::Admin).expect("merge blank days");
+        assert_eq!(merged.require_mfa, Some(true));
+        assert_eq!(merged.mfa_validity_days, None);
+
+        let mut form = SpecForm::from_spec(&base);
+        form.mfa_validity_days = "0".into();
+        let merged = form.into_spec(Some(&base), Role::Admin).expect("merge zero days");
+        assert_eq!(merged.require_mfa, Some(true));
+        assert_eq!(merged.mfa_validity_days, Some(0));
+
+        let mut form = SpecForm::from_spec(&base);
+        form.require_mfa.clear();
+        let merged = form.into_spec(Some(&base), Role::Admin).expect("merge unchecked");
+        assert_eq!(merged.require_mfa, None);
+        assert_eq!(merged.mfa_validity_days, None);
     }
 
     #[test]

--- a/crates/ruscker-admin/templates/admin/spec_form.html
+++ b/crates/ruscker-admin/templates/admin/spec_form.html
@@ -593,9 +593,15 @@
           <div class="spec-form-label-row">
             <label for="f-mfa-validity" class="spec-form-label">{{ self.t("spec-form-mfa-validity") }}</label>
           </div>
+          {# :disabled with the x-show (codex review): a merely-hidden input
+             still submits — persisting an inert value — and its native
+             min/max constraints can silently block the WHOLE form while
+             invisible. Disabled inputs neither submit nor validate; the
+             typed value survives re-enabling via x-model. #}
           <input id="f-mfa-validity" type="number" name="mfa_validity_days"
                  min="0" max="30" step="1" placeholder="7"
                  x-model="form.mfa_validity_days"
+                 :disabled="!form.require_mfa"
                  class="spec-form-input">
           <div class="spec-form-help">{{ self.t("spec-form-mfa-validity-hint") }}</div>
           <div class="spec-form-help" style="color:var(--color-lock)">{{ self.t("spec-form-mfa-staged-note") }}</div>

--- a/crates/ruscker-admin/templates/admin/spec_form.html
+++ b/crates/ruscker-admin/templates/admin/spec_form.html
@@ -573,6 +573,35 @@
       <div class="spec-form-help">{{ self.t("spec-form-access-help") }}</div>
       </div>{# /x-show restricted #}
 
+      {# Per-app step-up MFA policy (#1005 slice 1). The factor belongs to
+         the user; this spec only chooses whether and how recently the user
+         must have proved it. Runtime enforcement arrives in slice 4. #}
+      <label class="toggle-row">
+        <div>
+          <div class="toggle-row__label">{{ self.t("spec-form-require-mfa") }}</div>
+          <div class="toggle-row__hint">{{ self.t("spec-form-require-mfa-hint") }}</div>
+        </div>
+        <span class="switch">
+          <input type="checkbox" name="require_mfa" value="on"
+                 x-model="form.require_mfa"
+                 {% if !form.require_mfa.is_empty() %}checked{% endif %}>
+          <span class="switch__track"><span class="switch__dot"></span></span>
+        </span>
+      </label>
+      <div x-show="form.require_mfa" x-cloak>
+        <div class="spec-form-field">
+          <div class="spec-form-label-row">
+            <label for="f-mfa-validity" class="spec-form-label">{{ self.t("spec-form-mfa-validity") }}</label>
+          </div>
+          <input id="f-mfa-validity" type="number" name="mfa_validity_days"
+                 min="0" max="30" step="1" placeholder="7"
+                 x-model="form.mfa_validity_days"
+                 class="spec-form-input">
+          <div class="spec-form-help">{{ self.t("spec-form-mfa-validity-hint") }}</div>
+          <div class="spec-form-help" style="color:var(--color-lock)">{{ self.t("spec-form-mfa-staged-note") }}</div>
+        </div>
+      </div>
+
       {# Identity disclosure is an explicit per-app opt-in (#1001). #}
       <label class="toggle-row">
         <div>

--- a/crates/ruscker-cli/src/main.rs
+++ b/crates/ruscker-cli/src/main.rs
@@ -973,6 +973,21 @@ fn format_warning(w: &Warning) -> String {
         Warning::SpecLackingContainerHasContainerFields { spec_id } => {
             format!("spec {spec_id} has no container-image but uses container-only fields")
         }
+        Warning::MfaValidityOutOfRange { spec, days } => {
+            format!(
+                "spec {spec} sets mfa-validity-days: {days} — values above 30 clamp to 30"
+            )
+        }
+        Warning::MfaValidityWithoutRequire { spec } => {
+            format!(
+                "spec {spec} sets mfa-validity-days but require-mfa is not true — the validity setting has no effect"
+            )
+        }
+        Warning::MfaNotYetEnforced { spec } => {
+            format!(
+                "spec {spec} sets require-mfa: true, but MFA is not yet enforced — this app is NOT protected; enforcement ships in an upcoming release (#1005)"
+            )
+        }
         Warning::InvalidRateLimit { spec_id, value } => {
             format!(
                 "spec {spec_id} has an invalid api.rate-limit `{value}` \

--- a/crates/ruscker-config/src/lib.rs
+++ b/crates/ruscker-config/src/lib.rs
@@ -49,7 +49,7 @@ pub use schema::{
     is_valid_memory_size, normalize_base_path, ApiSpec, Config, Host, HostTls, IdentityClaim,
     LandingBlock, LandingCustomization, LandingLogo, Logging, Placement, Proxy, RatePolicy,
     RoutingStrategy, Server, Spec, SpecKind, SpecKindOverride, TemplateProperties, ThemeColors,
-    ThemePalette, DEFAULT_SCALE_DOWN_COOLDOWN_SECS,
+    ThemePalette, DEFAULT_SCALE_DOWN_COOLDOWN_SECS, MAX_MFA_VALIDITY_DAYS,
 };
 pub use validate::{
     is_reserved_label_key, is_valid_label_key, is_valid_network_name, is_valid_volume_bind,

--- a/crates/ruscker-config/src/schema.rs
+++ b/crates/ruscker-config/src/schema.rs
@@ -935,6 +935,18 @@ pub struct Spec {
     #[serde(rename = "access-users", default)]
     pub access_users: Option<Vec<String>>,
 
+    /// Require a fresh user-owned MFA proof before this app is trusted for
+    /// access (#1005). The factor belongs to the user and is enrolled once;
+    /// this per-app switch only decides whether that proof is required.
+    #[serde(rename = "require-mfa")]
+    pub require_mfa: Option<bool>,
+
+    /// Maximum age, in days, of the user-owned MFA proof this app trusts
+    /// (#1005). `0` deliberately limits trust to the current login session;
+    /// values above [`MAX_MFA_VALIDITY_DAYS`] are clamped.
+    #[serde(rename = "mfa-validity-days")]
+    pub mfa_validity_days: Option<u16>,
+
     /// Forward the authenticated user's ShinyProxy-compatible identity
     /// headers to this app. Deliberately defaults to `false`, unlike
     /// ShinyProxy: existing apps must opt in before Ruscker discloses a
@@ -1137,6 +1149,16 @@ pub const DEFAULT_SCALE_DOWN_COOLDOWN_SECS: u64 = 60;
 /// comes from `max-replicas`). APIs keep 100.
 pub const DEFAULT_SEATS_PER_APP: u32 = 10;
 
+/// Default age, in days, for an MFA proof trusted by a protected app (#1005).
+/// Seven days balances proof freshness with avoiding needless prompts when an
+/// operator enables MFA without choosing a custom remembered-device window.
+pub const DEFAULT_MFA_VALIDITY_DAYS: u16 = 7;
+
+/// Maximum age, in days, for an MFA proof trusted by a protected app (#1005).
+/// Bounding remembered-device trust to 30 days prevents a typo from silently
+/// creating a much longer security window.
+pub const MAX_MFA_VALIDITY_DAYS: u16 = 30;
+
 impl Spec {
     /// Container environment as Docker `NAME=value` strings, sorted for
     /// determinism (the field is a `BTreeMap`). Empty when no
@@ -1216,6 +1238,20 @@ impl Spec {
     pub fn is_open(&self) -> bool {
         self.access_groups.as_deref().is_none_or(<[String]>::is_empty)
             && self.access_users.as_deref().is_none_or(<[String]>::is_empty)
+    }
+
+    /// Whether this app requires a user-owned MFA proof (#1005).
+    pub fn effective_require_mfa(&self) -> bool {
+        self.require_mfa.unwrap_or(false)
+    }
+
+    /// Maximum age, in days, of the MFA proof this app trusts (#1005).
+    /// Unset uses seven days, `0` remains session-only, and larger authored
+    /// values are capped at the validated 30-day maximum.
+    pub fn effective_mfa_validity_days(&self) -> u16 {
+        self.mfa_validity_days
+            .unwrap_or(DEFAULT_MFA_VALIDITY_DAYS)
+            .min(MAX_MFA_VALIDITY_DAYS)
     }
 
     /// Whether authenticated identity headers are disclosed to this app.
@@ -2080,6 +2116,8 @@ proxy:
             labels: None,
             access_groups: None,
             access_users: None,
+            require_mfa: None,
+            mfa_validity_days: None,
             add_default_http_headers: None,
             identity_claims: None,
             template_properties: TemplateProperties::default(),
@@ -2133,6 +2171,8 @@ proxy:
             labels: None,
             access_groups: None,
             access_users: None,
+            require_mfa: None,
+            mfa_validity_days: None,
             add_default_http_headers: None,
             identity_claims: None,
             template_properties: TemplateProperties::default(),
@@ -2186,6 +2226,8 @@ proxy:
             labels: None,
             access_groups: None,
             access_users: None,
+            require_mfa: None,
+            mfa_validity_days: None,
             add_default_http_headers: None,
             identity_claims: None,
             template_properties: TemplateProperties::default(),
@@ -2335,6 +2377,27 @@ proxy:
         );
         assert_eq!(enabled.add_default_http_headers, Some(true));
         assert!(enabled.effective_add_default_http_headers());
+    }
+
+    #[test]
+    fn parses_mfa_policy_defaults_and_bounds() {
+        let default = parse_spec("id: a\ncontainer-image: x");
+        assert_eq!(default.require_mfa, None);
+        assert!(!default.effective_require_mfa());
+        assert_eq!(default.mfa_validity_days, None);
+        assert_eq!(default.effective_mfa_validity_days(), DEFAULT_MFA_VALIDITY_DAYS);
+
+        let session_only = parse_spec(
+            "id: a\ncontainer-image: x\nrequire-mfa: true\nmfa-validity-days: 0",
+        );
+        assert_eq!(session_only.require_mfa, Some(true));
+        assert!(session_only.effective_require_mfa());
+        assert_eq!(session_only.mfa_validity_days, Some(0));
+        assert_eq!(session_only.effective_mfa_validity_days(), 0);
+
+        let clamped = parse_spec("id: a\ncontainer-image: x\nmfa-validity-days: 31");
+        assert_eq!(clamped.mfa_validity_days, Some(31));
+        assert_eq!(clamped.effective_mfa_validity_days(), MAX_MFA_VALIDITY_DAYS);
     }
 
     #[test]

--- a/crates/ruscker-config/src/validate.rs
+++ b/crates/ruscker-config/src/validate.rs
@@ -23,7 +23,7 @@
 //! [`scan_raw_text`] runs against raw YAML; [`run`] runs against the
 //! parsed model. [`Config::validate`] merges results from both.
 
-use crate::schema::{AuthScheme, Config, Spec, SpecKind};
+use crate::schema::{AuthScheme, Config, Spec, SpecKind, MAX_MFA_VALIDITY_DAYS};
 use std::sync::LazyLock;
 use regex::Regex;
 use serde::Serialize;
@@ -81,6 +81,24 @@ pub enum Warning {
     },
     SpecLackingContainerHasContainerFields {
         spec_id: String,
+    },
+    /// `mfa-validity-days` exceeds the maximum remembered-proof trust
+    /// window. The effective value is clamped, so report both the authored
+    /// value and the behavior the operator will actually get (#1005).
+    MfaValidityOutOfRange {
+        spec: String,
+        days: u16,
+    },
+    /// `mfa-validity-days` is configured while MFA itself is off, so the
+    /// trust window is parsed but inert (#1005).
+    MfaValidityWithoutRequire {
+        spec: String,
+    },
+    /// TODO(#1005 slice 4): remove once the proxy guard enforces MFA.
+    /// `require-mfa` is security-sensitive but not consumed at runtime yet;
+    /// this warning prevents a silent false sense of protection.
+    MfaNotYetEnforced {
+        spec: String,
     },
     /// `api.rate-limit` is set but doesn't parse as `N/unit`
     /// (e.g. `100/min`). The proxy ignores an unparseable limit
@@ -531,6 +549,26 @@ fn check_spec(spec: &Spec, warnings: &mut Vec<Warning>) {
         });
     }
 
+    if let Some(days) = spec.mfa_validity_days {
+        if days > MAX_MFA_VALIDITY_DAYS {
+            warnings.push(Warning::MfaValidityOutOfRange {
+                spec: spec.id.clone(),
+                days,
+            });
+        }
+        if !spec.effective_require_mfa() {
+            warnings.push(Warning::MfaValidityWithoutRequire {
+                spec: spec.id.clone(),
+            });
+        }
+    }
+    // TODO(#1005 slice 4): remove once the proxy guard enforces MFA.
+    if spec.effective_require_mfa() {
+        warnings.push(Warning::MfaNotYetEnforced {
+            spec: spec.id.clone(),
+        });
+    }
+
     if let Some(t) = spec.template_properties.type_field() {
         if !KNOWN_TYPES.contains(&t) {
             warnings.push(Warning::UnknownTypeProperty {
@@ -810,6 +848,98 @@ fn collect_stats(config: &Config) -> Stats {
 #[cfg(test)]
 mod tests {
     use super::*;
+
+    fn is_mfa_warning(warning: &Warning) -> bool {
+        matches!(
+            warning,
+            Warning::MfaValidityOutOfRange { .. }
+                | Warning::MfaValidityWithoutRequire { .. }
+                | Warning::MfaNotYetEnforced { .. }
+        )
+    }
+
+    #[test]
+    fn flags_mfa_validity_above_maximum_only_when_out_of_range() {
+        let yaml = "proxy:\n  specs:\n    - id: guarded\n      container-image: a:1\n      require-mfa: true\n      mfa-validity-days: 31\n";
+        let report = Config::from_yaml(yaml).expect("parse").validate();
+        assert_eq!(
+            report
+                .warnings
+                .iter()
+                .filter(|w| matches!(w, Warning::MfaValidityOutOfRange { .. }))
+                .count(),
+            1
+        );
+        assert!(report.warnings.iter().any(|w| matches!(
+            w,
+            Warning::MfaValidityOutOfRange { spec, days }
+                if spec == "guarded" && *days == 31
+        )));
+
+        let at_max = yaml.replace("31", "30");
+        let report = Config::from_yaml(&at_max).expect("parse").validate();
+        assert!(!report
+            .warnings
+            .iter()
+            .any(|w| matches!(w, Warning::MfaValidityOutOfRange { .. })));
+    }
+
+    #[test]
+    fn flags_mfa_validity_without_requirement_only_when_inert() {
+        let yaml = "proxy:\n  specs:\n    - id: inert\n      container-image: a:1\n      mfa-validity-days: 7\n";
+        let report = Config::from_yaml(yaml).expect("parse").validate();
+        assert_eq!(
+            report
+                .warnings
+                .iter()
+                .filter(|w| matches!(w, Warning::MfaValidityWithoutRequire { .. }))
+                .count(),
+            1
+        );
+        assert!(report.warnings.iter().any(|w| matches!(
+            w,
+            Warning::MfaValidityWithoutRequire { spec } if spec == "inert"
+        )));
+
+        let enabled = yaml.replace("      mfa-validity-days", "      require-mfa: true\n      mfa-validity-days");
+        let report = Config::from_yaml(&enabled).expect("parse").validate();
+        assert!(!report
+            .warnings
+            .iter()
+            .any(|w| matches!(w, Warning::MfaValidityWithoutRequire { .. })));
+    }
+
+    #[test]
+    fn flags_required_mfa_as_not_yet_enforced_only_when_enabled() {
+        let yaml = "proxy:\n  specs:\n    - id: staged\n      container-image: a:1\n      require-mfa: true\n";
+        let report = Config::from_yaml(yaml).expect("parse").validate();
+        assert_eq!(
+            report
+                .warnings
+                .iter()
+                .filter(|w| matches!(w, Warning::MfaNotYetEnforced { .. }))
+                .count(),
+            1
+        );
+        assert!(report.warnings.iter().any(|w| matches!(
+            w,
+            Warning::MfaNotYetEnforced { spec } if spec == "staged"
+        )));
+
+        let disabled = yaml.replace("true", "false");
+        let report = Config::from_yaml(&disabled).expect("parse").validate();
+        assert!(!report
+            .warnings
+            .iter()
+            .any(|w| matches!(w, Warning::MfaNotYetEnforced { .. })));
+    }
+
+    #[test]
+    fn spec_without_mfa_fields_has_no_mfa_warning() {
+        let yaml = "proxy:\n  specs:\n    - id: plain\n      container-image: a:1\n";
+        let report = Config::from_yaml(yaml).expect("parse").validate();
+        assert!(!report.warnings.iter().any(is_mfa_warning));
+    }
 
     #[test]
     fn raw_scan_flags_plain_credential() {

--- a/docs/YAML_SCHEMA.md
+++ b/docs/YAML_SCHEMA.md
@@ -340,6 +340,8 @@ A spec describes one app, API, or external link. Every spec has an
     cost-center: GAPE
   access-groups: [staff, ops]         # who may see/reach this app
   access-users: [alice]               #   (ShinyProxy-compatible)
+  require-mfa: true                   # require a user-owned MFA proof (Ruscker-native)
+  mfa-validity-days: 7                # remembered-proof window; 0 = session-only
   add-default-http-headers: true       # opt in to X-SP-UserId / X-SP-UserGroups
   identity-claims: [email, setor]      # opt in to selected profile claims
 ```
@@ -389,6 +391,15 @@ visitors. Otherwise: a logged-in user sees it when their username is in
 always sees everything; an anonymous visitor sees only open apps. Group
 membership is set per user in the admin panel. Enforcement is real (not
 just hiding the card). See the [Roadmap](ROADMAP.md) Phase 8.
+
+`require-mfa` and `mfa-validity-days` are Ruscker-native per-spec controls
+for step-up MFA (#1005). MFA is off by default. When enabled, the app trusts
+a successful user-owned TOTP proof for 7 days unless
+`mfa-validity-days` overrides the window; `0` means proof is valid only in
+the current login session (no remembered device), and values above 30 clamp
+to 30. A user without an enrolled TOTP factor will be guided through
+enrollment on first access to a protected app. **Staged rollout: not yet
+enforced; the proxy guard ships in an upcoming release (#1005).**
 
 `add-default-http-headers` is a ShinyProxy-compatible, per-spec opt-in
 that forwards `X-SP-UserId` and comma-separated `X-SP-UserGroups` on HTTP


### PR DESCRIPTION
Slice 1 of 4 of the step-up MFA epic (#1005) — the per-spec **configuration surface only**. No TOTP, no enrollment, no proxy guard (slices 2–4).

## What changed
- **Schema**: `require-mfa` (`Option<bool>`, effective default **false**) + `mfa-validity-days` (`Option<u16>`): unset → **7-day** window (`DEFAULT_MFA_VALIDITY_DAYS`); **`0` is deliberate** — proof valid only within the current login session, preserved as `Some(0)` end-to-end; values above **30 clamp** (`MAX_MFA_VALIDITY_DAYS`).
- **Validation** (house 4-step convention), 3 warnings:
  - out-of-range validity (reports the clamp);
  - validity set without `require-mfa` (inert field — the #970 transparency policy);
  - **temporary** `MfaNotYetEnforced` whenever `require-mfa: true` — a security field that parses but isn't consumed yet must never be silent; marked `TODO(#1005 slice 4)` for removal when the guard lands.
- **Spec form** (Access section): "Exigir 2FA" toggle revealing "Solicitar novamente após N dias" (min 0 / max 30 / placeholder 7). Blank → `None`, `"0"` → `Some(0)`. Staged-rollout note is its own Fluent key (clean deletion in slice 4). i18n ×4.
- **Docs**: YAML_SCHEMA semantics + explicit staged-rollout note.

## Review hardening (3 real findings by Codex `gpt-5.6` high, each fixed + re-reviewed to a clean round 4)
1. An imported `mfa-validity-days: 31` rendered raw into the `max=30` input → the browser's constraint validation **blocked the whole form submit**, silently when the field was hidden. `from_spec` now renders the clamped value (what runtime applies anyway).
2. A crafted POST bypassing the HTML min/max (`-1`, `65536`) passed the generic i64 check but failed `parse_opt::<u16>` and **silently became the 7-day default**. Server-side range check now rejects with a dedicated localized error (same class as #877).
3. The hidden days input still submitted (persisting an inert value) and its native constraints could invisibly block submission. It's now `:disabled` when the toggle is off — neither submits nor validates; the typed value survives re-enabling.

## Validation
- Full gate green (incl. complete `cargo test` after the `.ftl` edits) ×4 rounds.
- CLI smoke: the 3 warnings each fire only in their case (`validate` on a 3-spec fixture).
- Live smoke: `import` → DB (`require-mfa=1`, `days=31` in `config_json`) → edit form renders the toggle **checked** with the Alpine seed populated → `export` re-emits `require-mfa: true` / `mfa-validity-days: 31`.
- `packaging/ruscker.yml.example` still parses warning-free (living gate).

Implemented by a Codex (`gpt-5.6`, high) agent; verified and hardened as above. Slice 2 (TOTP enrollment + recovery codes) follows on top of this.

🤖 Generated with [Claude Code](https://claude.com/claude-code)