### PR TITLE
docs: refresh architecture, roadmaps and diagram labels for v0.2.51

### DIFF
--- a/book/src/images/roadmap.svg
+++ b/book/src/images/roadmap.svg
@@ -1,8 +1,8 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 720 520" width="720" height="520" font-family="Jost, Inter, system-ui, -apple-system, sans-serif" role="img" aria-label="Roadmap timeline. Phases 0 through 7 are done. Phases 0 to 5 shipped in v0.1.0 (scaffolding, landing page, persistence and admin CRUD, proxy and Docker backend, monitoring dashboard, production polish); phase 6 (multi-host scheduling, app visibility, sub-path mounting) shipped across v0.1.1 and v0.1.2; phase 7 (HA / multi-instance) shipped in v0.1.1. After phase 7, the v0.1.x–v0.2.x point releases added the admin redesign, a full bug, security and UX audit (v0.2.5), and an operator-driven design-handoff sprint across the Appearance editor, Apps list and Media flows. Phase 8 (external auth) is planned and optional.">
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 720 520" width="720" height="520" font-family="Jost, Inter, system-ui, -apple-system, sans-serif" role="img" aria-label="Roadmap timeline. Phases 0 through 7 are done. Phases 0 to 5 shipped in v0.1.0 (scaffolding, landing page, persistence and admin CRUD, proxy and Docker backend, monitoring dashboard, production polish); phase 6 (multi-host scheduling, app visibility, sub-path mounting) shipped across v0.1.1 and v0.1.2; phase 7 (HA / multi-instance) shipped in v0.1.1. Post-phase releases added the admin redesign, group-scoped Editor delegation, scheduled jobs with an operator-selected IANA timezone, viewer-local admin timestamps, and security and reliability fixes. Phase 8 contains only the planned, optional external identity-provider integrations.">
   <title>Ruscker — roadmap</title>
 
-  <!-- rail: solid teal through the done phases (0–7) and the latest-release
+  <!-- rail: solid teal through the done phases (0–7) and the post-phase
        release marker, dashed grey after toward the planned phase 8 -->
   <line x1="60" y1="52" x2="60" y2="446" stroke="#1D9E75" stroke-width="3"/>
   <line x1="60" y1="446" x2="60" y2="476" stroke="#B9CDC6" stroke-width="3" stroke-dasharray="3 6"/>
@@ -64,12 +64,12 @@
     <text x="580" y="421" text-anchor="middle" font-size="11" font-weight="700" fill="#FFFFFF">v0.1.1</text>
   </g>
 
-  <!-- v0.1.3 release marker — between phase 7 and the planned phase 8.
+  <!-- Post-phase release marker — between phase 7 and the planned phase 8.
        A diamond (not a phase circle): a cross-cutting release, not a
        phase. Sits at the solid→dashed transition. -->
   <path d="M60,439 l7,7 l-7,7 l-7,-7 z" fill="#1D9E75" stroke="#FFFFFF" stroke-width="1.5"/>
   <text x="86" y="450" font-size="12.5">
-    <tspan font-weight="700" fill="#085041">v0.2.x</tspan><tspan fill="#5B6B66"> · latest — full audit (v0.2.5) + the admin design-handoff sprint (Appearance, Apps, Media)</tspan>
+    <tspan font-weight="700" fill="#085041">Post-phase polish</tspan><tspan fill="#5B6B66"> · admin UX · scoped Editors · schedules · security + reliability</tspan>
   </text>
 
   <!-- planned phase -->
@@ -77,7 +77,7 @@
     <!-- 8 -->
     <circle cx="60" cy="476" r="8.5" fill="#FFFFFF" stroke="#B9CDC6" stroke-width="2.5"/>
     <text x="86" y="473" font-weight="700" fill="#5B6B66">Phase 8 · External auth</text>
