### PR TITLE
fix: colapsar listas longas de membros/apps nos cards de grupo (follow-up #1030)

### DIFF
--- a/crates/ruscker-admin/assets/i18n/en/landing.ftl
+++ b/crates/ruscker-admin/assets/i18n/en/landing.ftl
@@ -919,6 +919,8 @@ admin-groups-flash-bad-input = Invalid input (empty name or unknown user).
 admin-groups-empty = No groups yet. Groups appear when you set access-groups on an app or groups on a user.
 admin-groups-no-members = No members
 admin-groups-no-apps = No app restricted to this group
+admin-groups-show-all = Show all
+admin-groups-show-less = Show less
 
 highlights-prev = Previous
 highlights-next = Next

--- a/crates/ruscker-admin/assets/i18n/es/landing.ftl
+++ b/crates/ruscker-admin/assets/i18n/es/landing.ftl
@@ -919,6 +919,8 @@ admin-groups-flash-bad-input = Datos inválidos (nombre vacío o usuario inexist
 admin-groups-empty = Aún no hay grupos. Aparecen cuando defines access-groups en un app o grupos en un usuario.
 admin-groups-no-members = Sin miembros
 admin-groups-no-apps = Ningún app restringido a este grupo
+admin-groups-show-all = Ver todos
+admin-groups-show-less = Ver menos
 
 highlights-prev = Anteriores
 highlights-next = Siguientes

--- a/crates/ruscker-admin/assets/i18n/fr/landing.ftl
+++ b/crates/ruscker-admin/assets/i18n/fr/landing.ftl
@@ -919,6 +919,8 @@ admin-groups-flash-bad-input = Entrée invalide (nom vide ou utilisateur inconnu
 admin-groups-empty = Aucun groupe pour l'instant. Les groupes apparaissent quand vous définissez access-groups sur une app ou des groupes sur un utilisateur.
 admin-groups-no-members = Aucun membre
 admin-groups-no-apps = Aucune app restreinte à ce groupe
+admin-groups-show-all = Tout afficher
+admin-groups-show-less = Voir moins
 
 highlights-prev = Précédents
 highlights-next = Suivants

--- a/crates/ruscker-admin/assets/i18n/pt/landing.ftl
+++ b/crates/ruscker-admin/assets/i18n/pt/landing.ftl
@@ -923,6 +923,8 @@ admin-groups-flash-bad-input = Entrada inválida (nome vazio ou usuário inexist
 admin-groups-empty = Nenhum grupo ainda. Grupos aparecem quando você define access-groups num app ou grupos num usuário.
 admin-groups-no-members = Sem membros
 admin-groups-no-apps = Nenhum app restrito a este grupo
+admin-groups-show-all = Ver todos
+admin-groups-show-less = Ver menos
 
 highlights-prev = Anteriores
 highlights-next = Próximos

--- a/crates/ruscker-admin/assets/tailwind/input.css
+++ b/crates/ruscker-admin/assets/tailwind/input.css
@@ -2375,16 +2375,15 @@ input[type="color"].cover-swatch::-webkit-color-swatch { border: 0; border-radiu
 
 /* Groups page (#503, read-only) — one card per derived group. */
 .groups-grid {
-  columns: 280px; column-gap: 14px;
+  display: grid;
+  grid-template-columns: repeat(auto-fill, minmax(300px, 1fr));
+  gap: 14px;
+  align-items: start;
 }
 /* Coloured left accent bar per group card (design handoff #623) — hue from
  * the group-name hash (set inline by the page script), matching the group
  * badges on the Users page so the same group reads the same colour. */
-.group-card {
-  position: relative; overflow: hidden;
-  display: inline-block; width: 100%; vertical-align: top;
-  break-inside: avoid;
-}
+.group-card { position: relative; overflow: hidden; }
 .group-card__bar { position: absolute; left: 0; top: 0; bottom: 0; width: 5px; background: var(--color-teal-600); }
 .group-card > .editor-card__head, .group-card > .group-col { padding-left: 6px; }
 
@@ -2405,9 +2404,21 @@ input[type="color"].cover-swatch::-webkit-color-swatch { border: 0; border-radiu
 }
 .group-pills {
   display: flex; flex-wrap: wrap; gap: 6px;
-  max-height: 11rem; overflow-y: auto; scrollbar-gutter: stable;
-  padding-right: 4px;
 }
+/* Collapsed preview for a long member/app list (#1030 follow-up): instead of
+ * a cramped inner scrollbar, show ~3 rows with a soft fade and a "show all"
+ * toggle. Only applied by the template when the list exceeds the preview. */
+.group-pills.is-collapsed {
+  max-height: 5.9rem; overflow: hidden;
+  -webkit-mask-image: linear-gradient(to bottom, #000 55%, transparent);
+          mask-image: linear-gradient(to bottom, #000 55%, transparent);
+}
+.group-more {
+  margin-top: 8px; font-size: 12px; font-weight: 500;
+  color: var(--color-teal-600); background: none; border: 0;
+  cursor: pointer; padding: 2px 0;
+}
+.group-more:hover { text-decoration: underline; }
 .group-pill {
   display: inline-flex; align-items: center; gap: 5px;
   max-width: 100%; overflow-wrap: anywhere;

--- a/crates/ruscker-admin/templates/admin/groups.html
+++ b/crates/ruscker-admin/templates/admin/groups.html
@@ -81,12 +81,12 @@
           <button type="submit" class="group-action group-action-del" title="{{ self.t("admin-groups-delete") }}"><i class="ti ti-trash" aria-hidden="true"></i></button>
         </form>
       </div>
-      <div class="group-col">
+      <div class="group-col"{% if g.members.len() > 8 %} x-data="{ open: false }"{% endif %}>
         <div class="group-col-title">{{ self.t("admin-groups-members") }} · {{ g.members.len() }}</div>
         {% if g.members.is_empty() %}
           <span class="group-empty">{{ self.t("admin-groups-no-members") }}</span>
         {% else %}
-          <div class="group-pills">
+          <div class="group-pills"{% if g.members.len() > 8 %} :class="{ 'is-collapsed': !open }"{% endif %}>
             {% for m in g.members %}
             <span class="group-pill">
               <i class="ti ti-user" aria-hidden="true"></i> {{ m }}
@@ -99,6 +99,15 @@
             </span>
             {% endfor %}
           </div>
+          {# Long lists collapse to a ~3-row preview; the label lives in
+             data-* (never inside the Alpine expression) so a translated
+             string can't break the handler. #}
+          {% if g.members.len() > 8 %}
+          <button type="button" class="group-more" @click="open = !open"
+                  data-more="{{ self.t("admin-groups-show-all") }} ({{ g.members.len() }})"
+                  data-less="{{ self.t("admin-groups-show-less") }}"
+                  x-text="open ? $el.dataset.less : $el.dataset.more">{{ self.t("admin-groups-show-all") }} ({{ g.members.len() }})</button>
+          {% endif %}
         {% endif %}
         {% if !all_users.is_empty() %}
         <form method="post" action="{{ base }}/admin/groups/members/add" class="group-add-member">
@@ -111,14 +120,20 @@
         </form>
         {% endif %}
       </div>
-      <div class="group-col">
+      <div class="group-col"{% if g.apps.len() > 8 %} x-data="{ open: false }"{% endif %}>
         <div class="group-col-title">{{ self.t("admin-groups-apps") }} · {{ g.apps.len() }}</div>
         {% if g.apps.is_empty() %}
           <span class="group-empty">{{ self.t("admin-groups-no-apps") }}</span>
         {% else %}
-          <div class="group-pills">
+          <div class="group-pills"{% if g.apps.len() > 8 %} :class="{ 'is-collapsed': !open }"{% endif %}>
             {% for a in g.apps %}<a href="{{ base }}/admin/specs/{{ a.id }}/edit" class="group-pill"><i class="ti ti-app-window" aria-hidden="true"></i> {{ a.name }}</a>{% endfor %}
           </div>
+          {% if g.apps.len() > 8 %}
+          <button type="button" class="group-more" @click="open = !open"
+                  data-more="{{ self.t("admin-groups-show-all") }} ({{ g.apps.len() }})"
+                  data-less="{{ self.t("admin-groups-show-less") }}"
+                  x-text="open ? $el.dataset.less : $el.dataset.more">{{ self.t("admin-groups-show-all") }} ({{ g.apps.len() }})</button>
+          {% endif %}
         {% endif %}
       </div>
     </section>

--- a/crates/ruscker-admin/templates/admin/groups.html
+++ b/crates/ruscker-admin/templates/admin/groups.html
@@ -86,7 +86,7 @@
         {% if g.members.is_empty() %}
           <span class="group-empty">{{ self.t("admin-groups-no-members") }}</span>
         {% else %}
-          <div class="group-pills"{% if g.members.len() > 8 %} :class="{ 'is-collapsed': !open }"{% endif %}>
+          <div class="group-pills{% if g.members.len() > 8 %} is-collapsed{% endif %}"{% if g.members.len() > 8 %} :class="{ 'is-collapsed': !open }"{% endif %}>
             {% for m in g.members %}
             <span class="group-pill">
               <i class="ti ti-user" aria-hidden="true"></i> {{ m }}
@@ -125,7 +125,7 @@
         {% if g.apps.is_empty() %}
           <span class="group-empty">{{ self.t("admin-groups-no-apps") }}</span>
         {% else %}
-          <div class="group-pills"{% if g.apps.len() > 8 %} :class="{ 'is-collapsed': !open }"{% endif %}>
+          <div class="group-pills{% if g.apps.len() > 8 %} is-collapsed{% endif %}"{% if g.apps.len() > 8 %} :class="{ 'is-collapsed': !open }"{% endif %}>
             {% for a in g.apps %}<a href="{{ base }}/admin/specs/{{ a.id }}/edit" class="group-pill"><i class="ti ti-app-window" aria-hidden="true"></i> {{ a.name }}</a>{% endfor %}
           </div>
           {% if g.apps.len() > 8 %}
@@ -189,6 +189,10 @@
   .group-pill-x:hover { color: var(--color-lock); }
   .group-add-member { display: flex; align-items: center; gap: 6px; margin-top: 8px; }
 </style>
+
+{# Alpine drives the per-card "show all / show less" collapse. Deferred, so
+   the server renders `is-collapsed` up-front (no flash of the full list). #}
+<script src="{{ base }}/assets/js/alpine.min.js?v={{ crate::APP_VERSION }}" defer></script>
 
 <script>
   // Colour each group card's accent bar from a hash of the group name —

--- a/crates/ruscker-admin/templates/admin/groups.html
+++ b/crates/ruscker-admin/templates/admin/groups.html
@@ -81,12 +81,15 @@
           <button type="submit" class="group-action group-action-del" title="{{ self.t("admin-groups-delete") }}"><i class="ti ti-trash" aria-hidden="true"></i></button>
         </form>
       </div>
-      <div class="group-col"{% if g.members.len() > 8 %} x-data="{ open: false }"{% endif %}>
+      {# Collapse is measured, not assumed: >8 pills that still FIT the
+         preview height (short names / wide card) must not fade visible
+         content — same scrollHeight probe as the card-description clamp. #}
+      <div class="group-col"{% if g.members.len() > 8 %} x-data="{ open: false, clip: true }" x-init="clip = $refs.pills.scrollHeight > $refs.pills.clientHeight + 2; if (!clip) open = true"{% endif %}>
         <div class="group-col-title">{{ self.t("admin-groups-members") }} · {{ g.members.len() }}</div>
         {% if g.members.is_empty() %}
           <span class="group-empty">{{ self.t("admin-groups-no-members") }}</span>
         {% else %}
-          <div class="group-pills{% if g.members.len() > 8 %} is-collapsed{% endif %}"{% if g.members.len() > 8 %} :class="{ 'is-collapsed': !open }"{% endif %}>
+          <div class="group-pills{% if g.members.len() > 8 %} is-collapsed{% endif %}"{% if g.members.len() > 8 %} x-ref="pills" :class="{ 'is-collapsed': clip && !open }"{% endif %}>
             {% for m in g.members %}
             <span class="group-pill">
               <i class="ti ti-user" aria-hidden="true"></i> {{ m }}
@@ -103,7 +106,8 @@
              data-* (never inside the Alpine expression) so a translated
              string can't break the handler. #}
           {% if g.members.len() > 8 %}
-          <button type="button" class="group-more" @click="open = !open"
+          <button type="button" class="group-more" @click="open = !open" x-show="clip"
+                  aria-expanded="false" :aria-expanded="open ? 'true' : 'false'"
                   data-more="{{ self.t("admin-groups-show-all") }} ({{ g.members.len() }})"
                   data-less="{{ self.t("admin-groups-show-less") }}"
                   x-text="open ? $el.dataset.less : $el.dataset.more">{{ self.t("admin-groups-show-all") }} ({{ g.members.len() }})</button>
@@ -120,16 +124,17 @@
         </form>
         {% endif %}
       </div>
-      <div class="group-col"{% if g.apps.len() > 8 %} x-data="{ open: false }"{% endif %}>
+      <div class="group-col"{% if g.apps.len() > 8 %} x-data="{ open: false, clip: true }" x-init="clip = $refs.pills.scrollHeight > $refs.pills.clientHeight + 2; if (!clip) open = true"{% endif %}>
         <div class="group-col-title">{{ self.t("admin-groups-apps") }} · {{ g.apps.len() }}</div>
         {% if g.apps.is_empty() %}
           <span class="group-empty">{{ self.t("admin-groups-no-apps") }}</span>
         {% else %}
-          <div class="group-pills{% if g.apps.len() > 8 %} is-collapsed{% endif %}"{% if g.apps.len() > 8 %} :class="{ 'is-collapsed': !open }"{% endif %}>
+          <div class="group-pills{% if g.apps.len() > 8 %} is-collapsed{% endif %}"{% if g.apps.len() > 8 %} x-ref="pills" :class="{ 'is-collapsed': clip && !open }"{% endif %}>
             {% for a in g.apps %}<a href="{{ base }}/admin/specs/{{ a.id }}/edit" class="group-pill"><i class="ti ti-app-window" aria-hidden="true"></i> {{ a.name }}</a>{% endfor %}
           </div>
           {% if g.apps.len() > 8 %}
-          <button type="button" class="group-more" @click="open = !open"
+          <button type="button" class="group-more" @click="open = !open" x-show="clip"
+                  aria-expanded="false" :aria-expanded="open ? 'true' : 'false'"
                   data-more="{{ self.t("admin-groups-show-all") }} ({{ g.apps.len() }})"
                   data-less="{{ self.t("admin-groups-show-less") }}"
                   x-text="open ? $el.dataset.less : $el.dataset.more">{{ self.t("admin-groups-show-all") }} ({{ g.apps.len() }})</button>


### PR DESCRIPTION
Follow-up do #1030 — o caso real do hugo (grupo `argos jps` com **380 membros**) mostrou que masonry + scroll de 11rem não escala: vira uma caixa de scroll apertada e o `columns` fragmenta o layout.

**Mudança:** grid responsivo limpo (`align-items:start`, sem masonry) + listas longas colapsam num **preview de ~3 linhas** com fade suave e um toggle **'Ver todos (N)' / 'Ver menos'** (Alpine; o label vem de `data-*`, nunca dentro da expressão — respeita o gotcha de string localizada em handler). Membros e apps colapsam acima de 8 itens. Só template + CSS + i18n×4.

Gate por mim (Opus): i18n ✅, clippy ✅, suíte admin ✅, e confirmei no `styles.css` servido que `is-collapsed` entrou e o `columns` masonry saiu.

🤖 Generated with [Claude Code](https://claude.com/claude-code)