### PR TITLE
feat: user_activity store + supervised writer (#1021 fatia 1)

### DIFF
--- a/crates/ruscker-admin/migrations-pg/0031_user_activity.sql
+++ b/crates/ruscker-admin/migrations-pg/0031_user_activity.sql
@@ -1,0 +1,20 @@
+-- Per-user activity log (#1021) — Postgres twin of the SQLite migration.
+-- One row per login or interactive app access, WITH identity. Distinct
+-- from `spec_access` (aggregate totals) and `audit_log` (admin actions).
+-- No foreign keys to `users`/`specs` so history survives deletion.
+CREATE TABLE user_activity (
+    id           BIGINT      GENERATED ALWAYS AS IDENTITY PRIMARY KEY,
+    event_type   TEXT        NOT NULL,
+    username     TEXT,
+    spec_id      TEXT,
+    event_key    TEXT        NOT NULL,
+    auth_method  TEXT,
+    client_ip    TEXT,
+    occurred_at  TIMESTAMPTZ NOT NULL
+);
+
+CREATE UNIQUE INDEX user_activity_dedup_idx ON user_activity (event_type, event_key);
+CREATE INDEX user_activity_occurred_idx ON user_activity (occurred_at);
+CREATE INDEX user_activity_username_idx ON user_activity (username);
+CREATE INDEX user_activity_spec_idx     ON user_activity (spec_id);
+CREATE INDEX user_activity_type_idx     ON user_activity (event_type);

--- a/crates/ruscker-admin/migrations/0031_user_activity.sql
+++ b/crates/ruscker-admin/migrations/0031_user_activity.sql
@@ -1,0 +1,31 @@
+-- Per-user activity log (#1021): one row per login or interactive app
+-- access, WITH identity. Distinct from `spec_access` (aggregate totals,
+-- no user) and `audit_log` (administrative actions, different growth
+-- rate). No foreign keys to `users`/`specs` so the history survives a
+-- user or app being deleted. Written off the proxy hot path by a
+-- supervised, bounded writer (`crate::activity`).
+CREATE TABLE user_activity (
+    id           INTEGER PRIMARY KEY AUTOINCREMENT,
+    -- 'login.success' | 'app.access'
+    event_type   TEXT    NOT NULL,
+    -- NULL for an anonymous access (no signed-in user).
+    username     TEXT,
+    -- Set for 'app.access'; NULL for 'login.success'.
+    spec_id      TEXT,
+    -- Session identifier — dedups the same event across HA instances.
+    event_key    TEXT    NOT NULL,
+    -- 'password' | 'token' (break-glass). NULL when not applicable.
+    auth_method  TEXT,
+    -- Optional; personal data — admin-only, define retention if used.
+    client_ip    TEXT,
+    -- RFC 3339 (UTC); TEXT in SQLite, TIMESTAMPTZ in Postgres.
+    occurred_at  TEXT    NOT NULL
+);
+
+-- Dedup the same session's event (HA: two instances, one session).
+CREATE UNIQUE INDEX user_activity_dedup_idx ON user_activity (event_type, event_key);
+-- Filters + newest-first paging.
+CREATE INDEX user_activity_occurred_idx ON user_activity (occurred_at);
+CREATE INDEX user_activity_username_idx ON user_activity (username);
+CREATE INDEX user_activity_spec_idx     ON user_activity (spec_id);
+CREATE INDEX user_activity_type_idx     ON user_activity (event_type);

--- a/crates/ruscker-admin/src/activity.rs
+++ b/crates/ruscker-admin/src/activity.rs
@@ -1,0 +1,341 @@
+//! User-activity capture (#1021).
+//!
+//! Records who logged in and who opened which app — one durable row per
+//! event, with identity. This is distinct from [`crate::access_counter`]
+//! (aggregate per-spec totals, no user) and the `audit_log` (administrative
+//! actions). It powers the "Atividades dos usuários" table.
+//!
+//! Design mirrors [`crate::alerts`]: emitting is a cheap synchronous
+//! [`ActivitySink::record`] on the hot path — a `try_send` into a bounded
+//! channel that never blocks and never fails the caller. One supervised task
+//! per process ([`spawn`]) drains the channel in batches and does the slow
+//! part (a single transaction per batch). If the channel is full (the DB is
+//! down and the drain has stalled), the overflow is counted in
+//! [`ActivitySink::dropped`] rather than applying backpressure to the proxy —
+//! activity logging is best-effort observability, never a request dependency.
+//!
+//! Persistence + querying live in [`crate::db::user_activity`]. This slice
+//! (#1021 fatia 1) delivers the schema, the store, and this writer; the
+//! capture sites (login, app access) and the admin UI are later slices.
+
+use crate::db::{self, ConfigDb};
+use chrono::{DateTime, Utc};
+use std::sync::atomic::{AtomicU64, Ordering};
+use std::sync::{Arc, Mutex, PoisonError};
+use std::time::Duration;
+use tokio::sync::mpsc;
+
+/// Queue depth between emit sites and the drain task. App accesses can
+/// burst (many users opening apps at once), so this is deeper than the
+/// alert queue; a full queue means the DB is down and the drain has
+/// stalled — dropping the overflow (counted) is the right call.
+const QUEUE_DEPTH: usize = 1024;
+
+/// Rows drained and written per transaction. Bounds the batch a single
+/// commit holds while still collapsing a burst into few writes.
+const BATCH_MAX: usize = 256;
+
+/// Attempts to persist one batch before giving up on it (first try +
+/// retries), with the pause growing per attempt.
+const MAX_ATTEMPTS: u32 = 3;
+const RETRY_BASE: Duration = Duration::from_millis(200);
+
+/// The kind of activity recorded. The string form is what lands in
+/// `user_activity.event_type` and what the UI filters on.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum ActivityEventType {
+    /// A user authenticated successfully (a session was created).
+    LoginSuccess,
+    /// A new interactive app session was established.
+    AppAccess,
+}
+
+impl ActivityEventType {
+    pub fn as_str(self) -> &'static str {
+        match self {
+            ActivityEventType::LoginSuccess => "login.success",
+            ActivityEventType::AppAccess => "app.access",
+        }
+    }
+}
+
+/// How the actor authenticated. `None` when not applicable (e.g. an
+/// anonymous app access).
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum AuthMethod {
+    /// Username + password.
+    Password,
+    /// `RUSCKER_ADMIN_TOKEN` break-glass session.
+    Token,
+}
+
+impl AuthMethod {
+    pub fn as_str(self) -> &'static str {
+        match self {
+            AuthMethod::Password => "password",
+            AuthMethod::Token => "token",
+        }
+    }
+}
+
+/// One activity event on its way to the store.
+#[derive(Debug, Clone)]
+pub struct ActivityEvent {
+    pub event_type: ActivityEventType,
+    /// Signed-in username; `None` for an anonymous access.
+    pub username: Option<String>,
+    /// Target spec for `AppAccess`; `None` for `LoginSuccess`.
+    pub spec_id: Option<String>,
+    /// Session identifier — the dedup key (unique per `event_type`), so the
+    /// same session logged by two HA instances collapses to one row.
+    pub event_key: String,
+    pub auth_method: Option<AuthMethod>,
+    /// Client IP if the deployment chooses to record it. Personal data —
+    /// admin-only, retention TBD (kept optional and unset by default).
+    pub client_ip: Option<String>,
+    /// When the event happened (stamped at emit, not at insert, so a
+    /// drained-late batch keeps accurate timestamps).
+    pub occurred_at: DateTime<Utc>,
+}
+
+impl ActivityEvent {
+    /// A successful login.
+    pub fn login_success(
+        username: impl Into<String>,
+        auth_method: AuthMethod,
+        event_key: impl Into<String>,
+        client_ip: Option<String>,
+    ) -> Self {
+        Self {
+            event_type: ActivityEventType::LoginSuccess,
+            username: Some(username.into()),
+            spec_id: None,
+            event_key: event_key.into(),
+            auth_method: Some(auth_method),
+            client_ip,
+            occurred_at: Utc::now(),
+        }
+    }
+
+    /// A new interactive app session. `username` is `None` for an
+    /// anonymous access.
+    pub fn app_access(
+        username: Option<String>,
+        spec_id: impl Into<String>,
+        event_key: impl Into<String>,
+        auth_method: Option<AuthMethod>,
+        client_ip: Option<String>,
+    ) -> Self {
+        Self {
+            event_type: ActivityEventType::AppAccess,
+            username,
+            spec_id: Some(spec_id.into()),
+            event_key: event_key.into(),
+            auth_method,
+            client_ip,
+            occurred_at: Utc::now(),
+        }
+    }
+}
+
+/// Cheap-to-clone handle held in [`crate::AppState`]. Emitting never blocks
+/// and never fails the caller; the receiving half is taken once by
+/// [`spawn`] to start the drain task (tests take it to assert on events).
+#[derive(Debug, Clone)]
+pub struct ActivitySink {
+    tx: mpsc::Sender<ActivityEvent>,
+    rx: Arc<Mutex<Option<mpsc::Receiver<ActivityEvent>>>>,
+    dropped: Arc<AtomicU64>,
+}
+
+impl Default for ActivitySink {
+    fn default() -> Self {
+        let (tx, rx) = mpsc::channel(QUEUE_DEPTH);
+        Self {
+            tx,
+            rx: Arc::new(Mutex::new(Some(rx))),
+            dropped: Arc::new(AtomicU64::new(0)),
+        }
+    }
+}
+
+impl ActivitySink {
+    /// Record one event. Hot path: a non-blocking `try_send`. If the queue
+    /// is full (drain stalled / DB down) the event is dropped and counted —
+    /// never blocks the caller.
+    pub fn record(&self, event: ActivityEvent) {
+        if self.tx.try_send(event).is_err() {
+            self.dropped.fetch_add(1, Ordering::Relaxed);
+        }
+    }
+
+    /// Take the receiving half — called once by [`spawn`]. Returns `None`
+    /// on a second call (the task is already running, or a test took it).
+    pub fn take_receiver(&self) -> Option<mpsc::Receiver<ActivityEvent>> {
+        self.rx
+            .lock()
+            .unwrap_or_else(PoisonError::into_inner)
+            .take()
+    }
+
+    /// Events dropped to the [`QUEUE_DEPTH`] backstop since boot —
+    /// observability for the overflow case.
+    pub fn dropped(&self) -> u64 {
+        self.dropped.load(Ordering::Relaxed)
+    }
+}
+
+/// Start the single per-process drain task: batch-reads events and writes
+/// each batch in one transaction, retrying a failed batch a few times
+/// before dropping it (logged). Returns `None` if the receiver was already
+/// taken. The task ends when every [`ActivitySink`] clone is dropped.
+pub fn spawn(sink: &ActivitySink, db: ConfigDb) -> Option<tokio::task::JoinHandle<()>> {
+    let mut rx = sink.take_receiver()?;
+    Some(tokio::spawn(async move {
+        let mut buf: Vec<ActivityEvent> = Vec::with_capacity(BATCH_MAX);
+        // `recv_many` appends up to BATCH_MAX and returns 0 only when the
+        // channel is closed and drained — i.e. all senders are gone.
+        while rx.recv_many(&mut buf, BATCH_MAX).await > 0 {
+            let mut attempt = 0u32;
+            loop {
+                match db::user_activity::insert_batch(&db, &buf).await {
+                    Ok(_) => break,
+                    Err(e) => {
+                        attempt += 1;
+                        if attempt >= MAX_ATTEMPTS {
+                            tracing::warn!(
+                                error = ?e, lost = buf.len(),
+                                "activity batch insert failed; events lost"
+                            );
+                            break;
+                        }
+                        tracing::warn!(error = ?e, attempt, "activity batch insert failed; retrying");
+                        tokio::time::sleep(RETRY_BASE * attempt).await;
+                    }
+                }
+            }
+            buf.clear();
+        }
+    }))
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    async fn mem_db() -> ConfigDb {
+        ConfigDb::Sqlite(crate::db::open_memory().await.expect("open in-memory"))
+    }
+
+    #[test]
+    fn record_full_queue_counts_dropped_never_blocks() {
+        let sink = ActivitySink::default();
+        // Don't start the drain, so nothing is consumed. QUEUE_DEPTH fit,
+        // the rest are dropped and counted — record never blocks.
+        for i in 0..(QUEUE_DEPTH + 50) {
+            sink.record(ActivityEvent::login_success(
+                "alice",
+                AuthMethod::Password,
+                format!("sess-{i}"),
+                None,
+            ));
+        }
+        assert_eq!(sink.dropped(), 50);
+    }
+
+    #[tokio::test]
+    async fn drain_persists_recorded_events() {
+        let db = mem_db().await;
+        let sink = ActivitySink::default();
+        let handle = spawn(&sink, db.clone()).expect("drain starts");
+
+        sink.record(ActivityEvent::login_success(
+            "alice",
+            AuthMethod::Password,
+            "login-1",
+            Some("10.0.0.1".into()),
+        ));
+        sink.record(ActivityEvent::app_access(
+            Some("alice".into()),
+            "sales",
+            "app-sess-1",
+            Some(AuthMethod::Password),
+            None,
+        ));
+        // Anonymous access — username None.
+        sink.record(ActivityEvent::app_access(
+            None,
+            "public-dash",
+            "app-sess-2",
+            None,
+            None,
+        ));
+
+        // Dropping every sink clone closes the channel; the drain then
+        // finishes its final batch and the task returns.
+        drop(sink);
+        handle.await.expect("drain task joins");
+
+        let filter = db::user_activity::ActivityFilter {
+            limit: 100,
+            ..Default::default()
+        };
+        let rows = db::user_activity::list_page(&db, &filter).await.unwrap();
+        assert_eq!(rows.len(), 3);
+        // Newest first: the two app accesses then the login (insertion order).
+        assert_eq!(
+            db::user_activity::count_filtered(&db, &filter)
+                .await
+                .unwrap(),
+            3
+        );
+        let logins: Vec<_> = rows
+            .iter()
+            .filter(|r| r.event_type == "login.success")
+            .collect();
+        assert_eq!(logins.len(), 1);
+        assert_eq!(logins[0].username.as_deref(), Some("alice"));
+        assert_eq!(logins[0].client_ip.as_deref(), Some("10.0.0.1"));
+        let anon: Vec<_> = rows
+            .iter()
+            .filter(|r| r.spec_id.as_deref() == Some("public-dash"))
+            .collect();
+        assert_eq!(anon.len(), 1);
+        assert_eq!(anon[0].username, None, "anonymous access has no username");
+    }
+
+    #[tokio::test]
+    async fn duplicate_event_key_is_deduped() {
+        let db = mem_db().await;
+        // Same (event_type, event_key) inserted twice — the unique index +
+        // ON CONFLICT DO NOTHING keeps exactly one (HA cross-instance case).
+        let e = ActivityEvent::app_access(
+            Some("bob".into()),
+            "sales",
+            "dup-key",
+            Some(AuthMethod::Password),
+            None,
+        );
+        assert_eq!(
+            db::user_activity::insert_batch(&db, std::slice::from_ref(&e))
+                .await
+                .unwrap(),
+            1
+        );
+        assert_eq!(
+            db::user_activity::insert_batch(&db, &[e]).await.unwrap(),
+            0,
+            "second insert of the same session event is a no-op"
+        );
+        let filter = db::user_activity::ActivityFilter {
+            limit: 100,
+            ..Default::default()
+        };
+        assert_eq!(
+            db::user_activity::count_filtered(&db, &filter)
+                .await
+                .unwrap(),
+            1
+        );
+    }
+}