-    <text x="86" y="489" font-size="11" fill="#90A39C">OIDC · SAML · LDAP · per-app ACLs (RBAC already shipped)</text>
+    <text x="86" y="489" font-size="11" fill="#90A39C">OIDC · SAML · LDAP (scoped RBAC + per-app ACLs already shipped)</text>
     <rect x="520" y="462" width="120" height="22" rx="11" fill="#FFFFFF" stroke="#B9CDC6" stroke-width="1.5"/>
     <text x="580" y="477" text-anchor="middle" font-size="11" font-weight="600" fill="#5B6B66">planned · optional</text>
   </g>

--- a/book/src/images/roadmap.svg
+++ b/book/src/images/roadmap.svg
@@ -37,7 +37,7 @@
     <circle cx="60" cy="260" r="9" fill="#0F6E56"/>
     <path d="M55.5,260 l3,3 l6,-6.5" fill="none" stroke="#FFFFFF" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"/>
     <text x="86" y="257" font-weight="700" fill="#085041">Phase 4 · Monitoring dashboard</text>
-    <text x="86" y="273" font-size="11" fill="#5B6B66">live SSE · per-replica CPU/mem · logs · actions</text>
+    <text x="86" y="273" font-size="11" fill="#5B6B66">live metrics · per-replica CPU/mem · logs · actions</text>
 
     <!-- 5 -->
     <circle cx="60" cy="312" r="9" fill="#0F6E56"/>

--- a/book/src/roadmap.md
+++ b/book/src/roadmap.md
@@ -8,7 +8,7 @@ live on a real deployment before the next. Phase 8 (external auth) is
 the main optional, demand-driven work left. For what changed in each
 release, see the [release notes](./news.md).
 
-![Roadmap timeline: phases 0–7 are done — 0 to 5 shipped in v0.1.0 (scaffolding, landing page, persistence + admin CRUD, proxy + Docker backend, monitoring dashboard, production polish); phase 6 (multi-host scheduling, app visibility, sub-path mounting) across v0.1.1–v0.1.2; phase 7 (HA / multi-instance) in v0.1.1. Post-1.0 point releases add demo forks, URL-rewrite modernization, unified credentials, the media library, portal logos, admin UX polish, and security + perf fixes. Phase 8 (external auth) is planned and optional.](images/roadmap.svg)
+![Roadmap timeline: phases 0–7 are done — 0 to 5 shipped in v0.1.0 (scaffolding, landing page, persistence + admin CRUD, proxy + Docker backend, monitoring dashboard, production polish); phase 6 (multi-host scheduling, app visibility, sub-path mounting) across v0.1.1–v0.1.2; phase 7 (HA / multi-instance) in v0.1.1. Post-phase releases add admin and portal UX, group-scoped Editor delegation, scheduled jobs, viewer-local admin timestamps, timezone-aware cron, and security + reliability fixes. Phase 8 contains only the planned, optional external identity-provider integrations.](images/roadmap.svg)
 
 ## Shipped
 
@@ -181,6 +181,20 @@ error + exit code instead of a generic "no port binding". Plus catalog
 cards expand their description on hover, and the dashboard's
 stop/restart actions show in-progress feedback.
 
+**Operations and delegated administration.** The Admin panel now runs
+scheduled, run-to-completion ETL jobs with history and alerting. Cron is
+evaluated on the IANA wall clock selected by `server.timezone`, preserving
+UTC when the setting is absent; the Schedules page uses that same clock.
+Other persisted admin timestamps stay in UTC and are converted in the
+browser to each viewer's timezone.
+
+Editor delegation is row-scoped from current group memberships across
+Applications, Users, and Groups. Open apps remain available to every
+Editor, Media is shared, and an out-of-scope target returns `404`.
+Admins and the break-glass token remain unrestricted. Account deletion,
+CSV user import, MFA reset, and creating, renaming, or deleting a group
+remain Admin-only.
+
 ## Planned (optional)
 
 Demand-driven — Ruscker is complete and useful without it.
