### PR TITLE
fix: replace process log SSE with incremental polling

### DIFF
--- a/crates/ruscker-admin/src/logbuf.rs
+++ b/crates/ruscker-admin/src/logbuf.rs
@@ -1,8 +1,8 @@
 //! In-memory ring buffer of recent Ruscker log lines (#100).
 //!
 //! A `tracing` layer (wired in `ruscker-cli`) pushes each formatted log
-//! line here; the admin "Logs" tab reads a snapshot and follows new
-//! lines over SSE. It's a bounded *recent tail* — lost on restart;
+//! line here; the admin "Logs" tab reads a snapshot and polls for new
+//! lines. It's a bounded *recent tail* — lost on restart;
 //! journald / `docker logs` / `container-log-path` remain the durable
 //! source. No `tracing` dependency lives here on purpose: the writer
 //! that feeds it is owned by the CLI.
@@ -10,7 +10,7 @@
 use std::collections::VecDeque;
 use std::sync::{Arc, Mutex};
 
-/// Monotonic, gap-tolerant line sequence — lets the SSE follower ask
+/// Monotonic, gap-tolerant line sequence — lets a polling client ask
 /// "anything after seq N?" even though old lines are evicted.
 struct Inner {
     lines: VecDeque<(u64, String)>,
@@ -70,16 +70,25 @@ impl LogBuffer {
     /// The last `n` lines (oldest-first within the tail) plus the total
     /// number of buffered lines. Caps the initial `/admin/logs` render so
     /// a long-lived buffer doesn't ship the whole ring on every load
-    /// (#200); the SSE stream then appends what's new.
+    /// (#200); the polling endpoint then appends what's new.
     pub fn tail(&self, n: usize) -> (Vec<String>, usize) {
+        let (lines, total, _) = self.tail_with_cursor(n);
+        (lines, total)
+    }
+
+    /// The last `n` lines, total buffered lines, and the cursor immediately
+    /// after that same snapshot. Taking all three under one lock prevents a
+    /// line written during the initial page render from falling between the
+    /// rendered tail and the first poll (#1039).
+    pub fn tail_with_cursor(&self, n: usize) -> (Vec<String>, usize, u64) {
         let g = self.lock();
         let total = g.lines.len();
         let start = total.saturating_sub(n);
         let lines = g.lines.iter().skip(start).map(|(_, l)| l.clone()).collect();
-        (lines, total)
+        (lines, total, g.next_seq)
     }
 
-    /// The next sequence number that will be assigned — an SSE follower
+    /// The next sequence number that will be assigned — a polling client
     /// records this at connect and asks [`Self::since`] for anything past
     /// it.
     pub fn cursor(&self) -> u64 {
@@ -135,6 +144,22 @@ mod tests {
     }
 
     #[test]
+    fn tail_cursor_hands_off_to_incremental_poll_without_a_gap() {
+        let b = LogBuffer::new(100);
+        b.push_line("a");
+        b.push_line("b");
+
+        let (tail, total, cursor) = b.tail_with_cursor(1);
+        assert_eq!(tail, vec!["b"]);
+        assert_eq!(total, 2);
+
+        b.push_line("c");
+        let (new, next) = b.since(cursor);
+        assert_eq!(new, vec!["c"]);
+        assert_eq!(next, cursor + 1);
+    }
+
+    #[test]
     fn since_returns_only_new_lines() {
         let b = LogBuffer::new(100);
         b.push_line("a");
@@ -167,6 +192,7 @@ mod tests {
         b.push_line("after panic");
         assert_eq!(b.snapshot(), vec!["before panic", "after panic"]);
         assert_eq!(b.tail(1), (vec!["after panic".to_string()], 2));
+        assert_eq!(b.tail_with_cursor(1).0, vec!["after panic"]);
         let cursor = b.cursor();
         b.push_line("new line");
         assert_eq!(b.since(cursor).0, vec!["new line"]);

--- a/crates/ruscker-admin/src/routes/admin/logs.rs
+++ b/crates/ruscker-admin/src/routes/admin/logs.rs
@@ -1,37 +1,33 @@
 //! Admin > Logs — the Ruscker process log (the `tracing` stream),
 //! tailed from the in-memory ring buffer (#100). Read-only; admin-only.
 //!
-//! `GET /admin/logs` renders the current snapshot; `GET
-//! /admin/logs/stream` is an SSE feed of new lines (the page follows).
-
-use std::convert::Infallible;
-use std::time::Duration;
+//! `GET /admin/logs` renders the current snapshot; short requests to
+//! `GET /admin/logs/poll` fetch new lines without occupying a persistent
+//! HTTP/1.1 connection (#1039).
 
 use askama::Template;
-use axum::extract::State;
-use axum::http::header;
-use axum::response::sse::{Event, KeepAlive, Sse};
+use axum::extract::{Query, State};
+use axum::http::{header, StatusCode};
 use axum::response::{IntoResponse, Response};
 use axum::routing::get;
-use axum::Router;
-use futures_util::Stream;
+use axum::{Json, Router};
+use serde::{Deserialize, Serialize};
 
 use crate::auth::{RequireAdmin, Role};
 use crate::i18n::{Locale, Locales};
 use crate::theme::Theme;
 use crate::AppState;
 
-const TICK: Duration = Duration::from_secs(1);
-const KEEPALIVE: Duration = Duration::from_secs(15);
-/// How many of the most recent lines the initial page renders. The SSE
-/// stream appends anything newer; the full buffer is a download away.
+/// How many of the most recent lines the initial page renders. Polling
+/// appends anything newer; the full buffer is a download away.
 /// Matches the per-replica logs viewer's tail (#200).
 const INITIAL_TAIL: usize = 500;
 
 pub fn routes() -> Router<AppState> {
     Router::new()
         .route("/admin/logs", get(index))
-        .route("/admin/logs/stream", get(stream))
+        .route("/admin/logs/poll", get(poll))
+        .route("/admin/logs/stream", get(retired_stream))
         .route("/admin/logs/download", get(download))
 }
 
@@ -56,6 +52,8 @@ struct LogsPage<'a> {
     total: usize,
     /// Whether a log buffer is actually wired.
     available: bool,
+    /// First polling cursor, captured atomically with `lines`.
+    cursor: u64,
 }
 
 impl LogsPage<'_> {
@@ -77,14 +75,14 @@ async fn index(
     loc: Locale,
     theme: Theme,
 ) -> Response {
-    let (lines, total, available) = match &state.log_buffer {
-        // Only the most recent slice — the SSE stream appends what's
+    let (lines, total, available, cursor) = match &state.log_buffer {
+        // Only the most recent slice — polling appends what's
         // newer, and the full buffer is one download away (#200).
         Some(b) => {
-            let (lines, total) = b.tail(INITIAL_TAIL);
-            (lines, total, true)
+            let (lines, total, cursor) = b.tail_with_cursor(INITIAL_TAIL);
+            (lines, total, true, cursor)
         }
-        None => (Vec::new(), 0, false),
+        None => (Vec::new(), 0, false, 0),
     };
     super::render(&LogsPage {
         locale: loc,
@@ -97,7 +95,48 @@ async fn index(
         lines,
         total,
         available,
+        cursor,
     })
+}
+
+#[derive(Deserialize)]
+struct PollQuery {
+    #[serde(default)]
+    cursor: u64,
+}
+
+#[derive(Serialize)]
+struct PollResponse {
+    lines: Vec<String>,
+    /// A decimal string avoids losing u64 precision in JavaScript.
+    cursor: String,
+    available: bool,
+}
+
+/// Return immediately with all lines newer than `cursor`. This deliberately
+/// stays a finite request: an intermediary that only speaks HTTP/1.1 cannot
+/// strand an infinite response and head-of-line block later admin navigation.
+async fn poll(
+    _: RequireAdmin,
+    State(state): State<AppState>,
+    Query(query): Query<PollQuery>,
+) -> Response {
+    let (lines, cursor, available) = match &state.log_buffer {
+        Some(buffer) => {
+            let (lines, cursor) = buffer.since(query.cursor);
+            (lines, cursor, true)
+        }
+        None => (Vec::new(), query.cursor, false),
+    };
+    (
+        [(header::CACHE_CONTROL, "no-store")],
+        Json(PollResponse {
+            lines,
+            cursor: cursor.to_string(),
+            available,
+        }),
+    )
+        .into_response()
 }
 
 /// Full buffer as a `text/plain` attachment — for forensics, since the
@@ -120,33 +159,8 @@ async fn download(_: RequireAdmin, State(state): State<AppState>) -> Response {
         .into_response()
 }
 
-/// SSE feed of lines appended since the client connected. The page
-/// already rendered the snapshot, so we start from the live cursor and
-/// only stream what's new.
-async fn stream(
-    _: RequireAdmin,
-    State(state): State<AppState>,
-) -> Sse<impl Stream<Item = Result<Event, Infallible>>> {
-    use async_stream::stream;
-    let buf = state.log_buffer.clone();
-    let s = stream! {
-        let Some(buf) = buf else {
-            // No buffer wired — nothing to stream; keep-alive holds the
-            // connection so the client doesn't error-loop.
-            std::future::pending::<()>().await;
-            return;
-        };
-        let mut cursor = buf.cursor();
-        let mut ticker = tokio::time::interval(TICK);
-        ticker.set_missed_tick_behavior(tokio::time::MissedTickBehavior::Skip);
-        loop {
-            ticker.tick().await;
-            let (new, next) = buf.since(cursor);
-            cursor = next;
-            if !new.is_empty() {
-                yield Ok::<_, Infallible>(Event::default().data(new.join("\n")));
-            }
-        }
-    };
-    Sse::new(s).keep_alive(KeepAlive::new().interval(KEEPALIVE))
+/// Stop pre-upgrade EventSource clients from reconnecting forever during a
+/// rolling deployment. EventSource treats 204 as a terminal response.
+async fn retired_stream(_: RequireAdmin) -> StatusCode {
+    StatusCode::NO_CONTENT
 }

--- a/crates/ruscker-admin/templates/admin/process_logs.html
+++ b/crates/ruscker-admin/templates/admin/process_logs.html
@@ -10,7 +10,7 @@
     <p class="text-sm text-[color:var(--text-muted)] mt-1">{{ self.t("admin-proclog-subtitle") }}</p>
   </div>
   {% if available %}
-  {# Live-stream badge (#623): the SSE follow keeps this terminal current. #}
+  {# Live badge: short incremental polls keep this terminal current. #}
   <span class="live-badge"><span class="live-dot"></span>{{ self.t("admin-dashboard-live") }}</span>
   {% endif %}
 </div>
@@ -50,7 +50,7 @@
     </div>
 
     {# Buffer wired but empty — say so explicitly so an operator can tell
-       "nothing logged yet" from a broken tab (#452). New lines still stream
+       "nothing logged yet" from a broken tab (#452). New lines still arrive
        in below as they happen. #}
     {% if lines.is_empty() %}
     <p id="log-empty" class="text-sm text-[color:var(--text-faint)] py-8 text-center">{{ self.t("admin-proclog-empty") }}</p>
@@ -60,7 +60,8 @@
        the terminal below. Hidden — never shown directly. #}
     <pre id="proclog-seed" hidden>{% for line in lines %}{{ line }}
 {% endfor %}</pre>
-    <div id="proclog" class="log-body" role="log" aria-live="polite"></div>
+    <div id="proclog" class="log-body" role="log" aria-live="polite"
+         data-cursor="{{ cursor }}" data-poll-url="{{ base }}/admin/logs/poll"></div>
   </div>
   {% if self.truncated() %}
   <p class="text-[11px] text-[color:var(--text-faint)] mt-2">{{ self.t("admin-proclog-tail-note") }} ({{ lines.len() }}/{{ total }})</p>
@@ -77,6 +78,12 @@
     var emptyHint = document.getElementById('log-empty');
     var chips = Array.prototype.slice.call(document.querySelectorAll('.log-chip'));
     var paused = false;
+    var cursor = box.dataset.cursor || '0';
+    var pollUrl = box.dataset.pollUrl;
+    var timer = null;
+    var inFlight = false;
+    var active = true;
+    var retryMs = 1000;
     var hiddenLevels = {};   // level -> true when its chip is toggled off
     var knownApps = {};      // app name -> true, to dedupe the app <select>
 
@@ -163,18 +170,65 @@
       var icon = pauseBtn.querySelector('i'), label = pauseBtn.querySelector('span');
       if (icon) icon.className = 'ti ' + (paused ? 'ti-player-play' : 'ti-player-pause');
       if (label) label.textContent = paused ? pauseBtn.dataset.resume : pauseBtn.dataset.pause;
+      if (paused) {
+        if (timer !== null) window.clearTimeout(timer);
+        timer = null;
+      } else {
+        schedulePoll(0);
+      }
     });
 
-    if (window.EventSource) {
-      var es = new EventSource((window.RUSCKER_BASE || '') + '/admin/logs/stream');
-      es.onmessage = function (e) {
-        if (paused) return;
-        var stick = nearBottom();
-        e.data.split('\n').forEach(append);
-        if (stick) box.scrollTop = box.scrollHeight;
-      };
-      es.onerror = function () { /* EventSource auto-reconnects */ };
+    function schedulePoll(delay) {
+      if (!active || paused || document.hidden || timer !== null) return;
+      timer = window.setTimeout(poll, delay);
     }
+
+    function poll() {
+      timer = null;
+      if (!active || paused || document.hidden || inFlight) return;
+      inFlight = true;
+      fetch(pollUrl + '?cursor=' + encodeURIComponent(cursor), {
+        credentials: 'same-origin',
+        cache: 'no-store',
+        headers: { 'Accept': 'application/json' }
+      }).then(function (response) {
+        if (!response.ok) throw new Error('log poll failed: ' + response.status);
+        return response.json();
+      }).then(function (data) {
+        // If the page was paused or hidden while this finite request was in
+        // flight, retain the old cursor so the next poll catches up.
+        if (!active || paused || document.hidden) return;
+        var stick = nearBottom();
+        (data.lines || []).forEach(append);
+        cursor = String(data.cursor || cursor);
+        if (stick) box.scrollTop = box.scrollHeight;
+        retryMs = 1000;
+      }).catch(function () {
+        retryMs = Math.min(retryMs * 2, 15000);
+      }).finally(function () {
+        inFlight = false;
+        schedulePoll(retryMs);
+      });
+    }
+
+    document.addEventListener('visibilitychange', function () {
+      if (document.hidden) {
+        if (timer !== null) window.clearTimeout(timer);
+        timer = null;
+      } else {
+        schedulePoll(0);
+      }
+    });
+    window.addEventListener('pagehide', function () {
+      active = false;
+      if (timer !== null) window.clearTimeout(timer);
+      timer = null;
+    });
+    window.addEventListener('pageshow', function () {
+      active = true;
+      schedulePoll(0);
+    });
+    schedulePoll(1000);
   })();
   </script>
 {% endif %}

--- a/crates/ruscker-admin/tests/rbac.rs
+++ b/crates/ruscker-admin/tests/rbac.rs
@@ -111,6 +111,8 @@ async fn viewer_cannot_reach_apps_or_admin_sections() {
         "/admin/blocks",
         "/admin/audit",
         "/admin/logs",
+        "/admin/logs/poll?cursor=0",
+        "/admin/logs/stream",
     ] {
         let st = state();
         let c = cookie_for(&st, Role::Viewer).await;
@@ -171,6 +173,8 @@ async fn editor_cannot_reach_admin_only_sections() {
         "/admin/blocks",
         "/admin/audit",
         "/admin/logs",
+        "/admin/logs/poll?cursor=0",
+        "/admin/logs/stream",
     ] {
         let st = state();
         let c = cookie_for(&st, Role::Editor).await;
@@ -208,11 +212,17 @@ async fn admin_passes_guard_everywhere() {
 
 #[tokio::test]
 async fn unauthenticated_is_redirected_to_login() {
-    let status = send(state(), "GET", "/admin/specs", None).await;
-    assert!(
-        status.is_redirection(),
-        "no session ⇒ redirect to login, got {status}"
-    );
+    for uri in [
+        "/admin/specs",
+        "/admin/logs/poll?cursor=0",
+        "/admin/logs/stream",
+    ] {
+        let status = send(state(), "GET", uri, None).await;
+        assert!(
+            status.is_redirection(),
+            "no session ⇒ redirect to login on {uri}, got {status}"
+        );
+    }
 }
 
 // ── Inline image upload (#213) — same RequireEditor guard ───────────

--- a/crates/ruscker-admin/tests/user_accounts.rs
+++ b/crates/ruscker-admin/tests/user_accounts.rs
@@ -680,6 +680,63 @@ async fn logs_tab_distinguishes_empty_buffer_from_unwired() {
         !body.contains("Buffer de log não disponível"),
         "should not show the unwired-buffer message when a buffer exists"
     );
+    assert!(body.contains("/admin/logs/poll"), "poll endpoint missing");
+    assert!(
+        !body.contains("new EventSource"),
+        "the process-log page must not open a persistent connection"
+    );
+}
+
+/// #1039: process-log following uses finite cursor polling. This avoids an
+/// infinite HTTP/1.1 response being retained by a reverse proxy and blocking
+/// subsequent admin navigation on the same backend connection.
+#[tokio::test]
+async fn process_log_poll_is_incremental_and_legacy_sse_is_retired() {
+    let (mut state, _pool) = state_with_db().await;
+    let buffer = ruscker_admin::logbuf::LogBuffer::new(16);
+    buffer.push_line("first");
+    let cursor = buffer.cursor();
+    buffer.push_line("second");
+    state.log_buffer = Some(buffer);
+
+    let sid = state.admin_sessions.create(Role::Admin, None).await;
+    let cookie = format!("{COOKIE_NAME}={sid}");
+    let app = router(state);
+    let response = app
+        .clone()
+        .oneshot(
+            Request::builder()
+                .uri(format!("/admin/logs/poll?cursor={cursor}"))
+                .header("cookie", &cookie)
+                .body(Body::empty())
+                .unwrap(),
+        )
+        .await
+        .unwrap();
+    assert_eq!(response.status(), StatusCode::OK);
+    assert_eq!(
+        response.headers().get("cache-control").unwrap(),
+        "no-store"
+    );
+    let bytes = axum::body::to_bytes(response.into_body(), 1 << 20)
+        .await
+        .unwrap();
+    let body: serde_json::Value = serde_json::from_slice(&bytes).unwrap();
+    assert_eq!(body["lines"], serde_json::json!(["second"]));
+    assert_eq!(body["cursor"], (cursor + 1).to_string());
+    assert_eq!(body["available"], true);
+
+    let retired = app
+        .oneshot(
+            Request::builder()
+                .uri("/admin/logs/stream")
+                .header("cookie", cookie)
+                .body(Body::empty())
+                .unwrap(),
+        )
+        .await
+        .unwrap();
+    assert_eq!(retired.status(), StatusCode::NO_CONTENT);
 }
 
 #[tokio::test]


### PR DESCRIPTION
Closes #1039.

## Root cause

The process Logs page automatically held an infinite `EventSource` response open. In the production path, the load balancer talks HTTP/1.1 to nginx; a stale/reused backend connection could retain that response and head-of-line block a later admin navigation, which explains the UI hanging after several tab changes.

## What changed

- replace the automatic process-log SSE feed with finite cursor-based polling
- capture the initial tail and cursor under one lock so no line can fall between the server render and first poll
- stop polling while paused or hidden, prevent overlapping requests, and retry with bounded backoff
- return `204 No Content` from the legacy stream route so pre-deploy EventSource clients stop reconnecting during rollout
- preserve admin-only access and add regression coverage for cursor handoff, response shape, caching, legacy shutdown, and RBAC

Container-log live follow remains explicitly user-activated, and image-pull event streams remain finite.

## Validation

- `DOCKER_REGISTRY_PASSWORD=test cargo test -p ruscker-admin`
- `DOCKER_REGISTRY_PASSWORD=test cargo clippy --all-targets -- -D warnings`
- `./scripts/i18n-check.sh`
- `git diff --check`