--- a/crates/ruscker-admin/src/db.rs
+++ b/crates/ruscker-admin/src/db.rs
@@ -172,6 +172,7 @@ pub mod settings;
 pub mod showcase;
 pub mod spec_access;
 pub mod specs;
+pub mod user_activity;
 pub mod user_favorites;
 pub mod users;
 

--- a/crates/ruscker-admin/src/db/user_activity.rs
+++ b/crates/ruscker-admin/src/db/user_activity.rs
@@ -1,0 +1,441 @@
+//! User-activity store (#1021).
+//!
+//! Append-only persistence for [`crate::activity`] — one row per login or
+//! interactive app access, with identity. Writes go through
+//! [`insert_batch`] (called by the supervised drain task, never inline on
+//! the proxy hot path); reads power the "Atividades dos usuários" table via
+//! [`list_page`] + [`count_filtered`] (server-side pagination, like
+//! `db::users`).
+//!
+//! Every value is bound through `push_bind` — no string interpolation, no
+//! SQL injection. The dynamic WHERE is shared across both dialects via a
+//! generic [`sqlx::QueryBuilder`], which emits `?` for SQLite and `$n` for
+//! Postgres automatically.
+
+use anyhow::{Context, Result};
+use chrono::{DateTime, Utc};
+
+use crate::activity::ActivityEvent;
+use crate::db::ConfigDb;
+
+/// One row of `user_activity` for the admin table. `event_key` is an
+/// internal dedup key and deliberately not surfaced here.
+#[derive(Debug, Clone)]
+pub struct ActivityRow {
+    pub id: i64,
+    /// `login.success` | `app.access`.
+    pub event_type: String,
+    pub username: Option<String>,
+    pub spec_id: Option<String>,
+    pub auth_method: Option<String>,
+    pub client_ip: Option<String>,
+    pub occurred_at: DateTime<Utc>,
+}
+
+/// Read filter for [`list_page`] / [`count_filtered`]. Every field is
+/// optional (`None` ⇒ don't restrict on that dimension). `limit`/`offset`
+/// drive server-side pagination.
+#[derive(Debug, Clone)]
+pub struct ActivityFilter {
+    pub event_type: Option<String>,
+    pub username: Option<String>,
+    pub spec_id: Option<String>,
+    /// Inclusive lower bound on `occurred_at`.
+    pub since: Option<DateTime<Utc>>,
+    /// Inclusive upper bound on `occurred_at`.
+    pub until: Option<DateTime<Utc>>,
+    pub limit: i64,
+    pub offset: i64,
+}
+
+impl Default for ActivityFilter {
+    fn default() -> Self {
+        Self {
+            event_type: None,
+            username: None,
+            spec_id: None,
+            since: None,
+            until: None,
+            limit: 50,
+            offset: 0,
+        }
+    }
+}
+
+/// Row tuple shared by both dialect arms of [`list_page`].
+type ListRow = (
+    i64,
+    String,
+    Option<String>,
+    Option<String>,
+    Option<String>,
+    Option<String>,
+    DateTime<Utc>,
+);
+
+/// Push the shared WHERE predicates onto a builder that already ends in a
+/// truthy anchor (`WHERE 1=1`). Generic over the database so SQLite and
+/// Postgres share one filter definition.
+fn push_where<DB>(qb: &mut sqlx::QueryBuilder<DB>, filter: &ActivityFilter)
+where
+    DB: sqlx::Database,
+    String: sqlx::Type<DB> + for<'q> sqlx::Encode<'q, DB>,
+    DateTime<Utc>: sqlx::Type<DB> + for<'q> sqlx::Encode<'q, DB>,
+{
+    if let Some(t) = &filter.event_type {
+        qb.push(" AND event_type = ");
+        qb.push_bind(t.clone());
+    }
+    if let Some(u) = &filter.username {
+        qb.push(" AND username = ");
+        qb.push_bind(u.clone());
+    }
+    if let Some(s) = &filter.spec_id {
+        qb.push(" AND spec_id = ");
+        qb.push_bind(s.clone());
+    }
+    if let Some(since) = filter.since {
+        qb.push(" AND occurred_at >= ");
+        qb.push_bind(since);
+    }
+    if let Some(until) = filter.until {
+        qb.push(" AND occurred_at <= ");
+        qb.push_bind(until);
+    }
+}
+
+const LIST_SELECT: &str = "SELECT id, event_type, username, spec_id, auth_method, client_ip, \
+     occurred_at FROM user_activity WHERE 1=1";
+const COUNT_SELECT: &str = "SELECT COUNT(*) FROM user_activity WHERE 1=1";
+
+/// Insert a batch of events in one transaction, newest kept. The unique
+/// index on `(event_type, event_key)` + `ON CONFLICT DO NOTHING` deduplicates
+/// the same session logged by two HA instances. Returns the number of rows
+/// actually inserted (conflicts are skipped, not counted).
+pub async fn insert_batch(db: &ConfigDb, events: &[ActivityEvent]) -> Result<u64> {
+    if events.is_empty() {
+        return Ok(0);
+    }
+    match db {
+        ConfigDb::Sqlite(pool) => {
+            let mut tx = pool.begin().await.context("activity insert begin (sqlite)")?;
+            let mut inserted = 0u64;
+            for e in events {
+                let res = sqlx::query(
+                    "INSERT INTO user_activity
+                        (event_type, username, spec_id, event_key, auth_method, client_ip, occurred_at)
+                     VALUES (?, ?, ?, ?, ?, ?, ?)
+                     ON CONFLICT (event_type, event_key) DO NOTHING",
+                )
+                .bind(e.event_type.as_str())
+                .bind(e.username.as_deref())
+                .bind(e.spec_id.as_deref())
+                .bind(&e.event_key)
+                .bind(e.auth_method.map(|m| m.as_str()))
+                .bind(e.client_ip.as_deref())
+                .bind(e.occurred_at)
+                .execute(&mut *tx)
+                .await
+                .context("activity insert (sqlite)")?;
+                inserted += res.rows_affected();
+            }
+            tx.commit().await.context("activity insert commit (sqlite)")?;
+            Ok(inserted)
+        }
+        ConfigDb::Postgres(pool) => {
+            let mut tx = pool.begin().await.context("activity insert begin (pg)")?;
+            let mut inserted = 0u64;
+            for e in events {
+                let res = sqlx::query(
+                    "INSERT INTO user_activity
+                        (event_type, username, spec_id, event_key, auth_method, client_ip, occurred_at)
+                     VALUES ($1, $2, $3, $4, $5, $6, $7)
+                     ON CONFLICT (event_type, event_key) DO NOTHING",
+                )
+                .bind(e.event_type.as_str())
+                .bind(e.username.as_deref())
+                .bind(e.spec_id.as_deref())
+                .bind(&e.event_key)
+                .bind(e.auth_method.map(|m| m.as_str()))
+                .bind(e.client_ip.as_deref())
+                .bind(e.occurred_at)
+                .execute(&mut *tx)
+                .await
+                .context("activity insert (pg)")?;
+                inserted += res.rows_affected();
+            }
+            tx.commit().await.context("activity insert commit (pg)")?;
+            Ok(inserted)
+        }
+    }
+}
+
+/// One page of activity rows matching `filter`, newest first.
+pub async fn list_page(db: &ConfigDb, filter: &ActivityFilter) -> Result<Vec<ActivityRow>> {
+    let limit = filter.limit.clamp(1, 500);
+    let offset = filter.offset.max(0);
+    let rows: Vec<ListRow> = match db {
+        ConfigDb::Sqlite(pool) => {
+            let mut qb: sqlx::QueryBuilder<sqlx::Sqlite> = sqlx::QueryBuilder::new(LIST_SELECT);
+            push_where(&mut qb, filter);
+            qb.push(" ORDER BY id DESC LIMIT ");
+            qb.push_bind(limit);
+            qb.push(" OFFSET ");
+            qb.push_bind(offset);
+            qb.build_query_as().fetch_all(pool).await
+        }
+        ConfigDb::Postgres(pool) => {
+            let mut qb: sqlx::QueryBuilder<sqlx::Postgres> = sqlx::QueryBuilder::new(LIST_SELECT);
+            push_where(&mut qb, filter);
+            qb.push(" ORDER BY id DESC LIMIT ");
+            qb.push_bind(limit);
+            qb.push(" OFFSET ");
+            qb.push_bind(offset);
+            qb.build_query_as().fetch_all(pool).await
+        }
+    }
+    .context("list user_activity")?;
+
+    Ok(rows
+        .into_iter()
+        .map(
+            |(id, event_type, username, spec_id, auth_method, client_ip, occurred_at)| {
+                ActivityRow {
+                    id,
+                    event_type,
+                    username,
+                    spec_id,
+                    auth_method,
+                    client_ip,
+                    occurred_at,
+                }
+            },
+        )
+        .collect())
+}
+
+/// Total rows matching `filter` (ignores limit/offset) — for the pager.
+pub async fn count_filtered(db: &ConfigDb, filter: &ActivityFilter) -> Result<i64> {
+    let (count,): (i64,) = match db {
+        ConfigDb::Sqlite(pool) => {
+            let mut qb: sqlx::QueryBuilder<sqlx::Sqlite> = sqlx::QueryBuilder::new(COUNT_SELECT);
+            push_where(&mut qb, filter);
+            qb.build_query_as().fetch_one(pool).await
+        }
+        ConfigDb::Postgres(pool) => {
+            let mut qb: sqlx::QueryBuilder<sqlx::Postgres> = sqlx::QueryBuilder::new(COUNT_SELECT);
+            push_where(&mut qb, filter);
+            qb.build_query_as().fetch_one(pool).await
+        }
+    }
+    .context("count user_activity")?;
+    Ok(count)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::activity::{ActivityEvent, AuthMethod};
+    use crate::db::open_memory;
+
+    fn login(user: &str, key: &str) -> ActivityEvent {
+        ActivityEvent::login_success(user, AuthMethod::Password, key, None)
+    }
+    fn access(user: Option<&str>, spec: &str, key: &str) -> ActivityEvent {
+        ActivityEvent::app_access(user.map(String::from), spec, key, None, None)
+    }
+
+    #[tokio::test]
+    async fn list_returns_newest_first_and_counts() {
+        let db = ConfigDb::Sqlite(open_memory().await.unwrap());
+        insert_batch(&db, &[login("alice", "l1"), access(Some("alice"), "sales", "a1")])
+            .await
+            .unwrap();
+        insert_batch(&db, &[access(Some("bob"), "ops", "a2")])
+            .await
+            .unwrap();
+
+        let all = list_page(&db, &ActivityFilter::default()).await.unwrap();
+        assert_eq!(all.len(), 3);
+        assert_eq!(all[0].spec_id.as_deref(), Some("ops"), "newest first");
+        assert_eq!(
+            count_filtered(&db, &ActivityFilter::default())
+                .await
+                .unwrap(),
+            3
+        );
+    }
+
+    #[tokio::test]
+    async fn filters_by_event_type_username_and_spec() {
+        let db = ConfigDb::Sqlite(open_memory().await.unwrap());
+        insert_batch(
+            &db,
+            &[
+                login("alice", "l1"),
+                access(Some("alice"), "sales", "a1"),
+                access(Some("bob"), "sales", "a2"),
+                access(None, "public", "a3"),
+            ],
+        )
+        .await
+        .unwrap();
+
+        let by_type = ActivityFilter {
+            event_type: Some("login.success".into()),
+            ..Default::default()
+        };
+        assert_eq!(count_filtered(&db, &by_type).await.unwrap(), 1);
+
+        let by_user = ActivityFilter {
+            username: Some("alice".into()),
+            ..Default::default()
+        };
+        // alice's login + alice's app access.
+        assert_eq!(count_filtered(&db, &by_user).await.unwrap(), 2);
+
+        let by_spec = ActivityFilter {
+            spec_id: Some("sales".into()),
+            ..Default::default()
+        };
+        assert_eq!(count_filtered(&db, &by_spec).await.unwrap(), 2);
+    }
+
+    #[tokio::test]
+    async fn pagination_pages_through_with_stable_total() {
+        let db = ConfigDb::Sqlite(open_memory().await.unwrap());
+        let events: Vec<_> = (0..10)
+            .map(|i| access(Some("u"), "s", &format!("k{i}")))
+            .collect();
+        insert_batch(&db, &events).await.unwrap();
+
+        let total = count_filtered(&db, &ActivityFilter::default())
+            .await
+            .unwrap();
+        assert_eq!(total, 10);
+
+        let page1 = list_page(
+            &db,
+            &ActivityFilter {
+                limit: 4,
+                offset: 0,
+                ..Default::default()
+            },
+        )
+        .await
+        .unwrap();
+        let page3 = list_page(
+            &db,
+            &ActivityFilter {
+                limit: 4,
+                offset: 8,
+                ..Default::default()
+            },
+        )
+        .await
+        .unwrap();
+        assert_eq!(page1.len(), 4);
+        assert_eq!(page3.len(), 2, "last page has the remainder");
+        // No overlap between pages (ids strictly decreasing across pages).
+        assert!(page1.last().unwrap().id > page3.first().unwrap().id);
+    }
+
+    #[tokio::test]
+    async fn since_until_filter_bounds_the_time_window() {
+        let db = ConfigDb::Sqlite(open_memory().await.unwrap());
+        // Three events at distinct, explicit timestamps (bypass the emit-time
+        // stamp so the window is deterministic).
+        let mk = |key: &str, ts: DateTime<Utc>| {
+            let mut e = access(Some("u"), "s", key);
+            e.occurred_at = ts;
+            e
+        };
+        let t = |h: u32| {
+            format!("2026-07-20T{h:02}:00:00Z")
+                .parse::<DateTime<Utc>>()
+                .unwrap()
+        };
+        insert_batch(&db, &[mk("k08", t(8)), mk("k12", t(12)), mk("k18", t(18))])
+            .await
+            .unwrap();
+
+        // Window [10:00, 15:00] captures only the 12:00 event.
+        let f = ActivityFilter {
+            since: Some(t(10)),
+            until: Some(t(15)),
+            ..Default::default()
+        };
+        assert_eq!(count_filtered(&db, &f).await.unwrap(), 1);
+        let rows = list_page(&db, &f).await.unwrap();
+        assert_eq!(rows.len(), 1);
+
+        // since-only lower bound (inclusive) keeps 12:00 and 18:00.
+        let f = ActivityFilter {
+            since: Some(t(12)),
+            ..Default::default()
+        };
+        assert_eq!(count_filtered(&db, &f).await.unwrap(), 2);
+    }
+
+    #[tokio::test]
+    async fn insert_dedups_on_event_type_and_key() {
+        let db = ConfigDb::Sqlite(open_memory().await.unwrap());
+        // Same key, same type → deduped to one.
+        assert_eq!(insert_batch(&db, &[access(Some("a"), "s", "dup")]).await.unwrap(), 1);
+        assert_eq!(insert_batch(&db, &[access(Some("a"), "s", "dup")]).await.unwrap(), 0);
+        // Same key but DIFFERENT type is a distinct event (login vs access).
+        assert_eq!(insert_batch(&db, &[login("a", "dup")]).await.unwrap(), 1);
+        assert_eq!(
+            count_filtered(&db, &ActivityFilter::default())
+                .await
+                .unwrap(),
+            2
+        );
+    }
+
+    // insert_batch + list_page/count_filtered (QueryBuilder<Postgres>, the
+    // dedup ON CONFLICT, DateTime binding) against a real daemon. Gated on
+    // `postgres-it`.
+    #[cfg(feature = "postgres-it")]
+    #[tokio::test]
+    async fn user_activity_against_real_postgres() {
+        let _guard = crate::db::pg_test_lock().lock().await;
+        let url = std::env::var("RUSCKER_TEST_PG_URL")
+            .expect("set RUSCKER_TEST_PG_URL to a reachable postgres:// DSN");
+        let pg = crate::db::open_pg(&url).await.unwrap();
+        sqlx::query("DELETE FROM user_activity")
+            .execute(&pg)
+            .await
+            .unwrap();
+        let db = ConfigDb::Postgres(pg);
+
+        insert_batch(
+            &db,
+            &[
+                login("alice", "l1"),
+                access(Some("alice"), "sales", "a1"),
+                access(None, "public", "a2"),
+            ],
+        )
+        .await
+        .unwrap();
+        // Dedup across a "second instance".
+        assert_eq!(
+            insert_batch(&db, &[access(Some("alice"), "sales", "a1")])
+                .await
+                .unwrap(),
+            0
+        );
+
+        assert_eq!(count_filtered(&db, &ActivityFilter::default()).await.unwrap(), 3);
+        let all = list_page(&db, &ActivityFilter::default()).await.unwrap();
+        assert_eq!(all[0].spec_id.as_deref(), Some("public"), "newest first");
+
+        let by_user = ActivityFilter {
+            username: Some("alice".into()),
+            ..Default::default()
+        };
+        assert_eq!(count_filtered(&db, &by_user).await.unwrap(), 2);
+        assert_eq!(all.iter().filter(|r| r.username.is_none()).count(), 1);
+    }
+}

