### PR TITLE
fix: strip reserved Set-Cookie + neutralize Clear-Site-Data from app responses (#1010)

### DIFF
--- a/crates/ruscker-admin/src/routes/proxy.rs
+++ b/crates/ruscker-admin/src/routes/proxy.rs
@@ -2127,6 +2127,7 @@ async fn do_forward(
     let mut resp = Response::from_parts(parts, body);
     strip_hop_headers(resp.headers_mut());
     strip_reserved_set_cookies(resp.headers_mut(), &replica.spec_id);
+    sanitize_clear_site_data(resp.headers_mut(), &replica.spec_id);
     Ok(resp)
 }
 
@@ -2234,6 +2235,62 @@ fn strip_ruscker_cookies(headers: &mut HeaderMap) {
 /// portal's origin, so allowing them to overwrite a root-scoped session,
 /// preference, sticky, or MFA cookie would let a container disrupt the
 /// user's portal session (#1010).
+/// Neutralise a same-origin app's attempt to CLEAR the shared origin's
+/// cookies via `Clear-Site-Data` (#1010 review). `Clear-Site-Data:
+/// "cookies"` (or `"*"`) wipes every cookie for the origin — including the
+/// HttpOnly admin session, sticky, and MFA device cookies — regardless of
+/// the per-name `Set-Cookie` strip. There is no per-cookie granularity, so
+/// we drop the `cookies` and `*` directives while preserving any explicit
+/// non-cookie directive (`cache`, `storage`, `executionContexts`) the app
+/// legitimately wants for its own state; if nothing else remains, the
+/// header is removed.
+fn sanitize_clear_site_data(headers: &mut HeaderMap, spec_id: &str) {
+    let values: Vec<HeaderValue> = headers
+        .get_all(header::HeaderName::from_static("clear-site-data"))
+        .iter()
+        .cloned()
+        .collect();
+    if values.is_empty() {
+        return;
+    }
+    headers.remove(header::HeaderName::from_static("clear-site-data"));
+    let mut neutralised = false;
+    for value in values {
+        let Ok(raw) = value.to_str() else {
+            // Undecodable — a valid Clear-Site-Data value is ASCII quoted
+            // tokens, so this can't be a legitimate directive; drop it.
+            neutralised = true;
+            continue;
+        };
+        let kept: Vec<&str> = raw
+            .split(',')
+            .map(str::trim)
+            .filter(|entry| {
+                // Directives are quoted, e.g. "cookies". Match the unquoted,
+                // lowercased token; `"cookies"` and the `"*"` wildcard both
+                // clear cookies for the origin.
+                let token = entry.trim_matches('"').trim().to_ascii_lowercase();
+                let clears_cookies = token == "cookies" || token == "*";
+                if clears_cookies {
+                    neutralised = true;
+                }
+                !clears_cookies && !entry.is_empty()
+            })
+            .collect();
+        if !kept.is_empty() {
+            if let Ok(v) = HeaderValue::from_str(&kept.join(", ")) {
+                headers.append(header::HeaderName::from_static("clear-site-data"), v);
+            }
+        }
+    }
+    if neutralised {
+        tracing::warn!(
+            spec = %spec_id,
+            "upstream app tried to clear the shared origin's cookies via Clear-Site-Data"
+        );
+    }
+}
+
 fn strip_reserved_set_cookies(headers: &mut HeaderMap, spec_id: &str) {
     let values: Vec<HeaderValue> = headers
         .get_all(header::SET_COOKIE)
@@ -2398,6 +2455,29 @@ mod tests {
         let remaining: Vec<_> = h.get_all(header::SET_COOKIE).iter().collect();
         assert_eq!(remaining.len(), 1);
         assert_eq!(remaining[0].as_bytes(), b"keep=1");
+    }
+
+    #[test]
+    fn sanitize_clear_site_data_drops_cookie_directive_keeps_others() {
+        // "cookies" and "*" clear the shared origin's cookies (#1010 review).
+        let mut h = HeaderMap::new();
+        h.append(
+            header::HeaderName::from_static("clear-site-data"),
+            HeaderValue::from_static("\"cache\", \"cookies\", \"storage\""),
+        );
+        sanitize_clear_site_data(&mut h, "app");
+        let v = h.get("clear-site-data").unwrap().to_str().unwrap();
+        assert!(!v.to_ascii_lowercase().contains("cookies"), "got: {v}");
+        assert!(v.contains("cache") && v.contains("storage"));
+
+        // A lone "*" (clears everything incl. cookies) → header removed.
+        let mut h = HeaderMap::new();
+        h.append(
+            header::HeaderName::from_static("clear-site-data"),
+            HeaderValue::from_static("\"*\""),
+        );
+        sanitize_clear_site_data(&mut h, "app");
+        assert!(h.get("clear-site-data").is_none());
     }
 
     #[test]

--- a/crates/ruscker-admin/src/routes/proxy.rs
+++ b/crates/ruscker-admin/src/routes/proxy.rs
@@ -2126,6 +2126,7 @@ async fn do_forward(
     let body = Body::new(body.map_err(std::io::Error::other));
     let mut resp = Response::from_parts(parts, body);
     strip_hop_headers(resp.headers_mut());
+    strip_reserved_set_cookies(resp.headers_mut(), &replica.spec_id);
     Ok(resp)
 }
 
@@ -2228,6 +2229,47 @@ fn strip_ruscker_cookies(headers: &mut HeaderMap) {
     }
 }
 
+/// Drop app-supplied `Set-Cookie` headers for names owned by Ruscker,
+/// preserving every app-owned cookie in the response. Apps share the
+/// portal's origin, so allowing them to overwrite a root-scoped session,
+/// preference, sticky, or MFA cookie would let a container disrupt the
+/// user's portal session (#1010).
+fn strip_reserved_set_cookies(headers: &mut HeaderMap, spec_id: &str) {
+    let values: Vec<HeaderValue> = headers
+        .get_all(header::SET_COOKIE)
+        .iter()
+        .cloned()
+        .collect();
+    if values.is_empty() {
+        return;
+    }
+
+    headers.remove(header::SET_COOKIE);
+    let mut stripped = 0usize;
+    for value in values {
+        let reserved = value
+            .to_str()
+            .ok()
+            .and_then(|raw| raw.split(';').next())
+            .and_then(|pair| pair.split('=').next())
+            .map(str::trim)
+            .is_some_and(is_ruscker_cookie);
+        if reserved {
+            stripped += 1;
+        } else {
+            headers.append(header::SET_COOKIE, value);
+        }
+    }
+
+    if stripped > 0 {
+        tracing::warn!(
+            spec = %spec_id,
+            stripped,
+            "upstream app attempted to set reserved Ruscker cookie"
+        );
+    }
+}
+
 /// Remove client-supplied identity claims before a request crosses the
 /// trust boundary into an app container. The WHOLE `X-SP-*` and
 /// `X-Ruscker-User-*` namespaces are reserved (codex review, #1001):
@@ -2306,6 +2348,29 @@ mod tests {
         );
         strip_ruscker_cookies(&mut h);
         assert!(!h.contains_key(header::COOKIE), "empty Cookie header should be removed");
+    }
+
+    #[test]
+    fn strip_reserved_set_cookies_drops_ours_keeps_app_cookies() {
+        let mut h = HeaderMap::new();
+        for value in [
+            "sid=abc; Path=/",
+            "__ruscker_mfa_device=x; Path=/",
+            "ruscker_admin_session=y; Path=/",
+            "__ruscker_session_alpha=z; Path=/",
+            "ruscker_theme=dark; Path=/",
+        ] {
+            h.append(header::SET_COOKIE, HeaderValue::from_static(value));
+        }
+
+        strip_reserved_set_cookies(&mut h, "my-app");
+
+        let remaining: Vec<&str> = h
+            .get_all(header::SET_COOKIE)
+            .iter()
+            .map(|value| value.to_str().unwrap())
+            .collect();
+        assert_eq!(remaining, ["sid=abc; Path=/"]);
     }
 
     #[test]

--- a/crates/ruscker-admin/src/routes/proxy.rs
+++ b/crates/ruscker-admin/src/routes/proxy.rs
@@ -2262,19 +2262,28 @@ fn sanitize_clear_site_data(headers: &mut HeaderMap, spec_id: &str) {
             neutralised = true;
             continue;
         };
+        // Fail CLOSED with an allowlist (codex review): a quoted-pair like
+        // `"cook\ies"` or `"\*"` decodes to `cookies`/`*` in the browser, so
+        // matching the raw token would miss it. Keep ONLY directives that are
+        // provably one of the safe non-cookie tokens — exact quoting, no
+        // backslash escapes — and drop everything else (cookies, *, escaped,
+        // malformed, or unknown).
+        const SAFE: &[&str] = &["cache", "storage", "executionContexts"];
         let kept: Vec<&str> = raw
             .split(',')
             .map(str::trim)
             .filter(|entry| {
-                // Directives are quoted, e.g. "cookies". Match the unquoted,
-                // lowercased token; `"cookies"` and the `"*"` wildcard both
-                // clear cookies for the origin.
-                let token = entry.trim_matches('"').trim().to_ascii_lowercase();
-                let clears_cookies = token == "cookies" || token == "*";
-                if clears_cookies {
+                let inner = entry
+                    .strip_prefix('"')
+                    .and_then(|e| e.strip_suffix('"'))
+                    .filter(|inner| !inner.contains('\\'));
+                let safe = inner.is_some_and(|inner| {
+                    SAFE.iter().any(|d| d.eq_ignore_ascii_case(inner))
+                });
+                if !safe && !entry.is_empty() {
                     neutralised = true;
                 }
-                !clears_cookies && !entry.is_empty()
+                safe
             })
             .collect();
         if !kept.is_empty() {
@@ -2478,6 +2487,20 @@ mod tests {
         );
         sanitize_clear_site_data(&mut h, "app");
         assert!(h.get("clear-site-data").is_none());
+
+        // Quoted-pair obfuscation must not slip through the allowlist.
+        for evil in [r#""cook\ies""#, r#""\*""#, r#""cookies""#, "bogus"] {
+            let mut h = HeaderMap::new();
+            h.append(
+                header::HeaderName::from_static("clear-site-data"),
+                HeaderValue::from_str(evil).unwrap(),
+            );
+            sanitize_clear_site_data(&mut h, "app");
+            assert!(
+                h.get("clear-site-data").is_none(),
+                "must fail closed on: {evil}"
+            );
+        }
     }
 
     #[test]

--- a/crates/ruscker-admin/src/routes/proxy.rs
+++ b/crates/ruscker-admin/src/routes/proxy.rs
@@ -2247,12 +2247,23 @@ fn strip_reserved_set_cookies(headers: &mut HeaderMap, spec_id: &str) {
     headers.remove(header::SET_COOKIE);
     let mut stripped = 0usize;
     for value in values {
-        let reserved = value
-            .to_str()
+        // Parse the cookie NAME from the raw bytes, not the decoded string
+        // (codex review, #1010): a value like `ruscker_admin_session=EVIL;
+        // Foo=\x80` has an ASCII reserved name but non-UTF-8 bytes later, so
+        // `to_str()` on the whole header would fail and fail OPEN. The name
+        // (before the first `=`, itself before the first `;`) is ASCII for
+        // any reserved cookie; decode only that slice.
+        let name = value
+            .as_bytes()
+            .split(|&b| b == b';')
+            .next()
+            .unwrap_or(&[])
+            .split(|&b| b == b'=')
+            .next()
+            .unwrap_or(&[])
+            .trim_ascii();
+        let reserved = std::str::from_utf8(name)
             .ok()
-            .and_then(|raw| raw.split(';').next())
-            .and_then(|pair| pair.split('=').next())
-            .map(str::trim)
             .is_some_and(is_ruscker_cookie);
         if reserved {
             stripped += 1;
@@ -2371,6 +2382,22 @@ mod tests {
             .map(|value| value.to_str().unwrap())
             .collect();
         assert_eq!(remaining, ["sid=abc; Path=/"]);
+    }
+
+    #[test]
+    fn strip_reserved_set_cookies_matches_name_despite_opaque_bytes() {
+        // Non-UTF-8 bytes AFTER the (ASCII, reserved) name must not let the
+        // header fail open (codex review, #1010).
+        let mut h = HeaderMap::new();
+        h.append(
+            header::SET_COOKIE,
+            HeaderValue::from_bytes(b"ruscker_admin_session=EVIL; Foo=\x80").unwrap(),
+        );
+        h.append(header::SET_COOKIE, HeaderValue::from_static("keep=1"));
+        strip_reserved_set_cookies(&mut h, "app");
+        let remaining: Vec<_> = h.get_all(header::SET_COOKIE).iter().collect();
+        assert_eq!(remaining.len(), 1);
+        assert_eq!(remaining[0].as_bytes(), b"keep=1");
     }
 
     #[test]

--- a/crates/ruscker-admin/src/routes/proxy.rs
+++ b/crates/ruscker-admin/src/routes/proxy.rs
@@ -2268,7 +2268,9 @@ fn sanitize_clear_site_data(headers: &mut HeaderMap, spec_id: &str) {
         // provably one of the safe non-cookie tokens — exact quoting, no
         // backslash escapes — and drop everything else (cookies, *, escaped,
         // malformed, or unknown).
-        const SAFE: &[&str] = &["cache", "storage", "executionContexts"];
+        // The full set of standardized NON-cookie directives — apps may use
+        // any of these for their own state without touching portal cookies.
+        const SAFE: &[&str] = &["cache", "storage", "executionContexts", "clientHints"];
         let kept: Vec<&str> = raw
             .split(',')
             .map(str::trim)
@@ -2478,6 +2480,16 @@ mod tests {
         let v = h.get("clear-site-data").unwrap().to_str().unwrap();
         assert!(!v.to_ascii_lowercase().contains("cookies"), "got: {v}");
         assert!(v.contains("cache") && v.contains("storage"));
+
+        // clientHints is a standardized non-cookie directive — it survives.
+        let mut h = HeaderMap::new();
+        h.append(
+            header::HeaderName::from_static("clear-site-data"),
+            HeaderValue::from_static("\"clientHints\", \"cookies\""),
+        );
+        sanitize_clear_site_data(&mut h, "app");
+        let v = h.get("clear-site-data").unwrap().to_str().unwrap();
+        assert!(v.contains("clientHints") && !v.to_ascii_lowercase().contains("cookies"));
 
         // A lone "*" (clears everything incl. cookies) → header removed.
         let mut h = HeaderMap::new();

--- a/crates/ruscker-admin/tests/identity_headers.rs
+++ b/crates/ruscker-admin/tests/identity_headers.rs
@@ -459,13 +459,17 @@ async fn set_cookie_upstream() -> (SocketAddr, tokio::task::JoinHandle<()>) {
     let addr = listener.local_addr().unwrap();
     let task = tokio::spawn(async move {
         let (mut stream, _) = listener.accept().await.unwrap();
+        // Accumulate across reads: the CRLFCRLF terminator can split across
+        // TCP segments (codex review), which a per-chunk check would miss.
+        let mut raw = Vec::new();
         let mut chunk = [0_u8; 4096];
         loop {
             let n = stream.read(&mut chunk).await.unwrap();
             if n == 0 {
                 break;
             }
-            if chunk[..n].windows(4).any(|w| w == b"\r\n\r\n") {
+            raw.extend_from_slice(&chunk[..n]);
+            if raw.windows(4).any(|w| w == b"\r\n\r\n") {
                 break;
             }
         }

--- a/crates/ruscker-admin/tests/identity_headers.rs
+++ b/crates/ruscker-admin/tests/identity_headers.rs
@@ -449,3 +449,77 @@ async fn mfa_device_cookie_never_reaches_the_upstream() {
         "MFA cookies must never reach a container: {cookie}"
     );
 }
+
+/// An upstream that answers with several `Set-Cookie` headers, so we can
+/// prove the proxy strips the ones whose names Ruscker owns (#1010) — a
+/// same-origin app must not be able to overwrite the user's session,
+/// sticky, or MFA device cookie — while the app's own cookie passes.
+async fn set_cookie_upstream() -> (SocketAddr, tokio::task::JoinHandle<()>) {
+    let listener = TcpListener::bind("127.0.0.1:0").await.unwrap();
+    let addr = listener.local_addr().unwrap();
+    let task = tokio::spawn(async move {
+        let (mut stream, _) = listener.accept().await.unwrap();
+        let mut chunk = [0_u8; 4096];
+        loop {
+            let n = stream.read(&mut chunk).await.unwrap();
+            if n == 0 {
+                break;
+            }
+            if chunk[..n].windows(4).any(|w| w == b"\r\n\r\n") {
+                break;
+            }
+        }
+        stream
+            .write_all(
+                b"HTTP/1.1 200 OK\r\n\
+                  Set-Cookie: app_pref=dark; Path=/\r\n\
+                  Set-Cookie: __ruscker_mfa_device=EVIL; Path=/\r\n\
+                  Set-Cookie: ruscker_admin_session=EVIL; Path=/\r\n\
+                  Set-Cookie: __ruscker_session_identity-off=EVIL; Path=/\r\n\
+                  Content-Length: 2\r\nConnection: close\r\n\r\nok",
+            )
+            .await
+            .unwrap();
+    });
+    (addr, task)
+}
+
+#[tokio::test]
+async fn reserved_set_cookies_from_the_app_never_reach_the_client() {
+    let db = open_db().await;
+    let (upstream, task) = set_cookie_upstream().await;
+    let state = state(db, "identity-off", upstream).await;
+    let response = router(state)
+        .oneshot(
+            Request::builder()
+                .method("GET")
+                .uri("/api/identity-off/data")
+                .body(Body::empty())
+                .unwrap(),
+        )
+        .await
+        .unwrap();
+    assert_eq!(response.status(), StatusCode::OK);
+    let set_cookies: Vec<String> = response
+        .headers()
+        .get_all(header::SET_COOKIE)
+        .iter()
+        .map(|v| v.to_str().unwrap().to_string())
+        .collect();
+    let _ = axum::body::to_bytes(response.into_body(), 1024).await.unwrap();
+    task.await.unwrap();
+
+    // The app's own cookie survives…
+    assert!(
+        set_cookies.iter().any(|c| c.starts_with("app_pref=dark")),
+        "app cookie must pass through: {set_cookies:?}"
+    );
+    // …but every reserved Ruscker cookie the app tried to set is gone.
+    assert!(
+        !set_cookies.iter().any(|c| {
+            let name = c.split(';').next().unwrap_or("").split('=').next().unwrap_or("");
+            name.starts_with("ruscker_") || name.starts_with("__ruscker_")
+        }),
+        "reserved cookies must be stripped: {set_cookies:?}"
+    );
+}


### PR DESCRIPTION
Closes #1010 (follow-up do review de segurança do #1005).

## Problema
O proxy filtrava os cookies do Ruscker nos **requests** aos containers (#258), mas deixava as **respostas** dos apps mexerem neles. Um app hospedado (same-origin com o portal) podia sobrescrever o cookie de dispositivo MFA / sessão admin / sticky do usuário via `Set-Cookie`, ou limpá-los todos via `Clear-Site-Data`. Não é bypass de auth (tokens de grant são hash+user-bound), mas é griefing/logout forçado — relevante desde o bearer MFA de longa duração do #1005.

## Solução (no caminho de resposta do `do_forward`, HTTP-only → WS-safe por construção)
- **`strip_reserved_set_cookies`**: remove os `Set-Cookie` cujo nome (parseado dos **bytes crus** — fail-open evitado para valores não-UTF-8) casa o `is_ruscker_cookie` já existente (prefix-aware: `ruscker_admin_session`, sticky `__ruscker_session*`, `__ruscker_mfa_*`); re-anexa os do app; `warn!` com spec + contagem.
- **`sanitize_clear_site_data`**: **fail-closed com allowlist** — mantém só as diretivas não-cookie padronizadas (`cache`/`storage`/`executionContexts`/`clientHints`), exatas e sem escape; dropa `cookies`, `*`, quoted-pairs obfuscados (`"cook\ies"`), e tudo desconhecido. Header vazio → removido.

## Validação
- Gate completo verde + `i18n`.
- Testes: unit do strip (multi-cookie), unit dos bytes opacos, unit do Clear-Site-Data (diretiva cookie/`*`/quoted-pair/clientHints), e **integração** dirigindo um upstream TCP real que emite `Set-Cookie` reservado + do app pelo router — só o do app chega ao cliente.
- Implementado por agente Codex (gpt-5.6, high); **review por Codex em 5 rodadas**, cada achado real corrigido (fail-open de bytes, Clear-Site-Data, quoted-pair, clientHints) até veredito limpo.

🤖 Generated with [Claude Code](https://claude.com/claude-code)