### PR TITLE
docs: refresh README + site + reference for the current release

### DIFF
--- a/README.md
+++ b/README.md
@@ -100,8 +100,8 @@ What's in the box:
   lifecycle settings), Media, encrypted Credentials, a live-preview
   Appearance editor, **Viewer / Editor / Admin** accounts with a password
   policy and generator, consolidated per-user editing, server-side
-  pagination (50 per page) with accent-tolerant search across usernames,
-  groups and profiles, and an **Activity** history.
+  pagination (50 per page) with case-insensitive search (accented letters
+  included) across usernames, groups and profiles, and an **Activity** history.
 - **Containers dashboard** — CPU/memory sparklines, live-follow logs and
   stop/restart controls, refreshed every five seconds by polling
   `GET /admin/dashboard/snapshot`.

--- a/README.md
+++ b/README.md
@@ -7,7 +7,7 @@
 
 [![Latest release](https://img.shields.io/github/v/release/StrategicProjects/ruscker?sort=semver)](https://github.com/StrategicProjects/ruscker/releases)
 [![License](https://img.shields.io/badge/license-Apache--2.0-blue.svg)](LICENSE)
-[![Docs](https://img.shields.io/badge/docs-ruscker.com-0F6E56)](https://strategicprojects.github.io/ruscker/)
+[![Docs](https://img.shields.io/badge/docs-online-0F6E56)](https://strategicprojects.github.io/ruscker/)
 [![DOI](https://zenodo.org/badge/DOI/10.5281/zenodo.20849123.svg)](https://doi.org/10.5281/zenodo.20849123)
 
 **Ruscker** is a lightweight, single-binary alternative to **ShinyProxy**
@@ -16,11 +16,12 @@ containerized web workloads. It serves and load-balances
 container-per-session interactive apps (R/Shiny, Streamlit, Dash, Voilà,
 Jupyter, RStudio) and container-per-API stateless HTTP services
 (Plumber2, FastAPI) behind a single proxy, with a custom landing page and
-an admin panel. It reads an existing ShinyProxy `application.yml`
-unchanged, so migration is friction-free.
+an admin panel. It accepts an existing ShinyProxy `application.yml`
+without schema rewrites, while `ruscker.yml` is the canonical service
+config, so migration is friction-free.
 
 It ships as a **single, ultra-lightweight static binary** with **instant
-startup** — the idle footprint sits in the low tens of megabytes.
+startup** — the idle footprint is about **14 MB**.
 
 📖 **Documentation: <https://strategicprojects.github.io/ruscker/>**
 (install · migrate · configure · admin · deploy).
@@ -51,8 +52,8 @@ that without giving up convenience:
   YAML schema, no rewrite.
 - **Single compiled binary** — one artifact to ship and run, with a tiny
   idle footprint (~14 MB) and instant startup.
-- **Batteries included** — a real admin panel, a live monitoring
-  dashboard, and load balancing, out of the box.
+- **Batteries included** — a real admin panel, a monitoring dashboard
+  with short polling, and load balancing, out of the box.
 - **Anything in a container** — interactive apps and stateless HTTP APIs
   alike, isolated per session or pooled per replica, with an auto-scaler
   that spawns and reaps containers on demand.
@@ -77,15 +78,8 @@ tool" cases) is in
 
 ## Status
 
-**Production-ready and running in production.** The whole codebase
-went through a systematic bug / security / UX audit in June 2026 with
-every finding fixed, followed by an
-operator-driven design sprint that brought the entire admin — the
-Appearance editor in particular — to the product's design handoff,
-with per-theme (light/dark) portal styling throughout, plus a round of
-private-image and deploy-robustness fixes from real production use.
-Releases are
-multi-arch (amd64 + arm64) and [cosign-signed]; the
+**Production-ready and running in production.** Releases are multi-arch
+(amd64 + arm64) and [cosign-signed]; the
 [releases page](https://github.com/StrategicProjects/ruscker/releases)
 has the current version.
 
@@ -102,26 +96,66 @@ What's in the box:
   rewriting so unmodified Shiny/Streamlit apps work behind a sub-path.
 - **Container backend** (Docker) that spawns app containers on demand,
   applies per-container CPU/memory limits, and reaps idle ones.
-- **Admin panel** — full apps CRUD (every spec field editable from the
-  form, including API/scaling/resource/lifecycle settings, with inline
-  help, plus one-click archive/restore from the list), image/media
-  library, encrypted credentials store, a landing-page editor with a
-  live preview (per-theme light/dark styling, logos, Markdown-enabled
-  per-locale intros, SEO,
-  social meta, analytics, custom HTML blocks), an audit log, **user
-  accounts with Viewer / Editor / Admin roles**, and a live monitoring
-  dashboard (CPU/memory sparklines, live-follow logs, stop/restart).
+- **Admin panel** — full apps CRUD (including API, scaling, resource and
+  lifecycle settings), Media, encrypted Credentials, a live-preview
+  Appearance editor, **Viewer / Editor / Admin** accounts with a password
+  policy and generator, consolidated per-user editing, server-side
+  pagination (50 per page) with accent-tolerant search across usernames,
+  groups and profiles, and an **Activity** history.
+- **Containers dashboard** — CPU/memory sparklines, live-follow logs and
+  stop/restart controls, refreshed every five seconds by polling
+  `GET /admin/dashboard/snapshot`.
+- **Per-app step-up MFA** — `require-mfa: true` gates a spec before a
+  replica is selected or spawned. Users enrol one TOTP factor, with
+  one-time recovery codes, shared by all protected apps;
+  `mfa-validity-days` controls proof freshness (7 by default, `0` for the
+  login session, capped at 30). Browser visits redirect to
+  enrolment/challenge and APIs fail with `401`/`403`. TOTP secrets require
+  `RUSCKER_MASTER_KEY`; trusted-device cookies are opaque, HttpOnly and
+  stored hash-only, with password changes/resets, MFA resets and **Forget
+  devices** revoking them. `RUSCKER_ADMIN_TOKEN` bypasses are audited. See
+  the [admin guide].
+- **Identity headers for apps** — `add-default-http-headers: true`
+  forwards `X-SP-UserId` / `X-SP-UserGroups`, while
+  `identity-claims: [email, setor]` adds the matching
+  `X-Ruscker-User-*` claims for signed-in users; Ruscker defaults both off
+  (unlike ShinyProxy's X-SP pair). Reserved client headers are stripped on
+  HTTP and WebSocket requests to prevent spoofing, and missing claims are
+  omitted. See the [YAML reference].
+- **Hardened cookie boundary** — hosted apps keep their own cookies, but
+  their responses cannot overwrite Ruscker session, sticky or MFA cookies:
+  reserved `Set-Cookie` values and cookie-clearing `Clear-Site-Data`
+  directives are filtered at the proxy. See the [security guide].
+- **Scheduled jobs** — the Admin-only [**Schedules** page] runs a spec's
+  image, environment, volumes and credentials to completion on a cron,
+  with an optional command override, run history/log tail, leader-only HA
+  firing, no fire-on-create, one catch-up after downtime and a per-run
+  timeout (1 hour by default); failures raise the `job-failed` alert webhook.
+- **Named-volume management** — the Disk panel lists Docker volumes with
+  live reference counts and can create labelled volumes; removal is offered
+  only for Ruscker-created volumes with zero references and no catalog use.
 - **Operations** — `/healthz` + `/readyz` probes, graceful shutdown,
   structured (JSON) logging, per-API rate limiting + CORS, request
   body-size limits, an opt-in Prometheus `/metrics` endpoint, and
-  `validate --strict-compat` migration pre-flight.
+  `validate --strict-compat` migration pre-flight, plus alert webhooks for
+  spawn failures, dead replicas, saturation and failed jobs.
+- **Persistence + UI stack** — SQLite is the zero-config source of truth;
+  Postgres provides the shared catalog and session stores for HA. The UI is
+  server-rendered with Askama templates, HTMX and Alpine.js, with no Node
+  build step.
 - **Distribution** — a multi-arch Docker image, a Debian package with a
   hardened `systemd` unit, static musl tarballs, a Homebrew tap, and
   cosign-signed release artifacts.
 
-600+ unit + integration tests run green on `cargo test` (no Docker
-required); extra feature-gated suites exercise a real Docker daemon
-(`docker-it`) and a full proxy + WebSocket end-to-end run (`e2e`).
+The repository contains 760+ unit + integration test cases. The default
+`cargo test` suite needs no Docker; feature-gated suites exercise the Docker
+backend (`docker-it`), the full proxy + WebSocket path (`e2e`), and real
+Shiny/Streamlit WebSockets (`ws-e2e`).
+
+[admin guide]: https://strategicprojects.github.io/ruscker/admin.html#two-factor-authentication-for-selected-apps
+[Schedules page]: https://strategicprojects.github.io/ruscker/admin.html#schedules
+[YAML reference]: docs/YAML_SCHEMA.md
+[security guide]: docs/SECURITY.md
 
 <p align="center">
   <img src="book/src/images/admin-apps.png" alt="The admin Apps table: each spec row with kind/state, and an Actions column with the featured star, edit, duplicate, archive and delete controls." width="860">
@@ -129,8 +163,8 @@ required); extra feature-gated suites exercise a real Docker daemon
 </p>
 
 <p align="center">
-  <img src="book/src/images/admin-dashboard.png" alt="The live monitoring dashboard: aggregate cards plus a per-replica table with CPU sparklines, memory, sessions and stop/restart/logs actions, refreshed on a short poll." width="860">
-  <br><em>Live monitoring dashboard — per-replica CPU/memory, refreshed on a short poll.</em>
+  <img src="book/src/images/admin-dashboard.png" alt="The Containers dashboard: aggregate cards plus a per-replica table with CPU sparklines, memory, sessions and stop/restart/logs actions, refreshed on a short poll." width="860">
+  <br><em>Containers dashboard — per-replica CPU/memory, refreshed on a short poll.</em>
 </p>
 
 ## Install
@@ -229,26 +263,33 @@ ruscker serve \
 ### CLI subcommands
 
 ```bash
-ruscker validate <path>              # parse + validate + report
+ruscker validate <path>                  # parse + validate + report
 ruscker validate <path> --strict-compat   # flag ShinyProxy features Ruscker ignores
-ruscker serve   --config <path> [--docker] [--db <file>]   # run the portal
-ruscker import  <path> --db <file>   # populate SQLite from YAML
-ruscker export  --db <file>          # round-trip back to YAML
-ruscker show    <path>               # render YAML with env vars interpolated
-ruscker inspect <path>               # dump the fully-parsed config as JSON
+ruscker serve [--config <path>] [--docker|--no-docker] [--db <file>]
+              [--config-db-url <dsn>] [--base-path <path>]   # run the portal
+ruscker import <path> --db <file>             # populate SQLite from YAML
+ruscker import <path> --config-db-url <dsn>   # populate a Postgres HA catalog
+ruscker export --db <file>               # round-trip SQLite back to YAML
+ruscker show <path>                       # render YAML with env vars interpolated
+ruscker inspect <path>                    # dump the fully-parsed config as JSON
 ```
+
+Without `--config`, `serve` loads `ruscker.yml` from the working directory,
+falling back to `application.yml` for existing deployments.
 
 ## YAML compatibility
 
-Ruscker reads an existing `application.yml` schema unchanged and adds
-Ruscker-specific fields (API specs, replica pools, landing
-customization) as you go. Migration is typically a one-line change in
-your reverse proxy — point it at Ruscker on the same port and paths.
+`ruscker.yml` is the canonical service config. Ruscker also reads an
+existing ShinyProxy `application.yml` schema unchanged as the migration
+and import format, and adds Ruscker-specific fields (API specs, replica
+pools, identity/MFA policy, landing customization) as you go. Migration
+is typically a one-line change in your reverse proxy — point it at Ruscker
+on the same port and paths.
 See [`docs/YAML_SCHEMA.md`](docs/YAML_SCHEMA.md) and the
 [migration guide](https://strategicprojects.github.io/ruscker/migrating.html).
 
-Credentials never go in YAML — use `${ENV_VAR}` interpolation; the
-validator flags any plaintext secret it finds.
+Secret values should never go in YAML — use `${ENV_VAR}` interpolation or
+the encrypted Credentials store; the validator flags plaintext secrets.
 
 ## Project layout
 
@@ -286,9 +327,10 @@ scope and how to extend it.
 
 ```bash
 cargo build
-cargo test                                   # 600+ tests, no Docker needed
+cargo test                                   # default suite; no Docker needed
 cargo test -p ruscker-docker --features docker-it   # + real Docker daemon
 cargo test -p ruscker-cli --features e2e            # + full proxy/WS e2e
+cargo test -p ruscker-admin --features ws-e2e --test ws_e2e  # + real Shiny/Streamlit WS
 cargo clippy --all-targets -- -D warnings
 ./scripts/i18n-check.sh                      # enforce locale key parity
 ```

--- a/README.md
+++ b/README.md
@@ -131,9 +131,11 @@ What's in the box:
   with an optional command override, run history/log tail, leader-only HA
   firing, no fire-on-create, one catch-up after downtime and a per-run
   timeout (1 hour by default); failures raise the `job-failed` alert webhook.
+  (Local Docker backend; not yet available with the multi-host backend.)
 - **Named-volume management** — the Disk panel lists Docker volumes with
   live reference counts and can create labelled volumes; removal is offered
   only for Ruscker-created volumes with zero references and no catalog use.
+  (Local Docker backend; the multi-host backend reports it as unavailable.)
 - **Operations** — `/healthz` + `/readyz` probes, graceful shutdown,
   structured (JSON) logging, per-API rate limiting + CORS, request
   body-size limits, an opt-in Prometheus `/metrics` endpoint, and
@@ -152,7 +154,7 @@ The repository contains 760+ unit + integration test cases. The default
 backend (`docker-it`), the full proxy + WebSocket path (`e2e`), and real
 Shiny/Streamlit WebSockets (`ws-e2e`).
 
-[admin guide]: https://strategicprojects.github.io/ruscker/admin.html#two-factor-authentication-for-selected-apps
+[admin guide]: https://strategicprojects.github.io/ruscker/admin.html#2fa--mfa-for-selected-apps
 [Schedules page]: https://strategicprojects.github.io/ruscker/admin.html#schedules
 [YAML reference]: docs/YAML_SCHEMA.md
 [security guide]: docs/SECURITY.md

--- a/book/src/admin.md
+++ b/book/src/admin.md
@@ -1,8 +1,9 @@
 # The admin panel
 
 The admin panel is Ruscker's main advantage over editing YAML by hand.
-It lives at `/admin`, is gated by a token, and needs a SQLite database
-(`serve --db <file>`).
+It lives at `/admin`, uses account login after token-based bootstrap,
+and needs a catalog database: SQLite with `serve --db <file>`, or shared
+Postgres with `--config-db-url` in HA.
 
 **Everything is configurable from the web UI** — every spec field
 (including API, scaling, resource and lifecycle settings), the media
@@ -26,9 +27,9 @@ as a **break-glass** login (`/admin/login?token=1`) so you can never be
 locked out. Until a token is set, `/admin/*` returns `503` and only the
 public landing + proxy are served.
 
-The footer has the same **language** (pt-BR / en-US / es-ES / fr-FR)
-and **theme** (light / dark / auto) pickers as the public portal. The
-top-right corner shows your current **access level**.
+The top-right account cluster has the same **language** (pt-BR / en-US /
+es-ES / fr-FR) and **theme** (light / dark / auto) pickers as the public
+portal, plus your current **access level** and account actions.
 
 ## Users and access levels (roles)
 
@@ -38,6 +39,9 @@ accounts under **Users** (`/admin/users`): create one, or open a row's
 one form with a single save, plus the password reset. Each row shows a
 coloured avatar with the user's initials and their groups as coloured
 badges (a group keeps the same colour on the Groups and Apps pages).
+The table is paginated on the server at 50 users per page. Its
+server-side, accent-tolerant search covers username, groups, department,
+email and phone on both SQLite and Postgres.
 
 Passwords follow a **policy**: at least 8 characters, with at least one
 uppercase letter, one lowercase letter, one digit and one special
@@ -55,7 +59,7 @@ read a password as you type it.
 | Role | Can do |
 |---|---|
 | **Viewer** | a **portal** account, not a panel operator: signs in to unlock group-restricted cards on the landing; reaches no admin section |
-| **Editor** | view + manage Apps and Media; view the Dashboard and stop/restart replicas |
+| **Editor** | view + manage Apps and Media; view Containers and stop/restart replicas |
 | **Admin** | everything, including managing users, credentials, the landing editor, custom blocks and the audit log |
 
 The panel shows only the sections your role can reach. Enforcement is
@@ -65,7 +69,7 @@ acting username. A **last-admin guard** stops you deleting or demoting
 the only remaining admin (so the portal can't be locked out); the
 `RUSCKER_ADMIN_TOKEN` break-glass login is the other safety net.
 
-### Two-factor authentication for selected apps
+### 2FA / MFA for selected apps
 
 In an app's **Access & scale** settings, enable **Require 2FA**
 (`require-mfa`) to require a user-owned authenticator-app code before the
@@ -73,13 +77,19 @@ proxy will select or start that app's container. The same enrolled TOTP
 factor is reused across protected apps; the switch is a per-app step-up
 policy, not a separate enrollment for every app.
 
-On first access, a signed-in user without a factor is guided through setup
-and receives recovery codes. Later access redirects to a challenge when the
-browser has no current trusted-device proof. **MFA validity days** controls
-that cadence (7 days by default, at most 30); `0` means every new login
-session must prove MFA, even if the browser still has a trusted-device
-cookie. API routes do not redirect: they return `401` without a login and
-`403` when MFA is still required.
+Users enrol once under **Account → 2FA**, either directly or when a
+protected app redirects them there. They re-enter their password, scan the
+QR code with a standard TOTP app such as Google Authenticator, Microsoft
+Authenticator, Authy or 1Password, confirm a six-digit code, and save the
+one-time recovery codes shown once. One successful proof satisfies every
+protected app, subject to each app's freshness policy.
+
+**MFA validity days** (`mfa-validity-days`) controls that policy: 7 days by
+default, capped at 30; `0` limits the proof to the current login session.
+The proxy checks it before any container is selected or started. An
+unenrolled or unproven `/app` visit redirects to enrolment or challenge
+without spawning; protected `/api` requests return `401` without a login
+and `403` when proof is still required.
 
 Users can open **Two-factor authentication** in their account to **forget
 this device** or **forget all trusted devices** without ending their login
@@ -89,14 +99,45 @@ and device grants, so the next protected-app visit starts guided enrollment
 again. The `RUSCKER_ADMIN_TOKEN` remains an audited break-glass bypass for
 emergencies and should not be used for routine app access.
 
+The remembered-device cookie is opaque and `HttpOnly`; only its salted hash
+is stored. Password change/reset, 2FA reset, user deletion and **Forget all
+trusted devices** revoke remembered proofs. TOTP secrets are encrypted with
+`RUSCKER_MASTER_KEY`; enrolment fails closed with `503` when the key is
+missing. Secrets and recovery-code plaintext never enter logs, audit rows or
+YAML exports. The flow works with both SQLite and Postgres; an Admin sees
+only whether 2FA is configured and can perform the audited reset.
+
+### Identity headers to apps
+
+For an app that needs the portal identity, enable
+`add-default-http-headers: true`. Ruscker then sends the
+ShinyProxy-compatible `X-SP-UserId` and `X-SP-UserGroups` headers. Unlike
+ShinyProxy, Ruscker defaults this off so upgrading or importing a spec does
+not disclose identity unexpectedly.
+
+Independently, use `identity-claims: [email, setor]` to opt into profile
+fields as `X-Ruscker-User-Email` and `X-Ruscker-User-Setor`. A claim with
+no stored value is omitted. These headers are forwarded only for signed-in
+users and work on both HTTP requests and WebSocket handshakes.
+
+Treat them as trusted identity only when the app is reachable exclusively
+through Ruscker. The proxy strips all client-supplied `X-SP-*` and
+`X-Ruscker-User-*` headers before inserting its authoritative values, which
+prevents direct request spoofing at this boundary.
+
 ## Screens
 
 The sections below follow the panel's tab order: daily drivers first
-(Dashboard, Apps, Media, Credentials, Appearance), people (Users above,
-Groups), then diagnostics and maintenance (Logs, Disk, Audit, System).
+(Containers, Apps, Media, Credentials, Appearance, Schedules), people
+(Users above, Groups), then diagnostics and maintenance (Logs, Disk,
+Activity, System). The former Dashboard/Painel nav label is now
+**Containers**, and Audit/Auditoria is **Activity/Atividades**. Core module
+headings use the standardized “X Management” / “Gestão de X” pattern;
+technical notes sit in helper text instead of subtitles.
 
-### Dashboard
-A live view of running replicas, refreshed over Server-Sent Events. The
+### Containers
+A live view of running replicas, refreshed by polling
+`GET /admin/dashboard/snapshot`. The
 headline KPI cards (containers, apps with replicas, sessions, memory)
 count up on load. Below them, replicas are **grouped by app** in
 expandable cards: each card's header summarises the app — replica count,
@@ -108,8 +149,6 @@ started without `--docker`. Stop and restart take a few seconds (drain,
 signal, and a respawn for restart), so while one runs the replica row
 dims, its buttons disable to prevent a double-fire, and the clicked
 action shows a spinner.
-
-![Monitoring dashboard: aggregate cards (containers, apps with replicas, active sessions, memory) above a per-replica table with live CPU sparklines and memory, and per-row stop/restart/logs actions.](images/admin-dashboard.png)
 
 ### Apps
 The list of specs — apps, APIs and external links — with create, edit
@@ -128,8 +167,6 @@ it is (no reload, no scroll jump, and the row keeps its position in the
 list — archiving doesn't count as an "update"). Delete asks for
 confirmation, stops the app's containers and is audited; apps defined
 in the `serve --config` YAML stay read-only here.
-
-![Apps table: id, name, kind and state columns, plus updated/version, and an Actions column where each row has the featured star, edit and duplicate buttons, the archive toggle and a delete button.](images/admin-apps.png)
 
 The add/edit form walks down the page in the order you think about an
 app: **Identity** (id, name, subject), **Kind** (app container /
@@ -156,8 +193,6 @@ centre of the screen: it confirms the app was created and asks where to
 go next — **back to the form** to keep editing it, or straight to the
 **apps list**. Editing an existing app just saves in place, with no
 prompt. The dialog is localized in all four interface languages.
-
-![The post-create confirmation: a centred dialog reading "App created — the app was created successfully", with "Back to the form" and "Go to the app list" buttons over the dimmed editor.](images/admin-app-created.png)
 
 Two editors can have the same app open without trampling each other:
 the form carries the version it was loaded against, and a stale save is
@@ -192,8 +227,6 @@ without touching YAML:
 Every advanced field is optional; leaving it blank keeps Ruscker's
 default, so the section stays out of the way until you need it.
 
-![Add/edit app form: the Kind selector and Identity/Visual bands on the left, with a live card preview on the right that updates as you type.](images/admin-spec-form.png)
-
 ### Media
 Upload images (PNG/JPEG → WebP), served at `/assets/img/<file>`. These
 are the card logos and covers.
@@ -217,8 +250,6 @@ flow; inline uploads auto-select the stored (possibly renamed) file, and
 every picker tile shows a **filename caption**, so look-alike images are
 easy to tell apart.
 
-![Media library: a gallery of images with built-in framework logos seeded alongside uploads, each tile showing its filename, size and type.](images/admin-media.png)
-
 ### Credentials
 A named, AES-256-GCM-encrypted store for registry credentials (needs
 `RUSCKER_MASTER_KEY`). Passwords never appear in the YAML or in the
@@ -238,8 +269,6 @@ without changing the saved default, and the action bar carries a
 **"Restore defaults"** button (with confirmation) that resets the
 styling while keeping titles, logos, texts, SEO, custom CSS and HTML
 blocks:
-
-![Appearance editor: control cards for header texts, logos, header style, catalog cards, theme and layout on the left, with a live portal preview pane (with its own light/dark switch) on the right.](images/admin-appearance.png)
 
 - **Header** — the portal title, subtitle and footer texts.
 - **Logos** — the **main header logo** in one place: built-in mark,
@@ -346,16 +375,12 @@ that app's editor.
 
 ### Logs
 
-![Logs viewer: a terminal-style live stream with colour-coded levels and a toolbar with pause, level chips, an app filter and download.](images/admin-logs.png)
-
 The server log stream, live over Server-Sent Events. Lines are colour-
 coded by level, with level chips (info / warn / error), an app filter
 dropdown, a line counter, and pause/resume + clear controls. A download
 link grabs the current buffer.
 
 ### Disk
-
-![Disk panel: a storage hero with a stacked usage bar, above panels listing Ruscker-managed containers and images with remove and prune actions.](images/admin-disk.png)
 
 Storage at a glance (Admin-only). A usage hero shows host disk used /
 total with a percentage and a stacked bar split into Ruscker images,
@@ -364,11 +389,17 @@ containers and images — each removable, with an "in use" cross-reference
 so you don't delete something a running app or the effective catalog
 needs, plus bulk "prune stopped containers" and "remove unused images".
 
-### Audit log
+The **Volumes** card lists named Docker volumes with live reference counts
+across all host containers. Volumes created here receive the
+`ruscker.created` label. Removal is offered only when Ruscker created the
+volume, no container references it, and no effective catalog spec names it;
+the server rechecks all three conditions before asking Docker to remove it.
+
+### Activity
 Every admin mutation (spec/image/credential/landing/block changes,
-imports) is recorded with actor, action, target and timestamp — and
-since v0.2.5 the dashboard's destructive **replica stop/restart**
-actions are too.
+imports) is recorded with actor, action, target and timestamp. Destructive
+**replica stop/restart**, schedule changes, MFA enrolment/reset/proof, and
+break-glass MFA bypasses are recorded too.
 
 ### System
 
@@ -387,6 +418,7 @@ operator should know about happens:
   control (crash, OOM, external stop) and was pruned;
 - **`saturated`** — an app is full at `max-replicas` and visitors may
   be turned away;
+- **`job-failed`** — a scheduled job exited non-zero or could not run;
 - **`test`** — the *Send test alert* button, for checking the wiring.
 
 The payload:
@@ -413,11 +445,12 @@ token).
 
 ## Config vs. database
 
-`serve --config` drives the public landing and the proxy. The admin
-panel reads and writes the SQLite DB. Use `ruscker import` to populate
-the DB from a YAML, and `ruscker export` to round-trip it back — both
-preserve specs, landing customization, SEO/analytics and custom
-blocks.
+`serve --config` supplies service settings and any YAML-managed specs. The
+admin panel reads and writes the catalog database: SQLite with `--db`, or
+Postgres with `--config-db-url`. `ruscker import` can populate either from
+YAML. For SQLite, `ruscker export --db <file>` reconstructs the portable
+configuration, including specs, landing customization, SEO/analytics and
+custom blocks; credential and MFA secrets are not exported.
 
 ### Importing card images into the Media library
 

--- a/book/src/admin.md
+++ b/book/src/admin.md
@@ -40,8 +40,10 @@ one form with a single save, plus the password reset. Each row shows a
 coloured avatar with the user's initials and their groups as coloured
 badges (a group keeps the same colour on the Groups and Apps pages).
 The table is paginated on the server at 50 users per page. Its
-server-side, accent-tolerant search covers username, groups, department,
-email and phone on both SQLite and Postgres.
+server-side, case-insensitive search (accented letters included — `GESTÃO`
+matches `Gestão`, though it does not strip diacritics, so `Joao` won't find
+`João`) covers username, groups, department, email and phone on both SQLite
+and Postgres.
 
 Passwords follow a **policy**: at least 8 characters, with at least one
 uppercase letter, one lowercase letter, one digit and one special
@@ -325,7 +327,9 @@ back at the blocks section.
 ### Schedules
 
 Cron-scheduled, run-to-completion jobs (Admin-only) — nightly ETL,
-report generation, cache warm-ups. A schedule picks one of your
+report generation, cache warm-ups. **Local Docker backend only** — the
+multi-host backend does not run jobs, so a due schedule there is recorded
+as an error. A schedule picks one of your
 containerized apps and runs **that app's image** with the same
 environment, volumes, resource limits and registry credentials a normal
 replica gets, optionally overriding the command (one argv element per
@@ -390,7 +394,8 @@ so you don't delete something a running app or the effective catalog
 needs, plus bulk "prune stopped containers" and "remove unused images".
 
 The **Volumes** card lists named Docker volumes with live reference counts
-across all host containers. Volumes created here receive the
+across all host containers. **Local Docker backend only** — with the
+multi-host backend the Disk page reports volumes as unavailable. Volumes created here receive the
 `ruscker.created` label. Removal is offered only when Ruscker created the
 volume, no container references it, and no effective catalog spec names it;
 the server rechecks all three conditions before asking Docker to remove it.

--- a/book/src/alternatives.md
+++ b/book/src/alternatives.md
@@ -5,7 +5,8 @@ container-per-API workloads** — interactive apps that want a fresh
 container per visitor, and stateless HTTP services pooled per replica. If
 your apps run in a container and speak HTTP or WebSocket, Ruscker wraps
 them in a portal, a reverse proxy, sticky sessions, auto-scaling and an
-admin panel — configured by a single YAML file.
+admin panel. Service settings can live in `ruscker.yml`; the editable app
+catalog and operational state live in SQLite, or Postgres for HA.
 
 ## What Ruscker is good at
 
@@ -19,8 +20,23 @@ admin panel — configured by a single YAML file.
 - **A real admin panel** — apps CRUD, a media library, an encrypted
   credentials store, a live monitoring dashboard, an audit log, and user
   roles — instead of editing a file and restarting.
-- **Light to run** — a single static binary with a low-tens-of-MB idle
-  footprint and instant startup.
+- **Sensitive internal apps** — per-app step-up TOTP MFA is enforced before
+  a container starts, while opt-in identity headers let the app consume the
+  signed-in username, groups and selected profile claims.
+- **Scheduled operations** — run the same app image/environment/volumes to
+  completion on a cron for ETL, reports and maintenance, with history,
+  timeouts and failure alerts.
+- **Light to run** — **~14 MB idle**, a single static binary, no JVM and
+  instant startup.
+
+## Compared with ShinyProxy
+
+Ruscker keeps the familiar spec schema and `/app/{spec}` shape, including
+opt-in `add-default-http-headers: true` compatibility through
+`X-SP-UserId` and `X-SP-UserGroups`. It adds per-app step-up MFA, selected
+`X-Ruscker-User-*` profile claims, stateless API pools, scheduled jobs and
+an editable database-backed admin catalog. Identity forwarding defaults
+off, so enable it explicitly for apps that need and trust those headers.
 
 ## Self-hosting a single framework
 
@@ -80,9 +96,9 @@ the systemd service) and reference them by name in the YAML.
 
 ## When Ruscker is *not* the right tool
 
-- You need a **publishing / authoring workflow** — pushing content from an
-  IDE, scheduled reports, content versioning. Ruscker is a
-  proxy/orchestrator; you bring your own container images.
+- You need a **publishing / authoring workflow** — pushing source from an
+  IDE, building content or versioning releases. Ruscker can schedule an
+  existing image, but it does not replace your build and publishing system.
 - You're **all-in on Kubernetes** and want a CRD-native operator today —
   Ruscker schedules onto Docker hosts (over ssh/tcp), not Kubernetes.
 - You need **enterprise SSO gating app access per user** (OIDC/SAML/LDAP

--- a/book/src/alternatives.md
+++ b/book/src/alternatives.md
@@ -23,8 +23,9 @@ catalog and operational state live in SQLite, or Postgres for HA.
 - **Sensitive internal apps** — per-app step-up TOTP MFA is enforced before
   a container starts, while opt-in identity headers let the app consume the
   signed-in username, groups and selected profile claims.
-- **Scheduled operations** — run the same app image/environment/volumes to
-  completion on a cron for ETL, reports and maintenance, with history,
+- **Scheduled operations** (local Docker backend) — run the same app
+  image/environment/volumes to completion on a cron for ETL, reports and
+  maintenance, with history,
   timeouts and failure alerts.
 - **Light to run** — **~14 MB idle**, a single static binary, no JVM and
   instant startup.

--- a/book/src/deploying.md
+++ b/book/src/deploying.md
@@ -18,10 +18,15 @@ option is documented inline in the shipped file); put your **secrets** in
 
 ```ini
 RUSCKER_ADMIN_TOKEN=...        # openssl rand -hex 32
-RUSCKER_MASTER_KEY=...         # for the credentials store
+RUSCKER_MASTER_KEY=...         # encrypted credentials and MFA secrets
 RUSCKER_COOKIE_KEY=...         # keep sticky sessions stable across restarts
 DOCKER_REGISTRY_PASSWORD=...   # referenced as ${DOCKER_REGISTRY_PASSWORD} in the YAML
 ```
+
+The package generates stable master and cookie keys when they are missing.
+Keep `RUSCKER_MASTER_KEY` backed up: 2FA enrolment returns `503` without it,
+and changing it makes existing encrypted credentials and TOTP factors
+undecryptable.
 
 ## 2. Enable the container backend
 
@@ -166,8 +171,8 @@ server {
 ```
 
 Set `server.useForwardHeaders: true` in the YAML so Ruscker trusts
-`X-Forwarded-*`. **Since v0.2.5 this is required** for cookies to carry
-the `Secure` flag behind a TLS-terminating proxy — without the flag,
+`X-Forwarded-*`. This is required for cookies to carry the `Secure` flag
+behind a TLS-terminating proxy — without the flag,
 forwarded headers from any client would be spoofable, so Ruscker
 ignores them entirely (cookies are then minted as if on plain HTTP, and
 per-client API rate limiting keys on the TCP peer, i.e. your proxy).
@@ -175,19 +180,19 @@ Both halves are needed: the `proxy_set_header X-Forwarded-Proto`
 above **and** the YAML flag. ShinyProxy-migrated configs usually carry
 the flag already.
 
-> Two Ruscker endpoints stream over **Server-Sent Events** (SSE):
-> the live dashboard (`/admin/dashboard/events`) and the Ruscker log
-> tail (`/admin/logs/stream`). nginx's default response buffering
-> delays or blocks these streams — disable it for both paths:
+> The Containers dashboard short-polls
+> `GET /admin/dashboard/snapshot`; it does not use SSE and needs no
+> buffering exception. The server log tail and per-replica live log tails
+> do use SSE, so disable nginx buffering for their paths:
 >
 > ```nginx
-> location = /admin/dashboard/events {
+> location = /admin/logs/stream {
 >     proxy_pass http://127.0.0.1:8090;
 >     proxy_buffering off;
 >     proxy_read_timeout 1h;
 >     # + the same proxy_set_header lines as above
 > }
-> location = /admin/logs/stream {
+> location ^~ /admin/dashboard/logs/ {
 >     proxy_pass http://127.0.0.1:8090;
 >     proxy_buffering off;
 >     proxy_read_timeout 1h;
@@ -231,7 +236,7 @@ location /apps/   { proxy_pass http://127.0.0.1:8080; /* + proxy_set_header from
 Ruscker then nests every route under `/apps` (`/apps`, `/apps/admin/…`,
 `/apps/app/{spec}/…`), rewrites the URLs/redirects it emits to carry the
 prefix, and injects a small runtime shim so JS-built requests (the live
-dashboard's SSE, `fetch`, etc.) resolve under `/apps` too. `/healthz` and
+dashboard poller, `fetch`, WebSockets, etc.) resolve under `/apps` too. `/healthz` and
 `/readyz` stay at the **root** for load-balancer probes — don't put them
 behind the `/apps` locations. `--base-path` is empty by default, so
 root-mounted deploys are unaffected.
@@ -256,7 +261,7 @@ sessions wind down up to `proxy.shutdown-grace-ms`, then exits.
 For high availability you can run **several Ruscker instances behind a
 load balancer**, all sharing one Postgres. There's a runnable harness
 (two instances + nginx + Postgres) in [`examples/ha/`][ha] — start
-there. The three things every instance must share:
+there. These things must be shared by every instance:
 
 - **`--config-db-url postgres://…`** — the admin catalog (specs,
   landing, users, credentials, audit) lives in Postgres instead of a
@@ -271,6 +276,9 @@ there. The three things every instance must share:
   instance pointed at the same Docker backend (so they reconcile the
   same replicas), a session survives the load balancer moving it
   between instances.
+- **the same `RUSCKER_MASTER_KEY`** on every instance — all nodes must be
+  able to decrypt stored registry credentials and user TOTP factors. A
+  missing key makes MFA enrolment fail closed.
 
 **Scaler leader election is automatic:** instances elect one leader via
 a Postgres advisory lock; only the leader spawns/reaps replicas, the
@@ -412,9 +420,10 @@ State lives in two places:
   sqlite3 /var/lib/ruscker/ruscker.db ".backup '/backup/ruscker.db'"
   ```
 
-  The encrypted credentials are useless without `RUSCKER_MASTER_KEY`, so
-  back up the key too — separately. `ruscker export --db <file>` also
-  writes a YAML snapshot (everything except the encrypted secrets).
+  The encrypted credentials and MFA factors are unusable without
+  `RUSCKER_MASTER_KEY`, so back up the key too — separately. `ruscker
+  export --db <file>` also writes a YAML snapshot; it does not export
+  credential or MFA secrets.
 
 ## Upgrading
 

--- a/book/src/faq.md
+++ b/book/src/faq.md
@@ -52,9 +52,32 @@ visibility**: every spec can declare `access-groups` / `access-users`
 and only matching users see the card and reach `/app` / `/api`
 (specs with no access keys remain open to anyone) —
 see [Per-user access](./configuration.md#per-user-access).
+An app can also set `require-mfa: true` for a TOTP step-up before its
+container starts; each user enrols one factor and each app chooses how
+recent the proof must be.
 External identity providers (OIDC / SAML / LDAP) for end-user
 sign-in are [Phase 8](./roadmap.md); user accounts are managed in
 the admin **Users** page until then.
+
+### How does my app receive the signed-in user?
+
+Identity forwarding is opt-in per spec. Set
+`add-default-http-headers: true` for `X-SP-UserId` and
+`X-SP-UserGroups`. Independently, select `identity-claims: [email, setor]`
+for `X-Ruscker-User-Email` / `X-Ruscker-User-Setor`. Ruscker sends values
+only for signed-in users, on HTTP and WebSocket, and strips client-supplied
+reserved identity headers first. It defaults off; if the app appears to
+have “lost” the user after migrating from ShinyProxy, enable it explicitly.
+
+### Can proxied apps set their own cookies?
+
+Yes. App-owned cookies pass through. Because apps share the portal origin,
+Ruscker drops response cookies that use its reserved session, preference,
+sticky or MFA names (including `ruscker_admin_session`, `ruscker_theme`,
+`ruscker_locale`, `__ruscker_session*` and `__ruscker_mfa_*`). It also
+neutralises `Clear-Site-Data` cookie-clearing directives. Rename a
+conflicting app cookie; this boundary prevents an app from overwriting the
+portal's login or MFA state.
 
 ### Where is configuration and state stored?
 
@@ -83,13 +106,12 @@ sticky upstream for the login paths remains the fallback — see
 
 ### Is it production-ready?
 
-Yes. Phases 0–7 are complete, the proxy is production-ready and
-horizontally scalable, and the codebase was systematically audited for
-bugs, security and UX in June 2026, with every finding fixed.
-Releases are multi-arch and cosign-signed; see the
-[release notes](./news.md) and the [Roadmap](./roadmap.md).
-Phase 8 (external auth: OIDC / SAML / LDAP) is the main remaining
-optional work.
+The current release includes health probes, graceful shutdown, structured
+logging, signed multi-arch artifacts and active-active operation with
+Postgres. Review the [release notes](./news.md) and
+[Roadmap](./roadmap.md), then stage your own workload and failure tests.
+External identity providers (OIDC / SAML / LDAP) are not yet available;
+use the built-in accounts when that limitation fits your deployment.
 
 ### What platforms does it run on?
 

--- a/book/src/images/crate-map.svg
+++ b/book/src/images/crate-map.svg
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 720 470" width="720" height="470" font-family="Jost, Inter, system-ui, -apple-system, sans-serif" role="img" aria-label="Crate dependency map: ruscker-cli (binary) builds on the I/O crates (docker, proxy, admin), which build on ruscker-core, which builds on ruscker-config. Config and core are pure-domain with no I/O.">
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 720 470" width="720" height="470" font-family="Jost, Inter, system-ui, -apple-system, sans-serif" role="img" aria-label="Crate dependency map: ruscker-cli (binary) builds on ruscker-admin + ruscker-docker; admin builds on ruscker-proxy; all build on ruscker-core, which builds on ruscker-config. Config and core are pure-domain with no I/O.">
   <title>Ruscker — crate map</title>
 
   <defs>
@@ -46,10 +46,11 @@
   <text x="360" y="404" text-anchor="middle" font-size="10.5" fill="#5B6B66">YAML schema · parsing · validation</text>
 
   <!-- edges: arrows point up, toward the consumer ("built on") -->
-  <!-- cli ← the three I/O crates -->
+  <!-- cli ← ruscker-admin + ruscker-docker (cli does not depend on ruscker-proxy directly) -->
   <line x1="146" y1="150" x2="300" y2="88" stroke="#1D9E75" stroke-width="2" marker-end="url(#up)"/>
-  <line x1="360" y1="150" x2="360" y2="88" stroke="#1D9E75" stroke-width="2" marker-end="url(#up)"/>
   <line x1="574" y1="150" x2="420" y2="88" stroke="#1D9E75" stroke-width="2" marker-end="url(#up)"/>
+  <!-- admin ← proxy (admin depends on proxy) -->
+  <line x1="452" y1="175" x2="481" y2="175" stroke="#1D9E75" stroke-width="2" marker-end="url(#up)"/>
   <!-- core ← I/O crates (fan out from core's top edge) -->
   <line x1="300" y1="296" x2="146" y2="202" stroke="#1D9E75" stroke-width="2" marker-end="url(#up)"/>
   <line x1="360" y1="296" x2="360" y2="202" stroke="#1D9E75" stroke-width="2" marker-end="url(#up)"/>

--- a/book/src/images/deployment.svg
+++ b/book/src/images/deployment.svg
@@ -53,7 +53,7 @@
   <line x1="605" y1="174" x2="570" y2="208" stroke="#1D9E75" stroke-width="2.2" marker-end="url(#dn)"/>
 
   <rect x="405" y="212" width="260" height="44" rx="9" fill="#E8F3EE" stroke="#1D9E75" stroke-width="1.6"/>
-  <text x="535" y="231" text-anchor="middle" font-size="12.5" font-weight="600" fill="#085041">Postgres — shared session state</text>
+  <text x="535" y="231" text-anchor="middle" font-size="12.5" font-weight="600" fill="#085041">Postgres — shared config + sessions</text>
   <text x="535" y="248" text-anchor="middle" font-size="10" fill="#5B6B66">either instance can serve any session</text>
   <line x1="535" y1="256" x2="535" y2="282" stroke="#1D9E75" stroke-width="2.2" marker-end="url(#dn)"/>
 

--- a/book/src/installation.md
+++ b/book/src/installation.md
@@ -21,10 +21,12 @@ This:
 - installs `/usr/bin/ruscker`,
 - creates a `ruscker` system user,
 - installs a hardened `ruscker.service` unit and enables + starts it,
-- drops a minimal config at `/etc/ruscker/application.yml` and a
+- drops a minimal config at `/etc/ruscker/ruscker.yml` and a
   secrets file at `/etc/ruscker/ruscker.env`,
 - **generates a unique admin token on first install and prints it
   once** (there is no default password),
+- generates stable master and cookie keys without overwriting existing
+  values, so encrypted credentials, MFA and sticky sessions survive restarts,
 - runs with the **admin catalog enabled** (`--db
   /var/lib/ruscker/ruscker.db`), so the admin panel works out of the box
   and a set of showcase apps seeds on first boot.
@@ -37,7 +39,7 @@ sudo grep RUSCKER_ADMIN_TOKEN /etc/ruscker/ruscker.env   # your admin token
 
 Log in at `/admin` with the printed token to manage **apps, the landing
 page and users** — that's where day-to-day configuration lives (stored
-in the catalog DB, not the YAML). `application.yml` holds **deployment**
+in the catalog DB, not the YAML). `ruscker.yml` holds **deployment**
 settings; put secrets in `/etc/ruscker/ruscker.env`. After editing either
 file, `sudo systemctl restart ruscker`.
 
@@ -53,8 +55,8 @@ Pick the scope you want:
 | Goal | Command | What's left |
 |---|---|---|
 | **Remove the software**, keep config + data | `sudo apt remove ruscker` | `/etc/ruscker` (config, admin token, keys) and `/var/lib/ruscker` (catalog DB) — a reinstall resumes where you left off. |
-| **Remove everything** (no trace) | `sudo apt purge ruscker` | Nothing. Drops the catalog DB **and** `/etc/ruscker` — including `application.yml` and the admin token / master key in `ruscker.env`. |
-| **Reset to a brand-new install** | `sudo apt purge ruscker && sudo apt install ./ruscker_<version>-1_amd64.deb` | A pristine box: the default `application.yml` (no custom title/specs) and a freshly generated admin token, exactly like a first install. |
+| **Remove everything** (no trace) | `sudo apt purge ruscker` | Nothing. Drops the catalog DB **and** `/etc/ruscker` — including `ruscker.yml` and the admin token / master key in `ruscker.env`. |
+| **Reset to a brand-new install** | `sudo apt purge ruscker && sudo apt install ./ruscker_<version>-1_amd64.deb` | A pristine box: the default `ruscker.yml` (no custom title/specs) and freshly generated keys and admin token, exactly like a first install. |
 | **Wipe the data only**, keep config | stop, remove the DB, start (below) | Config + token unchanged; the catalog is empty, so migrations re-run and the showcase cards re-seed on next boot. |
 
 To wipe just the catalog (a "fresh portal" without uninstalling):
@@ -68,7 +70,7 @@ sudo systemctl start ruscker
 > The catalog DB lives in `/var/lib/ruscker`; your config and secrets
 > live in `/etc/ruscker`. `purge` clears both; removing the DB clears
 > only the catalog. The portal **title** comes from `proxy.title` in
-> `application.yml`, so it survives a data-only wipe — only a `purge` (or
+> `ruscker.yml`, so it survives a data-only wipe — only a `purge` (or
 > editing the file) changes it.
 
 ## Static musl tarball
@@ -110,9 +112,9 @@ tap, so `brew upgrade` tracks the latest version.
 
 ```sh
 docker run --rm -p 8080:8080 \
-  -v "$PWD/application.yml:/etc/ruscker/application.yml:ro" \
+  -v "$PWD/ruscker.yml:/etc/ruscker/ruscker.yml:ro" \
   ghcr.io/strategicprojects/ruscker:latest \
-  serve --config /etc/ruscker/application.yml --bind 0.0.0.0:8080
+  serve --config /etc/ruscker/ruscker.yml --bind 0.0.0.0:8080
 ```
 
 To let Ruscker spawn app containers (the `--docker` backend), also
@@ -120,10 +122,10 @@ mount the Docker socket and add `--docker`:
 
 ```sh
 docker run --rm -p 8080:8080 \
-  -v "$PWD/application.yml:/etc/ruscker/application.yml:ro" \
+  -v "$PWD/ruscker.yml:/etc/ruscker/ruscker.yml:ro" \
   -v /var/run/docker.sock:/var/run/docker.sock \
   ghcr.io/strategicprojects/ruscker:latest \
-  serve --config /etc/ruscker/application.yml --bind 0.0.0.0:8080 --docker
+  serve --config /etc/ruscker/ruscker.yml --bind 0.0.0.0:8080 --docker
 ```
 
 > Mounting the Docker socket grants control of the host's Docker
@@ -171,21 +173,24 @@ The exact commands are also printed in each release's notes.
 ## The `serve` command
 
 ```text
-ruscker serve --config <path> [--bind 0.0.0.0:8080] [--docker]
-              [--db <file>] [--images-dir <dir>] [--log-format json]
+ruscker serve [--config <path>] [--bind 0.0.0.0:8080] [--docker|--no-docker]
+              [--db <file>] [--config-db-url <postgres-url>]
+              [--images-dir <dir>] [--log-format json]
               [--base-path <prefix>]
 ```
 
 | Flag | What it does |
 |---|---|
-| `--config` | Path to the `application.yml`. |
+| `--config` | Path to the service config. When omitted, Ruscker prefers `ruscker.yml` in the working directory and falls back to `application.yml` for compatibility. |
 | `--bind` | Listen address (defaults to the YAML's `proxy.port`). |
-| `--docker` | Enable the container backend (spawn app containers). |
-| `--db` | SQLite file backing the admin panel. Without it, `/admin/*` is read-only-ish and the editor returns 503. |
+| `--docker` / `--no-docker` | By default Ruscker auto-connects when the local daemon socket is reachable. `--docker` makes connection failure fatal; `--no-docker` forces landing-only mode. |
+| `--db` | SQLite file backing the admin panel. Without it or `--config-db-url`, `/admin/*` returns 503. |
+| `--config-db-url` | PostgreSQL URL backing the admin panel and shared catalog in HA deployments. |
 | `--images-dir` | Directory served at `/assets/img/`. Auto-discovered from the config / ShinyProxy `template-path` when omitted. |
 | `--log-format` | `text` (default) or `json`. |
 | `--base-path` | Mount the whole portal under a URL prefix (e.g. `--base-path /apps`). Overrides `server.context-path` in the YAML. Health probes (`/healthz`, `/readyz`) stay at the root. |
 
 Secrets come from the environment: `RUSCKER_ADMIN_TOKEN`,
 `RUSCKER_MASTER_KEY`, `RUSCKER_COOKIE_KEY`,
-`DOCKER_REGISTRY_PASSWORD`.
+`DOCKER_REGISTRY_PASSWORD`. `RUSCKER_MASTER_KEY` is required for encrypted
+credentials and 2FA enrolment; keep it stable and back it up.

--- a/book/src/installation.md
+++ b/book/src/installation.md
@@ -184,7 +184,7 @@ ruscker serve [--config <path>] [--bind 0.0.0.0:8080] [--docker|--no-docker]
 | `--config` | Path to the service config. When omitted, Ruscker prefers `ruscker.yml` in the working directory and falls back to `application.yml` for compatibility. |
 | `--bind` | Listen address (defaults to the YAML's `proxy.port`). |
 | `--docker` / `--no-docker` | By default Ruscker auto-connects when the local daemon socket is reachable. `--docker` makes connection failure fatal; `--no-docker` forces landing-only mode. |
-| `--db` | SQLite file backing the admin panel. Without it or `--config-db-url`, `/admin/*` returns 503. |
+| `--db` | SQLite file backing the admin catalog. Without it (and without `--config-db-url`), break-glass token login and the read-only monitoring dashboard still work, but the catalog-backed screens (Apps, Users, Groups, Media, Credentials, …) return 503. |
 | `--config-db-url` | PostgreSQL URL backing the admin panel and shared catalog in HA deployments. |
 | `--images-dir` | Directory served at `/assets/img/`. Auto-discovered from the config / ShinyProxy `template-path` when omitted. |
 | `--log-format` | `text` (default) or `json`. |

--- a/book/src/introduction.md
+++ b/book/src/introduction.md
@@ -13,13 +13,10 @@ containerized web workloads. Behind a single proxy, it manages both:
 - **Container-per-API** stateless HTTP services — Plumber2, FastAPI.
 
 Deployed as a single, ultra-lightweight **static binary** with **instant
-startup**, Ruscker comes fully equipped with an **admin panel**,
-**real-time monitoring**, and **load balancing**. It uses a familiar
-YAML schema, so migration is smooth and configuration is effortless.
-
-<p align="center">
-  <img src="images/landing.png" alt="The Ruscker landing page: a portal of app cards with a Featured carousel at the top, plus search and type/access filters — hovering a card reveals its full description — all served by a single binary." width="860">
-</p>
+startup** and no JVM, Ruscker comes fully equipped with an **admin panel**,
+live monitoring, load balancing and scheduled container jobs. It uses a
+familiar YAML schema, so migration is smooth and configuration is
+effortless.
 
 ## How it works
 
@@ -41,28 +38,26 @@ engineered to keep the runtime light while staying compatible:
 
 - **Zero-friction migration** — bring your apps over with a familiar
   YAML schema, no rewrite.
-- **Single compiled binary** — one artifact to ship and run, with a tiny
-  idle footprint and instant startup.
+- **Single compiled binary** — one artifact to ship and run, measured at
+  **~14 MB idle**, with instant startup.
 - **Batteries included** — a proper admin panel, a live monitoring
-  dashboard, and load balancing, out of the box.
+  dashboard, per-app step-up MFA, identity forwarding, scheduled jobs and
+  load balancing, out of the box.
 
 ## In production
 
 Ruscker runs in production today — the
 [releases page](https://github.com/StrategicProjects/ruscker/releases)
-has the current version, and the whole codebase went through a
-systematic bug / security / UX audit in June 2026, with every
-finding fixed. Built for extreme efficiency, its idle footprint sits
-in the low tens of megabytes:
+has the current release. Its measured idle footprint is:
 
 > **~14 MB idle** — measured on a real production deployment serving a
 > real multi-app config. (The JVM-based proxy it replaced on the same
 > machine sat at ~540 MB.)
 
-It handles complex, multi-spec configurations with **no unsupported
-features** during migration, and apps spawn on demand reliably. Releases
-are multi-arch and **cosign-signed**; the [Roadmap](./roadmap.md) tracks
-what's shipped and what's next.
+The compatibility checker reports imported, ignored and unsupported
+ShinyProxy fields before a migration. Releases are multi-arch and
+**cosign-signed**; the [Roadmap](./roadmap.md) tracks what's shipped and
+what's next.
 
 ## What's in the box
 
@@ -71,6 +66,9 @@ what's shipped and what's next.
   (a generalized runtime shim patches `fetch`, `XMLHttpRequest`,
   `WebSocket`, `script.src`, `link.href`, and more) so unmodified apps
   work behind a sub-path.
+- **Access at the proxy boundary** with users/groups, per-app step-up TOTP
+  MFA, and opt-in ShinyProxy-compatible identity headers plus selected
+  profile claims for authenticated apps.
 - **Container backend** (Docker) that spawns app containers on demand,
   applies per-container CPU/memory limits, and reaps idle ones. Per-spec
   `container-env` and `container-cmd` let you configure notebook servers
@@ -82,7 +80,9 @@ what's shipped and what's next.
   intros, SEO, social meta, analytics, custom HTML blocks, header/footer
   logos with alignment and links), audit log, **user accounts with
   Viewer / Editor / Admin roles**, and a live monitoring dashboard
-  (CPU/memory, live-follow logs, stop/restart).
+  (CPU/memory, live-follow logs, stop/restart). Operators can also manage
+  named Docker volumes and run a spec's image to completion on a cron
+  schedule, with history, log tails, timeouts and failure alerts.
 - **Sub-path mounting**: serve the whole portal under a prefix via
   `server.context-path` or `--base-path`. Health probes (`/healthz`,
   `/readyz`) stay at the root for load balancers.
@@ -92,7 +92,10 @@ what's shipped and what's next.
   endpoint.
 - **Distribution**: a cosign-signed multi-arch container image
   (`ghcr.io/strategicprojects/ruscker`), a Debian package with a
-  hardened `systemd` unit, static musl tarballs, and a Homebrew tap.
+  hardened `systemd` unit, static musl tarballs, and a Homebrew tap. The
+  project is Apache-2.0 licensed.
+- **Server-rendered UI**: Askama templates with HTMX and Alpine.js; there
+  is no Node build step.
 
 ## Where to next
 

--- a/book/src/introduction.md
+++ b/book/src/introduction.md
@@ -80,9 +80,10 @@ what's next.
   intros, SEO, social meta, analytics, custom HTML blocks, header/footer
   logos with alignment and links), audit log, **user accounts with
   Viewer / Editor / Admin roles**, and a live monitoring dashboard
-  (CPU/memory, live-follow logs, stop/restart). Operators can also manage
-  named Docker volumes and run a spec's image to completion on a cron
-  schedule, with history, log tails, timeouts and failure alerts.
+  (CPU/memory, live-follow logs, stop/restart). On the local Docker backend,
+  operators can also manage named Docker volumes and run a spec's image to
+  completion on a cron schedule, with history, log tails, timeouts and
+  failure alerts (both are unavailable with the multi-host backend).
 - **Sub-path mounting**: serve the whole portal under a prefix via
   `server.context-path` or `--base-path`. Health probes (`/healthz`,
   `/readyz`) stay at the root for load balancers.

--- a/book/src/migrating.md
+++ b/book/src/migrating.md
@@ -165,8 +165,9 @@ says what to do for each. Two to know about:
 Beyond parity, you also get: a real admin panel (no more hand-editing
 YAML), a live monitoring dashboard, per-spec `container-env` /
 `container-cmd` injection, per-API rate-limiting and CORS, per-user
-and per-group app visibility, per-app step-up MFA, scheduled jobs, named
-volume management, health probes, graceful shutdown, and **~14 MB idle**.
+and per-group app visibility, per-app step-up MFA, scheduled jobs and named
+volume management (local Docker backend), health probes, graceful shutdown,
+and **~14 MB idle**.
 The JVM-based proxy it replaced on the same machine used about 540 MB. See
 [The admin panel](./admin.md).
 

--- a/book/src/migrating.md
+++ b/book/src/migrating.md
@@ -59,7 +59,31 @@ The credential store accepts either an encrypted password or a pure
 > The inline fields are still valid and kept for back-compat — use
 > whichever fits your workflow.
 
-## 3. Sub-path mounting (`context-path`)
+## 3. Identity headers
+
+ShinyProxy's per-spec `add-default-http-headers: true` is supported. It
+forwards the signed-in account as `X-SP-UserId` and its comma-separated
+groups as `X-SP-UserGroups` over HTTP and WebSocket.
+
+Check specs whose applications read those headers: ShinyProxy defaults the
+setting on, while Ruscker deliberately defaults it off. If the field was
+omitted from the old config, add it explicitly where the application needs
+the identity:
+
+```yaml
+- id: internal-app
+  container-image: example/internal-app:latest
+  add-default-http-headers: true
+  identity-claims: [email, setor] # optional Ruscker profile headers
+```
+
+The optional claims become `X-Ruscker-User-Email` and
+`X-Ruscker-User-Setor`; missing values are omitted. Ruscker strips
+client-supplied `X-SP-*` and `X-Ruscker-User-*` headers before adding its
+own, but the app should still be reachable only through the proxy if it
+trusts them.
+
+## 4. Sub-path mounting (`context-path`)
 
 If you run Ruscker on a path prefix rather than a dedicated subdomain
 (e.g. `example.org/apps/` instead of `apps.example.org`), use
@@ -88,7 +112,7 @@ health probes (`/healthz`, `/readyz`) stay at the root so your load
 balancer does not need to know the prefix. Your reverse proxy just
 needs to forward requests under the same path through to Ruscker.
 
-## 4. Card logos
+## 5. Card logos
 
 ShinyProxy serves card logos from its `template-path`'s `assets/img/`
 folder. When you run `serve` without `--images-dir`, Ruscker
@@ -102,7 +126,7 @@ So a config left in place finds its logos with no extra flags.
 You can also upload images through the admin **Media** panel and
 reference them by filename in the spec's `logo` field.
 
-## 5. Side-by-side cutover (recommended)
+## 6. Side-by-side cutover (recommended)
 
 You don't have to flip everything at once. A safe pattern (proven in
 production) keeps ShinyProxy reachable while Ruscker takes the root:
@@ -118,8 +142,8 @@ bookmarks keep working after the cutover.
 
 ## After the cutover: read the startup warnings
 
-Since v0.2.5 `ruscker serve` runs the same validation as
-`ruscker validate` at boot and logs every finding. A migrated config
+`ruscker serve` runs the same validation as `ruscker validate` at boot and
+logs every finding. A migrated config
 typically produces a few `is set but has no effect` warnings —
 ShinyProxy fields Ruscker parses but doesn't honour
 (`server.secure-cookies`, `proxy.heartbeat-rate`, `hide-navbar`, …).
@@ -141,9 +165,9 @@ says what to do for each. Two to know about:
 Beyond parity, you also get: a real admin panel (no more hand-editing
 YAML), a live monitoring dashboard, per-spec `container-env` /
 `container-cmd` injection, per-API rate-limiting and CORS, per-user
-and per-group app visibility, health probes, graceful shutdown, and a
-tiny footprint — **~14 MB** idle, against the ~540 MB of the JVM-based
-proxy it replaced on the same machine. See
+and per-group app visibility, per-app step-up MFA, scheduled jobs, named
+volume management, health probes, graceful shutdown, and **~14 MB idle**.
+The JVM-based proxy it replaced on the same machine used about 540 MB. See
 [The admin panel](./admin.md).
 
 ## Not supported (yet)

--- a/book/src/quickstart.md
+++ b/book/src/quickstart.md
@@ -15,12 +15,18 @@ proxy:
   title: My Ruscker
 ```
 
-Then start it with an admin token and `--db` (the admin database):
+Then start it with an admin token, a master key and `--db` (the admin
+database):
 
 ```sh
-RUSCKER_ADMIN_TOKEN=$(openssl rand -hex 32) \
+export RUSCKER_ADMIN_TOKEN="$(openssl rand -hex 32)"
+export RUSCKER_MASTER_KEY="$(openssl rand -hex 32)"
 ruscker serve --bind 127.0.0.1:8080 --db ruscker.db
 ```
+
+The master key encrypts saved registry credentials and TOTP secrets. Keep
+it stable if you reuse this database; without it, 2FA enrolment fails with
+`503`.
 
 - Ruscker **auto-connects to Docker** when the daemon socket is
   reachable, so app containers spawn out of the box. Pass `--no-docker`
@@ -33,14 +39,13 @@ ruscker serve --bind 127.0.0.1:8080 --db ruscker.db
   framework logos into the Media library. The seed is idempotent; cards
   you delete stay deleted on subsequent boots.
 
-![The seeded landing page on first boot: a Featured carousel of highlighted apps above a filterable grid of showcase cards (Shiny, Streamlit, Dash, Jupyter, RStudio, …).](images/landing.png)
-
 Prefer the container image? Mount the Docker socket and a volume for the
 DB (the image is cosign-signed; `:latest` tracks the current release):
 
 ```sh
 docker run --rm -p 8080:8080 \
-  -e RUSCKER_ADMIN_TOKEN=$(openssl rand -hex 32) \
+  -e RUSCKER_ADMIN_TOKEN \
+  -e RUSCKER_MASTER_KEY \
   -v "$PWD/ruscker.yml:/etc/ruscker/ruscker.yml:ro" \
   -v "$PWD/ruscker.db:/data/ruscker.db" \
   -v /var/run/docker.sock:/var/run/docker.sock \
@@ -59,7 +64,7 @@ docker run --rm -p 8080:8080 \
 | <http://127.0.0.1:8080/healthz> | liveness (always `200`) |
 
 Click any live-demo card to see on-demand container spawn in action,
-then watch the [admin dashboard](./admin.md) to see the replica start,
+then watch the admin [Containers page](./admin.md) to see the replica start,
 serve, and stop. The first request to an app spawns its container; it's
 reaped automatically once idle.
 
@@ -118,7 +123,8 @@ limits…).
   [Per-user access](./configuration.md#per-user-access) to restrict
   apps by user / group.
 - [The admin panel](./admin.md) — manage specs, images, users, and the
-  live dashboard without editing YAML.
+  live container dashboard, identity headers, per-app 2FA and schedules
+  without editing YAML.
 - [Deploying in production](./deploying.md) — systemd + nginx, TLS,
   multi-host, and active-active HA (including
   [mounting the portal under a subpath][base-path] and the

--- a/book/src/troubleshooting.md
+++ b/book/src/troubleshooting.md
@@ -4,7 +4,7 @@
 No admin token is configured. Set `RUSCKER_ADMIN_TOKEN` (the `.deb`
 generates one — `sudo grep RUSCKER_ADMIN_TOKEN /etc/ruscker/ruscker.env`)
 and restart. The admin pages also need `serve --db <file>`; without it
-the editor/list screens return 503.
+or `--config-db-url <postgres-url>` the editor/list screens return 503.
 
 ## Card logos don't show up
 The images aren't being served at `/assets/img/`. Either pass
@@ -19,9 +19,51 @@ the spec form.
   (and give the service Docker access).
 - `502` — the container failed to start or pull. Check
   `docker logs` for the spawned `ruscker-<spec>-<id>` container, and
-  verify registry credentials. Private images need
-  `docker-registry-username` + `docker-registry-password` (the latter
-  via `${DOCKER_REGISTRY_PASSWORD}`).
+  verify registry credentials. Private images can use a named credential
+  from **Credentials**, or `docker-registry-username` plus an env-backed
+  `docker-registry-password: ${DOCKER_REGISTRY_PASSWORD}`.
+
+## 2FA enrolment returns `503`
+
+`RUSCKER_MASTER_KEY` is missing (or an existing MFA secret cannot be
+decrypted with the configured key). Set one stable 32-byte key, restart
+Ruscker, and try **Account → 2FA** again:
+
+```sh
+openssl rand -hex 32
+```
+
+Put the result in the service environment, such as
+`/etc/ruscker/ruscker.env`; do not regenerate it on each start. The `.deb`
+generates it automatically when missing. MFA deliberately fails closed,
+and the same key is also needed for encrypted registry credentials.
+
+## My app no longer receives the logged-in user
+
+Identity forwarding is off by default. Enable it on that spec:
+
+```yaml
+add-default-http-headers: true
+identity-claims: [email, setor] # optional
+```
+
+The app then receives `X-SP-UserId` / `X-SP-UserGroups` and the selected
+`X-Ruscker-User-*` claims for signed-in users, over HTTP and WebSocket. A
+blank profile claim is omitted. Ruscker strips client-supplied reserved
+identity headers, so test through Ruscker rather than by calling the
+container directly.
+
+## My app cannot set a cookie with a Ruscker-looking name
+
+Apps share the portal origin, so response cookies using Ruscker's reserved
+names are dropped to protect login, preference, sticky-session and MFA
+state. The reserved set includes `ruscker_admin_session`, `ruscker_theme`,
+`ruscker_locale`, `__ruscker_session*` and `__ruscker_mfa_*`; app-owned
+cookie names are preserved. Rename the conflicting app cookie.
+
+Ruscker also removes the cookie-clearing `Clear-Site-Data` directives
+`"cookies"` and `"*"` from app responses, while preserving safe non-cookie
+directives. An app must not try to clear all cookies on the shared origin.
 
 ## An app keeps failing with an old or broken image
 
@@ -125,7 +167,7 @@ sudo apt-get install -y ./ruscker_<version>-1_amd64.deb
 
 ## Cookies don't carry `Secure` behind my TLS proxy
 
-Since v0.2.5 Ruscker only honours `X-Forwarded-Proto` when
+Ruscker only honours `X-Forwarded-Proto` when
 `server.useForwardHeaders: true` is set (otherwise any client could
 spoof it). Behind a TLS-terminating reverse proxy you need **both**:
 the proxy sending `proxy_set_header X-Forwarded-Proto https;` (or
@@ -135,11 +177,10 @@ the proxy sending `proxy_set_header X-Forwarded-Proto https;` (or
 
 ## A Streamlit / Dash / Voilà app is unreachable (connection refused upstream)
 
-Before v0.2.5, `type: streamlit|dash|voila` without an explicit
-`container-port` forwarded to Shiny's 3838 — these frameworks listen on
-8501 / 8050 / 8866, so the proxy hit a closed port. v0.2.5 defaults to
-the framework's port; on older versions (or for a non-standard port)
-set `container-port` explicitly.
+The current defaults are 8501 / 8050 / 8866 for
+`type: streamlit|dash|voila`. If the image listens elsewhere, set
+`container-port` explicitly and confirm the process binds to `0.0.0.0`
+inside the container rather than loopback.
 
 ## Users bounce between replicas / lose their session after a restart
 The sticky-session cookie is signed with `RUSCKER_COOKIE_KEY`. If you
@@ -149,10 +190,12 @@ across replicas. Set a stable `RUSCKER_COOKIE_KEY` (e.g.
 `openssl rand -hex 32`) in `ruscker.env` and keep it constant.
 
 ## The dashboard doesn't update live (or lags badly)
-The dashboard streams over Server-Sent Events. A reverse proxy that
-buffers the response will hold the stream back. Disable buffering for
-`/admin/dashboard/events` — see the nginx note in
-[Deploying](./deploying.md).
+The Containers dashboard polls `GET /admin/dashboard/snapshot`; it does not
+use SSE. In browser developer tools, check that this request returns `200`
+every few seconds. Authentication redirects, a wrong base-path mapping or a
+slow/unreachable Docker daemon will stop or delay updates. nginx buffering
+does not affect the dashboard poll; it matters only for the server and
+per-replica live log streams described in [Deploying](./deploying.md).
 
 ## The favicon doesn't appear in Safari (or shows a stale icon)
 Safari caches favicons aggressively and sometimes keeps serving a stale
@@ -167,9 +210,9 @@ or broken icon long after you upgrade Ruscker. To force a refresh:
 For iOS Safari, a full Safari data clear (**Settings → Safari → Clear
 History and Website Data**) removes the icon cache.
 
-This is a browser-side caching behaviour, not a Ruscker bug. The favicon
-markup was hardened in v0.1.18 (the `sizes="any"` attribute that confused
-Safari's icon selection was removed).
+This is a browser-side caching behaviour, not a Ruscker bug. Ruscker's
+favicon markup avoids the `sizes="any"` attribute that can confuse Safari's
+icon selection.
 
 ## `docker pull ghcr.io/strategicprojects/ruscker` is denied
 A freshly-published image package starts **private**. Either make the

--- a/book/src/use-cases.md
+++ b/book/src/use-cases.md
@@ -10,7 +10,9 @@ Shiny host.
 Each app becomes a card on the landing page and a route under
 `/app/{spec}` (interactive) or `/api/{spec}` (stateless). Ruscker handles
 spawning, sticky sessions, WebSocket upgrades, URL rewriting, load
-balancing, and reaping idle containers.
+balancing, and reaping idle containers. Sensitive apps can require a
+recent MFA proof before any container starts; signed-in identity can be
+forwarded to trusted apps through opt-in headers.
 
 ## Showcase demos
 
@@ -118,6 +120,15 @@ Multiplex GPUs and isolate users in front of generative tools.
 - Apache Airflow, Dagster, Prefect, Mage, Kestra, NocoDB, Baserow,
   Directus, self-hosted Supabase Studio.
 
+## Scheduled ETL, reports and maintenance
+
+The admin **Schedules** page can run a containerized spec to completion on
+a five-field UTC cron: nightly ETL, report generation, cache refreshes or
+small maintenance tasks. A job reuses the spec's image, environment,
+volumes, resource limits and registry credentials, with an optional command
+override. Runs have a configurable timeout (1 hour by default), history and
+log tails; failures can trigger the `job-failed` alert webhook.
+
 ## Database admin consoles
 
 Surface a DB console as just another card on the portal.
@@ -140,8 +151,9 @@ Surface a DB console as just another card on the portal.
 - **Service-mesh-grade microservices** (automatic mTLS, dense distributed
   tracing, complex canaries) — that's Istio/Linkerd on Kubernetes.
   Ruscker is a portal proxy, not a service mesh.
-- **Long CPU-bound batch jobs** — use a scheduler (Slurm, Nomad, Airflow
-  workers). Ruscker is for interactive sessions and short requests.
+- **Large distributed or unbounded batch pipelines** — use Slurm, Nomad,
+  Airflow workers or another dedicated scheduler. Ruscker's cron runner is
+  for bounded run-to-completion jobs alongside the portal workloads.
 
 ## Who it's for
 

--- a/book/src/use-cases.md
+++ b/book/src/use-cases.md
@@ -122,8 +122,9 @@ Multiplex GPUs and isolate users in front of generative tools.
 
 ## Scheduled ETL, reports and maintenance
 
-The admin **Schedules** page can run a containerized spec to completion on
-a five-field UTC cron: nightly ETL, report generation, cache refreshes or
+The admin **Schedules** page (local Docker backend) can run a containerized
+spec to completion on a five-field UTC cron: nightly ETL, report generation,
+cache refreshes or
 small maintenance tasks. A job reuses the spec's image, environment,
 volumes, resource limits and registry credentials, with an optional command
 override. Runs have a configurable timeout (1 hour by default), history and

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -126,7 +126,8 @@ Postgres:
 ### Scheduled jobs
 
 `jobs::spawn` starts one scheduler loop per process when both a catalog DB
-and container backend exist. Every 30 seconds it loads enabled `schedules`;
+and container backend exist (the local Docker backend runs jobs; the
+multi-host backend does not, so a due schedule there records an error). Every 30 seconds it loads enabled `schedules`;
 only the `LeaderElector` winner may fire in HA. `db::schedules::mark_fired`
 atomically advances `last_run_at` before execution, so a split-brain second
 runner loses the claim and a crash does not double-fire the occurrence.

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -1,16 +1,18 @@
 # Architecture
 
-Ruscker is a Rust-based proxy and orchestrator for containerized
-interactive web apps and stateless HTTP APIs. This document describes
-how the pieces fit together.
+Ruscker is an Apache-2.0-licensed, lightweight Rust alternative to
+ShinyProxy and Shiny Server: a portal and orchestrator for
+container-per-session and container-per-API workloads. This document
+describes how the pieces fit together.
 
 ## High-level diagram
 
 ![How Ruscker works: browsers and API clients hit a single Ruscker binary, which serves the landing page + admin and reverse-proxies to app containers it spawns on demand via the Docker daemon.](images/architecture.svg)
 
 All of this is a single Rust process — one static binary, ~14 MB idle,
-no JVM. Visitors and API clients reach it on one port; it serves the
-landing page and admin UI, reverse-proxies `/app/{spec}` and
+no JVM. The portal uses Askama templates with HTMX and Alpine.js and has
+zero Node build step. Visitors and API clients reach it on one port; it
+serves the landing page and admin UI, reverse-proxies `/app/{spec}` and
 `/api/{spec}` to the right replica (keeping Shiny sessions sticky and
 upgrading WebSockets), and drives the Docker daemon to spawn and reap
 containers. SQLite is the source of truth for configuration; the live
@@ -28,8 +30,8 @@ and the `ruscker-cli` binary stitches them together.
 Keeping the backend behind the `ContainerBackend` trait in
 `ruscker-core` is what made the multi-host backend
 (`ruscker-docker::MultiHostDockerBackend`, Phase 6) a new impl rather
-than a rewrite — and leaves the same door open for Kubernetes. Since
-v0.2.5 the multi-host impl covers the **whole** trait surface
+than a rewrite — and leaves the same door open for Kubernetes. The
+multi-host impl covers the **whole** trait surface
 (spawn/stop/list, metrics/logs, disk management, image
 presence/pull), each operation fanning out across hosts with
 degraded-mode tolerance for an unreachable daemon. See
@@ -41,28 +43,30 @@ degraded-mode tolerance for an unreachable daemon. See
 
 ```
 1. Visitor hits  https://portal/app/sales-dashboard/
-2. Proxy reads cookie  __ruscker_session_sales-dashboard   (one per app)
-3. Cookie missing → resolve_replica:
-     a. Look up spec 'sales-dashboard' (DB first, YAML fallback)
-     b. pick_or_spawn: pick a Ready replica with a free seat
+2. Look up spec 'sales-dashboard' (DB first, YAML fallback)
+3. Resolve access identity; enforce ACL and mfa::evaluate before any
+   backend access or cold start
+4. Read cookie  __ruscker_session_sales-dashboard   (one per app)
+5. Cookie missing → resolve_replica:
+     a. pick_or_spawn: pick a Ready replica with a free seat
         (least-conn) and reserve the seat atomically
-     c. No replica yet → cold-start splash to the visitor while a
+     b. No replica yet → cold-start splash to the visitor while a
         coalesced spawn runs in the background; the splash polls a
         readiness probe and reloads into the app
-     d. At max-replicas with no free seat → the splash says "full"
+     c. At max-replicas with no free seat → the splash says "full"
         and keeps polling for a freed seat
-     e. SessionStore.touch_or_register(session, spec, R2)
-     f. Sign + set cookie  __ruscker_session_sales-dashboard
+     d. SessionStore.touch_or_register(session, spec, R2)
+     e. Sign + set cookie  __ruscker_session_sales-dashboard
         (Path={base}/app/sales-dashboard — never sent to other apps)
-4. Forward GET /  to  http://127.0.0.1:<R2_port>/   (path strip)
-5. Stream response back
-6. Browser opens WebSocket  ws://portal/app/sales-dashboard/websocket
-7. Proxy connects the upstream WS FIRST (query string preserved,
+6. Forward GET /  to  http://127.0.0.1:<R2_port>/   (path strip)
+7. Stream response back
+8. Browser opens WebSocket  ws://portal/app/sales-dashboard/websocket
+9. Proxy connects the upstream WS FIRST (query string preserved,
    subprotocol negotiated); only then answers the client's 101 — a
    dead replica gets a clean 502, not a post-upgrade drop
-8. Bidirectional frame pump
-9. On heartbeat: SessionStore.touch()
-10. Idle timeout reached → Session purged → if last seat, container drained
+10. Bidirectional frame pump
+11. On heartbeat: SessionStore.touch()
+12. Idle timeout reached → Session purged → if last seat, container drained
 ```
 
 ### An API request lifecycle
@@ -87,6 +91,63 @@ drops once the whole (possibly long) download has been sent to the
 client — a large file transfer keeps counting against the replica for
 its full duration, and the scaler sees real concurrency rather than a
 spike that vanishes the instant headers are written.
+
+### Access, MFA, and identity resolution
+
+The proxy resolves a signed-in user's groups and selected profile claims
+once per request when an ACL or identity disclosure needs them. The
+`IdentityCache` in `AppState` holds groups, e-mail, and department/unit for
+30 seconds so an app page's asset burst does not issue one database query
+per request. User/group/profile mutations invalidate the cache with a
+generation counter, preventing an in-flight stale read from repopulating
+revoked identity data.
+
+The request guard then applies these boundaries in order:
+
+1. `Spec::access_allows` enforces per-user/per-group access server-side.
+2. For `require-mfa`, `mfa::evaluate` checks the user factor and browser
+   grant before the backend, cold-start splash, replica picker, or spawn can
+   run. Interactive visits redirect to enrollment/challenge; APIs fail with
+   `401` or `403`; break-glass Admin sessions bypass with an audit record.
+3. The proxy strips the entire client-supplied `X-SP-*` and
+   `X-Ruscker-User-*` namespaces, then adds only the opted-in authoritative
+   values for a signed-in user. The same header list is passed to HTTP and
+   WebSocket upstream connections; absent claims are omitted.
+
+MFA persistence is part of the configuration catalog in both SQLite and
+Postgres:
+
+| Table | Purpose |
+|---|---|
+| `user_mfa` | One user-owned TOTP factor; AES-GCM ciphertext/nonce, confirmation state, replay step, and revocation epoch |
+| `user_mfa_recovery` | Salted hashes for the one-time recovery codes |
+| `user_mfa_grants` | Salted hashes of opaque trusted-device tokens, bound to the user, factor epoch, proof time, expiry, and login-session hash |
+
+### Scheduled jobs
+
+`jobs::spawn` starts one scheduler loop per process when both a catalog DB
+and container backend exist. Every 30 seconds it loads enabled `schedules`;
+only the `LeaderElector` winner may fire in HA. `db::schedules::mark_fired`
+atomically advances `last_run_at` before execution, so a split-brain second
+runner loses the claim and a crash does not double-fire the occurrence.
+
+A new schedule anchors at `created_at` (no fire-on-create). If downtime spans
+several cron occurrences, the next tick collapses them to one firing. The job
+uses the spec's image, platform, resolved environment, volumes, limits,
+network, labels, and registry credentials, with an optional command override,
+and runs to completion outside the interactive replica registry. A
+per-schedule timeout defaults to one hour in the backend. Results, duration,
+exit code, and log tail land in `schedule_runs`; failures enqueue the
+`job-failed` alert webhook.
+
+### Aggregated access counter
+
+`access_counter::AccessCounter` keeps the proxy hot path free of database
+writes. It synchronously increments an in-memory `(spec_id, UTC day)` delta
+for each API request, new sticky app session, or external-card click. One
+supervised task flushes touched buckets every two seconds into `spec_access`
+with additive UPSERTs. Failed flushes merge deltas back for bounded
+exponential-backoff retries, and graceful shutdown attempts a final flush.
 
 ### Proxying an app under `/app/{spec}/` — the strip-and-rewrite model
 
@@ -138,7 +199,7 @@ The generalized shim **retired the old Voilà-specific rewrite**: Voilà's
 RequireJS bootstrap assigns its static URLs to `script.src` at runtime,
 which the patched `src` setter now prefixes without a bespoke pass.
 
-**The rewriter needs uncompressed HTML** (v0.2.5): nothing between
+**The rewriter needs uncompressed HTML**: nothing between
 the container and the rewriter decompresses bodies, so when the
 transform is enabled the upstream request carries
 `Accept-Encoding: identity` (ShinyProxy does the same) — an app that
@@ -185,7 +246,10 @@ rewrite — only the redirect `Location` header (`prefix_base_path`).
 - `ruscker-proxy` — sticky-cookie + WebSocket helpers (a library; it
   owns no socket)
 - `ruscker-admin` — builds the single axum router (landing + admin +
-  proxy routes)
+  proxy routes). Proxy selection, access/MFA/identity guards, and response
+  filtering live in `routes::proxy`; persistent MFA operations live in
+  `db::mfa` / `db::mfa_grants`; background subsystems live in `jobs`,
+  `scaler`, and `access_counter`
 - `ruscker-cli` — owns the one TCP listener and the tokio runtime,
   serving `ruscker-admin`'s router
 
@@ -194,8 +258,9 @@ rewrite — only the redirect `Location` header (`prefix_base_path`).
 ### Three sources of state, ranked by authority
 
 1. **SQLite (admin DB)** — source of truth for spec configurations,
-   images, credentials, landing-page sections, audit log. Always
-   write here first.
+   images, credentials, users/groups, MFA factors and grants, schedules and
+   run history, per-day access totals, landing-page sections, and audit log.
+   Always write here first. Postgres implements the same catalog for HA.
 2. **Live in-memory** — `ReplicaRegistry` (in proxy), `SessionStore`
    (in proxy, in-memory by default). Reflects the *running* state of
    containers and sessions.
@@ -203,14 +268,17 @@ rewrite — only the redirect `Location` header (`prefix_base_path`).
    "is this thing alive". The proxy queries Docker on startup to
    rebuild the registry.
 
-The YAML file is **NOT** a source of truth in production — it's an
-import/export format. Ruscker can be configured to auto-export to YAML
-for git versioning, but the running config lives in SQLite.
+The YAML file is **NOT** the mutable source of truth in production — it is
+the service bootstrap plus import/export format. `ruscker.yml` is the
+canonical service-config filename; `application.yml` remains the compatible
+ShinyProxy import/fallback name. Once imported, live catalog edits reside in
+SQLite or the HA Postgres catalog.
 
 ### State transitions
 
-- **First boot, no DB**: Bootstrap from `application.yml` if present;
-  otherwise create empty DB.
+- **First boot, no DB**: Bootstrap from the selected service config
+  (`ruscker.yml` by default, with `application.yml` as fallback) if present;
+  otherwise create an empty DB.
 - **Subsequent boots**: Load from DB. The YAML is optional.
 
 ## Concurrency model
@@ -228,7 +296,12 @@ for git versioning, but the running config lives in SQLite.
   respawn on saturation, so a single-seat long session can't flap a
   replica up and down. Set `min-replicas: 1`+ to keep an app warm.
 - The session-purger runs as a periodic task (every 5s).
-- `DashMap` for in-memory state (lock-free reads, sharded writes).
+- The leader-only job scheduler checks cron schedules every 30s and detaches
+  each run-to-completion job so long ETL work cannot block later ticks.
+- The access-counter drain batches in-memory deltas every 2s instead of
+  writing on every proxy request.
+- `DashMap` backs the replica/in-flight state and the short-TTL identity/spec
+  caches (lock-free reads, sharded writes).
 
 ## Security boundary
 
@@ -236,9 +309,9 @@ for git versioning, but the running config lives in SQLite.
 
 - **Untrusted**: visitors. They can hit `/app/*` and `/api/*` only.
   Admin paths require an authenticated session.
-- **Privileged**: admin users. `/admin/*` is gated by per-user
-  password login with three roles — **Viewer** (read-only dashboard),
-  **Editor** (apps + media), **Admin** (everything, incl. user
+- **Privileged**: signed-in users. Authentication uses per-user passwords
+  and three roles — **Viewer** (portal access only; no admin section),
+  **Editor** (dashboard, apps, and media), **Admin** (everything, incl. user
   management) — enforced server-side. A break-glass `RUSCKER_ADMIN_TOKEN`
   bootstraps the first account. See `docs/SECURITY.md` §2.
 - **Operator**: filesystem access (the person running Ruscker). Can
@@ -249,6 +322,9 @@ for git versioning, but the running config lives in SQLite.
 - Docker registry passwords: stored encrypted in
   `credentials.password_enc` via AES-GCM with a master key from
   `RUSCKER_MASTER_KEY` env var.
+- User TOTP secrets: stored as AES-GCM ciphertext and nonce in `user_mfa`
+  under the same master key; recovery and trusted-device tokens are stored
+  only as salted hashes.
 - Session cookie signing: HMAC-SHA256 with key from
   `RUSCKER_COOKIE_KEY` env var (randomized per process when unset —
   set it explicitly to keep sessions across restarts and across HA
@@ -270,10 +346,10 @@ installs run — simple, fast, easy to operate.
 
 Two or more Ruscker instances behind an L4 load balancer share a Postgres
 config catalog and session store, so either can serve any session.
-Exactly one instance holds the scaler leadership at a time via a Postgres
-advisory lock; standbys serve traffic and reconcile counts but skip the
-spawn/reap loop. The sticky cookie is an HMAC over a shared key, so any
-instance can validate any other's cookie. See the deployment guide's
+Exactly one instance holds leadership at a time via a Postgres advisory
+lock; standbys serve traffic and reconcile counts but skip the scaler and
+scheduled-job firing loops. The sticky cookie is an HMAC over a shared key,
+so any instance can validate any other's cookie. See the deployment guide's
 "Running active-active" section for the runnable example.
 
 ### Multi-host Docker (since Phase 6)

--- a/docs/ROADMAP.md
+++ b/docs/ROADMAP.md
@@ -1,12 +1,12 @@
 # Roadmap
 
 > **Status: Phases 0–7 shipped and running in production**, followed by
-> the v0.2.x polish series (the v0.2.5 audit release and the
-> admin design-handoff sprint). Phase 8 is optional and demand-driven.
+> continuing security, operations, and admin work. Phase 8's external
+> identity-provider integrations are optional and demand-driven.
 > For the narrative, up-to-date version with a timeline diagram, see
 > the [Roadmap chapter](https://strategicprojects.github.io/ruscker/roadmap.html)
 > on the docs site. The phase checklists below are the original
-> planning detail (they predate v0.1.0); every item in Phases 0–7 has
+> planning detail; every item in Phases 0–7 has
 > since shipped, so their boxes are ticked. Phase 8 shows what remains.
 
 Phased plan from "config parsing only" to "production-ready ShinyProxy
@@ -35,8 +35,9 @@ a useful report.
 
 ## Phase 1 — Landing page (1 week)
 
-**Goal**: replace the Thymeleaf-based ShinyProxy landing with Askama +
-Tailwind 4. Specs and template properties drive what gets rendered.
+**Goal**: replace the Thymeleaf-based ShinyProxy landing with Askama
+templates enhanced by HTMX and Alpine.js. Specs and template properties
+drive what gets rendered.
 
 - [x] Add a new `ruscker-web` crate (or fold into `ruscker-admin`)
 - [x] Askama templates matching `docs/mockups/landing-page.html`
@@ -46,7 +47,7 @@ Tailwind 4. Specs and template properties drive what gets rendered.
 - [x] Light/dark theme toggle (cookie + system preference)
 - [x] Image library: serve static assets from a configurable
   directory
-- [x] Tailwind 4 build script (no Node required, uses standalone CLI)
+- [x] Browser assets with zero Node build step
 
 **Deliverable**: visit `localhost:8080` and see the bundled
 `examples/application.yml` portal rendered, looking visually
@@ -60,7 +61,7 @@ equivalent to today but in Tailwind. Cards are not yet clickable
 - [x] SQLite schema + sqlx migrations
 - [x] Importer: `ruscker import application.yml --db ruscker.db`
 - [x] Exporter: `ruscker export --db ruscker.db > application.yml`
-- [x] Admin login (basic auth or env-var token for MVP; OIDC later)
+- [x] Database-backed user login plus a break-glass environment token
 - [x] Apps list page (filter, search, bulk actions)
 - [x] Add/Edit spec form with type-driven fields (mockup:
   `admin-add-edit-app.html`)
@@ -78,16 +79,16 @@ without touching files.
 **Goal**: actually run apps. The technically hardest phase.
 
 - [x] `LocalDockerBackend` via bollard
-  - [ ] Image pulling with registry credentials
-  - [ ] Container spawn with resource limits, env, volumes
-  - [ ] Health-check polling
-  - [ ] Graceful stop (drain → SIGTERM → SIGKILL)
+  - [x] Image pulling with registry credentials
+  - [x] Container spawn with resource limits, env, volumes
+  - [x] Health-check polling (TCP followed by HTTP readiness)
+  - [x] Graceful stop (drain → SIGTERM → SIGKILL)
 - [x] HTTP request forwarding via hyper
 - [x] WebSocket upgrade hijack + bidirectional pump
 - [x] Path rewriting for Shiny's relative URLs
 - [x] Sticky session cookie signing (HMAC-SHA256 via `ring`)
 - [x] Session store (`DashMap` impl of `SessionStore`)
-- [x] Replica pool per spec with `Router` plumbed in
+- [x] Replica pool per spec with selection in `routes::proxy`
 - [x] Auto-scaler: spawn when utilization > threshold, retire when
   under threshold for grace period
 - [x] Heartbeat handling (per-spec timeout overrides, `-1` = never)
@@ -103,7 +104,8 @@ page refresh.
 
 - [x] `/admin/dashboard` page (mockup: `admin-dashboard.html`)
 - [x] Metric cards: containers, sessions, memory, CPU
-- [x] Live container table with utilization bars (SSE updates)
+- [x] Live container table with utilization bars (short polling via
+      `GET /admin/dashboard/snapshot`)
 - [x] Sessions-over-24h sparkline chart
 - [x] Recent events feed
 - [x] Logs streaming page with filter + regex + follow mode
@@ -141,7 +143,7 @@ drill into any container.
 ## Phase 7 (optional) — HA / multi-instance
 
 - [x] Postgres `SessionStore` implementation
-- [x] Postgres replication for SQLite admin DB
+- [x] PostgreSQL-backed admin catalog matching the SQLite schema
 - [x] Coordination via Postgres advisory locks
 - [x] Failover testing
 
@@ -149,11 +151,42 @@ drill into any container.
 
 - [ ] OIDC integration (Keycloak, Auth0, Google)
 - [ ] SAML for enterprise
+- [ ] LDAP directory integration
 - [x] Role-based access control (Viewer / Editor / Admin) — shipped
 - [x] Per-spec access lists (only group X can use this app) — shipped in Phase 6
+- [x] Per-app step-up MFA — one user-owned TOTP factor, recovery codes,
+      trusted-device grants, and per-spec proof-freshness policy
+- [x] Opt-in identity headers for signed-in users on HTTP and WebSocket —
+      ShinyProxy-compatible user/group headers plus selected profile claims
 
-> Only the external identity-provider items (OIDC / SAML) remain; the
-> coarse role model and per-spec access lists already ship.
+> Only the external identity-provider items (OIDC / SAML / LDAP) remain; the
+> database-backed role model, per-spec access lists, step-up MFA, and
+> identity forwarding already ship.
+
+## Continuing shipped work
+
+- [x] Scheduled jobs — Admin **Schedules** page, cron ETL semantics,
+      no fire-on-create, collapsed downtime catch-up, leader-only HA firing,
+      the spec's image/environment/volumes/credentials, optional command
+      override, run history/log tail, one-hour default timeout, and the
+      `job-failed` alert webhook
+- [x] Named-volume management — Admin Disk **Volumes** card with live
+      reference counts; create labels Ruscker-owned volumes, and remove is
+      offered only for Ruscker-created volumes with zero live references and
+      no catalog reference
+- [x] Users-page scaling — 50-row server-side pagination and server-side
+      accent-aware, case-insensitive search across username, groups, and
+      profile fields on SQLite and Postgres
+- [x] Password policy and password generator
+- [x] Consolidated per-user edit page, including profile, groups, role,
+      password reset, 2FA status/reset, and deletion
+- [x] Clearer admin navigation and titles: **Containers** and
+      **Activity/Atividades**, with management-oriented page titles
+- [x] Cookie-boundary hardening for shared-origin apps: reserved
+      `Set-Cookie` filtering and cookie-clearing `Clear-Site-Data`
+      neutralization
+- [x] `ruscker.yml` as the canonical service config, with
+      `application.yml` retained for ShinyProxy import/fallback
 
 ## What we explicitly defer / don't do
 

--- a/docs/SECURITY.md
+++ b/docs/SECURITY.md
@@ -7,9 +7,9 @@ Status: living document. Tracks the Phase 5 security audit
 
 > **Scope.** A single-operator install: Ruscker behind a
 > TLS-terminating reverse proxy, Docker on one or more hosts. The model
-> below reflects the hardening done in the 2026-06 security audit.
-> Multi-tenant / shared-team auth (OIDC, SAML) is out of scope until
-> Phase 8.
+> below reflects the current security audit.
+> External identity-provider integration (OIDC, SAML, LDAP) remains
+> Phase 8 work.
 
 ---
 
@@ -21,7 +21,7 @@ Status: living document. Tracks the Phase 5 security audit
 |-------|----------------|
 | `RUSCKER_ADMIN_TOKEN` | break-glass Admin login + first-account bootstrap — full access |
 | User passwords (DB) | per-user login; stored as argon2id hashes; policy on set/reset: ≥ 8 chars with upper + lower + digit + special |
-| `RUSCKER_MASTER_KEY` | decrypts the registry-credential store |
+| `RUSCKER_MASTER_KEY` | decrypts registry credentials and enrolled TOTP factors |
 | `RUSCKER_COOKIE_KEY` | forges sticky-session cookies |
 | Registry credentials (DB) | pull access to private images |
 | Running app sessions | per-visitor app state inside containers |
@@ -43,9 +43,8 @@ Status: living document. Tracks the Phase 5 security audit
 
 - Defending against a hostile operator (they own the host +
   Docker daemon + all keys).
-- Per-app ACLs and external identity providers (OIDC/SAML/LDAP).
-  Coarse RBAC (Viewer/Editor/Admin) exists (§2); fine-grained,
-  per-spec authorization is Phase 8.
+- External identity providers (OIDC/SAML/LDAP). Database-backed users,
+  coarse RBAC, per-spec user/group ACLs, and per-app step-up MFA exist.
 - Isolating **untrusted, third-party app code** from the admin on a
   shared origin. Apps are assumed first-party; multi-tenant hosting of
   hostile apps needs origin separation (§6.1, roadmap #878).
@@ -99,21 +98,43 @@ Status: living document. Tracks the Phase 5 security audit
   (`InMemoryAdminSessionStore`); for HA, point Ruscker at a shared
   Postgres via `--admin-session-store-url` (#185) so sessions survive
   a load-balancer hop.
-- **[implemented]** Per-app TOTP step-up MFA (#1005) — the factor belongs
-  to the user and is enrolled once; each spec may opt in with
-  `require-mfa` and choose how long a successful proof is trusted. Device
-  grants store only salted token hashes, are bound to the factor's security
-  epoch and confirmation time, and are revoked by password/factor resets or
-  the user's **forget devices** actions. A zero-day policy additionally binds
-  the proof to the current opaque login session. The proxy guard runs before
-  replica selection/spawn. `RUSCKER_ADMIN_TOKEN` break-glass sessions bypass
-  the user factor but emit a warning on every request and a cooldown-deduped
-  `mfa.break_glass_bypass` audit row. The reserved `__ruscker_mfa_*` cookies
-  are consumed by Ruscker and stripped before proxying, so trusted-device and
-  enrollment bearers never reach app containers (#258).
+- **[implemented]** Per-app TOTP step-up MFA (#1005) — a factor belongs to
+  the user, not an app. The user enrolls it once under **Account → 2FA** by
+  scanning a local QR code with Google Authenticator, Microsoft Authenticator,
+  Authy, 1Password, or another compatible app, then receives one-time
+  recovery codes that are shown once. Each spec independently opts
+  in with `require-mfa` and selects the acceptable proof age with
+  `mfa-validity-days` (seven days by default, session-only at `0`, capped at
+  30). One successful proof satisfies every protected app whose freshness
+  policy accepts it.
+- **[implemented]** Trusted-device grants use an opaque, `HttpOnly` cookie;
+  only a salted token hash and a one-way login-session binding are stored in
+  `user_mfa_grants`. Grants are bound to the factor confirmation time and
+  security epoch. Password change/reset, MFA reset, user deletion, **Forget
+  this device**, and **Forget all devices** revoke the applicable grants; a
+  zero-day policy also requires the current opaque login session.
+- **[implemented]** The MFA guard (`mfa::evaluate`) runs on `/app` and `/api`
+  before backend access, cold-start handling, replica selection, or spawn.
+  Unenrolled/unproven interactive-app visits redirect to enrollment or a
+  challenge without starting a container; protected APIs return `401` when
+  the caller is not signed in and `403` when the factor proof is unsatisfied.
+  WebSocket upgrades are guarded before the upstream handshake.
+- **[implemented]** TOTP secrets are AES-256-GCM encrypted at rest with
+  `RUSCKER_MASTER_KEY`; enrollment and TOTP verification fail closed with
+  `503` when the key is unavailable. Secrets and recovery codes never appear
+  in logs, audit diffs, or configuration exports. The factor, recovery-code,
+  and grant tables work with SQLite and Postgres/HA. Admins see only whether
+  2FA is configured and may perform an audited reset; they cannot retrieve a
+  factor secret or recovery code.
+- **[implemented]** `RUSCKER_ADMIN_TOKEN` break-glass sessions bypass the
+  user factor so recovery cannot deadlock. Every bypass emits a warning and
+  a cooldown-deduplicated `mfa.break_glass_bypass` audit row. Reserved
+  `__ruscker_mfa_*` cookies are consumed by Ruscker and stripped before HTTP
+  or WebSocket proxying, so device and enrollment bearers never reach an app.
 - **[implemented]** Role-based access control (#101/#107) — three
-  roles (**Viewer** = dashboard read-only; **Editor** = apps + media +
-  dashboard incl. stop/restart; **Admin** = everything, incl. user
+  roles (**Viewer** = signed-in portal user with no admin-panel section;
+  **Editor** = apps + media + dashboard incl. stop/restart; **Admin** =
+  everything, incl. user
   management). Enforcement is **server-side** via the `AdminSession` /
   `RequireEditor` / `RequireAdmin` extractors on each route group —
   the permission matrix lives in `Role::can_access_section` /
@@ -271,6 +292,14 @@ Status: living document. Tracks the Phase 5 security audit
   prefs from the upstream-bound `Cookie` header so an app container
   never sees them (the admin session id is a bearer). The WebSocket
   handshake path applies the same filter.
+- **[implemented]** Reserved-cookie response filtering (#1010) — apps share
+  the portal origin, so the proxy inspects every upstream `Set-Cookie` and
+  drops cookies whose names belong to Ruscker (admin session, preferences,
+  sticky sessions, and MFA), while preserving the app's own cookies. It also
+  neutralizes the `cookies` and `*` directives in app-supplied
+  `Clear-Site-Data`; safe non-cookie directives such as `cache` and `storage`
+  may remain. A same-origin app therefore cannot overwrite or bulk-clear the
+  user's portal, sticky, or trusted-device cookies through its response.
 - **[accepted limitation — needs origin separation]** Admin and apps
   share one origin by default. A script inside an **untrusted** app
   served at `/app/{spec}` is genuinely *same-origin* with `/admin`, so
@@ -282,11 +311,11 @@ Status: living document. Tracks the Phase 5 security audit
   apps, see [§6.1 Hosting untrusted apps](#61-hosting-untrusted-apps-same-origin)**
   — the host-safety backstops below (#871/#889/#894) bound the blast
   radius regardless.
-- **[implemented]** Per-app sticky cookies (#731, v0.2.5) — the
+- **[implemented]** Per-app sticky cookies (#731) — the
   sticky cookie is named `__ruscker_session_{spec}` and scoped with
   `Path={base}/app/{spec}`, so it is only ever sent to its own app:
   two apps in one browser can't fight over a session, and the cookie
-  never travels cross-app at all. A lingering pre-v0.2.5 global
+  never travels cross-app at all. A lingering legacy global
   cookie (`Path=/`) is actively expired. The embedded
   `session.spec_id == spec.id` check stays as defense-in-depth
   against a copied/forged cookie (`routes::proxy::resolve_replica`).
@@ -311,7 +340,7 @@ Status: living document. Tracks the Phase 5 security audit
   identify the app, replica, close origin/code/reason, frame count,
   and timeout policy (#933).
 - **[implemented]** `X-Forwarded-For` is normalized on the forward
-  (#744, v0.2.5) — in trusted mode (§7) the real peer IP is appended
+  (#744) — in trusted mode (§7) the real peer IP is appended
   to the inbound chain; untrusted, the spoofable client value is
   replaced with the peer. Upstream apps never see a forged chain.
   `X-Forwarded-Proto`/`-Port` are stripped and re-set authoritatively.
@@ -381,8 +410,8 @@ deliberate feature, not a config flip.
   (`default-src 'self'; … frame-ancestors 'none'; base-uri 'self';
   form-action 'self'`).
 - **[implemented]** `Secure` cookie flag under TLS — admin + sticky
-  cookies set `Secure` when `auth::request_is_https` is true. Since
-  v0.2.5 (#762) that reads `X-Forwarded-Proto` **only under the trust
+  cookies set `Secure` when `auth::request_is_https` is true. That reads
+  `X-Forwarded-Proto` **only under the trust
   opt-in below**, and takes the **rightmost** entry of a chained list
   (the one appended by the proxy closest to Ruscker — the leftmost
   slot is client-controlled whenever a proxy appends). Off on
@@ -421,7 +450,9 @@ actually flows, and why it is **deliberately not TLS**:
   forge those headers directly. Ruscker strips inbound claims and injects
   authoritative `X-SP-UserId` / `X-SP-UserGroups` and explicitly selected
   `X-Ruscker-User-Email` / `X-Ruscker-User-Setor` claims only on opted-in
-  specs, but it cannot protect a separate network path around the proxy.
+  specs and only for signed-in users. The same stripping and injection rules
+  apply to HTTP and WebSocket handshakes; a selected claim with no value is
+  omitted. Ruscker cannot protect a separate network path around the proxy.
   E-mail and department/unit values are PII; operators should enable each
   claim only for apps that need and are trusted to process it.
 
@@ -455,8 +486,11 @@ without `Secure`. ShinyProxy-migrated configs already carry the flag.
 - **[implemented]** Default `tracing` level (`info`) logs paths,
   spec ids, replica ids — operational metadata, no secrets, no
   PII.
-- **[accepted limitation]** No PII is collected today; revisit if
-  auth/user features land.
+- **[implemented]** User identity data is minimized at the app boundary:
+  identity forwarding is per-spec and off by default, optional profile claims
+  are individually selected, and blank claims are omitted. Usernames, groups,
+  e-mail addresses, and department/unit values are PII and should not be
+  enabled for an app without a need.
 - **[opt-in]** Prometheus `/metrics` (`proxy.metrics-enabled`, off by
   default). When enabled it's served **unauthenticated** — it exposes
   operational gauges (replica counts/states, per-spec sessions,
@@ -500,7 +534,7 @@ server {
 ```
 
 `X-Forwarded-Proto: https` is what flips the `Secure` cookie flag on
-(§7) — and since v0.2.5 it is only honoured when the YAML sets
+(§7) — and it is only honoured when the YAML sets
 `server.useForwardHeaders: true`. Behind a TLS-terminating proxy you
 need **both** (the header on the proxy, the flag in the YAML);
 without them Ruscker assumes plain HTTP and omits `Secure`.

--- a/docs/YAML_SCHEMA.md
+++ b/docs/YAML_SCHEMA.md
@@ -44,7 +44,7 @@ server:
 
 ### `server.useForwardHeaders` — forwarded-header trust
 
-Since v0.2.5 this single switch gates **every** read of
+This single switch gates **every** read of
 client-suppliable `X-Forwarded-*` headers: the cookie `Secure` flag
 (`X-Forwarded-Proto`), the per-client API rate-limit key, and the
 `X-Forwarded-For` chain forwarded to your apps (trusted → the real
@@ -97,7 +97,7 @@ ignored by Ruscker.
 | `container-log-path` | path | none | **Ignored** (warned when set) — use `docker logs` / the admin Logs tab |
 | `port` | u16 | `8080` | HTTP listener port |
 | `bind-address` | string | `"0.0.0.0"` | Listener interface |
-| `authentication` | enum | `none` | `none` (only `none` is implemented today) / `openid` / `ldap` / `saml` / `simple` |
+| `authentication` | enum | `none` | `none` (the only implemented value) / `openid` / `ldap` / `saml` / `simple` |
 | `landing-customization` | block | `{}` | Branding, SEO/social meta, analytics, custom HTML blocks, sign-in visibility — see [§ `proxy.landing-customization`](#proxylanding-customization). Ruscker extension |
 | `specs` | array | `[]` | List of apps/links/APIs |
 | `container-wait-time` | ms | `60000` | Max wait for a spawned container to become ready (TCP + HTTP probe) before the spawn fails; `0` keeps the default (#970) |
@@ -151,15 +151,13 @@ and `tls` mismatched with the scheme.
 
 ### Authentication
 
-**Ruscker currently supports only `none`.** The other variants are
-accepted by the parser (so existing YAML doesn't fail) but Ruscker will
-warn at boot that auth is unimplemented and continue as if `none`. An
-external identity provider (OIDC / SAML / LDAP) is the Phase 8 roadmap
-item; today, apps that handle their own auth are the common case, and
-`none` is correct — Ruscker just routes traffic.
-
-For applications that handle their own auth internally (a common
-case), `none` is the correct choice — Ruscker just routes traffic.
+**`proxy.authentication` currently supports only `none`.** The other
+variants are accepted by the parser so an imported configuration still
+loads, but Ruscker treats them as `none`; `ruscker validate --strict-compat`
+reports the unsupported scheme. This field is about an external identity provider; Ruscker's database-backed user
+accounts, roles, per-spec access lists, and step-up MFA work independently
+of it. OIDC / SAML / LDAP remain roadmap items. An app may also keep its
+own internal authentication behind the proxy.
 
 ### `proxy.landing-customization`
 
@@ -186,7 +184,7 @@ proxy:
 
     # SEO / social-share meta tags injected into the landing `<head>`
     seo-title: "Portal — Org Name"     # overrides `proxy.title` for <title>
-    seo-description: "Internal apps."  # <meta name="description"> + og:description
+    seo-description: "Team applications."  # <meta name="description"> + og:description
     og-image: /assets/img/og.png       # path or absolute URL for og:image
 
     # Analytics — admin-trusted, injected verbatim into landing <head>
@@ -304,6 +302,7 @@ A spec describes one app, API, or external link. Every spec has an
 ```yaml
 - id: my_app
   container-image: org/repo:tag       # required for containerized
+  platform: linux/amd64               # optional Docker target platform
   type: shiny                         # optional, default 'shiny' if image set
   container-port: 8501                # port the app listens on inside the
                                       #   container; default 3838 (Shiny).
@@ -323,11 +322,15 @@ A spec describes one app, API, or external link. Every spec has an
   docker-registry-credential: dockerhub-acme   # OR reference a stored
                                       #   credential by name (Ruscker
                                       #   extension; see below)
+  container-cpu-limit: 1.5            # hard cap in CPU cores
+  container-cpu-request: 0.5          # accepted; local Docker ignores CPU requests
+  container-memory-limit: 1g          # hard cap; bytes or k/m/g suffix
+  container-memory-request: 512m      # Docker memory reservation
   container-volumes:                  # bind mounts (ShinyProxy key; `volumes` also accepted)
     - /srv/myapp/data:/data           #   persistent data
     - /srv/myapp/www:/www:ro          #   static assets, read-only
   container-env:                      # env vars injected into the container
-    DB_HOST: db.internal              #   (ShinyProxy-compatible)
+    DB_HOST: db.example.org           #   (ShinyProxy-compatible)
     DB_PASSWORD: ${DB_PASSWORD}       #   ${VAR} resolved at spawn, not at parse —
                                       #   the literal is stored; secret never hits the DB
   container-cmd:                      # override the image's CMD (argv list)
@@ -337,7 +340,7 @@ A spec describes one app, API, or external link. Every spec has an
   container-network: ruscker_net      # attach to this Docker network (created if missing)
   labels:                             # extra Docker labels stamped on the container
     team: data                        #   (ShinyProxy-compatible)
-    cost-center: GAPE
+    cost-center: analytics
   access-groups: [staff, ops]         # who may see/reach this app
   access-users: [alice]               #   (ShinyProxy-compatible)
   require-mfa: true                   # require a user-owned MFA proof (Ruscker-native)
@@ -364,6 +367,17 @@ created — so an app secret passed this way never lands in the database.
 is an argv list that overrides the image's baked `CMD` (Docker
 `Config.Cmd`); omit it to keep the image default. Both are
 ShinyProxy-compatible and editable per spec.
+
+`platform` selects the Docker target platform used for image pull and
+container creation, such as `linux/amd64` or `linux/arm64`; when omitted,
+the daemon chooses the host-compatible manifest. The four resource fields
+are ShinyProxy-compatible: `container-cpu-limit` is a positive fractional
+CPU hard cap (`0.5` = half a core), `container-memory-limit` is a hard byte
+cap, and `container-memory-request` maps to Docker's soft memory
+reservation. `container-cpu-request` is parsed and retained for compatible
+backends but has no runtime effect on the local Docker backend, which has no
+CPU-request primitive. Memory accepts plain bytes or binary `k`/`m`/`g`
+suffixes. Invalid or non-positive values are warned and not applied.
 
 `container-network` (Ruscker extension) attaches the spec's containers to
 a named Docker network, mapped to the container's `HostConfig.NetworkMode`.
@@ -393,8 +407,11 @@ membership is set per user in the admin panel. Enforcement is real (not
 just hiding the card). See the [Roadmap](ROADMAP.md) Phase 8.
 
 `require-mfa` and `mfa-validity-days` are Ruscker-native per-spec controls
-for step-up MFA (#1005). MFA is off by default. When enabled, the app trusts
-a successful user-owned TOTP proof for 7 days unless
+for step-up MFA (#1005). MFA is off by default. A user enrolls one TOTP
+factor on **Account → 2FA**, using the QR code with a compatible
+authenticator app, and receives one-time recovery codes that are displayed
+once. Every protected app uses that same user-owned factor. When enabled,
+the app trusts a successful proof for 7 days unless
 `mfa-validity-days` overrides the window; `0` means proof is valid only in
 the current login session (no remembered device), and values above 30 clamp
 to 30. A user without an enrolled TOTP factor will be guided through
@@ -540,8 +557,8 @@ navigates to the link.
   container-image: org/my-api:latest
   api:
     port: 8080                         # container port
-    docs-path: /__docs__               # OpenAPI/Swagger UI
-    health-path: /__healthz__          # readiness check
+    docs-path: /__docs__               # parsed/stored; not consumed yet
+    health-path: /__healthz__          # parsed/stored; readiness still probes /
     rate-limit: 100/min                # per-IP rate limit at proxy
     cors: true                         # permissive CORS headers
   min-replicas: 1
@@ -549,6 +566,13 @@ navigates to the link.
   concurrent-requests-per-replica: 100
   routing-strategy: round-robin        # APIs don't need sticky
 ```
+
+`api.port`, `api.rate-limit`, and `api.cors` have runtime effects.
+`api.docs-path` and `api.health-path` are currently parsed, stored, and
+editable but not consumed by the proxy/backend: Ruscker does not publish a
+docs link from `docs-path`, and container readiness still performs TCP then
+HTTP at `/` rather than probing `health-path`. Do not rely on either field
+for routing or health behavior yet.
 
 #### `api.rate-limit` — per-client throttling
 
@@ -689,12 +713,12 @@ Rules:
 - Comments (lines starting with `#`, or trailing `# …`) are not
   interpolated
 - A **nested** reference in a default (`${A:-${B}}`) is refused with a
-  hard error (v0.2.5) — it used to silently corrupt the value
+  hard error; nested defaults are not supported
 - `docker-registry-password` and everything under `container-env` are
   **preserved verbatim** and resolved only at use (spawn/pull), so
   secrets never land in the database on `import`. This holds wherever
   `container-env` appears in the spec — including as the first key of
-  a list item (fixed in v0.2.5)
+  a list item
 
 This applies to the whole YAML file, not just credentials. Use it for
 any value that varies between environments.
@@ -736,7 +760,7 @@ and respects the `RUST_LOG` env var as well.
 
 ## Validation warnings
 
-`ruscker validate <config>` — and, since v0.2.5, `ruscker serve` at
+`ruscker validate <config>` — and `ruscker serve` at
 startup — reports these non-fatal findings. None of them stops the
 server; each one means some configured intent is **not** taking
 effect, so treat warnings in production logs as action items.
@@ -745,12 +769,15 @@ effect, so treat warnings in production logs as action items.
 |---|---|
 | duplicate spec id | Two specs share an `id`; only the last parsed wins |
 | no display-name / no description | Cosmetic: the landing card falls back to the `id` / renders empty |
-| embedded credential | A sensitive field (`docker-registry-password`, …) carries a literal value instead of a pure `${VAR}` reference — including a partial one like `${VAR}-suffix` (v0.2.5) |
+| embedded credential | A sensitive field (`docker-registry-password`, …) carries a literal value instead of a pure `${VAR}` reference — including a partial one like `${VAR}-suffix` |
 | unknown template-properties type | `template-properties.type` isn't one of the known card types |
 | invalid replica range | `max-replicas < min-replicas` — the scaler can't satisfy both |
-| replica ceiling zero (v0.2.5) | Explicit `max-replicas: 0` on a containerized spec — every spawn is refused; the app can never start |
-| missing container-image (v0.2.5) | A containerized `type:` with no `container-image` — fails only when first visited |
-| external with container-image (v0.2.5) | `type: external` + `container-image` — the image is silently ignored |
+| replica ceiling zero | Explicit `max-replicas: 0` on a containerized spec — every spawn is refused; the app can never start |
+| missing container-image | A containerized `type:` with no `container-image` — fails only when first visited |
+| external with container-image | `type: external` + `container-image` — the image is silently ignored |
+| MFA validity out of range | `mfa-validity-days` is above 30; the effective value clamps to 30 |
+| MFA validity without requirement | `mfa-validity-days` is set while `require-mfa` is not true, so the window is inert |
+| MFA on external link | `require-mfa` is set on a link Ruscker does not proxy; it cannot guard the linked site |
 | invalid scale threshold | `scale-up`/`scale-down` thresholds inverted or out of `0..1` |
 | container fields without image | `seats-per-container` etc. on a spec with no image |
 | invalid rate-limit / max-body-size / cpu / memory / volume | The value doesn't parse, so the intended cap or mount is **not enforced** |
@@ -759,16 +786,16 @@ effect, so treat warnings in production logs as action items.
 | invalid container-network | `container-network` isn't a valid Docker network name (`[a-zA-Z0-9][a-zA-Z0-9_.-]*`) — the create fails at spawn |
 | zero seats | `seats-per-container: 0` confuses the auto-scaler |
 | invalid docker host | A `proxy.hosts` entry that will fail to connect at startup |
-| ignored compat field (v0.2.5) | A modeled ShinyProxy field with no runtime effect is set (`server.secure-cookies`, `server.servlet.session.timeout`, `proxy.heartbeat-rate`, `proxy.hide-navbar`, `proxy.landing-page`, `proxy.container-log-path`, `logging.file`) |
+| ignored compat field | A modeled ShinyProxy field with no runtime effect is set (`server.secure-cookies`, `server.servlet.session.timeout`, `proxy.heartbeat-rate`, `proxy.hide-navbar`, `proxy.landing-page`, `proxy.container-log-path`, `logging.file`) |
 
 `ruscker validate --strict-compat` additionally lists every
 *unsupported* ShinyProxy feature a migrated config uses and exits
 non-zero — the recommended pre-flight when migrating.
 
-## Not supported (MVP)
+## Not supported
 
-These ShinyProxy fields are accepted by the parser but currently
-ignored:
+These ShinyProxy fields are accepted by the permissive parser but currently
+ignored and reported by `ruscker validate --strict-compat`:
 
 - `proxy.specs[*].kubernetes-*` — Kubernetes backend (out of scope)
 - `proxy.specs[*].minimum-seats-available` — pre-warm pool (planned)
@@ -781,18 +808,18 @@ ignored:
 `container-network` and `labels` are now supported — see "Containerized
 specs" above.)
 
-Setting any of these will produce a startup warning but not an error
-(`serve` runs the same validation `ruscker validate` does and logs
-each finding at startup). The same applies to fields that *parse* but
-have no runtime effect yet: `server.secure-cookies`,
+Setting the strict-compat fields above does not prevent ordinary parsing;
+run `ruscker validate --strict-compat <config>` to surface them and fail the
+migration pre-flight. Separately, modeled fields that parse but have no
+runtime effect produce an ordinary validation/startup warning:
+`server.secure-cookies`,
 `server.servlet.session.timeout`, `proxy.heartbeat-rate`,
 `proxy.hide-navbar`, `proxy.landing-page`, `proxy.container-log-path`
 and `logging.file` each produce a warning when set, so a migrated
-config never silently loses configured behaviour.
-Run `ruscker validate --strict-compat <config>` to list every
-unsupported feature a config uses (and exit non-zero if any are
-found) — the recommended pre-flight check when migrating from
-ShinyProxy.
+config does not silently lose those configured behaviors. The API
+`docs-path` and `health-path` compatibility placeholders described above are
+the exception: they are stored but currently have no runtime effect or
+dedicated validation warning.
 
 For a field-by-field ShinyProxy → Ruscker reference — every documented
 ShinyProxy 3.x key with its status here (supported /

--- a/docs/YAML_SCHEMA.md
+++ b/docs/YAML_SCHEMA.md
@@ -377,7 +377,12 @@ cap, and `container-memory-request` maps to Docker's soft memory
 reservation. `container-cpu-request` is parsed and retained for compatible
 backends but has no runtime effect on the local Docker backend, which has no
 CPU-request primitive. Memory accepts plain bytes or binary `k`/`m`/`g`
-suffixes. Invalid or non-positive values are warned and not applied.
+suffixes. An **unparseable** memory value (e.g. the `512mb` typo) is warned
+and ignored; a `0` is valid and means *no limit* (for `-limit`) or *no
+reservation* (for `-request`) — Docker treats zero as unlimited, so it is
+not warned. `container-cpu-limit` / `container-cpu-request` are stricter:
+only a positive, finite number of CPUs is accepted — `0`, negatives, and
+non-finite values are warned and not applied.
 
 `container-network` (Ruscker extension) attaches the spec's containers to
 a named Docker network, mapped to the container's `HostConfig.NetworkMode`.

--- a/docs/images/crate-map.svg
+++ b/docs/images/crate-map.svg
@@ -38,7 +38,7 @@
   <!-- ruscker-core -->
   <rect x="210" y="296" width="300" height="52" rx="10" fill="#FFFFFF" stroke="#0F6E56" stroke-width="1.8"/>
   <text x="360" y="319" text-anchor="middle" font-size="13" font-weight="700" fill="#085041">ruscker-core</text>
-  <text x="360" y="337" text-anchor="middle" font-size="10.5" fill="#5B6B66">traits · types · routing · ReplicaRegistry</text>
+  <text x="360" y="337" text-anchor="middle" font-size="10.5" fill="#5B6B66">traits · types · ReplicaRegistry</text>
 
   <!-- ruscker-config -->
   <rect x="210" y="364" width="300" height="50" rx="10" fill="#FFFFFF" stroke="#0F6E56" stroke-width="1.8"/>

--- a/docs/images/crate-map.svg
+++ b/docs/images/crate-map.svg
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 720 470" width="720" height="470" font-family="Jost, Inter, system-ui, -apple-system, sans-serif" role="img" aria-label="Crate dependency map: ruscker-cli (binary) builds on the I/O crates (docker, proxy, admin), which build on ruscker-core, which builds on ruscker-config. Config and core are pure-domain with no I/O.">
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 720 470" width="720" height="470" font-family="Jost, Inter, system-ui, -apple-system, sans-serif" role="img" aria-label="Crate dependency map: ruscker-cli (binary) builds on ruscker-admin + ruscker-docker; admin builds on ruscker-proxy; all build on ruscker-core, which builds on ruscker-config. Config and core are pure-domain with no I/O.">
   <title>Ruscker — crate map</title>
 
   <defs>
@@ -46,10 +46,11 @@
   <text x="360" y="404" text-anchor="middle" font-size="10.5" fill="#5B6B66">YAML schema · parsing · validation</text>
 
   <!-- edges: arrows point up, toward the consumer ("built on") -->
-  <!-- cli ← the three I/O crates -->
+  <!-- cli ← ruscker-admin + ruscker-docker (cli does not depend on ruscker-proxy directly) -->
   <line x1="146" y1="150" x2="300" y2="88" stroke="#1D9E75" stroke-width="2" marker-end="url(#up)"/>
-  <line x1="360" y1="150" x2="360" y2="88" stroke="#1D9E75" stroke-width="2" marker-end="url(#up)"/>
   <line x1="574" y1="150" x2="420" y2="88" stroke="#1D9E75" stroke-width="2" marker-end="url(#up)"/>
+  <!-- admin ← proxy (admin depends on proxy) -->
+  <line x1="452" y1="175" x2="481" y2="175" stroke="#1D9E75" stroke-width="2" marker-end="url(#up)"/>
   <!-- core ← I/O crates (fan out from core's top edge) -->
   <line x1="300" y1="296" x2="146" y2="202" stroke="#1D9E75" stroke-width="2" marker-end="url(#up)"/>
   <line x1="360" y1="296" x2="360" y2="202" stroke="#1D9E75" stroke-width="2" marker-end="url(#up)"/>

--- a/docs/images/deployment.svg
+++ b/docs/images/deployment.svg
@@ -53,7 +53,7 @@
   <line x1="605" y1="174" x2="570" y2="208" stroke="#1D9E75" stroke-width="2.2" marker-end="url(#dn)"/>
 
   <rect x="405" y="212" width="260" height="44" rx="9" fill="#E8F3EE" stroke="#1D9E75" stroke-width="1.6"/>
-  <text x="535" y="231" text-anchor="middle" font-size="12.5" font-weight="600" fill="#085041">Postgres — shared session state</text>
+  <text x="535" y="231" text-anchor="middle" font-size="12.5" font-weight="600" fill="#085041">Postgres — shared config + sessions</text>
   <text x="535" y="248" text-anchor="middle" font-size="10" fill="#5B6B66">either instance can serve any session</text>
   <line x1="535" y1="256" x2="535" y2="282" stroke="#1D9E75" stroke-width="2.2" marker-end="url(#dn)"/>
 

--- a/docs/images/roadmap.svg
+++ b/docs/images/roadmap.svg
@@ -1,8 +1,8 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 720 520" width="720" height="520" font-family="Jost, Inter, system-ui, -apple-system, sans-serif" role="img" aria-label="Roadmap timeline. Phases 0 through 7 are done. Phases 0 to 5 shipped in v0.1.0 (scaffolding, landing page, persistence and admin CRUD, proxy and Docker backend, monitoring dashboard, production polish); phase 6 (multi-host scheduling, app visibility, sub-path mounting) shipped across v0.1.1 and v0.1.2; phase 7 (HA / multi-instance) shipped in v0.1.1. After phase 7, the latest release v0.1.3 adds admin/UX and proxy polish across the shipped phases. Phase 8 (external auth) is planned and optional.">
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 720 520" width="720" height="520" font-family="Jost, Inter, system-ui, -apple-system, sans-serif" role="img" aria-label="Roadmap timeline. Phases 0 through 7 are done. Phases 0 to 5 shipped in v0.1.0 (scaffolding, landing page, persistence and admin CRUD, proxy and Docker backend, monitoring dashboard, production polish); phase 6 (multi-host scheduling, app visibility, sub-path mounting) shipped across v0.1.1 and v0.1.2; phase 7 (HA / multi-instance) shipped in v0.1.1. After phase 7, the v0.1.x–v0.2.x point releases added the admin redesign, a full bug, security and UX audit (v0.2.5), and an operator-driven design-handoff sprint across the Appearance editor, Apps list and Media flows. Phase 8 (external auth) is planned and optional.">
   <title>Ruscker — roadmap</title>
 
-  <!-- rail: solid teal through the done phases (0–7) and the v0.1.3
+  <!-- rail: solid teal through the done phases (0–7) and the latest-release
        release marker, dashed grey after toward the planned phase 8 -->
   <line x1="60" y1="52" x2="60" y2="446" stroke="#1D9E75" stroke-width="3"/>
   <line x1="60" y1="446" x2="60" y2="476" stroke="#B9CDC6" stroke-width="3" stroke-dasharray="3 6"/>
@@ -69,7 +69,7 @@
        phase. Sits at the solid→dashed transition. -->
   <path d="M60,439 l7,7 l-7,7 l-7,-7 z" fill="#1D9E75" stroke="#FFFFFF" stroke-width="1.5"/>
   <text x="86" y="450" font-size="12.5">
-    <tspan font-weight="700" fill="#085041">v0.1.3</tspan><tspan fill="#5B6B66"> · latest — admin &amp; UX + proxy polish (across phases 1–7)</tspan>
+    <tspan font-weight="700" fill="#085041">v0.2.x</tspan><tspan fill="#5B6B66"> · latest — full audit (v0.2.5) + the admin design-handoff sprint (Appearance, Apps, Media)</tspan>
   </text>
 
   <!-- planned phase -->


### PR DESCRIPTION
A general documentation review bringing README, the mdBook site, and the `docs/` reference up to date with everything shipped since the last audit (~v0.2.19). The docs had **none** of the major recent features.

## What changed (15 files, +693/-308 before review fixes)
- **README**: added per-app step-up MFA, identity headers (`X-SP-*` / `X-Ruscker-User-*`), the hardened cookie boundary, scheduled jobs and named-volume management (both qualified as local-backend); corrected dashboard polling, the **Containers**/**Activity** nav names, test count (764), config resolution and CLI flags.
- **Guide** (`book/src/`): a **2FA / MFA** subsection and an **identity-headers** section in the admin guide, users-page pagination + (correctly described) search, renamed nav, plus new troubleshooting/faq entries (2FA 503 → master key, missing identity → `add-default-http-headers`, reserved app cookie) and migrating/deploying notes.
- **Reference** (`docs/`): completed the MFA + identity-header + reserved-cookie trust boundaries in SECURITY; added the MFA tables/guard, identity cache, scheduler and access counter to ARCHITECTURE; ticked shipped Roadmap items; verified YAML_SCHEMA fields against the schema and removed the stale "not yet enforced" MFA caveat.

## How it was done & verified
- Drafted by **three Codex agents** (gpt-5.6, high) in isolated worktrees over non-overlapping files (README / narrative pages / reference), each given the same feature ground-truth + house doc policies.
- **Validated**: mdBook builds clean; every README deep-link resolves against the built HTML; house policies hold (evergreen versions, ~14 MB footprint framing with no banned arrow, no public-sector specifics, dashboard polls not SSE); MFA/identity schema fields cross-checked against the code.
- **Codex review, 5 rounds** — each surfaced real factual errors the agents missed (the `/admin` no-DB behaviour, `memory: 0` = unlimited, the multi-host jobs/volumes limitation across every summary, the "accent-tolerant" overclaim, a broken MFA anchor), each verified against code and fixed, to a clean round 5.
- `news.md` untouched (curated per-release).

🤖 Generated with [Claude Code](https://claude.com/claude-code)