### PR TITLE
feat: capture login + app-access into user_activity (#1021 fatia 2)

### DIFF
--- a/crates/ruscker-admin/src/lib.rs
+++ b/crates/ruscker-admin/src/lib.rs
@@ -283,6 +283,10 @@ pub struct AppState {
     /// when a DB is wired) POSTs the events to the operator-configured
     /// webhook URL.
     pub alerts: alerts::AlertSink,
+    /// User-activity sink (#1021). Capture sites (login, new app session)
+    /// call `record` — a non-blocking enqueue; one drain task (started in
+    /// `AdminServer::run` when a DB is wired) batch-writes to `user_activity`.
+    pub activity: activity::ActivitySink,
 }
 
 impl AppState {
@@ -353,6 +357,7 @@ impl AdminServer {
             catalog_cache: Arc::new(tokio::sync::RwLock::new(None)),
             access_counter: Arc::new(access_counter::AccessCounter::default()),
             alerts: alerts::AlertSink::default(),
+            activity: activity::ActivitySink::default(),
         };
         Ok(Self {
             addr,
@@ -592,6 +597,16 @@ impl AdminServer {
         if let Some(db) = self.state.db.clone() {
             #[allow(clippy::let_underscore_future)]
             let _ = alerts::spawn(&self.state.alerts, db);
+        }
+
+        // User-activity drain (#1021): one task batch-writes login/app-access
+        // events to `user_activity`. Capture sites (login, new app session)
+        // enqueue non-blocking; without a DB there's nowhere to write, so the
+        // task isn't started and `record` just drops into a never-drained
+        // queue (bounded — no leak).
+        if let Some(db) = self.state.db.clone() {
+            #[allow(clippy::let_underscore_future)]
+            let _ = activity::spawn(&self.state.activity, db);
         }
 
         let app = router_with_images(self.state.clone(), self.images_dir.as_deref());

--- a/crates/ruscker-admin/src/routes/admin.rs
+++ b/crates/ruscker-admin/src/routes/admin.rs
@@ -327,6 +327,16 @@ async fn login_submit(
         .admin_sessions
         .create(user.role, Some(user.username.clone()))
         .await;
+    // Record the successful password login (#1021). Non-blocking enqueue;
+    // the session id is the dedup key so the same login isn't double-counted
+    // across HA instances. (Break-glass token logins are operator emergency
+    // access and intentionally not surfaced as user activity.)
+    state.activity.record(crate::activity::ActivityEvent::login_success(
+        user.username.clone(),
+        crate::activity::AuthMethod::Password,
+        session_id.clone(),
+        None,
+    ));
     issue_session_cookie(&state, &cookies, &headers, session_id);
 
     // First login with an admin-assigned password ⇒ ask whether to
@@ -832,6 +842,7 @@ mod tests {
             catalog_cache: Arc::new(tokio::sync::RwLock::new(None)),
             access_counter: Arc::new(crate::access_counter::AccessCounter::default()),
             alerts: crate::alerts::AlertSink::default(),
+            activity: crate::activity::ActivitySink::default(),
         }
     }
 

--- a/crates/ruscker-admin/src/routes/proxy.rs
+++ b/crates/ruscker-admin/src/routes/proxy.rs
@@ -682,17 +682,31 @@ async fn forward(
             .sessions
             .touch_or_register(&state.replicas, session_id, &spec.id, &replica.id, seat_reserved)
             .await;
-        // stop-on-logout (#337): when a *known* user first registers a
-        // session on a spec that opts in, index it so their logout can
-        // end it immediately. Only on first registration and only for
-        // such specs — no cost on the common path.
-        if outcome == crate::sessions::TouchOutcome::Registered && spec.effective_stop_on_logout() {
-            if let Some(user) = &acting_user {
-                state
-                    .logout_index
-                    .entry(user.clone())
-                    .or_default()
-                    .insert(session_id);
+        // A newly-registered session is a genuine app access (#1021): one
+        // per visit, already past the access guard, and never fired for
+        // assets/XHR/WS (untracked) or APIs (not sticky). `acting_user` is
+        // `None` for an anonymous access. Non-blocking enqueue; the session
+        // id is the dedup key.
+        if outcome == crate::sessions::TouchOutcome::Registered {
+            state.activity.record(crate::activity::ActivityEvent::app_access(
+                acting_user.clone(),
+                spec.id.clone(),
+                session_id.to_string(),
+                None,
+                None,
+            ));
+            // stop-on-logout (#337): when a *known* user first registers a
+            // session on a spec that opts in, index it so their logout can
+            // end it immediately. Only on first registration and only for
+            // such specs — no cost on the common path.
+            if spec.effective_stop_on_logout() {
+                if let Some(user) = &acting_user {
+                    state
+                        .logout_index
+                        .entry(user.clone())
+                        .or_default()
+                        .insert(session_id);
+                }
             }
         }
     }
@@ -2939,6 +2953,7 @@ mod tests {
             catalog_cache: StdArc::new(tokio::sync::RwLock::new(None)),
             access_counter: StdArc::new(crate::access_counter::AccessCounter::default()),
             alerts: crate::alerts::AlertSink::default(),
+            activity: crate::activity::ActivitySink::default(),
         }
     }
 
@@ -4301,6 +4316,57 @@ proxy:
             );
             assert_eq!(state.sessions.len(), 1);
         }
+    }
+
+    /// #1021: a new interactive session (a text/html visit that resolves to
+    /// a Ready replica) records exactly one anonymous `app.access`. The
+    /// record fires before the upstream forward, so a dead upstream (502)
+    /// doesn't matter — and assets/APIs/repeat requests don't register a
+    /// session, so they emit nothing.
+    #[tokio::test]
+    async fn interactive_visit_records_one_app_access() {
+        use crate::activity::ActivityEventType;
+        use tower::ServiceExt;
+        let backend = StdArc::new(CountingBackend {
+            spawns: AtomicU32::new(0),
+            delay: StdDuration::ZERO,
+        });
+        let mut state = coalescer_state(backend as StdArc<dyn ContainerBackend>);
+        state.config = std::sync::Arc::new(
+            ruscker_config::Config::from_yaml(
+                "proxy:\n  specs:\n    - id: app\n      container-image: test:latest\n",
+            )
+            .expect("config"),
+        );
+        // A Ready replica with a free seat means the visit skips the splash
+        // and registers a session (its upstream is dead — the forward 502s
+        // after the app.access record has already fired).
+        state.replicas.write().await.add(accepting_replica("app"));
+
+        let app = Router::new()
+            .merge(routes())
+            .layer(tower_cookies::CookieManagerLayer::new())
+            .with_state(state.clone());
+        let req = Request::builder()
+            .method("GET")
+            .uri("/app/app/")
+            .header(header::ACCEPT, "text/html")
+            .body(Body::empty())
+            .unwrap();
+        let _ = app.oneshot(req).await.unwrap(); // 502 upstream — irrelevant
+
+        let mut rx = state
+            .activity
+            .take_receiver()
+            .expect("activity receiver available");
+        let ev = rx.try_recv().expect("an app.access was recorded");
+        assert_eq!(ev.event_type, ActivityEventType::AppAccess);
+        assert_eq!(ev.spec_id.as_deref(), Some("app"));
+        assert_eq!(ev.username, None, "anonymous visit has no username");
+        assert!(
+            rx.try_recv().is_err(),
+            "exactly one app.access per new session"
+        );
     }
 
     /// #1018 real smoke: against a live daemon, an externally-removed

--- a/crates/ruscker-admin/src/scaler.rs
+++ b/crates/ruscker-admin/src/scaler.rs
@@ -1631,6 +1631,7 @@ mod tests {
             catalog_cache: Arc::new(tokio::sync::RwLock::new(None)),
             access_counter: Arc::new(crate::access_counter::AccessCounter::default()),
             alerts: crate::alerts::AlertSink::default(),
+            activity: crate::activity::ActivitySink::default(),
         }
     }
 

--- a/crates/ruscker-admin/tests/admin_landing_picker.rs
+++ b/crates/ruscker-admin/tests/admin_landing_picker.rs
@@ -48,6 +48,7 @@ async fn state_with_db() -> AppState {
         catalog_cache: std::sync::Arc::new(tokio::sync::RwLock::new(None)),
         access_counter: std::sync::Arc::new(ruscker_admin::access_counter::AccessCounter::default()),
         alerts: ruscker_admin::alerts::AlertSink::default(),
+        activity: ruscker_admin::activity::ActivitySink::default(),
     }
 }
 

--- a/crates/ruscker-admin/tests/api_policies.rs
+++ b/crates/ruscker-admin/tests/api_policies.rs
@@ -65,6 +65,7 @@ fn state() -> AppState {
         catalog_cache: std::sync::Arc::new(tokio::sync::RwLock::new(None)),
         access_counter: std::sync::Arc::new(ruscker_admin::access_counter::AccessCounter::default()),
         alerts: ruscker_admin::alerts::AlertSink::default(),
+        activity: ruscker_admin::activity::ActivitySink::default(),
     }
 }
 