@@ -206,10 +220,10 @@ Tracked in the GitHub issues; picked up as real usage asks for them:
   long-session flap has since shipped.)*
 
 ### Phase 8 — External auth
-OIDC (Keycloak / Auth0 / Google), SAML, and LDAP, plus per-app access
-lists ("only group X can use this app"). The coarse Viewer / Editor /
-Admin RBAC already shipped in Phase 5; this is the federated-identity
-and fine-grained-ACL layer on top.
+OIDC (Keycloak / Auth0 / Google), SAML, and LDAP. Per-app access lists
+and the Viewer / Editor / Admin model already ship, including
+group-scoped Editor delegation across Applications, Users, and Groups.
+This phase is only the federated-identity layer on top.
 
 ## Explicitly out of scope
 

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -102,6 +102,15 @@ per request. User/group/profile mutations invalidate the cache with a
 generation counter, preventing an in-flight stale read from repopulating
 revoked identity data.
 
+Admin-panel authorization keeps identity and row scope separate:
+`crate::auth` answers who the caller is and which role the session carries;
+`scope::EditorScope` answers which Application, User, and Group rows that
+caller may see or change. It refetches an Editor's groups on every request
+and fails closed; an out-of-scope target looks absent (`404`). Admin and
+break-glass sessions are unrestricted, open apps are shared by all Editors,
+and Media is shared. Account deletion, CSV user import, MFA reset, and group
+creation/rename/deletion remain Admin-only.
+
 The request guard then applies these boundaries in order:
 
 1. `Spec::access_allows` enforces per-user/per-group access server-side.
@@ -127,10 +136,16 @@ Postgres:
 
 `jobs::spawn` starts one scheduler loop per process when both a catalog DB
 and container backend exist (the local Docker backend runs jobs; the
-multi-host backend does not, so a due schedule there records an error). Every 30 seconds it loads enabled `schedules`;
-only the `LeaderElector` winner may fire in HA. `db::schedules::mark_fired`
-atomically advances `last_run_at` before execution, so a split-brain second
-runner loses the claim and a crash does not double-fire the occurrence.
+multi-host backend does not, so a due schedule there records an error).
+Every 30 seconds it loads enabled `schedules`; only the `LeaderElector`
+winner may fire in HA. Cron expressions are evaluated against the IANA wall
+clock named by `server.timezone`; when it is absent, the historical UTC
+behaviour is preserved. An invalid name also falls back to UTC with a
+validation warning. The Schedules page calls the same `next_occurrence`
+function and renders firing times in that operational zone.
+`db::schedules::mark_fired` atomically advances `last_run_at` before
+execution, so a split-brain second runner loses the claim and a crash does
+not double-fire the occurrence.
 
 A new schedule anchors at `created_at` (no fire-on-create). If downtime spans
 several cron occurrences, the next tick collapses them to one firing. The job
@@ -140,6 +155,15 @@ and runs to completion outside the interactive replica registry. A
 per-schedule timeout defaults to one hour in the backend. Results, duration,
 exit code, and log tail land in `schedule_runs`; failures enqueue the
 `job-failed` alert webhook.
+
+These are deliberately two different time models. Stored instants remain
+UTC. Ordinary admin tables emit those instants as `<time datetime="…Z">`;
+the shared layout converts them in the browser to the viewer's timezone and
+keeps UTC as the no-JavaScript fallback. Schedules stay on the configured
+operational clock because their timestamps explain when cron will fire.
+Changing `server.timezone` on an installation with existing schedules can
+produce one extra run on the switch-over day, so operators should review
+their next-run values after adopting a zone.
 
 ### Aggregated access counter
 
@@ -298,7 +322,8 @@ SQLite or the HA Postgres catalog.
   replica up and down. Set `min-replicas: 1`+ to keep an app warm.
 - The session-purger runs as a periodic task (every 5s).
 - The leader-only job scheduler checks cron schedules every 30s and detaches
