### PR TITLE
feat: add per-app container readiness timeout

### DIFF
--- a/book/src/shinyproxy-fieldmap.md
+++ b/book/src/shinyproxy-fieldmap.md
@@ -140,6 +140,7 @@ is fully accounted for. Details in the
 `scale-down-threshold` / `scale-down-grace` / `scale-down-cooldown-secs`,
 `drain-timeout`, `routing-strategy`,
 `concurrent-requests-per-replica`, `container-lifetime`, `platform`,
+per-spec `container-wait-time` (the ShinyProxy counterpart is global-only),
 `inject-base-href`, `max-body-size` (global + per-spec),
 `docker-registry-credential`, `placement` / `anti-affinity`, the
 `api.*` block (`docs-path`, `health-path`, `rate-limit`, `cors`),

--- a/crates/ruscker-admin/assets/i18n/en/landing.ftl
+++ b/crates/ruscker-admin/assets/i18n/en/landing.ftl
@@ -555,6 +555,7 @@ spec-form-concurrent = Requests per replica
 spec-form-cpu-limit = CPU limit
 spec-form-memory-limit = Memory limit
 spec-form-heartbeat = Heartbeat timeout (ms)
+spec-form-container-wait = Container startup timeout (ms)
 spec-help-kind = What kind of thing this is. Drives routing, the card badge, and whether a container is started.
 spec-help-id = Stable identifier used in the URL (/app/<id>). Lowercase letters, digits, "-" and "_"; can't change after creation.
 spec-help-name = The title shown on the landing card.
@@ -579,6 +580,7 @@ spec-help-concurrent = Requests one API replica handles before the scaler adds a
 spec-help-cpu-limit = Max CPU as fractional cores (e.g. 0.5 = half a core). Blank = unlimited.
 spec-help-memory-limit = Max memory, e.g. 512m or 1.5g. Blank = unlimited.
 spec-help-heartbeat = Idle session timeout in milliseconds; -1 never expires. Blank = use the global default.
+spec-help-container-wait = Maximum time for this app to answer TCP and HTTP during startup. Blank or 0 = use the global container-wait-time.
 admin-blocks-slot-empty = No blocks in this slot yet.
 admin-blocks-drag-hint = Drag the handle to reorder blocks within a slot.
 spec-form-volumes-section = Volumes

--- a/crates/ruscker-admin/assets/i18n/es/landing.ftl
+++ b/crates/ruscker-admin/assets/i18n/es/landing.ftl
@@ -555,6 +555,7 @@ spec-form-concurrent = Solicitudes por réplica
 spec-form-cpu-limit = Límite de CPU
 spec-form-memory-limit = Límite de memoria
 spec-form-heartbeat = Tiempo de heartbeat (ms)
+spec-form-container-wait = Tiempo de inicio del contenedor (ms)
 spec-help-kind = Qué tipo de elemento es. Define el enrutamiento, la insignia de la tarjeta y si se inicia un contenedor.
 spec-help-id = Identificador estable usado en la URL (/app/<id>). Minúsculas, dígitos, "-" y "_"; no se puede cambiar tras crearlo.
 spec-help-name = El título mostrado en la tarjeta.
@@ -579,6 +580,7 @@ spec-help-concurrent = Solicitudes que atiende una réplica de API antes de que 
 spec-help-cpu-limit = CPU máxima en núcleos fraccionarios (p. ej. 0,5 = medio núcleo). Vacío = ilimitado.
 spec-help-memory-limit = Memoria máxima, p. ej. 512m o 1.5g. Vacío = ilimitado.
 spec-help-heartbeat = Tiempo de sesión inactiva en milisegundos; -1 nunca expira. Vacío = usa el valor global.
+spec-help-container-wait = Tiempo máximo para que esta app responda por TCP y HTTP durante el inicio. Vacío o 0 = usa el container-wait-time global.
 admin-blocks-slot-empty = Aún no hay bloques en este slot.
 admin-blocks-drag-hint = Arrastra desde el asa para reordenar los bloques dentro del slot.
 spec-form-volumes-section = Volúmenes

