### PR TITLE
docs: self-healing (external Docker) + user-activity page

### DIFF
--- a/README.md
+++ b/README.md
@@ -96,12 +96,25 @@ What's in the box:
   rewriting so unmodified Shiny/Streamlit apps work behind a sub-path.
 - **Container backend** (Docker) that spawns app containers on demand,
   applies per-container CPU/memory limits, and reaps idle ones.
+- **Self-healing on external Docker changes** — if an operator removes or
+  restarts a managed container directly with the Docker CLI, Ruscker
+  reconciles authoritatively: a removed container (`docker rm -f`) is pruned,
+  its stale sticky binding dropped, and a replacement brought up; a
+  restarted container is re-adopted once it's serving again, with no
+  duplicate spawned. A Docker events watcher makes this near-instant instead
+  of waiting for the periodic reconcile, and a request that hits a
+  just-removed upstream recovers on the spot. Recovery acts only on an
+  authoritative "gone" signal, so an app's own `5xx`, a transient daemon
+  error, or an unreachable host in a multi-host deployment never drops a
+  live replica.
 - **Admin panel** — full apps CRUD (including API, scaling, resource and
   lifecycle settings), Media, encrypted Credentials, a live-preview
   Appearance editor, **Viewer / Editor / Admin** accounts with a password
   policy and generator, consolidated per-user editing, server-side
   pagination (50 per page) with case-insensitive search (accented letters
-  included) across usernames, groups and profiles, and an **Activity** history.
+  included) across usernames, groups and profiles, and an **Activity** section
+  with two tables — **user activity** (logins and interactive app accesses,
+  filterable and paginated) alongside the **administrative audit** trail.
 - **Containers dashboard** — CPU/memory sparklines, live-follow logs and
   stop/restart controls, refreshed every five seconds by polling
   `GET /admin/dashboard/snapshot`.

--- a/book/src/admin.md
+++ b/book/src/admin.md
@@ -413,10 +413,32 @@ volume, no container references it, and no effective catalog spec names it;
 the server rechecks all three conditions before asking Docker to remove it.
 
 ### Activity
-Every admin mutation (spec/image/credential/landing/block changes,
-imports) is recorded with actor, action, target and timestamp. Destructive
-**replica stop/restart**, schedule changes, MFA enrolment/reset/proof, and
-break-glass MFA bypasses are recorded too.
+The Activity section holds two tables, switched by a pill toggle at the top
+of the page.
+
+**Atividades dos usuários (user activity)** lists who signed in and who
+opened which app:
+
+- a **login** is recorded when a user signs in with a password;
+- an **app access** is recorded once per new interactive app session — a
+  genuine visit, never counted for a page's assets, XHR calls or WebSocket
+  frames, and API calls keep only their aggregate access counter. An access
+  with no signed-in user shows as **Anonymous**.
+
+Filter by event kind, user, app, and time window (last 24 h / 7 / 30 days),
+with server-side pagination for a long history. The history carries no
+foreign keys to users or apps, so removing a user or an app doesn't erase
+the record of past activity. Events are captured off the proxy's hot path —
+a non-blocking enqueue plus a background writer that batches inserts — so
+activity logging never slows a request. The client IP is **not** stored in
+this release (it's personal data; a future opt-in would come with a
+retention policy).
+
+**Atividades administrativas (administrative audit)** records every admin
+mutation (spec/image/credential/landing/block changes, imports) with actor,
+action, target and timestamp. Destructive **replica stop/restart**, schedule
+changes, MFA enrolment/reset/proof, and break-glass MFA bypasses are recorded
+too; rows with a change diff expand to show it.
 
 ### System
 

--- a/book/src/troubleshooting.md
+++ b/book/src/troubleshooting.md
@@ -23,6 +23,25 @@ the spec form.
   from **Credentials**, or `docker-registry-username` plus an env-backed
   `docker-registry-password: ${DOCKER_REGISTRY_PASSWORD}`.
 
+## I removed or restarted a container with the Docker CLI
+
+Ruscker self-heals. If you `docker rm -f` a managed container, or
+`docker restart` it directly, Ruscker notices and reconciles on its own:
+
+- a **removed** container is pruned from the registry, its stale sticky
+  binding dropped, and a replacement is brought up (a browser visit lands on
+  the "Starting…" splash instead of a persistent `upstream error`);
+- a **restarted** container is re-adopted into the pool once it's serving
+  again, without a duplicate being spawned.
+
+A Docker events watcher makes this happen within about a second; the periodic
+reconcile (~10 s) is the fallback. You may still see a brief `502` in the
+window between the container going away and Ruscker reacting — retry and it
+recovers. If it *doesn't* recover, the container is genuinely unreachable
+(check `docker ps` and its logs). Recovery only acts on an authoritative
+"gone" signal, so an app returning its own `5xx` or a momentary Docker daemon
+hiccup never causes Ruscker to drop a healthy replica.
+
 ## 2FA enrolment returns `503`
 
 `RUSCKER_MASTER_KEY` is missing (or an existing MFA secret cannot be

--- a/docs/SECURITY.md
+++ b/docs/SECURITY.md
@@ -84,6 +84,13 @@ Status: living document. Tracks the Phase 5 security audit
 - **[implemented]** Operational replica actions are audited (#745) —
   dashboard stop/restart write `replica.stop`/`replica.restart` rows
   (with the acting user) to the same `audit_log` config mutations use.
+- **[implemented]** User activity is recorded (#1021) — a `user_activity`
+  table logs successful password logins and new interactive app sessions
+  (username or "anonymous", app id, timestamp) for the Admin-only Activity
+  page. It is **data minimizing by default**: the client IP is not stored,
+  API calls are not logged per-request (only the aggregate counter), and the
+  table has no foreign keys so deleting a user or app is not blocked by it.
+  Read access is Admin-only.
 - **[implemented]** HA admin-session cache is bounded (#738) — the
   Postgres-backed session store caches a negative entry per looked-up
   session id (anti-hammer); an amortized sweep now evicts expired


### PR DESCRIPTION
Documents the v0.2.46 self-healing behavior and the v0.2.47 user-activity feature (admin guide Activity section, README highlights, a troubleshooting entry, and a SECURITY note). Evergreen wording; mdBook builds clean. Follows #1015/#1016/#1018 and #1021.