-  each run-to-completion job so long ETL work cannot block later ticks.
+  each run-to-completion job so long ETL work cannot block later ticks. It
+  evaluates cron on the `server.timezone` wall clock (UTC when unset).
 - The access-counter drain batches in-memory deltas every 2s instead of
   writing on every proxy request.
 - `DashMap` backs the replica/in-flight state and the short-TTL identity/spec
@@ -312,9 +337,10 @@ SQLite or the HA Postgres catalog.
   Admin paths require an authenticated session.
 - **Privileged**: signed-in users. Authentication uses per-user passwords
   and three roles — **Viewer** (portal access only; no admin section),
-  **Editor** (dashboard, apps, and media), **Admin** (everything, incl. user
-  management) — enforced server-side. A break-glass `RUSCKER_ADMIN_TOKEN`
-  bootstraps the first account. See `docs/SECURITY.md` §2.
+  **Editor** (dashboard plus group-scoped Applications, Users, and Groups;
+  open apps and Media are shared), **Admin** (unrestricted) — enforced
+  server-side. A break-glass `RUSCKER_ADMIN_TOKEN` bootstraps the first
+  account and is also unrestricted. See `docs/SECURITY.md` §2.
 - **Operator**: filesystem access (the person running Ruscker). Can
   edit YAML, restart the process.
 

--- a/docs/ROADMAP.md
+++ b/docs/ROADMAP.md
@@ -154,7 +154,8 @@ drill into any container.
 - [ ] LDAP directory integration
 - [x] Role-based access control (Viewer / Editor / Admin), including
       group-scoped Editor delegation across Apps, Users and Groups; Admin
-      accounts and the break-glass token remain unrestricted
+      accounts and the break-glass token remain unrestricted, open apps and
+      Media stay shared, and out-of-scope row targets return 404
 - [x] Per-spec access lists (only group X can use this app) — shipped in Phase 6
 - [x] Per-app step-up MFA — one user-owned TOTP factor, recovery codes,
       trusted-device grants, and per-spec proof-freshness policy
@@ -169,9 +170,13 @@ drill into any container.
 
 - [x] Scheduled jobs — Admin **Schedules** page, cron ETL semantics,
       no fire-on-create, collapsed downtime catch-up, leader-only HA firing,
+      IANA `server.timezone` evaluation with the historical UTC default,
       the spec's image/environment/volumes/credentials, optional command
       override, run history/log tail, one-hour default timeout, and the
       `job-failed` alert webhook
+- [x] Viewer-local admin timestamps — persisted UTC instants are emitted as
+      machine-readable `<time>` values and converted in the browser, while
+      scheduled firing times remain on the scheduler's configured clock
 - [x] Named-volume management — Admin Disk **Volumes** card with live
       reference counts; create labels Ruscker-owned volumes, and remove is
       offered only for Ruscker-created volumes with zero live references and

--- a/docs/images/roadmap.svg
+++ b/docs/images/roadmap.svg
@@ -1,8 +1,8 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 720 520" width="720" height="520" font-family="Jost, Inter, system-ui, -apple-system, sans-serif" role="img" aria-label="Roadmap timeline. Phases 0 through 7 are done. Phases 0 to 5 shipped in v0.1.0 (scaffolding, landing page, persistence and admin CRUD, proxy and Docker backend, monitoring dashboard, production polish); phase 6 (multi-host scheduling, app visibility, sub-path mounting) shipped across v0.1.1 and v0.1.2; phase 7 (HA / multi-instance) shipped in v0.1.1. After phase 7, the v0.1.x–v0.2.x point releases added the admin redesign, a full bug, security and UX audit (v0.2.5), and an operator-driven design-handoff sprint across the Appearance editor, Apps list and Media flows. Phase 8 (external auth) is planned and optional.">
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 720 520" width="720" height="520" font-family="Jost, Inter, system-ui, -apple-system, sans-serif" role="img" aria-label="Roadmap timeline. Phases 0 through 7 are done. Phases 0 to 5 shipped in v0.1.0 (scaffolding, landing page, persistence and admin CRUD, proxy and Docker backend, monitoring dashboard, production polish); phase 6 (multi-host scheduling, app visibility, sub-path mounting) shipped across v0.1.1 and v0.1.2; phase 7 (HA / multi-instance) shipped in v0.1.1. Post-phase releases added the admin redesign, group-scoped Editor delegation, scheduled jobs with an operator-selected IANA timezone, viewer-local admin timestamps, and security and reliability fixes. Phase 8 contains only the planned, optional external identity-provider integrations.">
   <title>Ruscker — roadmap</title>
 