--- a/crates/ruscker-admin/assets/i18n/fr/landing.ftl
+++ b/crates/ruscker-admin/assets/i18n/fr/landing.ftl
@@ -555,6 +555,7 @@ spec-form-concurrent = Requêtes par réplica
 spec-form-cpu-limit = Limite CPU
 spec-form-memory-limit = Limite mémoire
 spec-form-heartbeat = Délai de heartbeat (ms)
+spec-form-container-wait = Délai de démarrage du conteneur (ms)
 spec-help-kind = Le type d'élément. Détermine le routage, le badge de la carte et si un conteneur est démarré.
 spec-help-id = Identifiant stable utilisé dans l'URL (/app/<id>). Minuscules, chiffres, « - » et « _ » ; non modifiable après création.
 spec-help-name = Le titre affiché sur la carte.
@@ -579,6 +580,7 @@ spec-help-concurrent = Requêtes qu'une réplica d'API gère avant que le scaler
 spec-help-cpu-limit = CPU max en cœurs fractionnaires (ex. 0,5 = un demi-cœur). Vide = illimité.
 spec-help-memory-limit = Mémoire max, ex. 512m ou 1.5g. Vide = illimité.
 spec-help-heartbeat = Délai de session inactive en millisecondes ; -1 = jamais. Vide = valeur globale.
+spec-help-container-wait = Temps maximal pour que cette app réponde en TCP et HTTP au démarrage. Vide ou 0 = utilise le container-wait-time global.
 admin-blocks-slot-empty = Aucun bloc dans cet emplacement.
 admin-blocks-drag-hint = Glissez par la poignée pour réordonner les blocs dans un emplacement.
 spec-form-volumes-section = Volumes

--- a/crates/ruscker-admin/assets/i18n/pt/landing.ftl
+++ b/crates/ruscker-admin/assets/i18n/pt/landing.ftl
@@ -559,6 +559,7 @@ spec-form-concurrent = Requisições por réplica
 spec-form-cpu-limit = Limite de CPU
 spec-form-memory-limit = Limite de memória
 spec-form-heartbeat = Timeout de heartbeat (ms)
+spec-form-container-wait = Timeout de subida do container (ms)
 spec-help-kind = Que tipo de coisa é. Define o roteamento, o selo do card e se um container é iniciado.
 spec-help-id = Identificador estável usado na URL (/app/<id>). Minúsculas, dígitos, "-" e "_"; não pode mudar após criado.
 spec-help-name = O título exibido no card da landing.
@@ -583,6 +584,7 @@ spec-help-concurrent = Requisições que uma réplica de API atende antes do sca
 spec-help-cpu-limit = CPU máxima em núcleos fracionários (ex.: 0,5 = meio núcleo). Vazio = ilimitado.
 spec-help-memory-limit = Memória máxima, ex.: 512m ou 1.5g. Vazio = ilimitado.
 spec-help-heartbeat = Timeout de sessão ociosa em milissegundos; -1 nunca expira. Vazio = usa o padrão global.
+spec-help-container-wait = Tempo máximo para este app responder TCP e HTTP durante a subida. Vazio ou 0 = usa o container-wait-time global.
 admin-blocks-slot-empty = Nenhum bloco neste slot ainda.
 admin-blocks-drag-hint = Arraste pela alça para reordenar os blocos dentro do slot.
 spec-form-volumes-section = Volumes

