### PR TITLE
feat: evaluate cron schedules in a configured timezone (#1042)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -724,6 +724,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "chrono-tz"
+version = "0.10.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a6139a8597ed92cf816dfb33f5dd6cf0bb93a6adc938f11039f371bc5bcd26c3"
+dependencies = [
+ "chrono",
+ "phf 0.12.1",
+]
+
+[[package]]
 name = "cipher"
 version = "0.4.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -987,7 +997,7 @@ dependencies = [
  "cssparser-macros",
  "dtoa-short",
  "itoa",
- "phf",
+ "phf 0.13.1",
  "smallvec",
 ]
 
@@ -2594,12 +2604,21 @@ checksum = "9b4f627cb1b25917193a259e49bdad08f671f8d9708acfd5fe0a8c1455d87220"
 
 [[package]]
 name = "phf"
+version = "0.12.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "913273894cec178f401a31ec4b656318d95473527be05c0752cc41cdc32be8b7"
+dependencies = [
+ "phf_shared 0.12.1",
+]
+
+[[package]]
+name = "phf"
 version = "0.13.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c1562dc717473dbaa4c1f85a36410e03c047b2e7df7f45ee938fbef64ae7fadf"
 dependencies = [
  "phf_macros",
- "phf_shared",
+ "phf_shared 0.13.1",
  "serde",
 ]
 
@@ -2610,7 +2629,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "49aa7f9d80421bca176ca8dbfebe668cc7a2684708594ec9f3c0db0805d5d6e1"
 dependencies = [
  "phf_generator",
- "phf_shared",
+ "phf_shared 0.13.1",
 ]
 
 [[package]]
@@ -2620,7 +2639,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "135ace3a761e564ec88c03a77317a7c6b80bb7f7135ef2544dbe054243b89737"
 dependencies = [
  "fastrand",
- "phf_shared",
+ "phf_shared 0.13.1",
 ]
 
 [[package]]
@@ -2630,10 +2649,19 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "812f032b54b1e759ccd5f8b6677695d5268c588701effba24601f6932f8269ef"
 dependencies = [
  "phf_generator",
- "phf_shared",
+ "phf_shared 0.13.1",
  "proc-macro2",
  "quote",
  "syn",
+]
+
+[[package]]
+name = "phf_shared"
+version = "0.12.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "06005508882fb681fd97892ecff4b7fd0fee13ef1aa569f8695dae7ab9099981"
+dependencies = [
+ "siphasher",
 ]
 
 [[package]]