--- a/crates/ruscker-admin/tests/health_probes.rs
+++ b/crates/ruscker-admin/tests/health_probes.rs
@@ -49,6 +49,7 @@ fn base_state() -> AppState {
         catalog_cache: std::sync::Arc::new(tokio::sync::RwLock::new(None)),
         access_counter: std::sync::Arc::new(ruscker_admin::access_counter::AccessCounter::default()),
         alerts: ruscker_admin::alerts::AlertSink::default(),
+        activity: ruscker_admin::activity::ActivitySink::default(),
     }
 }
 

--- a/crates/ruscker-admin/tests/identity_headers.rs
+++ b/crates/ruscker-admin/tests/identity_headers.rs
@@ -171,6 +171,7 @@ async fn state(db: ConfigDb, spec_id: &str, upstream: SocketAddr) -> AppState {
         catalog_cache: Arc::new(tokio::sync::RwLock::new(None)),
         access_counter: Arc::new(ruscker_admin::access_counter::AccessCounter::default()),
         alerts: ruscker_admin::alerts::AlertSink::default(),
+        activity: ruscker_admin::activity::ActivitySink::default(),
     }
 }
 

--- a/crates/ruscker-admin/tests/landing_access.rs
+++ b/crates/ruscker-admin/tests/landing_access.rs
@@ -87,6 +87,7 @@ async fn app_state(db: ConfigDb) -> AppState {
         catalog_cache: std::sync::Arc::new(tokio::sync::RwLock::new(None)),
         access_counter: std::sync::Arc::new(ruscker_admin::access_counter::AccessCounter::default()),
         alerts: ruscker_admin::alerts::AlertSink::default(),
+        activity: ruscker_admin::activity::ActivitySink::default(),
     }
 }
 