--- a/crates/ruscker-admin/src/routes/admin/spec_form.rs
+++ b/crates/ruscker-admin/src/routes/admin/spec_form.rs
@@ -441,6 +441,8 @@ pub struct SpecForm {
     //    default; nothing here is required. ──────────────────────
     /// `heartbeat-timeout` override in ms; `-1` = never expire.
     pub heartbeat_timeout: String,
+    /// `container-wait-time` readiness override in ms; blank/0 = global.
+    pub container_wait_time: String,
     /// Fractional CPUs, e.g. `0.5` (`container-cpu-limit`).
     pub container_cpu_limit: String,
     /// Memory cap, e.g. `512m` / `1.5g` (`container-memory-limit`).
@@ -578,6 +580,10 @@ impl SpecForm {
             max_lifetime: spec.max_lifetime.map(|n| n.to_string()).unwrap_or_default(),
             heartbeat_timeout: spec
                 .heartbeat_timeout
+                .map(|n| n.to_string())
+                .unwrap_or_default(),
+            container_wait_time: spec
+                .container_wait_time
                 .map(|n| n.to_string())
                 .unwrap_or_default(),
             container_cpu_limit: spec
@@ -807,6 +813,7 @@ impl SpecForm {
             seats_per_container: parse_opt(&self.seats_per_container),
             max_lifetime: parse_opt(&self.max_lifetime),
             heartbeat_timeout: parse_opt(&self.heartbeat_timeout),
+            container_wait_time: parse_opt(&self.container_wait_time),
             container_cpu_limit: parse_opt(&self.container_cpu_limit),
             container_memory_limit: empty_to_none(&self.container_memory_limit),
             template_properties: TemplateProperties(tp_map),
@@ -902,6 +909,7 @@ impl SpecForm {
             &self.seats_per_container,
             &self.max_lifetime,
             &self.heartbeat_timeout,
+            &self.container_wait_time,
             &self.min_replicas,
             &self.max_replicas,
             &self.concurrent_requests_per_replica,
@@ -916,6 +924,15 @@ impl SpecForm {
         if int_fields
             .iter()
             .any(|v| !v.trim().is_empty() && v.trim().parse::<i64>().is_err())
+        {
+            errs.push("spec-form-error-number");
+        }
+        // `container-wait-time` is unsigned: 0 deliberately inherits the
+        // global value, but a crafted negative POST must not silently parse
+        // to None and inherit by accident.
+        if !self.container_wait_time.trim().is_empty()
+            && self.container_wait_time.trim().parse::<u64>().is_err()
+            && !errs.contains(&"spec-form-error-number")
         {
             errs.push("spec-form-error-number");
         }
@@ -2060,8 +2077,35 @@ proxy:
         f.min_replicas = "1".into();
         f.max_replicas = "3".into();
         f.heartbeat_timeout = "-1".into();
+        f.container_wait_time = "120000".into();
         let errs = f.validate(FormMode::New);
         assert!(errs.is_empty(), "expected no errors, got {errs:?}");
+    }
+
+    #[test]
+    fn container_wait_time_round_trips_and_rejects_negative_values() {
+        let mut form = valid_form();
+        form.container_wait_time = "120000".into();
+        let spec = form.into_spec(None, Role::Admin).expect("into_spec");
+        assert_eq!(spec.container_wait_time, Some(120_000));
+        assert_eq!(SpecForm::from_spec(&spec).container_wait_time, "120000");
+
+        let mut inherited = valid_form();
+        inherited.container_wait_time = "0".into();
+        assert!(inherited.validate(FormMode::New).is_empty());
+        assert_eq!(
+            inherited
+                .into_spec(None, Role::Admin)
+                .expect("zero is valid")
+                .container_wait_time,
+            Some(0)
+        );
+
+        let mut invalid = valid_form();
+        invalid.container_wait_time = "-1".into();
+        assert!(invalid
+            .validate(FormMode::New)
+            .contains(&"spec-form-error-number"));
     }
 
     // ── #211: newly-modelled advanced fields ────────────────────

--- a/crates/ruscker-admin/src/routes/proxy.rs
+++ b/crates/ruscker-admin/src/routes/proxy.rs
@@ -1796,6 +1796,9 @@ async fn pick_or_spawn(state: &AppState, spec: &Spec) -> anyhow::Result<(Replica
         .with_env(env)
         .with_placement(spec.effective_placement())
         .with_anti_affinity(spec.effective_anti_affinity());
+    if let Some(millis) = spec.container_wait_time {
+        req = req.with_readiness_timeout_ms(millis);
+    }
     if let Some(port) = inner_port {
         req = req.with_port(port);
     }

--- a/crates/ruscker-admin/src/scaler.rs
+++ b/crates/ruscker-admin/src/scaler.rs
@@ -510,7 +510,10 @@ async fn readopt_running_replica(
         return;
     }
 
-    if let Err(error) = backend.wait_until_ready(&replica).await {
+    if let Err(error) = backend
+        .wait_until_ready_with_timeout(&replica, spec.container_wait_time)
+        .await
+    {
         warn!(
             spec = %spec.id,
             replica = %replica.id,
@@ -1299,6 +1302,9 @@ async fn spawn_one(
         .with_env(env)
         .with_placement(spec.effective_placement())
         .with_anti_affinity(spec.effective_anti_affinity());
+    if let Some(millis) = spec.container_wait_time {
+        req = req.with_readiness_timeout_ms(millis);
+    }
     if let Some(port) = inner_port {
         req = req.with_port(port);
     }

--- a/crates/ruscker-admin/templates/admin/spec_form.html
+++ b/crates/ruscker-admin/templates/admin/spec_form.html
@@ -1102,6 +1102,15 @@
                    value="{{ form.heartbeat_timeout }}" x-model="form.heartbeat_timeout"
                    placeholder="3600000" class="spec-form-input">
           </div>
+          <div class="spec-form-field">
+            <div class="spec-form-label-row">
+              <label for="f-container-wait" class="spec-form-label">{{ self.t("spec-form-container-wait") }}</label>
+              {% call help(self.t("spec-help-container-wait")) %}{% endcall %}
+            </div>
+            <input id="f-container-wait" type="number" name="container_wait_time" min="0"
+                   value="{{ form.container_wait_time }}" x-model="form.container_wait_time"
+                   placeholder="60000" class="spec-form-input">
+          </div>
         </div>
       </div>
       </template>

--- a/crates/ruscker-config/src/schema.rs
+++ b/crates/ruscker-config/src/schema.rs
@@ -813,6 +813,12 @@ pub struct Spec {
     #[serde(rename = "heartbeat-timeout")]
     pub heartbeat_timeout: Option<i64>,
 
+    /// Per-spec readiness timeout override in milliseconds. `None` or
+    /// zero inherits `proxy.container-wait-time`. Ruscker extension —
+    /// ShinyProxy only exposes this setting at `proxy.*` level.
+    #[serde(rename = "container-wait-time")]
+    pub container_wait_time: Option<u64>,
+
     /// Whether the container should be stopped when its last user logs
     /// out. Only meaningful when authentication is enabled.
     #[serde(rename = "stop-on-logout")]
@@ -2099,6 +2105,7 @@ proxy:
             max_lifetime: None,
             container_lifetime: None,
             heartbeat_timeout: None,
+            container_wait_time: None,
             stop_on_logout: None,
             docker_registry_username: None,
             docker_registry_password: None,
@@ -2154,6 +2161,7 @@ proxy:
             max_lifetime: None,
             container_lifetime: None,
             heartbeat_timeout: None,
+            container_wait_time: None,
             stop_on_logout: None,
             docker_registry_username: None,
             docker_registry_password: None,
@@ -2209,6 +2217,7 @@ proxy:
             max_lifetime: None,
             container_lifetime: None,
             heartbeat_timeout: None,
+            container_wait_time: None,
             stop_on_logout: None,
             docker_registry_username: None,
             docker_registry_password: None,
@@ -2256,6 +2265,19 @@ proxy:
 
     fn parse_spec(yaml: &str) -> Spec {
         serde_yaml_ng::from_str(yaml).expect("parse spec")
+    }
+
+    #[test]
+    fn parses_per_spec_container_wait_time() {
+        let spec = parse_spec(
+            "id: slow\ncontainer-image: example/slow\ncontainer-wait-time: 120000\n",
+        );
+        assert_eq!(spec.container_wait_time, Some(120_000));
+
+        let inherited = parse_spec(
+            "id: inherited\ncontainer-image: example/app\ncontainer-wait-time: 0\n",
+        );
+        assert_eq!(inherited.container_wait_time, Some(0));
     }
 
     #[test]

--- a/crates/ruscker-core/src/lib.rs
+++ b/crates/ruscker-core/src/lib.rs
@@ -199,6 +199,12 @@ pub struct SpawnRequest {
     /// collision. Empty ⇒ only the internal labels.
     pub labels: Vec<(String, String)>,
 
+    /// Per-spawn readiness budget in milliseconds. `None` (and zero via
+    /// [`Self::with_readiness_timeout_ms`]) means the backend's configured
+    /// default, normally `proxy.container-wait-time`. Regular replica
+    /// spawns consume it; run-to-completion jobs ignore it.
+    pub readiness_timeout_ms: Option<u64>,
+
     /// Wall-clock cap, in seconds, for a run-to-completion job (#986
     /// slice C). Only [`ContainerBackend::run_job`] consumes it — a
     /// regular replica spawn ignores the field entirely. `None` ⇒ the
@@ -222,6 +228,7 @@ impl SpawnRequest {
             cmd: None,
             network: None,
             labels: Vec::new(),
+            readiness_timeout_ms: None,
             job_timeout_secs: None,
         }
     }
@@ -272,6 +279,14 @@ impl SpawnRequest {
 
     pub fn with_labels(mut self, labels: Vec<(String, String)>) -> Self {
         self.labels = labels;
+        self
+    }
+
+    /// Override the readiness budget for this spawn. Zero is normalized to
+    /// `None`, preserving the configuration contract that `0` inherits the
+    /// backend/global default rather than failing the spawn immediately.
+    pub fn with_readiness_timeout_ms(mut self, millis: u64) -> Self {
+        self.readiness_timeout_ms = (millis > 0).then_some(millis);
         self
     }
 
@@ -463,6 +478,19 @@ pub trait ContainerBackend: Send + Sync {
         Err(CoreError::Backend(
             "readiness checks are not supported by this backend".into(),
         ))
+    }
+
+    /// Wait for a running replica using an optional per-spec readiness
+    /// budget. The default delegates to [`Self::wait_until_ready`] so
+    /// existing/mock backends remain source-compatible and may ignore the
+    /// override. Backends that support per-spawn readiness should override
+    /// this method.
+    async fn wait_until_ready_with_timeout(
+        &self,
+        replica: &Replica,
+        _readiness_timeout_ms: Option<u64>,
+    ) -> CoreResult<()> {
+        self.wait_until_ready(replica).await
     }
 
     /// Image refs (name/tag AND sha id) of **every** container on the
@@ -954,6 +982,19 @@ mod registry_tests {
         assert!(SpawnRequest::new("a", "img").job_timeout_secs.is_none());
         let req = SpawnRequest::new("etl", "img").with_job_timeout(600);
         assert_eq!(req.job_timeout_secs, Some(600));
+    }
+
+    #[test]
+    fn spawn_request_carries_readiness_timeout_and_zero_inherits() {
+        assert!(SpawnRequest::new("a", "img")
+            .readiness_timeout_ms
+            .is_none());
+        assert!(SpawnRequest::new("a", "img")
+            .with_readiness_timeout_ms(0)
+            .readiness_timeout_ms
+            .is_none());
+        let req = SpawnRequest::new("slow", "img").with_readiness_timeout_ms(120_000);
+        assert_eq!(req.readiness_timeout_ms, Some(120_000));
     }
 
     #[test]

--- a/crates/ruscker-docker/src/lib.rs
+++ b/crates/ruscker-docker/src/lib.rs
@@ -162,6 +162,15 @@ impl LocalDockerBackend {
         self
     }
 
+    /// Resolve a request/spec override against the backend-wide default.
+    /// Zero deliberately inherits, matching `proxy.container-wait-time`.
+    fn effective_readiness_timeout(&self, override_ms: Option<u64>) -> Duration {
+        override_ms
+            .filter(|millis| *millis > 0)
+            .map(Duration::from_millis)
+            .unwrap_or(self.readiness_timeout)
+    }
+
     /// Spawn a container for `spec_id` with the explicit inner
     /// port to bind. Use this when the spec carries an
     /// `api.port`; otherwise [`Self::spawn`] uses
@@ -330,7 +339,8 @@ impl LocalDockerBackend {
             // 5. Wait for the container's process to bind that port. Passes
             //    the backend + container id so a startup crash fails fast and
             //    the error carries the container's log tail (#550).
-            wait_for_ready(self, &container_id, upstream).await?;
+            let budget = self.effective_readiness_timeout(req.readiness_timeout_ms);
+            wait_for_ready(self, &container_id, upstream, budget).await?;
             Ok::<SocketAddr, CoreError>(upstream)
         }
         .await;
@@ -937,7 +947,22 @@ impl ContainerBackend for LocalDockerBackend {
     }
 
     async fn wait_until_ready(&self, replica: &Replica) -> CoreResult<()> {
-        wait_for_ready(self, &replica.container_id, replica.upstream).await
+        wait_for_ready(
+            self,
+            &replica.container_id,
+            replica.upstream,
+            self.readiness_timeout,
+        )
+        .await
+    }
+
+    async fn wait_until_ready_with_timeout(
+        &self,
+        replica: &Replica,
+        readiness_timeout_ms: Option<u64>,
+    ) -> CoreResult<()> {
+        let budget = self.effective_readiness_timeout(readiness_timeout_ms);
+        wait_for_ready(self, &replica.container_id, replica.upstream, budget).await
     }
 
     async fn container_events(&self) -> CoreResult<ruscker_core::ContainerEventStream> {
@@ -1608,8 +1633,8 @@ async fn wait_for_ready(
     backend: &LocalDockerBackend,
     container_id: &str,
     addr: SocketAddr,
+    budget: Duration,
 ) -> CoreResult<()> {
-    let budget = backend.readiness_timeout;
     let deadline = std::time::Instant::now() + budget;
 
     // Phase 1: TCP connect.
@@ -1954,7 +1979,12 @@ mod tests {
         let backend = backend.with_readiness_timeout(Duration::from_millis(300));
         let addr: SocketAddr = "127.0.0.1:1".parse().unwrap();
         let started = std::time::Instant::now();
-        let err = wait_for_ready(&backend, "no-such-container", addr)
+        let err = wait_for_ready(
+            &backend,
+            "no-such-container",
+            addr,
+            backend.readiness_timeout,
+        )
             .await
             .expect_err("nothing listens on port 1");
         assert!(
@@ -1975,6 +2005,26 @@ mod tests {
         };
         let backend = backend.with_readiness_timeout(Duration::ZERO);
         assert_eq!(backend.readiness_timeout, READINESS_TIMEOUT);
+    }
+
+    #[test]
+    fn per_spawn_readiness_timeout_overrides_and_zero_inherits() {
+        let Ok(backend) = LocalDockerBackend::local() else {
+            return;
+        };
+        let backend = backend.with_readiness_timeout(Duration::from_secs(17));
+        assert_eq!(
+            backend.effective_readiness_timeout(Some(120_000)),
+            Duration::from_secs(120)
+        );
+        assert_eq!(
+            backend.effective_readiness_timeout(Some(0)),
+            Duration::from_secs(17)
+        );
+        assert_eq!(
+            backend.effective_readiness_timeout(None),
+            Duration::from_secs(17)
+        );
     }
 
     #[test]

--- a/crates/ruscker-docker/src/multihost.rs
+++ b/crates/ruscker-docker/src/multihost.rs
@@ -704,6 +704,28 @@ impl ContainerBackend for MultiHostDockerBackend {
         backend.wait_until_ready(replica).await
     }
 
+    async fn wait_until_ready_with_timeout(
+        &self,
+        replica: &Replica,
+        readiness_timeout_ms: Option<u64>,
+    ) -> CoreResult<()> {
+        let backend = replica
+            .host
+            .as_deref()
+            .and_then(|host| self.hosts.iter().find(|entry| entry.id == host))
+            .map(|entry| &entry.backend)
+            .or_else(|| self.placed(&replica.id))
+            .ok_or_else(|| {
+                CoreError::Backend(format!(
+                    "replica {} is not placed on a reachable Docker host",
+                    replica.id
+                ))
+            })?;
+        backend
+            .wait_until_ready_with_timeout(replica, readiness_timeout_ms)
+            .await
+    }
+
     async fn container_events(&self) -> CoreResult<ruscker_core::ContainerEventStream> {
         // Merge every reachable host's event stream. A host whose stream fails
         // to open is skipped (logged) — its containers still recover via the

--- a/docs/YAML_SCHEMA.md
+++ b/docs/YAML_SCHEMA.md
@@ -315,6 +315,7 @@ A spec describes one app, API, or external link. Every spec has an
   max-lifetime: 360                   # minutes — hard recycle (enforced, #334)
   container-lifetime: 360             # minutes — soft recycle when idle (enforced, #334)
   heartbeat-timeout: 3600000          # ms — per-spec override (enforced)
+  container-wait-time: 120000         # ms — startup readiness override; 0/unset = global
   stop-on-logout: false               # end a user's sessions on logout (enforced, #337)
   docker-registry-username: acme
   docker-registry-password: ${DOCKER_REGISTRY_PASSWORD}   # use env vars!
@@ -656,6 +657,7 @@ applied) and flagged by `ruscker validate`.
 | `scale-down-grace` | s | unset | idle-grace before retiring a replica; unset ⇒ the global ~30 s grace (enforced, #333) |
 | `scale-down-cooldown-secs` | s | `60` | suppress saturation-driven scale-up after this app scales down, preventing immediate respawn flaps; `0` disables. Ruscker extension (#936) |
 | `drain-timeout` | s | `60` | grace for in-flight sessions on a `max-lifetime` recycle (enforced, #335) |
+| `container-wait-time` | ms | global `proxy.container-wait-time` | per-app TCP + HTTP startup-readiness budget; unset or `0` inherits the global value. Ruscker extension (#1026) |
 | `routing-strategy` | enum | varies | See below |
 | `concurrent-requests-per-replica` | u32 | `100` | API-only — per-replica in-flight cap the scaler scales on (enforced, #336) |
 


### PR DESCRIPTION
Closes #1026.

## What changed

- adds a per-spec `container-wait-time` override in milliseconds
- carries the override through `SpawnRequest` for on-demand and scaler spawns
- applies the same budget when re-adopting a container after an external restart
- keeps blank and `0` as inheritance from the global `proxy.container-wait-time`
- forwards the request unchanged through the multi-host backend
- exposes the field beside `heartbeat-timeout` in the advanced app form, with pt/en/es/fr help text
- documents that the per-spec field is a Ruscker extension because ShinyProxy exposes this knob globally only

## Why

Slow-starting apps currently force operators to increase the global readiness timeout and restart Ruscker. A per-app override lets those apps receive a larger startup budget without weakening feedback for every other container.

The request field is explicitly measured in milliseconds to match the existing YAML contract. Zero is normalized to inheritance so it cannot become an immediate timeout.

## Validation

- `DOCKER_REGISTRY_PASSWORD=test cargo test`
- `DOCKER_REGISTRY_PASSWORD=test cargo clippy --all-targets -- -D warnings`
- `./scripts/i18n-check.sh`
- `git diff --check`