@@ -3014,6 +3042,7 @@ dependencies = [
  "base64",
  "brotli",
  "chrono",
+ "chrono-tz",
  "croner",
  "dashmap",
  "flate2",
@@ -3084,6 +3113,7 @@ name = "ruscker-config"
 version = "0.2.50"
 dependencies = [
  "chrono",
+ "chrono-tz",
  "ordered-float",
  "pretty_assertions",
  "regex",
@@ -3294,7 +3324,7 @@ dependencies = [
  "derive_more",
  "log",
  "new_debug_unreachable",
- "phf",
+ "phf 0.13.1",
  "phf_codegen",
  "precomputed-hash",
  "rustc-hash",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -63,6 +63,10 @@ regex = "1.12"
 url = "2.5.8"
 uuid = { version = "1.23", features = ["v4", "serde"] }
 chrono = { version = "0.4.44", features = ["serde"] }
+# IANA zone database, for evaluating cron schedules in the operator's
+# local time instead of UTC (#1042). Pure data + arithmetic — no I/O, so
+# it's admissible in the pure-domain `ruscker-config` crate.
+chrono-tz = "0.10"
 dashmap = "6.2"
 ordered-float = { version = "5.3", features = ["serde"] }
 

--- a/book/src/admin.md
+++ b/book/src/admin.md
@@ -352,7 +352,13 @@ nothing to run.
 Semantics worth knowing:
 
 - **No run on creation.** A new schedule waits for its next cron
-  occurrence (times are UTC).
+  occurrence.
+- **Which clock.** Cron expressions are evaluated in `server.timezone`
+  (an IANA name like `America/Recife` in `ruscker.yml`), and the
+  next/last run columns are shown in that same zone, labelled with it.
+  Unset ⇒ **UTC**, the historical behaviour — so `0 8 * * *` fires at
+  08:00 UTC until you configure a zone. Setting one shifts existing
+  schedules by your offset; review them afterwards.
 - **Downtime collapses.** If the server was down across several
   occurrences, the schedule fires **once** on the next tick — ETL
   semantics, not a message queue.
@@ -450,9 +456,9 @@ too; rows with a change diff expand to show it.
 
 Timestamps are stored in UTC and rendered in **your browser's timezone**, so
 two operators in different zones each read the local wall clock of the same
-event. Hovering a timestamp shows the full date with the zone name. (The
-scheduler's own times — next occurrence and last run on the Schedules page —
-are still labelled UTC.)
+event. Hovering a timestamp shows the full date with the zone name. (The Schedules page is
+deliberately different: those times are when the *server* will fire a job,
+so they follow `server.timezone` — see the Schedules section.)
 
 ### System
 

--- a/crates/ruscker-admin/Cargo.toml
+++ b/crates/ruscker-admin/Cargo.toml
@@ -84,6 +84,7 @@ serde = { workspace = true }
 serde_json = { workspace = true }
 serde_yaml_ng = { workspace = true }
 chrono = { workspace = true }
+chrono-tz = { workspace = true }
 regex = { workspace = true }
 url = { workspace = true }
 uuid = { workspace = true }

--- a/crates/ruscker-admin/assets/i18n/en/landing.ftl
+++ b/crates/ruscker-admin/assets/i18n/en/landing.ftl
@@ -993,7 +993,7 @@ admin-schedules-subtitle = Run an app's image to completion on a cron schedule (
 admin-schedules-create = New schedule
 admin-schedules-spec = App
 admin-schedules-cron = Cron
-admin-schedules-cron-help = Standard 5-field cron, UTC. Examples: "0 3 * * *" = every day at 03:00; "*/15 * * * *" = every 15 minutes.
+admin-schedules-cron-help = Standard 5-field cron, in the server timezone. Examples: "0 3 * * *" = every day at 03:00; "*/15 * * * *" = every 15 minutes.
 admin-schedules-cmd = Command
 admin-schedules-cmd-help = One line per argument (argv). Empty = the app's own command (its container-cmd, else the image's CMD).
 admin-schedules-timeout = Timeout (minutes)

--- a/crates/ruscker-admin/assets/i18n/es/landing.ftl
+++ b/crates/ruscker-admin/assets/i18n/es/landing.ftl
@@ -993,7 +993,7 @@ admin-schedules-subtitle = Ejecuta la imagen de una app hasta terminar según un
 admin-schedules-create = Nueva programación
 admin-schedules-spec = App
 admin-schedules-cron = Cron
-admin-schedules-cron-help = Cron estándar de 5 campos, en UTC. Ejemplos: "0 3 * * *" = cada día a las 03:00; "*/15 * * * *" = cada 15 minutos.
+admin-schedules-cron-help = Cron estándar de 5 campos, en el huso horario del servidor. Ejemplos: "0 3 * * *" = cada día a las 03:00; "*/15 * * * *" = cada 15 minutos.
 admin-schedules-cmd = Comando
 admin-schedules-cmd-help = Un argumento por línea (argv). Vacío = el comando de la propia app (su container-cmd, si no el CMD de la imagen).
 admin-schedules-timeout = Timeout (minutos)

--- a/crates/ruscker-admin/assets/i18n/fr/landing.ftl
+++ b/crates/ruscker-admin/assets/i18n/fr/landing.ftl
@@ -993,7 +993,7 @@ admin-schedules-subtitle = Exécute l'image d'une app jusqu'au bout selon un hor
 admin-schedules-create = Nouvelle planification
 admin-schedules-spec = App
 admin-schedules-cron = Cron
-admin-schedules-cron-help = Cron standard à 5 champs, en UTC. Exemples : "0 3 * * *" = chaque jour à 03:00 ; "*/15 * * * *" = toutes les 15 minutes.
+admin-schedules-cron-help = Cron standard à 5 champs, dans le fuseau horaire du serveur. Exemples : "0 3 * * *" = chaque jour à 03:00 ; "*/15 * * * *" = toutes les 15 minutes.
 admin-schedules-cmd = Commande
 admin-schedules-cmd-help = Un argument par ligne (argv). Vide = la commande de l'app elle-même (son container-cmd, sinon le CMD de l'image).
 admin-schedules-timeout = Timeout (minutes)

--- a/crates/ruscker-admin/assets/i18n/pt/landing.ftl
+++ b/crates/ruscker-admin/assets/i18n/pt/landing.ftl
@@ -997,7 +997,7 @@ admin-schedules-subtitle = Executa a imagem de um app até o fim em um horário 
 admin-schedules-create = Novo agendamento
 admin-schedules-spec = App
 admin-schedules-cron = Cron
-admin-schedules-cron-help = Cron padrão de 5 campos, em UTC. Exemplos: "0 3 * * *" = todo dia às 03:00; "*/15 * * * *" = a cada 15 minutos.
+admin-schedules-cron-help = Cron padrão de 5 campos, no fuso horário do servidor. Exemplos: "0 3 * * *" = todo dia às 03:00; "*/15 * * * *" = a cada 15 minutos.
 admin-schedules-cmd = Comando
 admin-schedules-cmd-help = Um argumento por linha (argv). Vazio = o comando do próprio app (o container-cmd, senão o CMD da imagem).
 admin-schedules-timeout = Timeout (minutos)

--- a/crates/ruscker-admin/src/jobs.rs
+++ b/crates/ruscker-admin/src/jobs.rs
@@ -37,10 +37,11 @@ pub const TICK: Duration = Duration::from_secs(30);
 /// zone and is converted to UTC for storage and comparison, which are
 /// zone-free throughout.
 ///
-/// DST is croner's problem, and it has one: for a spring-forward gap
-/// the next matching local time simply doesn't exist that day, and for
-/// a fall-back repeat it returns the first of the two. Both are the
-/// conventional cron behaviours.
+/// DST is croner's to resolve, and it does so sanely — verified, not
+/// assumed, in `dst_transitions_neither_skip_nor_duplicate_a_run`: a
+/// spring-forward gap fires at the transition instant (the run is not
+/// lost) and a fall-back repeat fires only on the first of the two
+/// (no duplicate run).
 ///
 /// Public so the Schedules page computes "next run" through the very
 /// same function the scheduler fires on — a UI that disagreed with the
@@ -362,6 +363,60 @@ mod tests {
             next_occurrence("0 8 * * *", dst_era, sp).unwrap().to_rfc3339(),
             "2018-01-01T10:00:00+00:00"
         );
+    }
+
+
+    /// What croner ACTUALLY does across a DST transition, pinned here
+    /// because both plausible guesses are wrong and the answer decides
+    /// whether a nightly ETL silently skips or double-runs. Lisbon,
+    /// which still observes EU DST (Brazil dropped it in 2019).
+    #[test]
+    fn dst_transitions_neither_skip_nor_duplicate_a_run() {
+        let lisbon = chrono_tz::Europe::Lisbon;
+
+        // Spring forward, 2026-03-29: 01:00 WET → 02:00 WEST, so a
+        // 01:30 local never happens that day. The run is NOT skipped —
+        // croner lands on the transition instant itself (01:00 UTC),
+        // i.e. the job fires as the clock jumps.
+        let before: DateTime<Utc> = "2026-03-28T12:00:00Z".parse().unwrap();
+        assert_eq!(
+            next_occurrence("30 1 * * *", before, lisbon).unwrap().to_rfc3339(),
+            "2026-03-29T01:00:00+00:00"
+        );
+
+        // Fall back, 2026-10-25: 02:00 WEST → 01:00 WET, so 01:30 local
+        // happens twice. Croner takes the FIRST (00:30 UTC) and then
+        // moves to the next day — the repeat does not fire a second run.
+        let fb: DateTime<Utc> = "2026-10-24T12:00:00Z".parse().unwrap();
+        assert_eq!(
+            next_occurrence("30 1 * * *", fb, lisbon).unwrap().to_rfc3339(),
+            "2026-10-25T00:30:00+00:00"
+        );
+        let after_first: DateTime<Utc> = "2026-10-25T00:45:00Z".parse().unwrap();
+        assert_eq!(
+            next_occurrence("30 1 * * *", after_first, lisbon).unwrap().to_rfc3339(),
+            "2026-10-26T01:30:00+00:00",
+            "the second 01:30 must not fire a duplicate run"
+        );
+    }
+
+    /// Adopting a zone on an install that already has schedules can fire
+    /// one EXTRA run on the switch-over day: the fire marker is a UTC
+    /// instant, and re-reading the same expression on a westward clock
+    /// puts today's occurrence later than the marker. Pinned so the
+    /// behaviour is a documented consequence rather than a surprise —
+    /// it's why the docs tell operators to review their schedules after
+    /// setting `server.timezone`.
+    #[test]
+    fn adopting_a_zone_can_refire_on_the_switchover_day() {
+        // Fired today at 08:00 UTC under the old (UTC) behaviour…
+        let s = sched("0 8 * * *", Some("2026-07-29T08:00:00Z"), "2026-07-01T00:00:00Z");
+        let noon: DateTime<Utc> = "2026-07-29T12:00:00Z".parse().unwrap();
+        // …under UTC it is done for the day…
+        assert!(!is_due(&s, noon, chrono_tz::UTC));
+        // …but under Recife today's 08:00 local (11:00 UTC) is still
+        // ahead of the marker, so it runs once more.
+        assert!(is_due(&s, noon, chrono_tz::America::Recife));
     }
 
     #[test]