--- a/crates/ruscker-admin/tests/landing_render.rs
+++ b/crates/ruscker-admin/tests/landing_render.rs
@@ -54,6 +54,7 @@ fn state_from_yaml(yaml: &str) -> AppState {
         catalog_cache: std::sync::Arc::new(tokio::sync::RwLock::new(None)),
         access_counter: std::sync::Arc::new(ruscker_admin::access_counter::AccessCounter::default()),
         alerts: ruscker_admin::alerts::AlertSink::default(),
+        activity: ruscker_admin::activity::ActivitySink::default(),
     }
 }
 

--- a/crates/ruscker-admin/tests/max_body_size.rs
+++ b/crates/ruscker-admin/tests/max_body_size.rs
@@ -64,6 +64,7 @@ fn state() -> AppState {
         catalog_cache: std::sync::Arc::new(tokio::sync::RwLock::new(None)),
         access_counter: std::sync::Arc::new(ruscker_admin::access_counter::AccessCounter::default()),
         alerts: ruscker_admin::alerts::AlertSink::default(),
+        activity: ruscker_admin::activity::ActivitySink::default(),
     }
 }
 

--- a/crates/ruscker-admin/tests/metrics.rs
+++ b/crates/ruscker-admin/tests/metrics.rs
@@ -37,6 +37,7 @@ fn state(yaml: &str) -> AppState {
         catalog_cache: std::sync::Arc::new(tokio::sync::RwLock::new(None)),
         access_counter: std::sync::Arc::new(ruscker_admin::access_counter::AccessCounter::default()),
         alerts: ruscker_admin::alerts::AlertSink::default(),
+        activity: ruscker_admin::activity::ActivitySink::default(),
     }
 }
 

--- a/crates/ruscker-admin/tests/mfa_challenge.rs
+++ b/crates/ruscker-admin/tests/mfa_challenge.rs
@@ -45,6 +45,7 @@ async fn state_with_db() -> (AppState, ruscker_admin::db::ConfigDb) {
         catalog_cache: Arc::new(tokio::sync::RwLock::new(None)),
         access_counter: Arc::new(ruscker_admin::access_counter::AccessCounter::default()),
         alerts: ruscker_admin::alerts::AlertSink::default(),
+        activity: ruscker_admin::activity::ActivitySink::default(),
     };
     (state, db)
 }