--- a/crates/ruscker-admin/src/lib.rs
+++ b/crates/ruscker-admin/src/lib.rs
@@ -22,6 +22,7 @@ use tower_cookies::CookieManagerLayer;
 use tracing::info;
 
 pub mod access_counter;
+pub mod activity;
 pub mod alerts;
 pub mod auth;
 pub mod catalog;


### PR DESCRIPTION
## O quê

Fatia 1 de #1021 — a **fundação de persistência + writer** para a tela "Atividades dos usuários" (logins + acessos a apps, com identidade). Sem captura de eventos nem UI ainda (fatias 2 e 3); esta fatia entrega o schema, o store e o writer, todos testados isoladamente. **Zero mudança em `AppState`** (o campo + wiring no `serve` entram na fatia 2, junto com os pontos de captura, que é quando o sink precisa ser alcançável pelos handlers).

## O que entra

- **Migração 0031 (dual-dialect `migrations/` + `migrations-pg/`):** tabela `user_activity` (`event_type`, `username`, `spec_id`, `event_key`, `auth_method`, `client_ip`, `occurred_at`). **Sem FKs** para `users`/`specs` → o histórico sobrevive à remoção de usuário/app. `UNIQUE(event_type, event_key)` deduplica a mesma sessão vista por instâncias diferentes em HA; índices para os filtros (occurred_at, username, spec_id, event_type). `id` = `INTEGER AUTOINCREMENT` (sqlite) / `BIGINT GENERATED ALWAYS AS IDENTITY` (pg); `occurred_at` = TEXT / TIMESTAMPTZ.
- **`db::user_activity`:** `insert_batch` (uma transação por lote, `INSERT ... ON CONFLICT (event_type, event_key) DO NOTHING`), `list_page` + `count_filtered` (paginação server-side + filtros por tipo/usuário/spec/janela de tempo). WHERE dinâmico compartilhado via `QueryBuilder` genérico sobre `DB` (emite `?` no SQLite e `$n` no Postgres) — tudo por `push_bind`, sem interpolação de string.
- **`activity`:** `ActivitySink` (canal `mpsc` limitado; `record` é `try_send` — **nunca bloqueia** o caminho quente do proxy, overflow contado em `dropped()`) + task de dreno supervisionada que insere em lote com retry limitado. Espelha o padrão de `alerts`/`access_counter`. `ActivityEvent` carimba `occurred_at` no emit (não no insert), então um lote drenado tarde mantém o timestamp correto.