--- a/crates/ruscker-admin/src/jobs.rs
+++ b/crates/ruscker-admin/src/jobs.rs
@@ -28,18 +28,42 @@ pub const TICK: Duration = Duration::from_secs(30);
 /// The next occurrence of `cron` strictly after `after`, or `None`
 /// for an unparseable expression (surfaced by the caller once — a bad
 /// expression must not wedge the tick).
-fn next_occurrence(cron: &str, after: DateTime<Utc>) -> Option<DateTime<Utc>> {
+///
+/// The cron fields are matched against the **wall clock in `tz`**
+/// (`server.timezone`, UTC when unset — #1042): an operator writing
+/// `0 8 * * *` means eight in the morning where they live. Croner does
+/// the matching on `start_time.naive_local()`, so handing it a
+/// `DateTime<Tz>` is all it takes; the result comes back in the same
+/// zone and is converted to UTC for storage and comparison, which are
+/// zone-free throughout.
+///
+/// DST is croner's problem, and it has one: for a spring-forward gap
+/// the next matching local time simply doesn't exist that day, and for
+/// a fall-back repeat it returns the first of the two. Both are the
+/// conventional cron behaviours.
+///
+/// Public so the Schedules page computes "next run" through the very
+/// same function the scheduler fires on — a UI that disagreed with the
+/// runner about when a job fires would be worse than no UI.
+pub fn next_occurrence(
+    cron: &str,
+    after: DateTime<Utc>,
+    tz: chrono_tz::Tz,
+) -> Option<DateTime<Utc>> {
     let parsed: croner::Cron = cron.parse().ok()?;
-    parsed.find_next_occurrence(&after, false).ok()
+    parsed
+        .find_next_occurrence(&after.with_timezone(&tz), false)
+        .ok()
+        .map(|dt| dt.with_timezone(&Utc))
 }
 
 /// Whether `schedule` is due at `now`: its cron has an occurrence in
 /// `(anchor, now]`, where the anchor is the last fire marker (or the
 /// schedule's creation, so a brand-new "every day at 03:00" waits for
 /// 03:00 instead of firing on creation).
-fn is_due(schedule: &Schedule, now: DateTime<Utc>) -> bool {
+fn is_due(schedule: &Schedule, now: DateTime<Utc>, tz: chrono_tz::Tz) -> bool {
     let anchor = schedule.last_run_at.unwrap_or(schedule.created_at);
-    match next_occurrence(&schedule.cron, anchor) {
+    match next_occurrence(&schedule.cron, anchor, tz) {
         Some(next) => next <= now,
         None => false,
     }
@@ -116,8 +140,11 @@ async fn tick(state: &AppState) {
         }
     };
     let now = Utc::now();
+    // One zone for the whole pass, so two schedules in the same tick
+    // can't disagree about what "08:00" means.
+    let tz = state.config.server.effective_timezone();
     for schedule in schedules.into_iter().filter(|s| s.enabled) {
-        if next_occurrence(&schedule.cron, now).is_none() {
+        if next_occurrence(&schedule.cron, now, tz).is_none() {
             tracing::warn!(
                 schedule = schedule.id,
                 spec = %schedule.spec_id,
@@ -126,7 +153,7 @@ async fn tick(state: &AppState) {
             );
             continue;
         }
-        if !is_due(&schedule, now) {
+        if !is_due(&schedule, now, tz) {
             continue;
         }
         // Claim BEFORE running — a crash mid-job must not double-fire,
@@ -275,23 +302,72 @@ mod tests {
     fn due_when_an_occurrence_passed_since_the_anchor() {
         let now: DateTime<Utc> = "2026-07-13T03:05:00Z".parse().unwrap();
         // Daily at 03:00, last fired yesterday 03:00 → due.
-        assert!(is_due(&sched("0 3 * * *", Some("2026-07-12T03:00:30Z"), "2026-07-01T00:00:00Z"), now));
+        assert!(is_due(&sched("0 3 * * *", Some("2026-07-12T03:00:30Z"), "2026-07-01T00:00:00Z"), now, chrono_tz::UTC));
         // Already fired today at 03:00 → not due again.
-        assert!(!is_due(&sched("0 3 * * *", Some("2026-07-13T03:00:30Z"), "2026-07-01T00:00:00Z"), now));
+        assert!(!is_due(&sched("0 3 * * *", Some("2026-07-13T03:00:30Z"), "2026-07-01T00:00:00Z"), now, chrono_tz::UTC));
         // Brand new schedule created at 02:00 today → 03:00 passed → due.
-        assert!(is_due(&sched("0 3 * * *", None, "2026-07-13T02:00:00Z"), now));
+        assert!(is_due(&sched("0 3 * * *", None, "2026-07-13T02:00:00Z"), now, chrono_tz::UTC));
         // Brand new created at 04:00 → next is tomorrow → NOT due (no
         // fire-on-create).
         let later: DateTime<Utc> = "2026-07-13T04:10:00Z".parse().unwrap();
-        assert!(!is_due(&sched("0 3 * * *", None, "2026-07-13T04:00:00Z"), later));
+        assert!(!is_due(&sched("0 3 * * *", None, "2026-07-13T04:00:00Z"), later, chrono_tz::UTC));
         // Downtime over several occurrences collapses to one firing.
-        assert!(is_due(&sched("0 3 * * *", Some("2026-07-09T03:00:00Z"), "2026-07-01T00:00:00Z"), now));
+        assert!(is_due(&sched("0 3 * * *", Some("2026-07-09T03:00:00Z"), "2026-07-01T00:00:00Z"), now, chrono_tz::UTC));
+    }
+
+    /// The whole point of #1042: `0 8 * * *` under `America/Recife`
+    /// means 08:00 THERE, i.e. 11:00 UTC. Firing at 08:00 UTC (05:00
+    /// local) is the bug this fixes.
+    #[test]
+    fn cron_is_evaluated_in_the_configured_zone() {
+        let recife = chrono_tz::America::Recife;
+        let anchor: DateTime<Utc> = "2026-07-12T12:00:00Z".parse().unwrap();
+        assert_eq!(
+            next_occurrence("0 8 * * *", anchor, recife).unwrap().to_rfc3339(),
+            "2026-07-13T11:00:00+00:00"
+        );
+        // Same expression, no zone configured → unchanged behaviour.
+        assert_eq!(
+            next_occurrence("0 8 * * *", anchor, chrono_tz::UTC).unwrap().to_rfc3339(),
+            "2026-07-13T08:00:00+00:00"
+        );
+
+        // And the due check follows: at 08:05 UTC the Recife job has NOT
+        // fired yet (it is 05:05 there); at 11:05 UTC it has.
+        let sched = sched("0 8 * * *", Some("2026-07-12T11:00:30Z"), "2026-07-01T00:00:00Z");
+        let morning_utc: DateTime<Utc> = "2026-07-13T08:05:00Z".parse().unwrap();
+        let morning_local: DateTime<Utc> = "2026-07-13T11:05:00Z".parse().unwrap();
+        assert!(!is_due(&sched, morning_utc, recife));
+        assert!(is_due(&sched, morning_local, recife));
+        // Under UTC the same schedule is due at 08:05 — the old behaviour,
+        // which an upgrade must preserve for anyone who sets nothing.
+        assert!(is_due(&sched, morning_utc, chrono_tz::UTC));
+    }
+
+    /// A zone whose offset changes across the year must be read from the
+    /// zone database, not frozen: São Paulo is −03 in July and was −02
+    /// under DST in January. (Brazil dropped DST in 2019, so the January
+    /// case is historical — which is exactly why a hardcoded offset
+    /// would be wrong and a zone name is right.)
+    #[test]
+    fn zone_offset_follows_the_date() {
+        let sp = chrono_tz::America::Sao_Paulo;
+        let winter: DateTime<Utc> = "2026-07-01T00:00:00Z".parse().unwrap();
+        assert_eq!(
+            next_occurrence("0 8 * * *", winter, sp).unwrap().to_rfc3339(),
+            "2026-07-01T11:00:00+00:00"
+        );
+        let dst_era: DateTime<Utc> = "2018-01-01T00:00:00Z".parse().unwrap();
+        assert_eq!(
+            next_occurrence("0 8 * * *", dst_era, sp).unwrap().to_rfc3339(),
+            "2018-01-01T10:00:00+00:00"
+        );
     }
 
     #[test]
     fn unparseable_cron_is_never_due() {
         let now = Utc::now();
-        assert!(!is_due(&sched("not a cron", None, "2026-07-01T00:00:00Z"), now));
-        assert!(next_occurrence("61 99 * * *", now).is_none());
+        assert!(!is_due(&sched("not a cron", None, "2026-07-01T00:00:00Z"), now, chrono_tz::UTC));
+        assert!(next_occurrence("61 99 * * *", now, chrono_tz::UTC).is_none());
     }
 }

--- a/crates/ruscker-admin/src/lib.rs
+++ b/crates/ruscker-admin/src/lib.rs
@@ -637,6 +637,11 @@ impl AdminServer {
             db = db_kind,
             specs = self.state.config.proxy.specs.len(),
             images_dir = ?self.images_dir,
+            // The scheduler's clock (#1042). Worth a line in the banner:
+            // an operator who set `timezone` in the wrong file or section
+            // gets a silent UTC fallback otherwise, and would only find
+            // out when a nightly job fires hours off.
+            timezone = self.state.config.server.effective_timezone().name(),
             "ruscker started — listening"
         );
         // `into_make_service_with_connect_info` exposes the TCP peer

--- a/crates/ruscker-admin/src/routes/admin/schedules_ui.rs
+++ b/crates/ruscker-admin/src/routes/admin/schedules_ui.rs
@@ -44,10 +44,10 @@ struct ScheduleRow {
     /// First line of the argv override, or an em dash for "the spec's
     /// own command".
     cmd_summary: String,
-    /// `YYYY-MM-DD HH:MM UTC`, or an em dash when the schedule is
-    /// disabled or its cron no longer parses.
+    /// `YYYY-MM-DD HH:MM <zone>` in the scheduler's timezone, or an em
+    /// dash when the schedule is disabled or its cron no longer parses.
     next_run: String,
-    /// `YYYY-MM-DD HH:MM UTC`, or an em dash before the first fire.
+    /// `YYYY-MM-DD HH:MM <zone>`, or an em dash before the first fire.
     last_run: String,
     enabled: bool,
 }
@@ -82,6 +82,11 @@ struct SchedulesPage<'a> {
     kpi_jobs: i64,
     kpi_active: i64,
     kpi_recent_failures: i64,
+    /// The scheduler's zone, spelled out for the cron field's help text
+    /// (`America/Recife`, or `UTC` when unconfigured) — an operator
+    /// writing an expression shouldn't have to open `ruscker.yml` to
+    /// learn which clock it will be read in (#1042).
+    tz_label: String,
     flash: Option<&'static str>,
     flash_error: bool,
 }
@@ -110,23 +115,35 @@ impl SchedulesPage<'_> {
 
 /// `2026-07-13T03:00:12Z` → `2026-07-13 03:00 UTC` — minute precision
 /// is all a cron UI needs.
-fn fmt_utc(dt: &DateTime<Utc>) -> String {
-    dt.format("%Y-%m-%d %H:%M UTC").to_string()
+///
+/// Rendered in the SCHEDULER's zone (`server.timezone`, UTC when unset
+/// — #1042), not the viewer's: these times are when the server will
+/// fire a job, and the operator writing the cron expression needs to
+/// read them in the same clock they wrote it in. That's the opposite
+/// call from the admin tables (#1041), which are records of past
+/// events and follow each viewer's browser. `%Z` labels the zone, so
+/// an unconfigured install still reads exactly `… UTC` as before.
+fn fmt_dt(dt: &DateTime<Utc>, tz: chrono_tz::Tz) -> String {
+    dt.with_timezone(&tz).format("%Y-%m-%d %H:%M %Z").to_string()
 }
 
 /// The schedule's next occurrence, from the same anchor the scheduler
 /// uses ([`crate::jobs`]): the last fire marker, or creation for a
 /// schedule that never fired (no fire-on-create). `None` when the
 /// stored cron no longer parses.
-fn next_run(schedule: &Schedule) -> Option<DateTime<Utc>> {
+///
+/// Delegates to [`crate::jobs::next_occurrence`] instead of re-deriving
+/// it, so the page can't drift from the runner — it used to hold its
+/// own copy of the croner call, which would now have silently kept
+/// computing in UTC while the scheduler moved to the configured zone.
+fn next_run(schedule: &Schedule, tz: chrono_tz::Tz) -> Option<DateTime<Utc>> {
     let anchor = schedule.last_run_at.unwrap_or(schedule.created_at);
-    let parsed: croner::Cron = schedule.cron.parse().ok()?;
-    parsed.find_next_occurrence(&anchor, false).ok()
+    crate::jobs::next_occurrence(&schedule.cron, anchor, tz)
 }
 
-fn schedule_row(s: Schedule) -> ScheduleRow {
+fn schedule_row(s: Schedule, tz: chrono_tz::Tz) -> ScheduleRow {
     let next = if s.enabled {
-        next_run(&s).map(|dt| fmt_utc(&dt))
+        next_run(&s, tz).map(|dt| fmt_dt(&dt, tz))
     } else {
         None // a disabled schedule has no next fire
     };
@@ -136,7 +153,10 @@ fn schedule_row(s: Schedule) -> ScheduleRow {
             .and_then(|argv| argv.first().cloned())
             .unwrap_or_else(|| "—".to_string()),
         next_run: next.unwrap_or_else(|| "—".to_string()),
-        last_run: s.last_run_at.map(|dt| fmt_utc(&dt)).unwrap_or_else(|| "—".to_string()),
+        last_run: s
+            .last_run_at
+            .map(|dt| fmt_dt(&dt, tz))
+            .unwrap_or_else(|| "—".to_string()),
         id: s.id,
         spec_id: s.spec_id,
         cron: s.cron,
@@ -153,10 +173,10 @@ fn fmt_duration(ms: Option<i64>) -> String {
     }
 }
 
-fn run_view(r: RunRow) -> RunView {
+fn run_view(r: RunRow, tz: chrono_tz::Tz) -> RunView {
     RunView {
         spec_id: r.spec_id,
-        started: fmt_utc(&r.started_at),
+        started: fmt_dt(&r.started_at, tz),
         status: r.status,
         exit_code: r.exit_code.map(|c| c.to_string()).unwrap_or_else(|| "—".to_string()),
         duration: fmt_duration(r.duration_ms),
@@ -220,6 +240,10 @@ async fn index(
     let kpi_active = schedules.iter().filter(|schedule| schedule.enabled).count() as i64;
     let kpi_recent_failures = runs.iter().filter(|run| run.status != "ok").count() as i64;
 
+    // The scheduler's zone — every time on this page is a server firing
+    // time, so they all render in it (#1042).
+    let tz = state.config.server.effective_timezone();
+
     super::render(&SchedulesPage {
         locale: loc,
         theme,
@@ -229,11 +253,12 @@ async fn index(
         nav_section: "schedules",
         role: admin.role,
         specs,
-        schedules: schedules.into_iter().map(schedule_row).collect(),
-        runs: runs.into_iter().map(run_view).collect(),
+        schedules: schedules.into_iter().map(|s| schedule_row(s, tz)).collect(),
+        runs: runs.into_iter().map(|r| run_view(r, tz)).collect(),
         kpi_jobs,
         kpi_active,
         kpi_recent_failures,
+        tz_label: tz.name().to_string(),
         flash,
         flash_error,
     })
@@ -421,19 +446,56 @@ mod tests {
     #[test]
     fn schedule_row_formats_next_and_last_run() {
         // Fired 2026-07-12 03:00 → next daily 03:00 is the 13th.
-        let row = schedule_row(sched("0 3 * * *", true, Some("2026-07-12T03:00:10Z")));
+        let row = schedule_row(
+            sched("0 3 * * *", true, Some("2026-07-12T03:00:10Z")),
+            chrono_tz::UTC,
+        );
         assert_eq!(row.next_run, "2026-07-13 03:00 UTC");
         assert_eq!(row.last_run, "2026-07-12 03:00 UTC");
         assert_eq!(row.cmd_summary, "Rscript");
 
         // Disabled → no next fire; never fired → em-dash last run.
-        let row = schedule_row(sched("0 3 * * *", false, None));
+        let row = schedule_row(sched("0 3 * * *", false, None), chrono_tz::UTC);
         assert_eq!(row.next_run, "—");
         assert_eq!(row.last_run, "—");
 
         // A stored cron that no longer parses can't show a next run.
-        let row = schedule_row(sched("not a cron", true, None));
+        let row = schedule_row(sched("not a cron", true, None), chrono_tz::UTC);
         assert_eq!(row.next_run, "—");
+    }
+
+    /// With a zone configured, the page reports the firing time on the
+    /// operator's clock — and the STORED instant is unchanged, so this
+    /// is purely how it reads (#1042). `0 3 * * *` in Recife fires at
+    /// 06:00 UTC; the row must say 03:00, not 06:00, or the operator
+    /// can't tell whether their cron means what they wrote.
+    #[test]
+    fn schedule_row_renders_in_the_configured_zone() {
+        let row = schedule_row(
+            sched("0 3 * * *", true, Some("2026-07-12T06:00:10Z")),
+            chrono_tz::America::Recife,
+        );
+        assert_eq!(row.next_run, "2026-07-13 03:00 -03");
+        assert_eq!(row.last_run, "2026-07-12 03:00 -03");
+    }
+
+    /// The page's "next run" must be the very instant the scheduler
+    /// will fire on. Both go through `jobs::next_occurrence`, and this
+    /// pins them together: the same schedule, the same zone, one answer.
+    #[test]
+    fn page_next_run_matches_the_scheduler() {
+        let s = sched("0 8 * * *", true, Some("2026-07-12T11:00:00Z"));
+        let tz = chrono_tz::America::Recife;
+        let anchor = s.last_run_at.unwrap();
+        assert_eq!(
+            next_run(&s, tz),
+            crate::jobs::next_occurrence("0 8 * * *", anchor, tz)
+        );
+        // …and that instant is 08:00 local = 11:00 UTC, not 08:00 UTC.
+        assert_eq!(
+            next_run(&s, tz).unwrap().to_rfc3339(),
+            "2026-07-13T11:00:00+00:00"
+        );
     }
 
     #[test]

--- a/crates/ruscker-admin/templates/admin/schedules.html
+++ b/crates/ruscker-admin/templates/admin/schedules.html
@@ -49,7 +49,10 @@
         <span class="admin-login-label">{{ self.t("admin-schedules-cron") }}</span>
         <input type="text" name="cron" required placeholder="0 3 * * *"
                autocapitalize="none" spellcheck="false" class="dash-mono">
-        <span class="text-xs text-[color:var(--text-faint)] mt-1">{{ self.t("admin-schedules-cron-help") }}</span>
+        {# The zone itself is data, not a translatable string — appended
+           so the operator sees which clock their expression will be read
+           in without having to open ruscker.yml (#1042). #}
+        <span class="text-xs text-[color:var(--text-faint)] mt-1">{{ self.t("admin-schedules-cron-help") }} ({{ tz_label }})</span>
       </label>
 
       <label class="admin-login-field" style="margin:0">

--- a/crates/ruscker-cli/src/main.rs
+++ b/crates/ruscker-cli/src/main.rs
@@ -1000,6 +1000,13 @@ fn format_warning(w: &Warning) -> String {
                  (expected a size like `10m`, `1g`, or plain bytes) — no limit will be applied"
             )
         }
+        Warning::UnknownTimezone { value } => {
+            format!(
+                "server.timezone `{value}` is not an IANA zone name \
+                 (expected e.g. `America/Recife`, not an abbreviation like `BRT`) — \
+                 scheduled jobs will keep firing on UTC"
+            )
+        }
         Warning::InvalidCpuLimit {
             spec_id,
             field,

--- a/crates/ruscker-config/Cargo.toml
+++ b/crates/ruscker-config/Cargo.toml
@@ -13,6 +13,7 @@ thiserror = { workspace = true }
 regex = { workspace = true }
 tracing = { workspace = true }
 chrono = { workspace = true }
+chrono-tz = { workspace = true }
 ordered-float = { workspace = true }
 
 [dev-dependencies]

--- a/crates/ruscker-config/src/schema.rs
+++ b/crates/ruscker-config/src/schema.rs
@@ -80,6 +80,23 @@ pub struct Server {
     /// [`Self::effective_base_path`] when the flat form isn't set.
     #[serde(rename = "servlet.context-path")]
     pub flat_servlet_context_path: Option<String>,
+
+    /// IANA timezone name (e.g. `America/Recife`) the **scheduler**
+    /// evaluates cron expressions in, and the Schedules page displays
+    /// its times in (#1042). An operator writing `0 8 * * *` means
+    /// eight in the morning where they live, not 08:00 UTC.
+    ///
+    /// Absent ⇒ **UTC**, which is the behaviour every existing install
+    /// already has: an upgrade must not silently move the firing time
+    /// of schedules that are running in production. Unparseable names
+    /// also fall back to UTC and raise a validation warning rather
+    /// than failing the boot — a typo here must not take the portal
+    /// down.
+    ///
+    /// This does NOT affect the admin tables (audit, activity, …):
+    /// those render in each viewer's own browser timezone (#1041).
+    /// The scheduler has no viewer, which is why it needs a setting.
+    pub timezone: Option<String>,
 }
 
 impl Server {
@@ -95,6 +112,20 @@ impl Server {
             .or(self.flat_servlet_context_path.as_deref())
             .unwrap_or("");
         normalize_base_path(raw)
+    }
+
+    /// The zone [`Self::timezone`] names, or UTC when it is unset,
+    /// empty or unparseable. Never fails: an invalid name is reported
+    /// by `validate` (as [`crate::validate::Warning::UnknownTimezone`])
+    /// and behaves as the historical UTC default, so a typo degrades
+    /// to "what it did before" instead of wedging the scheduler.
+    pub fn effective_timezone(&self) -> chrono_tz::Tz {
+        self.timezone
+            .as_deref()
+            .map(str::trim)
+            .filter(|s| !s.is_empty())
+            .and_then(|s| s.parse::<chrono_tz::Tz>().ok())
+            .unwrap_or(chrono_tz::UTC)
     }
 }
 
@@ -2002,6 +2033,49 @@ mod tests {
         };
         assert_eq!(both.effective_base_path(), "/a");
         assert_eq!(Server::default().effective_base_path(), "");
+    }
+
+    /// `server.timezone` resolves to an IANA zone, and every way of NOT
+    /// naming one lands on UTC — the historical default, so an upgrade
+    /// can't move a production schedule's firing time (#1042).
+    #[test]
+    fn server_timezone_falls_back_to_utc() {
+        let named = Server {
+            timezone: Some("America/Recife".into()),
+            ..Default::default()
+        };
+        assert_eq!(named.effective_timezone(), chrono_tz::America::Recife);
+
+        assert_eq!(Server::default().effective_timezone(), chrono_tz::UTC);
+        for absent in ["", "   ", "BRT", "Mars/Olympus_Mons"] {
+            let s = Server {
+                timezone: Some(absent.into()),
+                ..Default::default()
+            };
+            assert_eq!(
+                s.effective_timezone(),
+                chrono_tz::UTC,
+                "`{absent}` must degrade to UTC, not panic"
+            );
+        }
+        // Surrounding whitespace is an editing artefact, not a new zone.
+        let padded = Server {
+            timezone: Some("  America/Recife  ".into()),
+            ..Default::default()
+        };
+        assert_eq!(padded.effective_timezone(), chrono_tz::America::Recife);
+    }
+
+    #[test]
+    fn server_timezone_parses_from_yaml() {
+        let cfg: Config = serde_yaml_ng::from_str(
+            "server:\n  timezone: America/Recife\nproxy:\n  specs: []\n",
+        )
+        .expect("parse");
+        assert_eq!(
+            cfg.server.effective_timezone(),
+            chrono_tz::America::Recife
+        );
     }
 
     #[test]

--- a/crates/ruscker-config/src/validate.rs
+++ b/crates/ruscker-config/src/validate.rs
@@ -118,6 +118,14 @@ pub enum Warning {
         location: String,
         value: String,
     },
+    /// `server.timezone` isn't a name in the IANA zone database
+    /// (a typo, or an abbreviation like `BRT` rather than the zone
+    /// `America/Recife`). The scheduler falls back to UTC, so cron
+    /// expressions keep firing at UTC o'clock instead of the intended
+    /// local time — silent and easy to miss for a nightly job (#1042).
+    UnknownTimezone {
+        value: String,
+    },
     /// `container-cpu-limit` / `container-cpu-request` is set but isn't
     /// a positive, finite number of CPUs (e.g. `0,5` with a comma, `-1`,
     /// `abc`). The backend applies *no* CPU limit in that case, so the
@@ -426,6 +434,17 @@ pub fn run(config: &Config) -> ValidationReport {
             location: "proxy".to_string(),
             value: config.proxy.max_body_size.clone().unwrap_or_default(),
         });
+    }
+
+    // A timezone that doesn't resolve leaves the scheduler on UTC —
+    // the very default the operator was trying to move off (#1042).
+    if let Some(raw) = config.server.timezone.as_deref() {
+        let named = raw.trim();
+        if !named.is_empty() && named.parse::<chrono_tz::Tz>().is_err() {
+            warnings.push(Warning::UnknownTimezone {
+                value: named.to_string(),
+            });
+        }
     }
 
     check_hosts(&config.proxy.hosts, &mut warnings);
@@ -1021,6 +1040,39 @@ proxy:
             "valid rate-limit should not warn, got {:?}",
             report.warnings
         );
+    }
+
+    /// A zone name that isn't in the IANA database must be reported —
+    /// it silently leaves the scheduler on UTC, which is the very thing
+    /// the operator was configuring away from (#1042).
+    #[test]
+    fn flags_unknown_timezone() {
+        let yaml = "server:\n  timezone: BRT\nproxy:\n  specs: []\n";
+        let report = Config::from_yaml(yaml).expect("parse").validate();
+        assert!(
+            report.warnings.iter().any(|w| matches!(
+                w,
+                Warning::UnknownTimezone { value } if value == "BRT"
+            )),
+            "expected UnknownTimezone, got {:?}",
+            report.warnings
+        );
+
+        // A real zone, and no zone at all, are both quiet.
+        for yaml in [
+            "server:\n  timezone: America/Recife\nproxy:\n  specs: []\n",
+            "proxy:\n  specs: []\n",
+        ] {
+            let report = Config::from_yaml(yaml).expect("parse").validate();
+            assert!(
+                !report
+                    .warnings
+                    .iter()
+                    .any(|w| matches!(w, Warning::UnknownTimezone { .. })),
+                "should not warn for `{yaml}`, got {:?}",
+                report.warnings
+            );
+        }
     }
 
     #[test]

--- a/docs/YAML_SCHEMA.md
+++ b/docs/YAML_SCHEMA.md
@@ -27,6 +27,7 @@ server:
   context-path: /apps                  # Mount portal under a subpath (see below)
   # ShinyProxy's nested form is also accepted:
   servlet.context-path: /apps
+  timezone: America/Recife             # Zone the SCHEDULER uses (see below)
 ```
 
 Parsed for compatibility but **ignored** (each produces a startup
@@ -53,6 +54,32 @@ replaced). **If a reverse proxy terminates TLS in front of Ruscker,
 set it to `true`** — otherwise cookies are minted without `Secure`.
 ShinyProxy's `secure-cookies` flag is *not* what does this in Ruscker;
 it's ignored. Full rationale in `docs/SECURITY.md` §7.
+
+### `server.timezone` — the scheduler's clock
+
+An [IANA zone name](https://en.wikipedia.org/wiki/List_of_tz_database_time_zones)
+(`America/Recife`, `Europe/Lisbon`, …) telling the **scheduled-jobs
+runner** which wall clock a cron expression refers to. `0 8 * * *`
+under `America/Recife` fires at 08:00 there — 11:00 UTC — instead of
+08:00 UTC. The Schedules page shows next/last run in the same zone,
+labelled with it.
+
+Absent ⇒ **UTC**, which is what every install did before this key
+existed: upgrading never moves the firing time of a schedule already
+running in production. Set it deliberately, and check your schedules
+afterwards — a nightly job *will* shift by your UTC offset.
+
+Use a zone name, not an abbreviation: `BRT` is not a zone and produces
+a startup warning while the scheduler quietly stays on UTC. Zone names
+also carry the historical DST rules, so a schedule keeps meaning
+"08:00 local" across a DST transition, which a fixed offset couldn't
+express.
+
+This key does **not** affect the admin tables (audit, user activity,
+apps, users, credentials) or the Logs tab. Those render in each
+viewer's own browser timezone — they're records of past events with a
+human looking at them, whereas the scheduler has no viewer, which is
+why it needs a configured zone.
 
 ### `server.context-path` — subpath mounting
 

--- a/docs/YAML_SCHEMA.md
+++ b/docs/YAML_SCHEMA.md
@@ -69,6 +69,18 @@ existed: upgrading never moves the firing time of a schedule already
 running in production. Set it deliberately, and check your schedules
 afterwards — a nightly job *will* shift by your UTC offset.
 
+One consequence worth planning for: **adopting a zone can fire one
+extra run on the switch-over day.** The fire marker is a UTC instant,
+so re-reading the same expression on a westward clock can put today's
+occurrence *after* the marker — a job that already ran at 08:00 UTC
+runs again at 08:00 local. It settles from the next day on. If a
+re-run would be harmful (a non-idempotent ETL), disable the schedule,
+restart with the zone set, then re-enable it.
+
+Across DST transitions the runner neither skips nor duplicates: a
+spring-forward gap fires at the transition instant, and a fall-back
+repeat fires only on the first of the two.
+
 Use a zone name, not an abbreviation: `BRT` is not a zone and produces
 a startup warning while the scheduler quietly stays on UTC. Zone names
 also carry the historical DST rules, so a schedule keeps meaning

--- a/packaging/ruscker.yml.example
+++ b/packaging/ruscker.yml.example
@@ -42,6 +42,17 @@ server:
   # recipe in /usr/share/doc/ruscker/README.Debian.
   #context-path: /apps
 
+  # IANA zone the SCHEDULED-JOBS runner evaluates cron expressions in.
+  # With this set, `0 8 * * *` on the Schedules page means 08:00 HERE;
+  # without it, 08:00 UTC (the default, and what every install did
+  # before this key existed — so setting it WILL shift existing
+  # schedules by your UTC offset; check them afterwards).
+  # Use a zone name, never an abbreviation: `BRT` is not a zone and
+  # leaves the scheduler on UTC with a startup warning.
+  # Admin tables and the Logs tab are unaffected — they follow each
+  # viewer's own browser timezone.
+  #timezone: America/Recife
+
 proxy:
   # Portal title. This is a SEED/fallback: once you set a title in the
   # admin's Appearance editor, the database value wins (that's the

--- a/packaging/ruscker.yml.example
+++ b/packaging/ruscker.yml.example
@@ -46,7 +46,10 @@ server:
   # With this set, `0 8 * * *` on the Schedules page means 08:00 HERE;
   # without it, 08:00 UTC (the default, and what every install did
   # before this key existed — so setting it WILL shift existing
-  # schedules by your UTC offset; check them afterwards).
+  # schedules by your UTC offset; check them afterwards, and note that
+  # the switch-over day can fire one extra run of a job that already
+  # ran. Disable/re-enable the schedule around the restart if a re-run
+  # would hurt).
   # Use a zone name, never an abbreviation: `BRT` is not a zone and
   # leaves the scheduler on UTC with a startup warning.
   # Admin tables and the Logs tab are unaffected — they follow each


### PR DESCRIPTION
Closes #1042. Segue o #1043 (que consertou os timestamps das telas de admin): mesmo conceito faltando, mas aqui com consequência **operacional**, não visual.

## O bug

O agendador casava as expressões cron contra o relógio UTC (`jobs.rs:118`). Quem escreve `0 8 * * *` esperando 08h ganhava o job às **05h locais**. E, diferente do #1041, isto não dá para resolver no navegador: quem dispara é o servidor, que não tem viewer.

## A correção

Campo `server.timezone` no `ruscker.yml`, nome IANA (`America/Recife`). O cron passa a ser casado contra o relógio de parede daquela zona — croner faz o match em `naive_local()`, então basta entregar um `DateTime<Tz>` — e a página de Agendamentos mostra próxima/última execução na mesma zona, rotulada.

**Ausente ⇒ UTC**, o comportamento de hoje. Essa é a parte importante: box e hugo já têm agendamentos em produção, e um upgrade não pode mover o horário de disparo deles. Configurar a chave é ato deliberado, e a doc diz na cara que isso desloca os agendamentos existentes pelo offset.

**Nome de zona, não offset fixo.** O banco IANA carrega as regras históricas de horário de verão, então "08:00 local" continua significando isso atravessando uma transição. Um teste prende São Paulo em −03 em julho e −02 em janeiro de 2018, quando o Brasil ainda tinha DST — justamente o que um `-03` hardcoded não expressaria.

## Achado durante a implementação

A página de Agendamentos tinha **uma cópia própria** da chamada ao croner. Se eu tivesse deixado, ela seguiria calculando em UTC enquanto o runner migrava para a zona configurada — uma UI mentindo sobre quando o job dispara, que é pior que não ter UI. Agora ela delega para `jobs::next_occurrence`, e um teste prende as duas respostas juntas.

## Modos de falha, que são silenciosos por natureza

- Nome inválido (`BRT` é abreviação, não zona) → cai em UTC com **warning de validação** (`Warning::UnknownTimezone` + formatter no CLI), nunca derruba o boot por um typo.
- O fuso efetivo entrou no **banner de boot**, senão uma chave posta na seção errada só apareceria quando um job noturno rodasse horas fora.
- A ajuda do campo cron dizia "em UTC" nos 4 idiomas; agora fala do fuso do servidor e a página anexa a zona real, então ninguém precisa abrir o YAML para saber em que relógio está escrevendo.

## Verificação ao vivo

Instância com `timezone: America/Recife` (máquina em UTC−3), Playwright/Chrome:

| o quê | resultado |
|---|---|
| `0 8 * * *` → próxima execução | `2026-07-30 08:00 -03` (= 11:00 UTC; antes diria 08:00 UTC) |
| `* * * * *` → **disparou de fato** | `18:23:19Z` = **15:23 local**, o minuto exato que a página previu, exit 0 |
| ajuda do formulário | "…no fuso horário do servidor… **(America/Recife)**" |
| histórico de execuções | `2026-07-29 15:23 -03` |

Gate: `cargo test` completo verde, `clippy --all-targets -- -D warnings` limpo, `i18n-check` OK (as 4 `.ftl` mudaram, então rodei a suíte inteira — o `i18n-check` sozinho não pega id duplicado).

## Notas

- `chrono-tz` 0.10.4 conferida no crates.io antes de entrar; é dado puro + aritmética, por isso é admissível no crate puro `ruscker-config`.
- `book/src/configuration.md` inclui o `YAML_SCHEMA.md`, então a doc da chave já sai no ruscker.com.
- Não mexi nos timestamps pré-formatados de `users.rs:374` e `mfa.rs:198`, que seguem rotulados `UTC` — são horários de eventos passados, não de disparo; se for para alinhar, o lugar é o modelo do #1041.

🤖 Generated with [Claude Code](https://claude.com/claude-code)