--- a/crates/ruscker-admin/tests/mfa_enrollment.rs
+++ b/crates/ruscker-admin/tests/mfa_enrollment.rs
@@ -46,6 +46,7 @@ async fn state_with_db(master_key: bool) -> (AppState, ruscker_admin::db::Config
         catalog_cache: Arc::new(tokio::sync::RwLock::new(None)),
         access_counter: Arc::new(ruscker_admin::access_counter::AccessCounter::default()),
         alerts: ruscker_admin::alerts::AlertSink::default(),
+        activity: ruscker_admin::activity::ActivitySink::default(),
     };
     (state, db)
 }

--- a/crates/ruscker-admin/tests/mfa_guard.rs
+++ b/crates/ruscker-admin/tests/mfa_guard.rs
@@ -168,6 +168,7 @@ fn state(
         catalog_cache: Arc::new(tokio::sync::RwLock::new(None)),
         access_counter: Arc::new(ruscker_admin::access_counter::AccessCounter::default()),
         alerts: ruscker_admin::alerts::AlertSink::default(),
+        activity: ruscker_admin::activity::ActivitySink::default(),
     }
 }
 

--- a/crates/ruscker-admin/tests/proxy_access.rs
+++ b/crates/ruscker-admin/tests/proxy_access.rs
@@ -85,6 +85,7 @@ async fn app_state(db: ConfigDb) -> AppState {
         catalog_cache: std::sync::Arc::new(tokio::sync::RwLock::new(None)),
         access_counter: Arc::new(ruscker_admin::access_counter::AccessCounter::default()),
         alerts: ruscker_admin::alerts::AlertSink::default(),
+        activity: ruscker_admin::activity::ActivitySink::default(),
     }
 }
 

--- a/crates/ruscker-admin/tests/rbac.rs
+++ b/crates/ruscker-admin/tests/rbac.rs
@@ -61,6 +61,7 @@ fn state() -> AppState {
         catalog_cache: std::sync::Arc::new(tokio::sync::RwLock::new(None)),
         access_counter: std::sync::Arc::new(ruscker_admin::access_counter::AccessCounter::default()),
         alerts: ruscker_admin::alerts::AlertSink::default(),
+        activity: ruscker_admin::activity::ActivitySink::default(),
     }
 }
 

--- a/crates/ruscker-admin/tests/schedules_ui.rs
+++ b/crates/ruscker-admin/tests/schedules_ui.rs
@@ -69,6 +69,7 @@ async fn app_state(db: ConfigDb) -> AppState {
         catalog_cache: std::sync::Arc::new(tokio::sync::RwLock::new(None)),
         access_counter: Arc::new(ruscker_admin::access_counter::AccessCounter::default()),
         alerts: ruscker_admin::alerts::AlertSink::default(),
+        activity: ruscker_admin::activity::ActivitySink::default(),
     }
 }
 

--- a/crates/ruscker-admin/tests/user_accounts.rs
+++ b/crates/ruscker-admin/tests/user_accounts.rs
@@ -48,6 +48,7 @@ async fn state_with_db() -> (AppState, sqlx::SqlitePool) {
         catalog_cache: std::sync::Arc::new(tokio::sync::RwLock::new(None)),
         access_counter: std::sync::Arc::new(ruscker_admin::access_counter::AccessCounter::default()),
         alerts: ruscker_admin::alerts::AlertSink::default(),
+        activity: ruscker_admin::activity::ActivitySink::default(),
     };
     (state, pool)
 }
@@ -116,6 +117,59 @@ async fn password_login_succeeds_and_wrong_fails() {
 
     let (bad_status, _) = post(state, "/admin/login", "username=alice&password=WRONG", None).await;
     assert_eq!(bad_status, StatusCode::UNAUTHORIZED);
+}
+
+#[tokio::test]
+async fn successful_login_records_activity_but_failed_does_not() {
+    use ruscker_admin::activity::{ActivityEventType, AuthMethod};
+    let (state, pool) = state_with_db().await;
+    ruscker_admin::db::users::create(
+        &ruscker_admin::db::ConfigDb::Sqlite(pool.clone()),
+        "alice",
+        "alicepass1",
+        Role::Editor,
+        false,
+        &[],
+        None,
+    )
+    .await
+    .unwrap();
+
+    // A correct password login enqueues exactly one `login.success`.
+    let (ok, _) = post(
+        state.clone(),
+        "/admin/login",
+        "username=alice&password=alicepass1",
+        None,
+    )
+    .await;
+    assert_eq!(ok, StatusCode::SEE_OTHER);
+
+    // The drain task isn't started in this harness, so the receiver still
+    // holds what the capture site enqueued (deterministic, no timing).
+    let mut rx = state
+        .activity
+        .take_receiver()
+        .expect("activity receiver available");
+    let ev = rx.try_recv().expect("a login.success was recorded");
+    assert_eq!(ev.event_type, ActivityEventType::LoginSuccess);
+    assert_eq!(ev.username.as_deref(), Some("alice"));
+    assert_eq!(ev.auth_method, Some(AuthMethod::Password));
+    assert!(ev.spec_id.is_none(), "a login is not tied to a spec");
+
+    // A wrong password records nothing.
+    let (bad, _) = post(
+        state.clone(),
+        "/admin/login",
+        "username=alice&password=WRONG",
+        None,
+    )
+    .await;
+    assert_eq!(bad, StatusCode::UNAUTHORIZED);
+    assert!(
+        rx.try_recv().is_err(),
+        "a failed login must not record activity"
+    );
 }
 
 #[tokio::test]

