### PR TITLE
fix: layout dos cards de grupos — masonry + teto nos pills (#1030)

### DIFF
--- a/crates/ruscker-admin/assets/tailwind/input.css
+++ b/crates/ruscker-admin/assets/tailwind/input.css
@@ -2375,13 +2375,16 @@ input[type="color"].cover-swatch::-webkit-color-swatch { border: 0; border-radiu
 
 /* Groups page (#503, read-only) — one card per derived group. */
 .groups-grid {
-  display: grid; grid-template-columns: repeat(auto-fill, minmax(280px, 1fr));
-  gap: 14px;
+  columns: 280px; column-gap: 14px;
 }
 /* Coloured left accent bar per group card (design handoff #623) — hue from
  * the group-name hash (set inline by the page script), matching the group
  * badges on the Users page so the same group reads the same colour. */
-.group-card { position: relative; overflow: hidden; }
+.group-card {
+  position: relative; overflow: hidden;
+  display: inline-block; width: 100%; vertical-align: top;
+  break-inside: avoid;
+}
 .group-card__bar { position: absolute; left: 0; top: 0; bottom: 0; width: 5px; background: var(--color-teal-600); }
 .group-card > .editor-card__head, .group-card > .group-col { padding-left: 6px; }
 
@@ -2400,9 +2403,14 @@ input[type="color"].cover-swatch::-webkit-color-swatch { border: 0; border-radiu
   font-size: 11px; font-weight: 600; color: var(--text-muted);
   text-transform: uppercase; letter-spacing: 0.04em; margin-bottom: 6px;
 }
-.group-pills { display: flex; flex-wrap: wrap; gap: 6px; }
+.group-pills {
+  display: flex; flex-wrap: wrap; gap: 6px;
+  max-height: 11rem; overflow-y: auto; scrollbar-gutter: stable;
+  padding-right: 4px;
+}
 .group-pill {
   display: inline-flex; align-items: center; gap: 5px;
+  max-width: 100%; overflow-wrap: anywhere;
   font-size: 12px; color: var(--text); text-decoration: none;
   background: var(--surface-soft); border: 0.5px solid var(--border);
   border-radius: 999px; padding: 4px 10px;


### PR DESCRIPTION
Closes #1030.

Troca o grid de altura acoplada por masonry (`columns: 280px`) com `break-inside: avoid` (card não parte entre colunas); listas de membros/apps ganham teto `11rem` + scroll interno; pills longos quebram sem overflow horizontal. Só CSS (`assets/tailwind/input.css`).

Agente **codex gpt-5.6-sol high**; revisado + gate por mim (Opus): clippy + i18n verdes, e confirmei que o Tailwind recompilou a regra no `styles.css` servido (anti-staleness).

🤖 Generated with [Claude Code](https://claude.com/claude-code)