-  <!-- rail: solid teal through the done phases (0–7) and the latest-release
+  <!-- rail: solid teal through the done phases (0–7) and the post-phase
        release marker, dashed grey after toward the planned phase 8 -->
   <line x1="60" y1="52" x2="60" y2="446" stroke="#1D9E75" stroke-width="3"/>
   <line x1="60" y1="446" x2="60" y2="476" stroke="#B9CDC6" stroke-width="3" stroke-dasharray="3 6"/>
@@ -64,12 +64,12 @@
     <text x="580" y="421" text-anchor="middle" font-size="11" font-weight="700" fill="#FFFFFF">v0.1.1</text>
   </g>
 
-  <!-- v0.1.3 release marker — between phase 7 and the planned phase 8.
+  <!-- Post-phase release marker — between phase 7 and the planned phase 8.
        A diamond (not a phase circle): a cross-cutting release, not a
        phase. Sits at the solid→dashed transition. -->
   <path d="M60,439 l7,7 l-7,7 l-7,-7 z" fill="#1D9E75" stroke="#FFFFFF" stroke-width="1.5"/>
   <text x="86" y="450" font-size="12.5">
-    <tspan font-weight="700" fill="#085041">v0.2.x</tspan><tspan fill="#5B6B66"> · latest — full audit (v0.2.5) + the admin design-handoff sprint (Appearance, Apps, Media)</tspan>
+    <tspan font-weight="700" fill="#085041">Post-phase polish</tspan><tspan fill="#5B6B66"> · admin UX · scoped Editors · schedules · security + reliability</tspan>
   </text>
 
   <!-- planned phase -->
@@ -77,7 +77,7 @@
     <!-- 8 -->
     <circle cx="60" cy="476" r="8.5" fill="#FFFFFF" stroke="#B9CDC6" stroke-width="2.5"/>
     <text x="86" y="473" font-weight="700" fill="#5B6B66">Phase 8 · External auth</text>
-    <text x="86" y="489" font-size="11" fill="#90A39C">OIDC · SAML · LDAP · per-app ACLs (RBAC already shipped)</text>
+    <text x="86" y="489" font-size="11" fill="#90A39C">OIDC · SAML · LDAP (scoped RBAC + per-app ACLs already shipped)</text>
     <rect x="520" y="462" width="120" height="22" rx="11" fill="#FFFFFF" stroke="#B9CDC6" stroke-width="1.5"/>
     <text x="580" y="477" text-anchor="middle" font-size="11" font-weight="600" fill="#5B6B66">planned · optional</text>
   </g>

--- a/docs/images/roadmap.svg
+++ b/docs/images/roadmap.svg
@@ -37,7 +37,7 @@
     <circle cx="60" cy="260" r="9" fill="#0F6E56"/>
     <path d="M55.5,260 l3,3 l6,-6.5" fill="none" stroke="#FFFFFF" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"/>
     <text x="86" y="257" font-weight="700" fill="#085041">Phase 4 · Monitoring dashboard</text>