--- a/crates/ruscker-admin/tests/ws_e2e.rs
+++ b/crates/ruscker-admin/tests/ws_e2e.rs
@@ -136,6 +136,7 @@ async fn serve() -> (AppState, SocketAddr) {
         catalog_cache: Arc::new(tokio::sync::RwLock::new(None)),
         access_counter: Arc::new(ruscker_admin::access_counter::AccessCounter::default()),
         alerts: ruscker_admin::alerts::AlertSink::default(),
+        activity: ruscker_admin::activity::ActivitySink::default(),
     };
     let listener = tokio::net::TcpListener::bind("127.0.0.1:0").await.unwrap();
     let addr = listener.local_addr().unwrap();


### PR DESCRIPTION
## O quê

Fatia 2 de #1021 — **captura de eventos** + wiring do writer. Liga a fundação da fatia 1 (#1022): agora logins e novas sessões de app geram linhas em `user_activity`, gravadas fora do caminho quente pela task de dreno supervisionada.

## O que entra

- **`AppState.activity: ActivitySink`** + spawn da task de dreno no `serve` (ao lado de `alerts::spawn`, só quando há DB). Enfileirar é não-bloqueante; sem DB a task não sobe e o `record` só cai numa fila limitada (sem leak).
- **Captura `login.success`** (admin.rs, após validar senha + criar a sessão): `record(login_success(user, Password, session_id, None))`. O `session_id` é a chave de dedup. Login **inválido não registra nada**. Break-glass por token é acesso de emergência do operador e **intencionalmente não** é logado como atividade de usuário (fora de escopo).
- **Captura `app.access` interativo** (proxy.rs, no `TouchOutcome::Registered`): uma linha por nova sessão interativa, `username = acting_user` (`None` p/ anônimo), `spec_id`, `event_key = session_id`. Já é **pós-guard de acesso** e **nunca** dispara p/ assets/XHR/WS (untracked) nem APIs (não-sticky) — exatamente o ponto que a análise identificou.
- **`client_ip` fica `None` no MVP** (é PII; o issue pede opcional/off por padrão) — a coluna existe para uso futuro com política de retenção.

## Fora de escopo desta fatia

- **Captura de clique em app External:** o bounce External (`record_access` + `Redirect`) ocorre **antes** do guard de acesso; registrar corretamente (só após autorização) exige subir o cálculo de identidade/`access_allows` acima do bounce — um reorder do handler do proxy melhor feito como mudança própria. Fica como follow-up dentro do #1021.
- **UI** (a segunda tabela na aba Atividades + filtros + paginação): **fatia 3**.

## Testes

- **Login** (integration, `user_accounts.rs`): um login correto enfileira exatamente um `login.success` (usuário + método `password`, sem `spec_id`); um login com senha errada **não** registra nada. Determinístico via `take_receiver()` (a task de dreno não sobe neste harness, então o receiver segura o que o site de captura enfileirou).
- **App.access** (unit, `proxy.rs`): uma visita text/html que resolve p/ uma réplica Ready registra **exatamente um** `app.access` anônimo (`spec_id` certo, `username=None`); como o `record` dispara **antes** do forward, o upstream morto (502) é irrelevante — e uma segunda leitura do canal está vazia (uma sessão = um evento).
- Os ~20 construtores de `AppState` (lib.rs + helpers de src + 16 arquivos de teste) ganharam o campo `activity` (o custo conhecido de um novo campo em `AppState`).

## Gate

`cargo test` (default) · clippy limpo nos arquivos tocados · `./scripts/i18n-check.sh` — verdes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
