### PR TITLE
fix: alinhar campo 'Senha inicial' no form de criação de usuário (#1029)

### DIFF
--- a/crates/ruscker-admin/templates/admin/users.html
+++ b/crates/ruscker-admin/templates/admin/users.html
@@ -67,7 +67,6 @@
           <i class="ti ti-eye" aria-hidden="true"></i>
         </button>
       </span>
-      <span class="text-xs text-[color:var(--text-faint)] mt-1">{{ self.t("admin-users-password-rule") }}</span>
     </label>
     <label class="admin-login-field" style="margin:0">
       <span class="admin-login-label">{{ self.t("admin-users-role") }}</span>


### PR DESCRIPTION
Closes #1029.

Remove o hint inline redundante da política de senha (que, sob `items-end`, deixava só aquele campo mais alto e empurrava o rótulo 'Senha inicial' para cima). A regra continua no `title` do input e na linha de rodapé — sem perda de acessibilidade.

Agente **codex gpt-5.6-sol high**; revisado + gate verde por mim (Opus): key `admin-users-password-rule` ainda referenciada (não órfã), Askama compila, clippy + i18n OK.

🤖 Generated with [Claude Code](https://claude.com/claude-code)