## Fora de escopo (fatias seguintes de #1021)

- **Fatia 2:** campo `activity` no `AppState` + `spawn` do dreno no `serve` + **pontos de captura** — `login.success` no login; `app.access` em `TouchOutcome::Registered` (proxy.rs, já é pós-guard, já exclui asset/XHR/WS/API); External **após** o guard de acesso.
- **Fatia 3:** a segunda tabela na aba Atividades (filtros + paginação + i18n×4).

## Testes

- **Writer** (`activity`): `record` em fila cheia conta `dropped` e nunca bloqueia; o dreno persiste os eventos gravados (incl. acesso anônimo sem username); dedup de `(event_type, event_key)`.
- **Store** (`db::user_activity`): lista newest-first + contagem; filtros por tipo/usuário/spec; paginação (páginas sem sobreposição, total estável); dedup no insert (mesma chave = no-op; mesma chave com tipo diferente = evento distinto); **janela `since`/`until`** (valida o bind de `DateTime<Utc>` contra o `occurred_at` TEXT do SQLite).
- **postgres-it**: `insert_batch` + `list_page`/`count_filtered` + dedup `ON CONFLICT` + bind de `DateTime` contra **Postgres 16 real** (rodado local, verde). Suite postgres-it completa verde (0031-pg aplica limpo junto de todas as migrações).
- Paridade de nomes `migrations/` ↔ `migrations-pg/` verde no gate default.

## Gate

`cargo test` (default, sem falhas) · clippy limpo nos arquivos tocados · `./scripts/i18n-check.sh` · postgres-it completo contra Postgres 16 real — tudo verde.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