-    <text x="86" y="273" font-size="11" fill="#5B6B66">live SSE · per-replica CPU/mem · logs · actions</text>
+    <text x="86" y="273" font-size="11" fill="#5B6B66">live metrics · per-replica CPU/mem · logs · actions</text>
 
     <!-- 5 -->
     <circle cx="60" cy="312" r="9" fill="#0F6E56"/>


### PR DESCRIPTION
Segunda de duas PRs de doc para a v0.2.51 (arquitetura, os dois roadmaps, rótulos de diagrama). Arquivos disjuntos da #1050.

Implementada por agente `codex exec` (gpt-5.6-sol, high); revisada por mim, com **uma correção minha** (`3b4e72e`).

## Duas defasagens estruturais que eu levantei antes de despachar

**Existiam dois roadmaps e eles divergiram.** A fatia 4 do #990 atualizou o `docs/ROADMAP.md`, mas o `book/src/roadmap.md` tem conteúdo próprio e ainda dizia que o RBAC é "coarse Viewer / Editor / Admin" — impreciso desde que Editor passou a ser escopado. Os dois foram alinhados **sem** virar cópia um do outro: são públicos diferentes.

**Cada diagrama existe em duas ou três cópias byte a byte idênticas.** Conferi por md5: `architecture.svg` existe 3 vezes (README, `docs/ARCHITECTURE.md`, site) e os outros 2 vezes. Editar uma cópia só faria README e site mostrarem diagramas diferentes — divergência silenciosa. Isso virou instrução explícita, e conferi ao final que as famílias seguem idênticas.

## Arquitetura

`docs/ARCHITECTURE.md` não mencionava nem o fuso do agendador nem o `EditorScope`. Agora registra a separação que importa para quem for mexer nisso depois: **`crate::auth` responde quem é o chamador; `scope::EditorScope` responde quais linhas ele pode ver ou alterar** — com o refetch por request, o fail-closed e o 404. E documenta os **dois modelos de tempo** deliberadamente diferentes: instantes persistidos em UTC convertidos no navegador, versus o relógio operacional do agendador.

## Diagramas — regra dura, e por quê

Este repositório já se queimou editando geometria de SVG às cegas (#919), então a instrução foi: **só texto e rótulo, nenhuma coordenada, path ou viewBox**; se algo exigir geometria, descrever em vez de fazer.

Verifiquei eu mesmo, não por confiança:

- **Diff de atributos geométricos: nenhum.** O `viewBox` aparece no diff apenas porque a linha inteira do `<svg>` mudou (o `aria-label` fica nela) — o valor é idêntico nos dois lados.
- **Render verificado em navegador**, antes e depois: nenhum `<text>` transborda o `viewBox` e nada colide. Texto em SVG não reflui, então rótulo mais longo é risco real de sobreposição — medi, e o novo rótulo até encurtou.
- As duplicatas seguem idênticas por md5.

**Minha correção (`3b4e72e`):** a Fase 4 do roadmap ainda dizia `live SSE`. A Fase 4 **é** o dashboard de monitoramento, e ele saiu de SSE para polling em `GET /admin/dashboard/snapshot` na v0.2.37 (#916) — mudança que foi justamente o que impediu uma conexão longa de estrangular o pool por origem do navegador. O rótulo estava errado desde então; virou `live metrics`. Aplicado nas duas cópias e re-renderizado.

O `architecture.svg` **mantém** sua menção a SSE de propósito: ali é um rol geral de recursos da admin, e o SSE ainda serve o follow ao vivo de log de container — decisão já tomada na revisão do #1013.

## Deixado para um passe geométrico

As pendências herdadas do #919 seguem intactas: arestas do `crate-map.svg` e o rótulo do Postgres no `deployment.svg`. Representar o `EditorScope` explicitamente no diagrama de arquitetura também exigiria forma ou aresta nova — não foi feito, porque exige verificação de render caso a caso.

Checkboxes de OIDC/SAML/LDAP seguem **desmarcados**. `mdbook build book` passa.

🤖 Generated with [Claude Code](https://claude.com/claude-code)